### PR TITLE
update docs for bootstrapping single node cluster

### DIFF
--- a/docs/platform/quickstart/quick-start-docker.mdx
+++ b/docs/platform/quickstart/quick-start-docker.mdx
@@ -28,8 +28,6 @@ docker run -d --pull=always --name=redpanda-1 --rm \
 docker.redpanda.com/vectorized/redpanda:latest \
 redpanda start \
 --overprovisioned \
---seeds "redpanda-1:33145" \
---set redpanda.empty_seed_starts_cluster=false \
 --smp 1  \
 --memory 1G \
 --reserve-memory 0M \
@@ -181,8 +179,6 @@ services:
     - --reserve-memory
     - 0M
     - --overprovisioned
-    - --set redpanda.empty_seed_starts_cluster=false
-    - --seeds "redpanda-1:33145"
     - --kafka-addr
     - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
     - --advertise-kafka-addr


### PR DESCRIPTION
initializing a single node cluster should not set `--seeds` in order to trigger auto-init per https://github.com/redpanda-data/redpanda/issues/333#issuecomment-952656262

also remove apparently invalid property `empty_seed_starts_cluster` per:

```
INFO  2022-11-09 02:19:46,745 [shard 0] redpanda::main - application.cc:255 - Failure during startup: std::invalid_argument (Unknown property empty_seed_starts_cluster)
```