### PR TITLE
docs:#522 maintenance mode

### DIFF
--- a/docs/platform/cluster-administration/node-management.mdx
+++ b/docs/platform/cluster-administration/node-management.mdx
@@ -9,7 +9,7 @@ title: Node Maintenance Mode
 
 Node maintenance mode enables you to take a Redpanda node offline temporarily while minimizing disruption to client operations. When a node is in maintenance mode, you can safely perform operations that require the Redpanda process to be temporarily stopped; for example, performing hardware or system maintenance, or performing a [rolling upgrade](../../install-upgrade/rolling-upgrade).
 
-:::important
+:::caution
 A node cannot be decommissioned while it is in maintenance mode. Take the node out of maintenance mode first by running `rpk cluster maintenance disable <node-id>`.
 :::
 

--- a/docs/platform/cluster-administration/node-management.mdx
+++ b/docs/platform/cluster-administration/node-management.mdx
@@ -9,7 +9,7 @@ title: Node Maintenance Mode
 
 Node maintenance mode enables you to take a Redpanda node offline temporarily while minimizing disruption to client operations. When a node is in maintenance mode, you can safely perform operations that require the Redpanda process to be temporarily stopped; for example, performing hardware or system maintenance, or performing a [rolling upgrade](../../install-upgrade/rolling-upgrade).
 
-:::note
+:::important
 A node cannot be decommissioned while it is in maintenance mode. Take the node out of maintenance mode first by running `rpk cluster maintenance disable <node-id>`.
 :::
 

--- a/docs/platform/cluster-administration/node-management.mdx
+++ b/docs/platform/cluster-administration/node-management.mdx
@@ -10,7 +10,7 @@ title: Node Maintenance Mode
 Node maintenance mode enables you to take a Redpanda node offline temporarily while minimizing disruption to client operations. When a node is in maintenance mode, you can safely perform operations that require the Redpanda process to be temporarily stopped; for example, performing hardware or system maintenance, or performing a [rolling upgrade](../../install-upgrade/rolling-upgrade).
 
 :::note
-A node cannot be decommissioned while it is in maintenance mode. Take the node out of maintenance mode first by running 'rpk cluster maintenance disable <node-id>`.
+A node cannot be decommissioned while it is in maintenance mode. Take the node out of maintenance mode first by running `rpk cluster maintenance disable <node-id>`.
 :::
 
 When a node is placed in maintenance mode, it reassigns partition leadership to other nodes in the cluster. The node is not eligible for partition leadership again until it is taken out of maintenance mode. Note that maintenance mode only transfers leadership; it does not move any partitions to other nodes in the cluster. 

--- a/docs/platform/cluster-administration/node-management.mdx
+++ b/docs/platform/cluster-administration/node-management.mdx
@@ -9,6 +9,10 @@ title: Node Maintenance Mode
 
 Node maintenance mode enables you to take a Redpanda node offline temporarily while minimizing disruption to client operations. When a node is in maintenance mode, you can safely perform operations that require the Redpanda process to be temporarily stopped; for example, performing hardware or system maintenance, or performing a [rolling upgrade](../../install-upgrade/rolling-upgrade).
 
+:::note
+A node cannot be decommissioned while it is in maintenance mode. Take the node out of maintenance mode first by running 'rpk cluster maintenance disable <node-id>`.
+:::
+
 When a node is placed in maintenance mode, it reassigns partition leadership to other nodes in the cluster. The node is not eligible for partition leadership again until it is taken out of maintenance mode. Note that maintenance mode only transfers leadership; it does not move any partitions to other nodes in the cluster. 
 
 If a node hosts a partition with a replica count of 1, you have three options:

--- a/docs/platform/install-upgrade/rolling-upgrade.mdx
+++ b/docs/platform/install-upgrade/rolling-upgrade.mdx
@@ -23,7 +23,10 @@ To perform a rolling upgrade:
 2. Select a node that has not been upgraded yet and place it into maintenance mode using `rpk cluster maintenance enable <node-id> --wait`. The `--wait` option ensures that the cluster is healthy before putting the node into maintenance mode.
 3. Verify that the node is in maintenance mode by running `rpk cluster maintenance status` and confirming  that `FINISHED` is `true`.
 
-4. Validate the health of the cluster by running `rpk cluster health`. If the cluster is healthy, the output shows `Healthy: true`. You can also evaluate [external metrics](../../cluster-administration/monitoring). If you encounter any issues, take the node out of maintenance mode by running `rpk cluster maintenance disable <node-id>`.
+4. Validate the health of the cluster by running `rpk cluster health`.
+
+    If the cluster is healthy, the output shows `Healthy: true`.
+    You can also evaluate [external metrics](../../cluster-administration/monitoring) to determine cluster health. If the cluster has any issues, take the node out of maintenance mode by running `rpk cluster maintenance disable <node-id>` before proceeding with other operations, such as decommissioning or retrying the rolling upgrade.
 5. If there are no issues, perform a node upgrade by following the [version upgrade](../../install-upgrade/version-upgrade/) process specific to your deployment model. The basic steps include node shutdown, upgrade, and restart.
 6. Take the node out of maintenance mode by running `rpk cluster maintenance disable <node-id>`.
 7. Run `rpk cluster maintenance status` to ensure that the node is no longer in maintenance mode.


### PR DESCRIPTION
In "Node Maintenance Mode", added note that node cannot be decommissioned while in maintenance mode.

In "Rolling Upgrade", expanded on instructions to take node out of maintenance mode if cluster is unhealthy. Users might want to decommission the unhealthy node, but won't be able to if it's still in maintenance mode.

Resolves issue #522 .