### PR TITLE
Update doc to remove duplicate key

### DIFF
--- a/docs/console/reference/config.mdx
+++ b/docs/console/reference/config.mdx
@@ -313,7 +313,6 @@ server:
   listenPort: 8080
   listenAddress:
   gracefulShutdownTimeout: 30s
-  listenPort: 8080
   readTimeout: 30s
   writeTimeout: 30s
   idleTimeout: 30s


### PR DESCRIPTION
Duplicate key causes the example to throw duplicate key error.