### PR TITLE
Update deprecated rpk commands in prod deployment doc

### DIFF
--- a/docs/platform/deployment/production-deployment.mdx
+++ b/docs/platform/deployment/production-deployment.mdx
@@ -101,7 +101,7 @@ sudo rpk iotune # takes 10mins
 
 ## Configure and start seed nodes
 
-Configure and start up the seed servers with the [`rpk config bootstrap`](../../reference/rpk/rpk-redpanda/rpk-redpanda-config-bootstrap) command: 
+Configure and start up the seed servers with the [`rpk redpanda config bootstrap`](../../reference/rpk/rpk-redpanda/rpk-redpanda-config-bootstrap) command: 
 
 ```bash
 sudo rpk redpanda config bootstrap --self <private ip> --ips <seed nodes ips> && \

--- a/docs/platform/deployment/production-deployment.mdx
+++ b/docs/platform/deployment/production-deployment.mdx
@@ -104,8 +104,8 @@ sudo rpk iotune # takes 10mins
 Configure and start up the seed servers with the [`rpk config bootstrap`](../../reference/rpk/rpk-redpanda/rpk-redpanda-config-bootstrap) command: 
 
 ```bash
-sudo rpk config bootstrap --self <private ip> --ips <seed nodes ips> && \
-sudo rpk config set redpanda.empty_seed_starts_cluster false && \ 
+sudo rpk redpanda config bootstrap --self <private ip> --ips <seed nodes ips> && \
+sudo rpk redpanda config set redpanda.empty_seed_starts_cluster false && \ 
 sudo systemctl start redpanda-tuner redpanda
 ```
 
@@ -127,8 +127,8 @@ If clients will connect from a different subnet, see [Configuring Listeners](../
 Let every other node know where to reach the seed nodes:
 
 ```bash
-sudo rpk config bootstrap --self <private ip> --ips <seed nodes ips> && \
-sudo rpk config set redpanda.empty_seed_starts_cluster false && \ 
+sudo rpk redpanda config bootstrap --self <private ip> --ips <seed nodes ips> && \
+sudo rpk redpanda config set redpanda.empty_seed_starts_cluster false && \ 
 sudo systemctl start redpanda-tuner redpanda
 ```
 


### PR DESCRIPTION
This updates the `rpk config...` commands to use the new version of the commands.