### PR TITLE
add documentation for configuring SASL with the helm chart

### DIFF
--- a/docs/reference/redpanda-operator/index.mdx
+++ b/docs/reference/redpanda-operator/index.mdx
@@ -7,10 +7,10 @@ title: Redpanda Operator
   <meta name="description" content="Redpanda Operator reference topics" />
 </head>
 
-This section includes information about installing, deploying, and securing Redpanda on Kubernetes using the Redpanda Operator. This is supported for backward compatibility. 
+This section includes information about installing, deploying, and securing Redpanda on Kubernetes using the Redpanda Operator (`redpanda-operator` Helm chart). This is supported only for backward compatibility. 
 
 :::important
-To use the recommended Redpanda Helm chart, see: 
+To use the recommended `redpanda` Helm chart, see: 
 - [60-Second Guide for Kubernetes](../../quickstart/kubernetes-qs-dev)
 - [Configuring TLS on Kubernetes](../../security/kubernetes-tls)
 - [Configuring SASL on Kubernetes](../../security/sasl-kubernetes)

--- a/docs/reference/redpanda-operator/index.mdx
+++ b/docs/reference/redpanda-operator/index.mdx
@@ -10,9 +10,10 @@ title: Redpanda Operator
 This section includes information about installing, deploying, and securing Redpanda on Kubernetes using the Redpanda Operator. This is supported for backward compatibility. 
 
 :::important
-To use the latest recommended Redpanda Helm chart, see: 
+To use the recommended Redpanda Helm chart, see: 
 - [60-Second Guide for Kubernetes](../../quickstart/kubernetes-qs-dev)
 - [Configuring TLS on Kubernetes](../../security/kubernetes-tls)
+- [Configuring SASL on Kubernetes](../../security/sasl-kubernetes)
 :::
 
 Install

--- a/docs/reference/redpanda-operator/kubernetes-sasl.mdx
+++ b/docs/reference/redpanda-operator/kubernetes-sasl.mdx
@@ -7,7 +7,11 @@ title: Configuring Redpanda SASL on Kubernetes
     <meta name="description" content="Configuring Redpanda SASL on Kubernetes."/>
 </head>
 
-This section provides details on how to enable SASL authentication on Kubernetes. Alone, SASL authenticates the server and the client. To encrypt communication between the server and the client, combine SASL authentication with TLS encryption. Redpanda supports the SASL/SCRAM authentication method for the Kafka API.
+:::important
+See [Configuring Redpanda SASL on Kubernetes](../../../security/sasl-kubernetes) for the most up-to-date instructions using the Redpanda Helm chart. This page is preserved for backward compatibility.
+:::
+
+This section provides details on how to enable SASL authentication on Kubernetes using the Redpanda Operator. Alone, SASL authenticates the server and the client. To encrypt communication between the server and the client, combine SASL authentication with TLS encryption. Redpanda supports the SASL/SCRAM authentication method for the Kafka API.
 
 For general security information, see [Redpanda Security on Kubernetes](../security-kubernetes).
 

--- a/docs/reference/redpanda-operator/kubernetes-sasl.mdx
+++ b/docs/reference/redpanda-operator/kubernetes-sasl.mdx
@@ -8,7 +8,7 @@ title: Configuring Redpanda SASL on Kubernetes
 </head>
 
 :::important
-See [Configuring Redpanda SASL on Kubernetes](../../../security/sasl-kubernetes) for the most up-to-date instructions using the Redpanda Helm chart. This page is preserved for backward compatibility.
+See [Configuring Redpanda SASL on Kubernetes](../../../security/sasl-kubernetes) for the most up-to-date instructions using the `redpanda` Helm chart. This page is based on the `redpanda-operator` Helm chart and is preserved only for backward compatibility.
 :::
 
 The Simple Authentication and Security Layer (SASL) is a method for adding authentication support to connection-based protocols. When using the Redpanda Operator, SASL provides authentication between the server and client. To encrypt communication, use TLS encryption. You must use TLS encryption to have secure authentication using SASL.

--- a/docs/reference/redpanda-operator/kubernetes-sasl.mdx
+++ b/docs/reference/redpanda-operator/kubernetes-sasl.mdx
@@ -11,7 +11,7 @@ title: Configuring Redpanda SASL on Kubernetes
 See [Configuring Redpanda SASL on Kubernetes](../../../security/sasl-kubernetes) for the most up-to-date instructions using the Redpanda Helm chart. This page is preserved for backward compatibility.
 :::
 
-This section provides details on how to enable SASL authentication on Kubernetes using the Redpanda Operator. Alone, SASL authenticates the server and the client. To encrypt communication between the server and the client, combine SASL authentication with TLS encryption. Redpanda supports the SASL/SCRAM authentication method for the Kafka API.
+The Simple Authentication and Security Layer (SASL) is a method for adding authentication support to connection-based protocols. When using the Redpanda Operator, SASL provides authentication between the server and client. To encrypt communication, use TLS encryption. You must use TLS encryption to have secure authentication using SASL.
 
 For general security information, see [Redpanda Security on Kubernetes](../security-kubernetes).
 

--- a/docs/reference/redpanda-operator/kubernetes-sasl.mdx
+++ b/docs/reference/redpanda-operator/kubernetes-sasl.mdx
@@ -198,7 +198,7 @@ kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal Us
 --sasl-mechanism SCRAM-SHA-256
 ```
 
-2. Optionally, you can use the superuser to grant permissions to the new user for a topic within the cluster. The following command grants `describe` privileges to a topic that doesn’t exist yet. In the next step, you create the topic that you reference in this command. Note that if a user has `describe` privileges on a cluster, they do not automatically have `describe` privileges on topics within the cluster.
+1. Optionally, you can use the superuser to grant permissions to a new user for a topic within the cluster. The following command grants `describe` privileges to a topic that doesn’t exist yet. In the next step, you create the topic that you reference in this command. 
 
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal User:<username> --operation describe --topic <topic_name> \

--- a/docs/reference/redpanda-operator/tls-kubernetes.mdx
+++ b/docs/reference/redpanda-operator/tls-kubernetes.mdx
@@ -8,7 +8,7 @@ title: "Configuring Redpanda TLS on Kubernetes"
 </head>
 
 :::important
-See [Configuring Redpanda TLS on Kubernetes](../../../security/kubernetes-tls) for the most up-to-date instructions using the Redpanda Helm chart. This page is preserved for backward compatibility.
+See [Configuring Redpanda TLS on Kubernetes](../../../security/kubernetes-tls) for the most up-to-date instructions using the `redpanda` Helm chart. This page is based on the `redpanda-operator` Helm chart and is preserved only for backward compatibility.
 :::
 
 This section explains how to enable Transport Layer Security (TLS) on Kubernetes using the Redpanda Operator. Alone, TLS authenticates the server and encrypts communication between the client and the server. To add client authentication, you can combine TLS encryption with SASL authentication, or you can configure mTLS authentication.

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -16,6 +16,7 @@ Redpanda recommends that you always configure encryption, authentication, and au
 
 Security on Kubernetes
   - [Configuring TLS on Kubernetes](./kubernetes-tls)
+  - [Configuring SASL on Kubernetes](./sasl-kubernetes)
 
 :::note
 All concepts described in this section are compatible with Kafka and its client libraries and CLIs. This section does not cover ways you can protect your Redpanda cluster externally; for example, through network ACLs or private networks.

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -7,7 +7,7 @@ title: Configuring Redpanda SASL on Kubernetes
     <meta name="description" content="Configuring Redpanda SASL on Kubernetes."/>
 </head>
 
-The Simple Authentication and Security Layer (SASL) is a method for adding authentication support to connection-based protocols. When using the Redpanda Helm chart, SASL provides authentication between the server and client. To encrypt communication, use TLS encryption. You must use TLS encryption to have secure authentication using SASL.
+Simple Authentication and Security Layer (SASL) is a method for adding authentication support to connection-based protocols. When using the Redpanda Helm chart, SASL provides authentication between the server and client. To encrypt communication, use TLS encryption. You must use TLS encryption to have secure authentication using SASL.
 
 :::note
 This page uses the recommended Helm chart for configuring security. For information about using the older Redpanda Operator, see [Redpanda Operator](../../reference/redpanda-operator).

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -56,7 +56,7 @@ kubectl exec -n redpanda -c redpanda redpanda-0 -- \
 
 ## Grant permissions
 
-The superuser can grant permissions to additional users through access control lists ([ACLs](../authorization/#ACLs)). For details on how ACLs function in Redpanda, see the [rpk acl](../../reference/rpk/rpk-acl/) documentation.
+The superuser can grant permissions to additional users through access control lists ([ACLs](../authorization/#ACLs)). For details on how ACLs function in Redpanda, see [rpk acl](../../reference/rpk/rpk-acl/).
 
 1. Use the superuser to grant `create` and `describe` permissions to another user for the cluster. Edit the `rpk acl create` command to grant permissions to specific users or groups:
 

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -7,7 +7,7 @@ title: Configuring Redpanda SASL on Kubernetes
     <meta name="description" content="Configuring Redpanda SASL on Kubernetes."/>
 </head>
 
-Redpanda supports the SASL/SCRAM authentication method for the Kafka API. The Redpanda Helm chart lets you configure SASL authentication.
+The Simple Authentication and Security Layer (SASL) is a method for adding authentication support to connection-based protocols. When using the Redpanda Helm chart, SASL provides authentication between the server and client. To encrypt communication, use TLS encryption. You must use TLS encryption to have secure authentication using SASL.
 
 :::note
 This page uses the recommended Helm chart for configuring security. For information about using the older Redpanda Operator, see [Redpanda Operator](../../reference/redpanda-operator).

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -13,7 +13,7 @@ For general security information, see [Redpanda Security on Kubernetes](/docs/se
 
 ## Step 1: Enable SASL
 
-Create a yaml file containing the values to override from the defaults:
+Create a YAML file containing the values to override from the defaults:
 
 _**sasl_enable.yaml**_
 

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -60,23 +60,23 @@ The superuser can grant permissions to additional users through access control l
 
 1. Use the superuser to grant `create` and `describe` permissions to another user for the cluster. Edit the `rpk acl create` command to grant permissions to specific users or groups:
 
-```bash
-kubectl exec -n redpanda -c redpanda redpanda-0 -- \
-  rpk acl create --allow-principal User:myuser \
-  --operation create,describe \
-  --cluster \
-  --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
-```
+  ```bash
+  kubectl exec -n redpanda -c redpanda redpanda-0 -- \
+    rpk acl create --allow-principal User:myuser \
+    --operation create,describe \
+    --cluster \
+    --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
+  ```
 
 2. Optionally, you can use the superuser to grant permissions to a new user for a topic. The following command grants `describe` privileges to a topic:
 
-```bash
-kubectl exec -n redpanda -c redpanda redpanda-0 -- \
-  rpk acl create --allow-principal User:myuser \
-  --operation describe \
-  --topic myfirsttopic \
-  --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
-```
+  ```bash
+  kubectl exec -n redpanda -c redpanda redpanda-0 -- \
+    rpk acl create --allow-principal User:myuser \
+    --operation describe \
+    --topic myfirsttopic \
+    --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
+  ```
 
 :::note
 When a user is granted `describe` privileges on a cluster, that user is not automatically granted `describe` privileges on topics.

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -44,7 +44,7 @@ helm upgrade --install redpanda redpanda/redpanda -n redpanda --create-namespace
 Create users (not superusers) and set passwords for the new users. By default, these users don't have any permissions on the cluster.
 
 :::tip
-As a security best practice, you don't want to use the superuser to run commands on the cluster. You can use these additional users to interact with the cluster.
+As a security best practice, superusers should not run commands on the cluster. Instead, have these additional or new users interact with the cluster.
 :::
 
 To create the user `myuser` with a password `changethispassword`, run:
@@ -84,7 +84,7 @@ When a user is granted `describe` privileges on a cluster, that user is not auto
 
 ## Use rpk to interact with Redpanda
 
-Now you can connect to Redpanda with the additional (non-superuser) user and start working with the cluster.
+Connect to Redpanda with the additional (non-superuser) user and start working with the cluster.
 
 To create a topic:
 

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -47,7 +47,7 @@ Create users (not superusers) and set passwords for the new users. By default, t
 As a security best practice, you don't want to use the superuser to run commands on the cluster. You can use these additional users to interact with the cluster.
 :::
 
-For each user that you want to create, run:
+To create the user `myuser` with a password `changethispassword`, run:
 
 ```bash
 kubectl exec -n redpanda -c redpanda redpanda-0 -- \

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -79,7 +79,7 @@ The superuser can grant permissions to additional users through access control l
   ```
 
 :::note
-When a user is granted `describe` privileges on a cluster, that user is not automatically granted `describe` privileges on topics.
+If a user has `describe` privileges on a cluster, it does not mean that user is automatically granted `describe` privileges on topics.
 :::
 
 ## Use rpk to interact with Redpanda

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -79,7 +79,7 @@ kubectl exec -n redpanda -c redpanda redpanda-0 -- \
 ```
 
 :::note
-If a user has `describe` privileges on a cluster, they don't automatically have `describe` privileges on topics.
+When a user is granted `describe` privileges on a cluster, that user is not automatically granted `describe` privileges on topics.
 :::
 
 ## Use rpk to interact with Redpanda

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -1,0 +1,97 @@
+---
+title: Configuring Redpanda SASL on Kubernetes
+---
+
+<head>
+    <meta name="title" content="Configuring Redpanda SASL on Kubernetes | Redpanda Docs"/>
+    <meta name="description" content="Configuring Redpanda SASL on Kubernetes."/>
+</head>
+
+Redpanda supports the SASL/SCRAM authentication method for the Kafka API. The Redpanda helm chart allows you to configure SASL authentication.
+
+For general security information, see [Redpanda Security on Kubernetes](/docs/security/security-kubernetes).
+
+## Step 1: Enable SASL
+
+Create a yaml file containing the values to override from the defaults:
+
+_**sasl_enable.yaml**_
+
+```yaml
+auth:
+  sasl:
+    enabled: true
+    users:
+      - name: admin
+        password: changeme
+```
+
+:::note
+In this YAML document, `users` is a list of superusers.
+:::
+
+Upgrade or install, enabling the SASL configuration
+
+```bash
+helm upgrade --install redpanda redpanda/redpanda -n redpanda --create-namespace \
+  --values sasl_enable.yaml
+```
+
+## Step 2: Create users
+
+Create users (not superusers) and set the passwords for the new users. By default, these users don't have any permissions on the cluster.
+
+:::tip
+As a security best practice, you don't want to use the superuser to run commands on the cluster. You can use these additional users to interact with the cluster.
+:::
+
+For each user that you want to create, run:
+
+```bash
+kubectl exec -n redpanda -c redpanda redpanda-0 -- \
+  rpk acl user create myuser -p changethispassword
+```
+
+## Step 3: Grant permissions
+
+The superuser can grant permissions to additional users through access control lists (ACLs). For details on how ACLs function in Redpanda, see the [rpk acl](/docs/reference/rpk/rpk-acl/) documentation.
+
+1. Use the superuser to grant `create` and `describe` permissions to another user for the cluster. You can edit the `rpk acl create` command to grant permissions to specific users or groups:
+
+```bash
+kubectl exec -n redpanda -c redpanda redpanda-0 -- \
+  rpk acl create --allow-principal User:myuser \
+  --operation create,describe \
+  --cluster \
+  --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
+```
+
+2. Optionally, you can use the superuser to grant permissions to the new user for a topic. The following command grants `describe` privileges to a topic Note that if a user has `describe` privileges on a cluster, they do not automatically have `describe` privileges on topics.
+
+```bash
+kubectl exec -n redpanda -c redpanda redpanda-0 -- \
+  rpk acl create --allow-principal User:myuser \
+  --operation describe \
+  --topic myfirsttopic \
+  --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
+```
+
+## Step 4: Use rpk to interact with Redpanda
+
+Now you can connect to Redpanda with the additional (non-superuser) user and start working with the cluster.
+
+To create a topic, run:
+
+```bash
+kubectl exec -n redpanda -c redpanda redpanda-0 -- \
+  rpk topic create myfirsttopic \
+  --user myuser --password changethispassword --sasl-mechanism SCRAM-SHA-256
+```
+
+To describe the topic, run:
+
+```bash
+kubectl exec -n redpanda -c redpanda <cluster_name>-0 -- \
+  rpk topic describe myfirsttopic \
+  --user myuser --password changethispassword --sasl-mechanism SCRAM-SHA-256
+```

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -82,7 +82,7 @@ kubectl exec -n redpanda -c redpanda redpanda-0 -- \
 If a user has `describe` privileges on a cluster, they don't automatically have `describe` privileges on topics.
 :::
 
-## Use `rpk` to interact with Redpanda
+## Use rpk to interact with Redpanda
 
 Now you can connect to Redpanda with the additional (non-superuser) user and start working with the cluster.
 

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -7,9 +7,9 @@ title: Configuring Redpanda SASL on Kubernetes
     <meta name="description" content="Configuring Redpanda SASL on Kubernetes."/>
 </head>
 
-Redpanda supports the SASL/SCRAM authentication method for the Kafka API. The Redpanda helm chart allows you to configure SASL authentication.
+Redpanda supports the SASL/SCRAM authentication method for the Kafka API. The Redpanda Helm chart lets you configure SASL authentication.
 
-For general security information, see [Redpanda Security on Kubernetes](/docs/security/security-kubernetes).
+For general security information, see [Redpanda Security on Kubernetes](/../../security/security-kubernetes).
 
 ## Step 1: Enable SASL
 
@@ -30,7 +30,7 @@ auth:
 In this YAML document, `users` is a list of superusers.
 :::
 
-Upgrade or install, enabling the SASL configuration
+During install or upgrade, enable SASL configuration:
 
 ```bash
 helm upgrade --install redpanda redpanda/redpanda -n redpanda --create-namespace \
@@ -56,7 +56,7 @@ kubectl exec -n redpanda -c redpanda redpanda-0 -- \
 
 The superuser can grant permissions to additional users through access control lists (ACLs). For details on how ACLs function in Redpanda, see the [rpk acl](/docs/reference/rpk/rpk-acl/) documentation.
 
-1. Use the superuser to grant `create` and `describe` permissions to another user for the cluster. You can edit the `rpk acl create` command to grant permissions to specific users or groups:
+1. Use the superuser to grant `create` and `describe` permissions to another user for the cluster. Edit the `rpk acl create` command to grant permissions to specific users or groups:
 
 ```bash
 kubectl exec -n redpanda -c redpanda redpanda-0 -- \
@@ -66,7 +66,7 @@ kubectl exec -n redpanda -c redpanda redpanda-0 -- \
   --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
 ```
 
-2. Optionally, you can use the superuser to grant permissions to the new user for a topic. The following command grants `describe` privileges to a topic Note that if a user has `describe` privileges on a cluster, they do not automatically have `describe` privileges on topics.
+2. Optionally, you can use the superuser to grant permissions to the new user for a topic. The following command grants `describe` privileges to a topic. Note that if a user has `describe` privileges on a cluster, they do not automatically have `describe` privileges on topics.
 
 ```bash
 kubectl exec -n redpanda -c redpanda redpanda-0 -- \
@@ -76,11 +76,11 @@ kubectl exec -n redpanda -c redpanda redpanda-0 -- \
   --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
 ```
 
-## Step 4: Use rpk to interact with Redpanda
+## Step 4: Use `rpk` to interact with Redpanda
 
 Now you can connect to Redpanda with the additional (non-superuser) user and start working with the cluster.
 
-To create a topic, run:
+To create a topic:
 
 ```bash
 kubectl exec -n redpanda -c redpanda redpanda-0 -- \
@@ -88,7 +88,7 @@ kubectl exec -n redpanda -c redpanda redpanda-0 -- \
   --user myuser --password changethispassword --sasl-mechanism SCRAM-SHA-256
 ```
 
-To describe the topic, run:
+To describe the topic:
 
 ```bash
 kubectl exec -n redpanda -c redpanda <cluster_name>-0 -- \

--- a/docs/security/sasl-kubernetes.mdx
+++ b/docs/security/sasl-kubernetes.mdx
@@ -9,13 +9,15 @@ title: Configuring Redpanda SASL on Kubernetes
 
 Redpanda supports the SASL/SCRAM authentication method for the Kafka API. The Redpanda Helm chart lets you configure SASL authentication.
 
-For general security information, see [Redpanda Security on Kubernetes](/../../security/security-kubernetes).
+:::note
+This page uses the recommended Helm chart for configuring security. For information about using the older Redpanda Operator, see [Redpanda Operator](../../reference/redpanda-operator).
+:::
 
-## Step 1: Enable SASL
+## Enable SASL
 
 Create a YAML file containing the values to override from the defaults:
 
-_**sasl_enable.yaml**_
+`sasl_enable.yaml`
 
 ```yaml
 auth:
@@ -37,9 +39,9 @@ helm upgrade --install redpanda redpanda/redpanda -n redpanda --create-namespace
   --values sasl_enable.yaml
 ```
 
-## Step 2: Create users
+## Create users
 
-Create users (not superusers) and set the passwords for the new users. By default, these users don't have any permissions on the cluster.
+Create users (not superusers) and set passwords for the new users. By default, these users don't have any permissions on the cluster.
 
 :::tip
 As a security best practice, you don't want to use the superuser to run commands on the cluster. You can use these additional users to interact with the cluster.
@@ -52,9 +54,9 @@ kubectl exec -n redpanda -c redpanda redpanda-0 -- \
   rpk acl user create myuser -p changethispassword
 ```
 
-## Step 3: Grant permissions
+## Grant permissions
 
-The superuser can grant permissions to additional users through access control lists (ACLs). For details on how ACLs function in Redpanda, see the [rpk acl](/docs/reference/rpk/rpk-acl/) documentation.
+The superuser can grant permissions to additional users through access control lists ([ACLs](../authorization/#ACLs)). For details on how ACLs function in Redpanda, see the [rpk acl](../../reference/rpk/rpk-acl/) documentation.
 
 1. Use the superuser to grant `create` and `describe` permissions to another user for the cluster. Edit the `rpk acl create` command to grant permissions to specific users or groups:
 
@@ -66,7 +68,7 @@ kubectl exec -n redpanda -c redpanda redpanda-0 -- \
   --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
 ```
 
-2. Optionally, you can use the superuser to grant permissions to the new user for a topic. The following command grants `describe` privileges to a topic. Note that if a user has `describe` privileges on a cluster, they do not automatically have `describe` privileges on topics.
+2. Optionally, you can use the superuser to grant permissions to a new user for a topic. The following command grants `describe` privileges to a topic:
 
 ```bash
 kubectl exec -n redpanda -c redpanda redpanda-0 -- \
@@ -76,7 +78,11 @@ kubectl exec -n redpanda -c redpanda redpanda-0 -- \
   --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
 ```
 
-## Step 4: Use `rpk` to interact with Redpanda
+:::note
+If a user has `describe` privileges on a cluster, they don't automatically have `describe` privileges on topics.
+:::
+
+## Use `rpk` to interact with Redpanda
 
 Now you can connect to Redpanda with the additional (non-superuser) user and start working with the cluster.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -227,6 +227,11 @@ module.exports = {
               label: "Configuring TLS on Kubernetes",
               id: "security/kubernetes-tls",
             },
+            {
+              type: "doc",
+              label: "Configuring SASL on Kubernetes",
+              id: "security/sasl-kubernetes",
+            },
           ],
         },
       ],


### PR DESCRIPTION
Fixes #615 

Preview:
- https://deploy-preview-706--redpanda-documentation.netlify.app/docs/security/
- https://deploy-preview-706--redpanda-documentation.netlify.app/docs/security/sasl-kubernetes/
- https://deploy-preview-706--redpanda-documentation.netlify.app/docs/reference/redpanda-operator/
- https://deploy-preview-706--redpanda-documentation.netlify.app/docs/reference/redpanda-operator/kubernetes-sasl/
- https://deploy-preview-706--redpanda-documentation.netlify.app/docs/reference/redpanda-operator/tls-kubernetes/