### PR TITLE
docs:#632 single quotes around passwords

### DIFF
--- a/docs/platform/console/reference/config.mdx
+++ b/docs/platform/console/reference/config.mdx
@@ -45,8 +45,9 @@ The following `config.yaml` configuration file contains a complete list of all C
 Provide the filepath to your configuration file by setting either the flag
 `-config.filepath` or the environment variable `CONFIG_FILEPATH`.
 
-:::note
-This configuration file contains both Redpanda Enterprise and Redpanda Community configurations. If you don't provide a Redpanda Enterprise license, Console ignores configurations for Redpanda Enterprise features.
+:::note notes
+- This configuration file contains both Redpanda Enterprise and Redpanda Community configurations. If you don't provide a Redpanda Enterprise license, Console ignores configurations for Redpanda Enterprise features.
+- To avoid conflicts with special characters, ensure arguments are properly quoted.
 :::
 
 ```yaml
@@ -65,7 +66,6 @@ kafka:
     enabled: false
     username:
     # Password can also be set using the --kafka.sasl.password flag.
-    # Put passwords in single quotes to avoid conflicts with special characters.
     password:
     # Valid mechanisms are: PLAIN, SCRAM-SHA-256, 
     # SCRAM-SHA-512, GSSAPI, OAUTHBEARER and AWS_MSK_IAM.
@@ -119,7 +119,6 @@ kafka:
     # Basic auth username
     username: 
     # Basic auth password. This can also be set using the --schema.registry.password
-    # Put passwords in single quotes to avoid conflicts with special characters.
     # flag
     password: 
     # Can also be set using the --schema.registry.token flag
@@ -168,7 +167,6 @@ kafka:
       # Basic Auth
       # To use GitHub's personal access tokens, use `token`
       # as username and pass the token as password
-      # Put passwords in single quotes to avoid conflicts with special characters.
       basicAuth:
         enabled: true
         username: token
@@ -226,7 +224,6 @@ console:
       refreshInterval: 1m
       # To use GitHub's personal access tokens, use `token`
       # for the username and pass the token as password.
-      # Put passwords in single quotes to avoid conflicts with special characters.
       basicAuth:
         enabled: true
         username: token
@@ -247,7 +244,6 @@ redpanda:
     # Username for basic auth
     username:
     # Password for basic auth
-    # Put passwords in single quotes to avoid conflicts with special characters.
     password:
     tls:
       enabled: false

--- a/docs/platform/console/reference/config.mdx
+++ b/docs/platform/console/reference/config.mdx
@@ -65,6 +65,7 @@ kafka:
     enabled: false
     username:
     # Password can also be set using the --kafka.sasl.password flag.
+    # Put passwords with special characters in single quotes.
     password:
     # Valid mechanisms are: PLAIN, SCRAM-SHA-256, 
     # SCRAM-SHA-512, GSSAPI, OAUTHBEARER and AWS_MSK_IAM.
@@ -118,6 +119,7 @@ kafka:
     # Basic auth username
     username: 
     # Basic auth password. This can also be set using the --schema.registry.password
+    # Put passwords with special characters in single quotes.
     # flag
     password: 
     # Can also be set using the --schema.registry.token flag
@@ -166,6 +168,7 @@ kafka:
       # Basic Auth
       # To use GitHub's personal access tokens, use `token`
       # as username and pass the token as password
+      # Put passwords with special characters in single quotes.
       basicAuth:
         enabled: true
         username: token
@@ -223,6 +226,7 @@ console:
       refreshInterval: 1m
       # To use GitHub's personal access tokens, use `token`
       # for the username and pass the token as password.
+      # Put passwords with special characters in single quotes.
       basicAuth:
         enabled: true
         username: token
@@ -243,6 +247,7 @@ redpanda:
     # Username for basic auth
     username:
     # Password for basic auth
+    # Put passwords with special characters in single quotes.
     password:
     tls:
       enabled: false

--- a/docs/platform/console/reference/config.mdx
+++ b/docs/platform/console/reference/config.mdx
@@ -65,7 +65,7 @@ kafka:
     enabled: false
     username:
     # Password can also be set using the --kafka.sasl.password flag.
-    # Put passwords with special characters in single quotes.
+    # Put passwords in single quotes to avoid conflicts with special characters.
     password:
     # Valid mechanisms are: PLAIN, SCRAM-SHA-256, 
     # SCRAM-SHA-512, GSSAPI, OAUTHBEARER and AWS_MSK_IAM.
@@ -119,7 +119,7 @@ kafka:
     # Basic auth username
     username: 
     # Basic auth password. This can also be set using the --schema.registry.password
-    # Put passwords with special characters in single quotes.
+    # Put passwords in single quotes to avoid conflicts with special characters.
     # flag
     password: 
     # Can also be set using the --schema.registry.token flag
@@ -168,7 +168,7 @@ kafka:
       # Basic Auth
       # To use GitHub's personal access tokens, use `token`
       # as username and pass the token as password
-      # Put passwords with special characters in single quotes.
+      # Put passwords in single quotes to avoid conflicts with special characters.
       basicAuth:
         enabled: true
         username: token
@@ -226,7 +226,7 @@ console:
       refreshInterval: 1m
       # To use GitHub's personal access tokens, use `token`
       # for the username and pass the token as password.
-      # Put passwords with special characters in single quotes.
+      # Put passwords in single quotes to avoid conflicts with special characters.
       basicAuth:
         enabled: true
         username: token
@@ -247,7 +247,7 @@ redpanda:
     # Username for basic auth
     username:
     # Password for basic auth
-    # Put passwords with special characters in single quotes.
+    # Put passwords in single quotes to avoid conflicts with special characters.
     password:
     tls:
       enabled: false

--- a/docs/platform/reference/node-configuration-sample.mdx
+++ b/docs/platform/reference/node-configuration-sample.mdx
@@ -335,7 +335,7 @@ rpk:
     # The SASL config, if enabled in the brokers.
     sasl:
       user: user
-      password: `pass`
+      password: 'pass'
       type: SCRAM-SHA-256
 
   # The Admin API configuration

--- a/docs/platform/reference/node-configuration-sample.mdx
+++ b/docs/platform/reference/node-configuration-sample.mdx
@@ -262,7 +262,7 @@ pandaproxy_client:
   scram_username: ""
 
   # Password for SCRAM authentication mechanisms
-  # Use single quotes for potential special characters.
+  # Put passwords in single quotes to avoid conflicts with special characters.
   # Default: ""
   scram_password: ""
 

--- a/docs/platform/reference/node-configuration-sample.mdx
+++ b/docs/platform/reference/node-configuration-sample.mdx
@@ -262,6 +262,7 @@ pandaproxy_client:
   scram_username: ""
 
   # Password for SCRAM authentication mechanisms
+  # Use single quotes for potential special characters.
   # Default: ""
   scram_password: ""
 
@@ -334,7 +335,7 @@ rpk:
     # The SASL config, if enabled in the brokers.
     sasl:
       user: user
-      password: pass
+      password: `pass`
       type: SCRAM-SHA-256
 
   # The Admin API configuration

--- a/docs/platform/reference/redpanda-operator/kubernetes-sasl.mdx
+++ b/docs/platform/reference/redpanda-operator/kubernetes-sasl.mdx
@@ -140,11 +140,15 @@ kubectl apply -f https://raw.githubusercontent.com/redpanda-data/redpanda-exampl
 
 You must create the superuser through the Admin API. This user has [ALL permissions](../../../security/authorization#operations) on the cluster and is the user that grants permissions to new users. Without a superuser, you can create other users, but you will not be able to grant them permissions to the cluster.
 
+:::note
+Passwords are in single quotes for potential special characters.
+:::
+
 To create the superuser and specify a password for the user, run:
 
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl user create <super_user_username> \
--p <super_user_password> 
+-p <`superuser_password`> 
 ```
 
 The `-0` in this command refers to the first node of the cluster. You can change this integer to specify a different node in the cluster. 
@@ -163,7 +167,7 @@ This command executes the `rpk` command from within a Redpanda cluster container
 
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl user create <super_user_username> \
--p <super_user_password> \
+-p <`superuser_password`> \
 --api-urls localhost:<port>
 // highlight-start
 --brokers <cluster_name>-0.<cluster_name>.default.svc.cluster.local:<port>
@@ -182,7 +186,7 @@ For each user that you want to create, run:
 
 ```bash
 kubectl exec -c redpanda external-connectivity-0 -- rpk acl user create <username> \
--p <password> \
+-p <`password`> \
 ```
 
 ## Step 5: Grant permissions
@@ -194,7 +198,7 @@ The superuser can grant permissions to additional users through access control l
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal User:<username> --operation create,describe --cluster \
 --user <super_user_username> \
---password <super_user_password> \
+--password <`superuser_password`> \
 --sasl-mechanism SCRAM-SHA-256
 ```
 
@@ -203,7 +207,7 @@ kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal Us
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal User:<username> --operation describe --topic <topic_name> \
 --user <super_user_username> \
---password <super_user_password> \
+--password <`superuser_password`> \
 --sasl-mechanism SCRAM-SHA-256
 ```
 
@@ -216,7 +220,7 @@ To create a topic, run:
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk topic create <topic_name> \
 --user <username> \
---password <user_password> \
+--password <`user_password`> \
 --sasl-mechanism SCRAM-SHA-256
 ```
 
@@ -225,7 +229,7 @@ To describe the topic, run:
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk topic describe <topic_name> \
 --user <username> \
---password <user_password> \
+--password <`user_password`> \
 --sasl-mechanism SCRAM-SHA-256
 ```
 

--- a/docs/platform/reference/redpanda-operator/kubernetes-sasl.mdx
+++ b/docs/platform/reference/redpanda-operator/kubernetes-sasl.mdx
@@ -141,7 +141,7 @@ kubectl apply -f https://raw.githubusercontent.com/redpanda-data/redpanda-exampl
 You must create the superuser through the Admin API. This user has [ALL permissions](../../../security/authorization#operations) on the cluster and is the user that grants permissions to new users. Without a superuser, you can create other users, but you will not be able to grant them permissions to the cluster.
 
 :::note
-Passwords are in single quotes for potential special characters.
+Passwords are in single quotes to avoid conflicts with special characters. Enclosing characters in single quotes preserves the literal value of each character.
 :::
 
 To create the superuser and specify a password for the user, run:

--- a/docs/platform/reference/redpanda-operator/kubernetes-sasl.mdx
+++ b/docs/platform/reference/redpanda-operator/kubernetes-sasl.mdx
@@ -147,13 +147,13 @@ Passwords are in single quotes for potential special characters.
 To create the superuser and specify a password for the user, run:
 
 ```bash
-kubectl exec -c redpanda <cluster_name>-0 -- rpk acl user create <super_user_username> \
--p <`superuser_password`> 
+kubectl exec -c redpanda <cluster_name>-0 -- rpk acl user create <superuser_username> \
+-p <'superuser_password'> 
 ```
 
 The `-0` in this command refers to the first node of the cluster. You can change this integer to specify a different node in the cluster. 
 
-The `super_user_username` is the superuser that you defined in the cluster specification file. 
+The 'superuser_username' is the superuser that you defined in the cluster specification file. 
 
 :::note
 If you changed the Admin API port from the default, you must add the following line to each command that creates a new user, in this step and the next step: 
@@ -166,8 +166,8 @@ If you changed the Admin API port from the default, you must add the following l
 This command executes the `rpk` command from within a Redpanda cluster container, using the local host. To run the command from another pod, you must include the broker location with the command. The text below shows the full command with the broker location highlighted:
 
 ```bash
-kubectl exec -c redpanda <cluster_name>-0 -- rpk acl user create <super_user_username> \
--p <`superuser_password`> \
+kubectl exec -c redpanda <cluster_name>-0 -- rpk acl user create <superuser_username> \
+-p <'superuser_password'> \
 --api-urls localhost:<port>
 // highlight-start
 --brokers <cluster_name>-0.<cluster_name>.default.svc.cluster.local:<port>
@@ -186,7 +186,7 @@ For each user that you want to create, run:
 
 ```bash
 kubectl exec -c redpanda external-connectivity-0 -- rpk acl user create <username> \
--p <`password`> \
+-p <'password'> \
 ```
 
 ## Step 5: Grant permissions
@@ -197,8 +197,8 @@ The superuser can grant permissions to additional users through access control l
 
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal User:<username> --operation create,describe --cluster \
---user <super_user_username> \
---password <`superuser_password`> \
+--user <superuser_username> \
+--password <'superuser_password'> \
 --sasl-mechanism SCRAM-SHA-256
 ```
 
@@ -206,8 +206,8 @@ kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal Us
 
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal User:<username> --operation describe --topic <topic_name> \
---user <super_user_username> \
---password <`superuser_password`> \
+--user <superuser_username> \
+--password <'superuser_password'> \
 --sasl-mechanism SCRAM-SHA-256
 ```
 
@@ -220,7 +220,7 @@ To create a topic, run:
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk topic create <topic_name> \
 --user <username> \
---password <`user_password`> \
+--password <'user_password'> \
 --sasl-mechanism SCRAM-SHA-256
 ```
 
@@ -229,7 +229,7 @@ To describe the topic, run:
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk topic describe <topic_name> \
 --user <username> \
---password <`user_password`> \
+--password <'user_password'> \
 --sasl-mechanism SCRAM-SHA-256
 ```
 

--- a/docs/platform/reference/redpanda-operator/kubernetes-sasl.mdx
+++ b/docs/platform/reference/redpanda-operator/kubernetes-sasl.mdx
@@ -153,7 +153,7 @@ kubectl exec -c redpanda <cluster_name>-0 -- rpk acl user create <superuser_user
 
 The `-0` in this command refers to the first node of the cluster. You can change this integer to specify a different node in the cluster. 
 
-The 'superuser_username' is the superuser that you defined in the cluster specification file. 
+The `superuser_username` is the superuser that you defined in the cluster specification file. 
 
 :::note
 If you changed the Admin API port from the default, you must add the following line to each command that creates a new user, in this step and the next step: 

--- a/docs/platform/reference/redpanda-operator/kubernetes-sasl.mdx
+++ b/docs/platform/reference/redpanda-operator/kubernetes-sasl.mdx
@@ -141,14 +141,14 @@ kubectl apply -f https://raw.githubusercontent.com/redpanda-data/redpanda-exampl
 You must create the superuser through the Admin API. This user has [ALL permissions](../../../security/authorization#operations) on the cluster and is the user that grants permissions to new users. Without a superuser, you can create other users, but you will not be able to grant them permissions to the cluster.
 
 :::note
-Passwords are in single quotes to avoid conflicts with special characters. Enclosing characters in single quotes preserves the literal value of each character.
+Passwords are in single quotes to avoid conflicts with special characters. Ensure arguments are properly quoted.
 :::
 
 To create the superuser and specify a password for the user, run:
 
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl user create <superuser_username> \
--p <'superuser_password'> 
+-p '<superuser_password>' 
 ```
 
 The `-0` in this command refers to the first node of the cluster. You can change this integer to specify a different node in the cluster. 
@@ -167,7 +167,7 @@ This command executes the `rpk` command from within a Redpanda cluster container
 
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl user create <superuser_username> \
--p <'superuser_password'> \
+-p '<superuser_password>' \
 --api-urls localhost:<port>
 // highlight-start
 --brokers <cluster_name>-0.<cluster_name>.default.svc.cluster.local:<port>
@@ -186,7 +186,7 @@ For each user that you want to create, run:
 
 ```bash
 kubectl exec -c redpanda external-connectivity-0 -- rpk acl user create <username> \
--p <'password'> \
+-p '<password>' \
 ```
 
 ## Step 5: Grant permissions
@@ -198,7 +198,7 @@ The superuser can grant permissions to additional users through access control l
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal User:<username> --operation create,describe --cluster \
 --user <superuser_username> \
---password <'superuser_password'> \
+--password '<superuser_password>' \
 --sasl-mechanism SCRAM-SHA-256
 ```
 
@@ -207,7 +207,7 @@ kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal Us
 ```bash
 kubectl exec -c redpanda <cluster_name>-0 -- rpk acl create --allow-principal User:<username> --operation describe --topic <topic_name> \
 --user <superuser_username> \
---password <'superuser_password'> \
+--password '<superuser_password>' \
 --sasl-mechanism SCRAM-SHA-256
 ```
 

--- a/docs/platform/security/authentication.mdx
+++ b/docs/platform/security/authentication.mdx
@@ -19,7 +19,7 @@ See also:
 - [Writing Custom Deployment Automation](../../deployment/custom-deployment)
 
 :::note
-Passwords are in single quotes to avoid conflicts with special characters. Enclosing characters in single quotes preserves the literal value of each character.
+Passwords are in single quotes to avoid conflicts with special characters. Ensure arguments are properly quoted.
 :::
 
 ## Enable authentication
@@ -52,7 +52,7 @@ When you configure authentication, you include one or more superusers in the Red
 Specify the name of the superuser. This can be a new user or an existing user. For example, if you use the superuser named `admin`, then Redpanda allows the `admin` user to do anything, but Redpanda does not create the `admin` user. To create this superuser, run:
 
 ```bash
-rpk acl user create <superuser_username> -p <'superuser_password'>
+rpk acl user create <superuser_username> -p '<superuser_password>'
 ```
 
 Now the `admin` user has full access to the cluster and can grant permissions to other users.
@@ -65,7 +65,7 @@ To create users and set passwords, run:
 
 ```bash
 rpk acl user create admin \
--p <'password'> \
+-p '<password>' \
 --api-urls localhost:9644
 ```
 

--- a/docs/platform/security/authentication.mdx
+++ b/docs/platform/security/authentication.mdx
@@ -19,7 +19,7 @@ See also:
 - [Writing Custom Deployment Automation](../../deployment/custom-deployment)
 
 :::note
-Passwords are in single quotes for potential special characters.
+Passwords are in single quotes to avoid conflicts with special characters. Enclosing characters in single quotes preserves the literal value of each character.
 :::
 
 ## Enable authentication

--- a/docs/platform/security/authentication.mdx
+++ b/docs/platform/security/authentication.mdx
@@ -100,8 +100,8 @@ For example, to use the `SCRAM-SHA-256` mechanism, run:
 
 ```bash
 rpk topic create littlefoot \
---user panda \
---password 'pandaPassword' \
+--user <username> \
+--password <password> \
 --sasl-mechanism SCRAM-SHA-256
 ```
 
@@ -162,8 +162,8 @@ schema_registry_client:
   brokers:
     - address: 127.0.0.1
       port: 9092
-  scram_username: panda
-  scram_password: 'pandaPassword'
+  scram_username: <user>
+  scram_password: <password>
   sasl_mechanism: SCRAM-SHA-256
 // highlight-end
 ```
@@ -182,8 +182,8 @@ schema_registry_client:
     truststore_file: ca.crt
     enabled: true
 // highlight-end
-  scram_username: panda
-  scram_password: 'pandaPassword'
+  scram_username: <user>
+  scram_password: <password>
   sasl_mechanism: SCRAM-SHA-256
 ```
 
@@ -201,8 +201,8 @@ pandaproxy_client:
     cert_file: server.crt
     truststore_file: ca.crt
     enabled: true
-  scram_username: panda
-  scram_password: 'pandaPassword'
+  scram_username: <user>
+  scram_password: <password>
   sasl_mechanism: SCRAM-SHA-256
 ```
 
@@ -213,7 +213,7 @@ You can use the newly-created user to interact with Redpanda with `rpk`:
 ```bash
 rpk topic describe test-topic \
 --user admin \
---password <'password'> \
+--password <password> \
 --sasl-mechanism SCRAM-SHA-256 \
 --brokers localhost:9092
 ```

--- a/docs/platform/security/authentication.mdx
+++ b/docs/platform/security/authentication.mdx
@@ -18,6 +18,10 @@ See also:
 - [Configuring Listeners](../../cluster-administration/listener-configuration)
 - [Writing Custom Deployment Automation](../../deployment/custom-deployment)
 
+:::note
+Passwords are in single quotes for potential special characters.
+:::
+
 ## Enable authentication
 
 To enable authentication, set `kafka_enable_authorization` to `true`, and specify at least one value for the `superusers` property. This superuser is used to bootstrap permissions for other users in the cluster. See [Cluster configuration properties](../../cluster-administration/cluster-property-configuration).
@@ -48,7 +52,7 @@ When you configure authentication, you include one or more superusers in the Red
 Specify the name of the superuser. This can be a new user or an existing user. For example, if you use the superuser named `admin`, then Redpanda allows the `admin` user to do anything, but Redpanda does not create the `admin` user. To create this superuser, run:
 
 ```bash
-rpk acl user create <superuser_username> -p <superuser_password>
+rpk acl user create <superuser_username> -p <`superuser_password`>
 ```
 
 Now the `admin` user has full access to the cluster and can grant permissions to other users.
@@ -61,7 +65,7 @@ To create users and set passwords, run:
 
 ```bash
 rpk acl user create admin \
--p <password> \
+-p <`password`> \
 --api-urls localhost:9644
 ```
 
@@ -97,7 +101,7 @@ For example, to use the `SCRAM-SHA-256` mechanism, run:
 ```bash
 rpk topic create littlefoot \
 --user panda \
---password pandaPassword \
+--password `pandaPassword` \
 --sasl-mechanism SCRAM-SHA-256
 ```
 
@@ -159,7 +163,7 @@ schema_registry_client:
     - address: 127.0.0.1
       port: 9092
   scram_username: panda
-  scram_password: pandaPassword
+  scram_password: `pandaPassword`
   sasl_mechanism: SCRAM-SHA-256
 // highlight-end
 ```
@@ -179,7 +183,7 @@ schema_registry_client:
     enabled: true
 // highlight-end
   scram_username: panda
-  scram_password: pandaPassword
+  scram_password: `pandaPassword`
   sasl_mechanism: SCRAM-SHA-256
 ```
 
@@ -198,7 +202,7 @@ pandaproxy_client:
     truststore_file: ca.crt
     enabled: true
   scram_username: panda
-  scram_password: pandaPassword
+  scram_password: `pandaPassword`
   sasl_mechanism: SCRAM-SHA-256
 ```
 
@@ -209,7 +213,7 @@ You can use the newly-created user to interact with Redpanda with `rpk`:
 ```bash
 rpk topic describe test-topic \
 --user admin \
---password <password> \
+--password <`password`> \
 --sasl-mechanism SCRAM-SHA-256 \
 --brokers localhost:9092
 ```
@@ -265,9 +269,9 @@ schema_registry:
 Then to use basic authentication:
 
 ```
-rpk acl user create foo --password bar # Creates SASL user "foo" for the Kafka API
-curl -u "foo:bar" "http://localhost:8082/topics" # A request to the HTTP Proxy with user foo. Don't forget the colon!
-curl -u "foo:bar" "http://localhost:8081/subjects" # A request to the Schema Registry with user foo. Don't forget the colon!
+rpk acl user create foo --password `bar` # Creates SASL user "foo" for the Kafka API
+curl -u "foo:`bar`" "http://localhost:8082/topics" # A request to the HTTP Proxy with user foo. Don't forget the colon!
+curl -u "foo:`bar`" "http://localhost:8081/subjects" # A request to the Schema Registry with user foo. Don't forget the colon!
 ```
 
 ## Configure mTLS with authentication

--- a/docs/platform/security/authentication.mdx
+++ b/docs/platform/security/authentication.mdx
@@ -52,7 +52,7 @@ When you configure authentication, you include one or more superusers in the Red
 Specify the name of the superuser. This can be a new user or an existing user. For example, if you use the superuser named `admin`, then Redpanda allows the `admin` user to do anything, but Redpanda does not create the `admin` user. To create this superuser, run:
 
 ```bash
-rpk acl user create <superuser_username> -p <`superuser_password`>
+rpk acl user create <superuser_username> -p <'superuser_password'>
 ```
 
 Now the `admin` user has full access to the cluster and can grant permissions to other users.
@@ -65,7 +65,7 @@ To create users and set passwords, run:
 
 ```bash
 rpk acl user create admin \
--p <`password`> \
+-p <'password'> \
 --api-urls localhost:9644
 ```
 
@@ -101,7 +101,7 @@ For example, to use the `SCRAM-SHA-256` mechanism, run:
 ```bash
 rpk topic create littlefoot \
 --user panda \
---password `pandaPassword` \
+--password 'pandaPassword' \
 --sasl-mechanism SCRAM-SHA-256
 ```
 
@@ -163,7 +163,7 @@ schema_registry_client:
     - address: 127.0.0.1
       port: 9092
   scram_username: panda
-  scram_password: `pandaPassword`
+  scram_password: 'pandaPassword'
   sasl_mechanism: SCRAM-SHA-256
 // highlight-end
 ```
@@ -183,7 +183,7 @@ schema_registry_client:
     enabled: true
 // highlight-end
   scram_username: panda
-  scram_password: `pandaPassword`
+  scram_password: 'pandaPassword'
   sasl_mechanism: SCRAM-SHA-256
 ```
 
@@ -202,7 +202,7 @@ pandaproxy_client:
     truststore_file: ca.crt
     enabled: true
   scram_username: panda
-  scram_password: `pandaPassword`
+  scram_password: 'pandaPassword'
   sasl_mechanism: SCRAM-SHA-256
 ```
 
@@ -213,7 +213,7 @@ You can use the newly-created user to interact with Redpanda with `rpk`:
 ```bash
 rpk topic describe test-topic \
 --user admin \
---password <`password`> \
+--password <'password'> \
 --sasl-mechanism SCRAM-SHA-256 \
 --brokers localhost:9092
 ```
@@ -269,9 +269,9 @@ schema_registry:
 Then to use basic authentication:
 
 ```
-rpk acl user create foo --password `bar` # Creates SASL user "foo" for the Kafka API
-curl -u "foo:`bar`" "http://localhost:8082/topics" # A request to the HTTP Proxy with user foo. Don't forget the colon!
-curl -u "foo:`bar`" "http://localhost:8081/subjects" # A request to the Schema Registry with user foo. Don't forget the colon!
+rpk acl user create foo --password 'bar' # Creates SASL user "foo" for the Kafka API
+curl -u "foo:bar" "http://localhost:8082/topics" # A request to the HTTP Proxy with user foo. Don't forget the colon!
+curl -u "foo:bar" "http://localhost:8081/subjects" # A request to the Schema Registry with user foo. Don't forget the colon!
 ```
 
 ## Configure mTLS with authentication

--- a/docs/platform/security/authorization.mdx
+++ b/docs/platform/security/authorization.mdx
@@ -326,7 +326,7 @@ Every `rpk acl` command can use these flags:
 </tr>
 <tr>
 <td>--password</td>
-<td>SASL password to be used for authentication. Passwords with special characters must be in single quotes.</td>
+<td>SASL password to be used for authentication. Passwords with special characters must be in single quotes to preserve the literal value of each character.</td>
 </tr>
 <tr>
 <td>--sasl-mechanism</td>

--- a/docs/platform/security/authorization.mdx
+++ b/docs/platform/security/authorization.mdx
@@ -242,7 +242,7 @@ For example, to create a user:
 ```bash
 rpk acl user create \
 --new-username Jack \
---new-password <password> \
+--new-password <`password`> \
 --api-urls localhost:9644
 ```
  
@@ -326,7 +326,7 @@ Every `rpk acl` command can use these flags:
 </tr>
 <tr>
 <td>--password</td>
-<td>SASL password to be used for authentication.</td>
+<td>SASL password to be used for authentication. Passwords with special characters must be in single quotes.</td>
 </tr>
 <tr>
 <td>--sasl-mechanism</td>
@@ -570,7 +570,7 @@ Before a created SASL account can be used, you must also create ACLs to grant th
 To create a SASL user, run:
  
 ```bash
-rpk acl user create [USER] -p [PASSWORD] [globalACLFlags] [globalUserFlags] [localFlags]
+rpk acl user create [user] -p [`password`] [globalACLFlags] [globalUserFlags] [localFlags]
 ```
  
 Here are the local flags:

--- a/docs/platform/security/authorization.mdx
+++ b/docs/platform/security/authorization.mdx
@@ -240,9 +240,8 @@ rpk acl [command] [flags]
 For example, to create a user:
  
 ```bash
-rpk acl user create \
---new-username Jack \
---new-password <'password'> \
+rpk acl user create Jack \
+--password <'password'> \
 --api-urls localhost:9644
 ```
  

--- a/docs/platform/security/authorization.mdx
+++ b/docs/platform/security/authorization.mdx
@@ -241,7 +241,7 @@ For example, to create a user:
  
 ```bash
 rpk acl user create Jack \
---password <'password'> \
+--password '<password>' \
 --api-urls localhost:9644
 ```
  

--- a/docs/platform/security/authorization.mdx
+++ b/docs/platform/security/authorization.mdx
@@ -242,7 +242,7 @@ For example, to create a user:
 ```bash
 rpk acl user create \
 --new-username Jack \
---new-password <`password`> \
+--new-password <'password'> \
 --api-urls localhost:9644
 ```
  
@@ -570,7 +570,7 @@ Before a created SASL account can be used, you must also create ACLs to grant th
 To create a SASL user, run:
  
 ```bash
-rpk acl user create [user] -p [`password`] [globalACLFlags] [globalUserFlags] [localFlags]
+rpk acl user create [user] -p ['password'] [globalACLFlags] [globalUserFlags] [localFlags]
 ```
  
 Here are the local flags:

--- a/docs/platform/security/sasl-kubernetes.mdx
+++ b/docs/platform/security/sasl-kubernetes.mdx
@@ -25,7 +25,7 @@ auth:
     enabled: true
     users:
       - name: admin
-        password: `changeme`
+        password: 'changeme'
 ```
 
 :::note notes
@@ -48,11 +48,11 @@ Create users (not superusers) and set passwords for the new users. By default, t
 As a security best practice, superusers should not run commands on the cluster. Instead, have these additional or new users interact with the cluster.
 :::
 
-To create the user `myuser` with a password `changethispassword`, run:
+To create the user `myuser` with a password 'changethispassword', run:
 
 ```bash
 kubectl exec -n redpanda -c redpanda redpanda-0 -- \
-  rpk acl user create myuser -p `changethispassword`
+  rpk acl user create myuser -p 'changethispassword'
 ```
 
 ## Grant permissions
@@ -66,7 +66,7 @@ The superuser can grant permissions to additional users through access control l
     rpk acl create --allow-principal User:myuser \
     --operation create,describe \
     --cluster \
-    --user admin --password `changeme` --sasl-mechanism SCRAM-SHA-256
+    --user admin --password 'changeme' --sasl-mechanism SCRAM-SHA-256
   ```
 
 2. Optionally, you can use the superuser to grant permissions to a new user for a topic. The following command grants `describe` privileges to a topic:
@@ -76,7 +76,7 @@ The superuser can grant permissions to additional users through access control l
     rpk acl create --allow-principal User:myuser \
     --operation describe \
     --topic myfirsttopic \
-    --user admin --password `changeme` --sasl-mechanism SCRAM-SHA-256
+    --user admin --password 'changeme' --sasl-mechanism SCRAM-SHA-256
   ```
 
 :::note
@@ -92,7 +92,7 @@ To create a topic:
 ```bash
 kubectl exec -n redpanda -c redpanda redpanda-0 -- \
   rpk topic create myfirsttopic \
-  --user myuser --password `changethispassword` --sasl-mechanism SCRAM-SHA-256
+  --user myuser --password 'changethispassword' --sasl-mechanism SCRAM-SHA-256
 ```
 
 To describe the topic:
@@ -100,5 +100,5 @@ To describe the topic:
 ```bash
 kubectl exec -n redpanda -c redpanda <cluster_name>-0 -- \
   rpk topic describe myfirsttopic \
-  --user myuser --password `changethispassword` --sasl-mechanism SCRAM-SHA-256
+  --user myuser --password 'changethispassword' --sasl-mechanism SCRAM-SHA-256
 ```

--- a/docs/platform/security/sasl-kubernetes.mdx
+++ b/docs/platform/security/sasl-kubernetes.mdx
@@ -25,11 +25,12 @@ auth:
     enabled: true
     users:
       - name: admin
-        password: changeme
+        password: `changeme`
 ```
 
-:::note
-In this YAML document, `users` is a list of superusers.
+:::note notes
+- In this YAML document, `users` is a list of superusers.
+- Passwords are in single quotes for potential special characters.
 :::
 
 During install or upgrade, enable SASL configuration:
@@ -51,7 +52,7 @@ To create the user `myuser` with a password `changethispassword`, run:
 
 ```bash
 kubectl exec -n redpanda -c redpanda redpanda-0 -- \
-  rpk acl user create myuser -p changethispassword
+  rpk acl user create myuser -p `changethispassword`
 ```
 
 ## Grant permissions
@@ -65,7 +66,7 @@ The superuser can grant permissions to additional users through access control l
     rpk acl create --allow-principal User:myuser \
     --operation create,describe \
     --cluster \
-    --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
+    --user admin --password `changeme` --sasl-mechanism SCRAM-SHA-256
   ```
 
 2. Optionally, you can use the superuser to grant permissions to a new user for a topic. The following command grants `describe` privileges to a topic:
@@ -75,7 +76,7 @@ The superuser can grant permissions to additional users through access control l
     rpk acl create --allow-principal User:myuser \
     --operation describe \
     --topic myfirsttopic \
-    --user admin --password changeme --sasl-mechanism SCRAM-SHA-256
+    --user admin --password `changeme` --sasl-mechanism SCRAM-SHA-256
   ```
 
 :::note
@@ -91,7 +92,7 @@ To create a topic:
 ```bash
 kubectl exec -n redpanda -c redpanda redpanda-0 -- \
   rpk topic create myfirsttopic \
-  --user myuser --password changethispassword --sasl-mechanism SCRAM-SHA-256
+  --user myuser --password `changethispassword` --sasl-mechanism SCRAM-SHA-256
 ```
 
 To describe the topic:
@@ -99,5 +100,5 @@ To describe the topic:
 ```bash
 kubectl exec -n redpanda -c redpanda <cluster_name>-0 -- \
   rpk topic describe myfirsttopic \
-  --user myuser --password changethispassword --sasl-mechanism SCRAM-SHA-256
+  --user myuser --password `changethispassword` --sasl-mechanism SCRAM-SHA-256
 ```

--- a/docs/platform/security/sasl-kubernetes.mdx
+++ b/docs/platform/security/sasl-kubernetes.mdx
@@ -30,7 +30,7 @@ auth:
 
 :::note notes
 - In this YAML document, `users` is a list of superusers.
-- Passwords are in single quotes for potential special characters.
+- Passwords are in single quotes to avoid conflicts with special characters. Enclosing characters in single quotes preserves the literal value of each character.
 :::
 
 During install or upgrade, enable SASL configuration:


### PR DESCRIPTION
resolves #632 

This adds singles quotes around passwords in case of special characters.  

preview:
- https://deploy-preview-922--redpanda-documentation.netlify.app/docs/platform/security/authentication/
- https://deploy-preview-922--redpanda-documentation.netlify.app/docs/platform/security/authorization/#rpk-for-managing-users-and-acls
- https://deploy-preview-922--redpanda-documentation.netlify.app/docs/platform/security/sasl-kubernetes/
- https://deploy-preview-922--redpanda-documentation.netlify.app/docs/platform/reference/redpanda-operator/kubernetes-sasl/
- https://deploy-preview-922--redpanda-documentation.netlify.app/docs/platform/reference/node-configuration-sample/
- https://deploy-preview-922--redpanda-documentation.netlify.app/docs/platform/console/reference/config/
