### PR TITLE
docs: remove note for consumer offset in v22.11

### DIFF
--- a/versioned_docs/version-21.11/data-management/data-migration.mdx
+++ b/versioned_docs/version-21.11/data-management/data-migration.mdx
@@ -89,10 +89,6 @@ To start MirrorMaker in the `kafka_2.13-3.0.0/bin/` directory, run:
 With this command, MirrorMaker consumes all topics from the redpanda1 cluster and replicates them into the redpanda2 cluster.
 MirrorMaker adds the prefix `redpanda1` to the names of replicated topics.
 
-:::note
-MirrorMaker uses the `__consumer_offsets` topic to replicate consumer offsets between clusters. This is currently not supported in Redpanda, but you can follow the progress of this issue at: https://github.com/redpanda-data/redpanda/issues/1752
-:::
-
 ## See migration in action
 
 Here are the basic commands to produce and consume streams:


### PR DESCRIPTION
Resolves #672 

Preview: 
https://deploy-preview-917--redpanda-documentation.netlify.app/docs/21.11/data-management/data-migration/#run-mirrormaker-to-start-replication