### PR TITLE
Adds details on how to customize external access

### DIFF
--- a/docs/platform/quickstart/kubernetes-qs-dev.mdx
+++ b/docs/platform/quickstart/kubernetes-qs-dev.mdx
@@ -163,3 +163,124 @@ When it's ready, the output should look similar to the following:
 ```text
 statefulset rolling update complete 3 pods at revision redpanda-8654f645b4...
 ```
+
+## External access
+
+External access is made available by a NodePort service. Run the following command for details:
+
+```bash
+kubectl get service redpanda-external -n redpanda
+```
+```text
+NAME                TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)                                                       AGE
+redpanda-external   NodePort   10.100.15.142   <none>        9644:31644/TCP,9094:31092/TCP,8083:30082/TCP,8080:30081/TCP   22m
+```
+
+The following ports are opened by default:
+
+| Node port | Pod port | Purpose |
+|---|---|---|
+| 30081 | 8080 | Schema registry |
+| 30082 | 8083 | HTTP proxy |
+| 31092 | 9094 | Kafka API |
+| 31644 | 9644 | Admin API |
+
+You can modify these ports in `values.yaml`. If you do so, then make sure to use the same ports in the steps below.
+
+### Modify inbound security
+
+Cloud-based Kubernetes clusters will have a security group tied to each node in the cluster. For instance, in EKS a security group is applied to each EC2 node.
+
+You must add inbound rules allowing traffic to reach each port above on all nodes that are part of the cluster to enable external access. How these rules are added depends on your Kubernetes environment and cloud provider.
+
+### Update external access
+
+By default the cluster is available externally at `redpanda-<replica index>.<redpanda.external.domain>`. The default values would make this address `redpanda-0.local`. But no external DNS provider is updated to make this address resolvable by default. There are a few ways to resolve this:
+
+1. Use IP address resolution
+2. Make `redpanda-0.local` resolvable to the external address of the related Kubernetes node
+3. Customize the subdomain and/or domain to point to something resolvable via DNS
+
+Since options 2 and 3 require an external DNS provider, this guide focuses on option 1.
+
+Each Kubernetes node has an external IP address, and they can be found with the following command:
+
+```bash
+kubectl get nodes -o wide
+```
+```text
+NAME                                           STATUS   ROLES    AGE   VERSION                INTERNAL-IP      EXTERNAL-IP     OS-IMAGE         KERNEL-VERSION                 CONTAINER-RUNTIME
+ip-192-168-31-253.us-east-2.compute.internal   Ready    <none>   24m   v1.22.15-eks-fb459a0   192.168.31.253   203.0.113.3     Amazon Linux 2   5.4.219-126.411.amzn2.x86_64   docker://20.10.17
+ip-192-168-41-207.us-east-2.compute.internal   Ready    <none>   24m   v1.22.15-eks-fb459a0   192.168.41.207   203.0.113.5     Amazon Linux 2   5.4.219-126.411.amzn2.x86_64   docker://20.10.17
+ip-192-168-90-157.us-east-2.compute.internal   Ready    <none>   24m   v1.22.15-eks-fb459a0   192.168.90.157   203.0.113.7     Amazon Linux 2   5.4.219-126.411.amzn2.x86_64   docker://20.10.17
+```
+
+The above example shows there are three nodes with the external IP addresses `3.129.52.203`, `3.12.164.46`, and `3.144.145.170`. You will need to associate each Kubernetes node to the appropriate Redpanda node. In order to do this you also need output from the following command:
+
+```bash
+kubectl get pods -o wide -n redpanda
+```
+```text
+NAME                          READY   STATUS      RESTARTS   AGE    IP               NODE                                           NOMINATED NODE   READINESS GATES
+redpanda-0                    1/1     Running     0          109m   192.168.30.134   ip-192-168-31-253.us-east-2.compute.internal   <none>           <none>
+redpanda-1                    1/1     Running     0          109m   192.168.60.112   ip-192-168-41-207.us-east-2.compute.internal   <none>           <none>
+redpanda-2                    1/1     Running     0          110m   192.168.68.55    ip-192-168-90-157.us-east-2.compute.internal   <none>           <none>
+redpanda-post-install-skkl7   0/1     Completed   0          110m   192.168.73.172   ip-192-168-90-157.us-east-2.compute.internal   <none>           <none>
+redpanda-post-upgrade-r85f6   0/1     Completed   0          110m   192.168.33.87    ip-192-168-41-207.us-east-2.compute.internal   <none>           <none>
+```
+
+The above example shows `redpanda-0` running on a node with the name `ip-192-168-31-253.us-east-2.compute.internal`, giving us the internal IP address of `192.168.31.253`. Using this combined with the output from the previous command, you get the following associations:
+
+| Redpanda node | External IP |
+|---|---|
+| redpanda-0 | 203.0.113.3 |
+| redpanda-1 | 203.0.113.5 |
+| redpanda-2 | 203.0.113.7 |
+
+:::note
+The Kubernetes node order and Redpanda node order were the same in the above example, but this will not always be the case.
+:::
+
+
+Now update `values.yaml` with the external IPs, making sure to match the Redpanda node order:
+
+```yaml
+redpanda:
+  external:
+    addressType: ip
+    addresses: "203.0.113.3 203.0.113.5 203.0.113.7"
+```
+
+Apply these updates using the following helm command:
+
+```bash
+helm upgrade redpanda redpanda/redpanda -n redpanda
+```
+
+### Verify external access
+
+You should now be able to connect to your cluster from an external client. The steps below show how to connect a locally-installed `rpk` client to your cluster. Details on how to install `rpk` are [here](https://docs.redpanda.com/docs/platform/quickstart/rpk-install/)).
+
+Set the `REDPANDA_BROKERS` environment variable using the external IP addresses from above:
+
+```bash
+export REDPANDA_BROKERS=203.0.113.3:31092,203.0.113.5:31092,203.0.113.7:31092
+```
+
+Get the cluster info:
+
+```bash
+rpk cluster info
+```
+```text
+CLUSTER
+=======
+redpanda.ad4a2f55-f34e-4a7f-babd-01d392cf4e80
+
+BROKERS
+=======
+ID    HOST           PORT
+0     203.0.113.3    31092
+1*    203.0.113.5    31092
+2     203.0.113.7    31092
+```


### PR DESCRIPTION
This PR requires the following helm chart PR to be merged first: https://github.com/redpanda-data/helm-charts/pull/220

This details how to make use of new features in the helm chart to customize external access. The process would be slightly different if DNS is a factor, and this is mentioned as other paths (paths 2 and 3) in this doc. These paths are not covered though since they entirely depend on how the user would need to update/manage DNS. They could be using Route53, hosts file, a custom DNS service, etc.