### PR TITLE
Bug: rpk maintenance to rpk cluster maintenance

### DIFF
--- a/docs/install-upgrade/rolling-upgrade.mdx
+++ b/docs/install-upgrade/rolling-upgrade.mdx
@@ -23,7 +23,7 @@ To perform a rolling upgrade:
 2. Select a node that has not been upgraded yet and place it into maintenance mode using `rpk cluster maintenance enable <node-id> --wait`. The `--wait` option ensures that the cluster is healthy before putting the node into maintenance mode.
 3. Verify that the node is in maintenance mode by running `rpk cluster maintenance status` and confirming  that `FINISHED` is `true`.
 
-4. Validate the health of the cluster by running `rpk cluster health`. If the cluster is healthy, the output shows `Healthy: true`. You can also evaluate [external metrics](../../cluster-administration/monitoring). If you encounter any issues, take the node out of maintenance mode by running `rpk maintenance mode disable <node-id>`.
+4. Validate the health of the cluster by running `rpk cluster health`. If the cluster is healthy, the output shows `Healthy: true`. You can also evaluate [external metrics](../../cluster-administration/monitoring). If you encounter any issues, take the node out of maintenance mode by running `rpk cluster maintenance disable <node-id>`.
 5. If there are no issues, perform a node upgrade by following the [version upgrade](../../install-upgrade/version-upgrade/) process specific to your deployment model. The basic steps include node shutdown, upgrade, and restart.
 6. Take the node out of maintenance mode by running `rpk cluster maintenance disable <node-id>`.
 7. Run `rpk cluster maintenance status` to ensure that the node is no longer in maintenance mode.

--- a/versioned_docs/version-22.1/cluster-administration/node-management.mdx
+++ b/versioned_docs/version-22.1/cluster-administration/node-management.mdx
@@ -43,7 +43,7 @@ To perform a rolling upgrade:
 1. Check to ensure all nodes are healthy by running `rpk cluster health`.
 2. Select a non-upgraded node and place it into maintenance mode using `rpk cluster maintenance enable <node-id> --wait`. This may take some time to complete.
 3. Confirm the node is in maintenance mode by running `rpk cluster maintenance status` and confirming  that `FINISHED` is `true`.
-4. Validate the health of the cluster by running `rpk cluster health` and using external metrics, such as consumer lag. If you encounter any issues, take the node out of maintenance mode by running `rpk maintenance mode disable <node-id>`.
+4. Validate the health of the cluster by running `rpk cluster health` and using external metrics, such as consumer lag. If you encounter any issues, take the node out of maintenance mode by running `rpk cluster maintenance disable <node-id>`.
 5. If there are no issues, perform a node upgrade by following the version upgrade process specific to your deployment model. The basic steps include node shutdown, upgrade, and restart.
 6. Take the node out of maintenance mode by running `rpk cluster maintenance disable <node-id>`.
 7. Run `rpk cluster maintenance status` to ensure that the node is ready.


### PR DESCRIPTION
Changing `rpk maintenance mode disable` to `rpk cluster maintenance disable`

Related Docs:
https://docs.redpanda.com/docs/reference/rpk/rpk-cluster/rpk-cluster-maintenance-disable/

This comes from a thread in the community channel: https://redpandacommunity.slack.com/archives/C01AJDUT88N/p1666099640386339