### PR TITLE
docs: 817 fix docker quickstart examples

### DIFF
--- a/docs/platform/deployment/disk-utilization.mdx
+++ b/docs/platform/deployment/disk-utilization.mdx
@@ -41,6 +41,10 @@ Based on these properties, Redpanda runs a log cleanup process in the background
 
 A message is deleted if its age exceeds the value specified in `delete_retention_ms` (the cluster-level property) or `retention.ms` (the topic-level property). If `retention.ms` is not set at the topic-level, the topic inherits the `delete_retention_ms` setting.
 
+:::note
+Time-based retention is calculated from the timestamp of batches in a segment. Segments are removed when they're closed: either when they reach the limit or when partition leadership changes. Each segment index stores the maximum timestamp in the segment. The timestamp policy can be either `CreateTime` (client timestamp set by producer) or `AppendTime` (server timestamp set by Redpanda).
+:::
+
 To set retention time for a single topic, use `retention.ms`, which overrides `delete_retention_ms`. 
 
 * `retention.ms` - Topic-level property that specifies how long a message stays on disk before it's deleted. 

--- a/docs/platform/quickstart/quick-start-docker.mdx
+++ b/docs/platform/quickstart/quick-start-docker.mdx
@@ -35,7 +35,8 @@ redpanda start \
 --smp 1  \
 --memory 1G \
 --reserve-memory 0M \
---check=false
+--check=false \
+--advertise-rpc-addr redpanda-1:33145
 ```
 
 :::note Notes
@@ -197,7 +198,7 @@ Copy this code, and save it as `docker-compose.yml`:
 version: '3.7'
 services:
   redpanda:
-    # NOTE: Please use the latest version here!
+    # NOTE: Use the latest version here!
     image: docker.redpanda.com/vectorized/redpanda:latest
     container_name: redpanda-1
     command:
@@ -218,6 +219,7 @@ services:
     - PLAINTEXT://0.0.0.0:28082,OUTSIDE://0.0.0.0:8082
     - --advertise-pandaproxy-addr
     - PLAINTEXT://redpanda:28082,OUTSIDE://localhost:8082
+    - --advertise-rpc-addr redpanda-1:33145
     ports:
     - 8081:8081
     - 8082:8082

--- a/docs/platform/quickstart/quick-start-windows.mdx
+++ b/docs/platform/quickstart/quick-start-windows.mdx
@@ -43,7 +43,8 @@ redpanda start ^
 --smp 1  ^
 --memory 1G ^
 --reserve-memory 0M ^
---check=false
+--check=false ^
+--advertise-rpc-addr redpanda-1:33145
 ```
 
 #### Clean up a one-node cluster
@@ -175,7 +176,7 @@ Copy this code, and save it as `docker-compose.yaml`:
 version: '3.7'
 services:
   redpanda:
-    # NOTE: Please use the latest version here!
+    # NOTE: Use the latest version here!
     image: docker.redpanda.com/vectorized/redpanda:latest
     container_name: redpanda-1
     command:
@@ -196,6 +197,7 @@ services:
     - PLAINTEXT://0.0.0.0:28082,OUTSIDE://0.0.0.0:8082
     - --advertise-pandaproxy-addr
     - PLAINTEXT://redpanda:28082,OUTSIDE://localhost:8082
+    - --advertise-rpc-addr redpanda-1:33145
     ports:
     - 8081:8081
     - 8082:8082


### PR DESCRIPTION
resolves #817 

This adds `--advertise-rpc-addr redpanda-1:33145` to Docker Compose and 1 node cluster examples 

preview: 
- https://deploy-preview-850--redpanda-documentation.netlify.app/docs/platform/quickstart/quick-start-docker/
- https://deploy-preview-850--redpanda-documentation.netlify.app/docs/platform/quickstart/quick-start-windows/