### PR TITLE
docs: Correct changing replication.factor value command

### DIFF
--- a/docs/platform/data-management/data-migration.mdx
+++ b/docs/platform/data-management/data-migration.mdx
@@ -109,7 +109,7 @@ The `replication.factor` property is a topic property set at topic creation. A r
 You can increase or decrease the replication factor on an existing topic. For example, if topics were initially created in a test environment with a replication factor of `1` (no replication), to change the topic replication factor to `3`, run: 
 
 ```
-rpk topic alter-config [TOPICS...] --set replication.factor 3
+rpk topic alter-config [TOPICS...] --set replication.factor=3
 ```
 
 ## See migration in action

--- a/docs/platform/deployment/production-deployment.mdx
+++ b/docs/platform/deployment/production-deployment.mdx
@@ -133,7 +133,7 @@ journalctl -u redpanda
 If topics were initially created in a test environment with a replication factor of `1`, use `rpk topic alter-config` to change the topic replication factor: 
 
 ```
-rpk topic alter-config [TOPICS...] --set replication.factor 3
+rpk topic alter-config [TOPICS...] --set replication.factor=3
 ```
 
 To create a topic:


### PR DESCRIPTION
The original command fails with 

```
$ rpk topic alter-config test3 --set replication.factor 3
unable to parse --set: unable to find key=value pair in "replication.factor"
```

This should be 

```
$ rpk topic alter-config test3 --set replication.factor=3
TOPIC  STATUS
test3  OK
```