### PR TITLE
rpk: add fetch_reads_debounce_timeouts to start

### DIFF
--- a/docs/platform/reference/rpk/rpk-redpanda/rpk-redpanda-start.mdx
+++ b/docs/platform/reference/rpk/rpk-redpanda/rpk-redpanda-start.mdx
@@ -33,6 +33,7 @@ Bundled cluster properties:
   * `group_topic_partitions: 3`
   * `storage_min_free_bytes: 10485760 (10MiB)`
   * `topic_partitions_per_shard: 1000`
+  * `fetch_reads_debounce_timeout: 10`
 
 After redpanda starts you can modify the cluster properties using:
 


### PR DESCRIPTION
This help text was missing in rpk when v22.3 docs were created.

See: https://github.com/redpanda-data/redpanda/pull/7413