### PR TITLE
docs #1020 added 'Restart required' for tunable properties

### DIFF
--- a/docs/platform/reference/tunable-properties.mdx
+++ b/docs/platform/reference/tunable-properties.mdx
@@ -30,6 +30,8 @@ Enables creation of a process ID lock file. Recommended to be set `true`.
 
 **Default**: true
 
+**Restart required**: yes
+
 ---
 
 ### features_auto_enable
@@ -39,6 +41,8 @@ Flag to auto-enable new feature flags after upgrades.
 **Type**: boolean 
 
 **Default**: true
+
+**Restart required**: no
 
 --------------------------------------------------------------------------------
 
@@ -52,6 +56,8 @@ Timeout to check if cache eviction should be triggered.
 
 **Default**: 30000 (30 seconds)
 
+**Restart required**: yes
+
 ---
 
 ### cloud_storage_enable_compacted_topic_reupload
@@ -61,6 +67,8 @@ Enable re-upload of data for compacted topics.
 **Type**: boolean
 
 **Default**: true
+
+**Restart required**: no
 
 ---
 
@@ -72,6 +80,8 @@ Default remote read configuration value for new topics.
 
 **Default**: false
 
+**Restart required**: no
+
 ---
 
 ### cloud_storage_enable_remote_write
@@ -81,6 +91,8 @@ Default remote write configuration value for new topics.
 **Type**: boolean
 
 **Default**: false
+
+**Restart required**: no
 
 ---
 
@@ -92,6 +104,8 @@ Interval for cloud storage housekeeping tasks.
 
 **Default**: 300000 (5 minutes)
 
+**Restart required**: no
+
 ---
 
 ### cloud_storage_initial_backoff_ms
@@ -101,6 +115,8 @@ Initial backoff time for exponential backoff algorithm.
 **Units**: milliseconds
 
 **Default**: 100
+
+**Restart required**: yes
 
 ---
 
@@ -112,6 +128,8 @@ Manifest upload timeout.
 
 **Default**: 10000 (10 seconds)
 
+**Restart required**: yes
+
 ---
 
 ### cloud_storage_max_connection_idle_time_ms
@@ -121,6 +139,8 @@ Maximum HTTPS connection idle time.
 **Units**: milliseconds
 
 **Default**: 5000
+
+**Restart required**: yes
 
 ---
 
@@ -134,6 +154,8 @@ Maximum number of concurrent readers of remote data per shard (CPU core).  If `n
 
 **Default**: null
 
+**Restart required**: no
+
 ---
 
 ### cloud_storage_max_readers_per_shard
@@ -145,6 +167,8 @@ Maximum concurrent readers of remote data per shard (CPU core).  If `null`, the 
 **Units**: number of concurrent readers
 
 **Default**: null
+
+**Restart required**: no
 
 ---
 
@@ -158,6 +182,8 @@ The maximum limit per partition for the number of segments pending deletion from
 
 **Default**: 5000
 
+**Restart required**: no
+
 ---
 
 ### cloud_storage_metadata_sync_timeout_ms
@@ -168,6 +194,8 @@ Timeout for shadow indexing (SI) metadata synchronization.
 
 **Default**: 10000 (10 seconds)
 
+**Restart required**: no
+
 ---
 
 ### cloud_storage_readreplica_manifest_sync_timeout_ms
@@ -177,6 +205,8 @@ Timeout to check if new data is available for a partition in S3 for read replica
 **Units**: milliseconds
 
 **Default**: 30000 (30 seconds)
+
+**Restart required**: no
 
 ---
 
@@ -190,6 +220,8 @@ Interval at which the archival service runs reconciliation.
 
 **Default**: 1000
 
+**Restart required**: yes
+
 ---
 
 ### cloud_storage_segment_max_upload_interval_sec
@@ -199,6 +231,8 @@ Duration that a segment can be kept in local storage without uploading it to rem
 **Units**: seconds
 
 **Default**: null (infinite duration)
+
+**Restart required**: yes
 
 ---
 
@@ -210,6 +244,8 @@ Log segment upload timeout.
 
 **Default**: 30000 (30 seconds)
 
+**Restart required**: yes
+
 ---
 
 ### cloud_storage_upload_ctrl_d_coeff
@@ -219,6 +255,8 @@ Derivative coefficient of the upload PID controller.
 **Type**: double
 
 **Default**: 0.0
+
+**Restart required**: yes
 
 ---
 
@@ -230,6 +268,8 @@ Maximum number of IO and CPU shares that the archival upload can use.
 
 **Default**: 1000
 
+**Restart required**: yes
+
 ---
 
 ### cloud_storage_upload_ctrl_min_shares 
@@ -239,6 +279,8 @@ Minimum number of IO and CPU shares that the archival upload can use.
 **Units**: number of IO and CPU shares
 
 **Default**: 100
+
+**Restart required**: yes
 
 ---
 
@@ -250,6 +292,8 @@ Proportional coefficient of the upload PID controller.
 
 **Default**: -2.0
 
+**Restart required**: yes
+
 ---
 
 ### cloud_storage_upload_ctrl_update_interval_ms
@@ -259,6 +303,8 @@ Sampling interval of the upload PID controller.
 **Units**: milliseconds
 
 **Default**: 60000 (1 minute)
+
+**Restart required**: yes
 
 ---
 
@@ -270,6 +316,8 @@ Initial backoff interval when there is nothing to upload for a partition.
 
 **Default**: 100
 
+**Restart required**: yes
+
 ---
 
 ### cloud_storage_upload_loop_max_backoff_ms
@@ -279,6 +327,8 @@ Maximum backoff interval when there is nothing to upload for a partition.
 **Units**: milliseconds
 
 **Default**: 10000 (10 seconds)
+
+**Restart required**: yes
 
 --------------------------------------------------------------------------------
 
@@ -292,6 +342,8 @@ Interval between iterations of the controller backend's housekeeping loop.
 
 **Default**: 1000
 
+**Restart required**: yes
+
 ---
 
 ### controller_log_accummulation_rps_capacity_acls_and_users_operations
@@ -303,6 +355,8 @@ Maximum capacity of accumulated requests for the cluster controller's access con
 **Units**: number of requests
 
 **Default**: null
+
+**Restart required**: no
 
 **Related properties**: [rps_limit_acls_and_users_operations](#rps_limit_acls_and_users_operations) 
 
@@ -318,6 +372,8 @@ Maximum capacity of accumulated requests for the cluster controller's configurat
 
 **Default**: null
 
+**Restart required**: no
+
 **Related properties**: [rps_limit_configuration_operations](#rps_limit_configuration_operations) 
 
 ---
@@ -331,6 +387,8 @@ Maximum capacity of accumulated requests for the cluster controller's move opera
 **Units**: number of requests
 
 **Default**: null
+
+**Restart required**: no
 
 **Related properties**: [rps_limit_move_operations](#rps_limit_move_operations) 
 
@@ -346,6 +404,8 @@ Maximum capacity of accumulated requests for the cluster controller's node manag
 
 **Default**: null
 
+**Restart required**: no
+
 **Related properties**: [rps_limit_node_management_operations](#rps_limit_node_management_operations) 
 
 ---
@@ -358,6 +418,8 @@ Period at which the health manager runs.
 
 **Default**: 180000 (3 minutes)
 
+**Restart required**: yes
+
 ---
 
 ### health_monitor_max_metadata_age
@@ -368,6 +430,8 @@ Maximum duration that metadata is cached in the health monitor of a non-controll
 
 **Default**: 10000 (10 seconds)
 
+**Restart required**: no
+
 ---
 
 ### health_monitor_tick_interval
@@ -377,6 +441,8 @@ Period at which the health monitor refreshes cluster state.
 **Units**: milliseconds
 
 **Default**: 10000 (10 seconds)
+
+**Restart required**: no
 
 ---
 
@@ -390,6 +456,8 @@ Size of one batch message (one log record) of an ID allocator log.
 
 **Default**: 1000
 
+**Restart required**: yes
+
 ---
 
 ### id_allocator_log_capacity
@@ -402,6 +470,8 @@ Maximum number of messages (batches) of an ID allocator log. Once the log reache
 
 **Default**: 100
 
+**Restart required**: yes
+
 ---
 
 ### join_retry_timeout_ms
@@ -411,6 +481,8 @@ Duration between cluster join retries.
 **Units**: milliseconds
 
 **Default**: 5000 (5 seconds)
+
+**Restart required**: yes
 
 ---
 
@@ -422,6 +494,8 @@ Timeout at which to run the leader balancer when in an idle state.
 
 **Default**: 120000 (2 minutes)
 
+**Restart required**: no
+
 ---
 
 ### leader_balancer_mute_timeout
@@ -432,6 +506,8 @@ Timeout used to mute groups, where muted groups are removed from consideration a
 
 **Default**: 300000 (5 minutes)
 
+**Restart required**: no
+
 ---
 
 ### leader_balancer_node_mute_timeout
@@ -441,6 +517,8 @@ Timeout used to mute a node, where a muted node is removed from consideration as
 **Units**: milliseconds
 
 **Default**: 20000 (20 seconds)
+
+**Restart required**: no
 
 ---
 
@@ -456,6 +534,8 @@ Maximum limit per shard (CPU core) on the number of in-progress leadership trans
 
 **Range**: [1, 2048]
 
+**Restart required**: no
+
 ---
 
 ### max_concurrent_producer_ids
@@ -470,6 +550,8 @@ Maximum number of producer IDs that the resource manager state machine caches in
 
 **Range**: [1, maximum value of a 64-bit unsigned integer]
 
+**Restart required**: no
+
 ---
 
 ### members_backend_retry_ms
@@ -479,6 +561,8 @@ Duration between members backend reconciliation loop retries.
 **Units**: milliseconds
 
 **Default**: 5000 
+
+**Restart required**: yes
 
 ---
 
@@ -490,6 +574,8 @@ Interval for metadata dissemination batching.
 
 **Default**: 3000 
 
+**Restart required**: yes
+
 ---
 
 ### metadata_dissemination_retries
@@ -499,6 +585,8 @@ Number of attempts looking up a topic's metadata, like shard, before failing a r
 **Units**: number of retries
 
 **Default**: 30
+
+**Restart required**: yes
 
 ---
 
@@ -510,6 +598,8 @@ Delay before retrying a topic-lookup in a shard or other meta-tables.
 
 **Default**: 500
 
+**Restart required**: yes
+
 ---
 
 ### metadata_status_wait_timeout_ms
@@ -519,6 +609,8 @@ Maximum duration to wait in metadata request for cluster health to be refreshed.
 **Units**: milliseconds
 
 **Default**: 2000
+
+**Restart required**: yes
 
 ---
 
@@ -530,6 +622,8 @@ Timeout for executing node management operations.
 
 **Default**: 5000
 
+**Restart required**: yes
+
 ---
 
 ### node_status_interval
@@ -539,6 +633,8 @@ Time interval between two node status messages, which establish liveness status 
 **Units**: milliseconds
 
 **Default**: 100
+
+**Restart required**: no
 
 ---
 
@@ -552,6 +648,8 @@ Number of partitions that can be reassigned at once by the partition auto-balanc
 
 **Default**: 50
 
+**Restart required**: no
+
 ---
 
 ### partition_autobalancing_tick_interval_ms
@@ -561,6 +659,8 @@ Tick interval of the partition auto-balancer.
 **Units**: milliseconds
 
 **Default**: 30000 (30 seconds)
+
+**Restart required**: no
 
 ---
 
@@ -574,6 +674,8 @@ Total size of partitions that the partition auto-balancer moves in one batch.
 
 **Default**: 5368709120 (5 GiB)
 
+**Restart required**: no
+
 --- 
 
 ### rps_limit_acls_and_users_operations
@@ -585,6 +687,8 @@ Request-per-second (rps) rate limit for the cluster controller's access control 
 **Units**: requests per second
 
 **Default**: 1000
+
+**Restart required**: no
 
 ---
 
@@ -598,6 +702,8 @@ Request-per-second (rps) rate limit for the cluster controller's configuration o
 
 **Default**: 1000
 
+**Restart required**: no
+
 ---
 
 ### rps_limit_move_operations
@@ -609,6 +715,8 @@ Request-per-second (rps) rate limit for the cluster controller's move operations
 **Units**: requests per second
 
 **Default**: 1000
+
+**Restart required**: no
 
 ---
 
@@ -622,6 +730,8 @@ Request-per-second (rps) rate limit for the cluster controller's node management
 
 **Default**: 1000
 
+**Restart required**: no
+
 --- 
 
 ### rps_limit_topic_operations
@@ -633,6 +743,8 @@ Request-per-second (rps) rate limit for the cluster controller's topic operation
 **Units**: requests per second
 
 **Default**: 1000
+
+**Restart required**: no
 
 -----------------------------------------------------------------------------------
 
@@ -646,6 +758,8 @@ Default number of quota tracking windows.
 
 **Default**: 10
 
+**Restart required**: no
+
 ---
 
 ### default_window_sec
@@ -655,6 +769,8 @@ Default duration of quota tracking window.
 **Units**: milliseconds
 
 **Default**: 1000
+
+**Restart required**: no
 
 ---
 
@@ -666,6 +782,8 @@ Duration to wait for the next read in fetch request when minimum number of reque
 
 **Default**: 1
 
+**Restart required**: no
+
 ---
 
 ### fetch_session_eviction_timeout_ms
@@ -675,6 +793,8 @@ Minimum time before an unused session gets evicted. The maximum time after which
 **Units**: milliseconds
 
 **Default**: 60000 (1 minute)
+
+**Restart required**: yes
 
 ---
 
@@ -688,6 +808,8 @@ A delay at the start of a consumer group rebalancing event to wait for new membe
 
 **Range**: [0, ...]
 
+**Restart required**: no
+
 ---
 
 ### group_new_member_join_timeout
@@ -699,6 +821,8 @@ Timeout to wait for new members to join a consumer group.
 **Default**: 30000
 
 **Range**: [0, ...]
+
+**Restart required**: no
 
 ---
 
@@ -712,6 +836,8 @@ Number of partitions in the internal group membership topic.
 
 **Default**: 16
 
+**Restart required**: no
+
 ---
 
 ### kafka_batch_max_bytes
@@ -723,6 +849,8 @@ Maximum size of a batch processed by the server. If the batch is compressed, thi
 **Units**: bytes
 
 **Default**: 1048576 (1 MiB)
+
+**Restart required**: no
 
 ---
 
@@ -736,6 +864,8 @@ Maximum amount of data a consumer receives when fetching a record.
 
 **Default**: 67108864 (64 MiB)
 
+**Restart required**: no
+
 ---
 
 ### kafka_qdc_depth_alpha
@@ -745,6 +875,8 @@ Smoothing factor for queue depth control depth tracking.
 **Type**: double
 
 **Default**: 0.8
+
+**Restart required**: yes
 
 ---
 
@@ -756,6 +888,8 @@ The update frequency of the queue depth control algorithm.
 
 **Default**: 7000 (7 seconds)
 
+**Restart required**: yes
+
 ---
 
 ### kafka_qdc_idle_depth
@@ -766,6 +900,8 @@ Queue depth of the queue depth control algorithm when in an idle state.
 
 **Default**: 10
 
+**Restart required**: no
+
 ---
 
 ### kafka_qdc_latency_alpha
@@ -775,6 +911,8 @@ Smoothing parameter for queue depth control algorithm.
 **Type**: double
 
 **Default**: 0.002
+
+**Restart required**: yes
 
 ---
 
@@ -788,6 +926,8 @@ Maximum queue depth of the queue depth control algorithm.
 
 **Range**: >= [kafka_qdc_min_depth](#kafka_qdc_min_depth)
 
+**Restart required**: yes
+
 ---
 
 ### kafka_qdc_min_depth
@@ -800,6 +940,8 @@ Minimum queue depth of the queue depth control algorithm.
 
 **Range**: <= [kafka_qdc_max_depth](#kafka_qdc_max_depth)
 
+**Restart required**: yes
+
 ---
 
 ### kafka_qdc_window_count
@@ -810,6 +952,8 @@ Number of time windows used by the queue depth control algorithm.
 
 **Default**: 12
 
+**Restart required**: yes
+
 ---
 
 ### kafka_qdc_window_size_ms
@@ -819,6 +963,8 @@ Duration of a time window used by the queue depth control algorithm.
 **Units**: milliseconds
 
 **Default**: 1500
+
+**Restart required**: yes
 
 ---
 
@@ -831,6 +977,8 @@ Maximum size of a request processed by a Kafka API.
 **Units**: bytes
 
 **Default**: 104857600 (100 MiB)
+
+**Restart required**: no
 
 ---
 
@@ -846,6 +994,8 @@ Maximum size of the user-space receive buffer. If `null`, this limit is not appl
 
 **Range**: [512, 512 KiB]. Must be 4096-byte aligned.
 
+**Restart required**: yes
+
 ---
 
 ### max_kafka_throttle_delay_ms
@@ -855,6 +1005,8 @@ Fail-safe maximum throttle delay on Kafka requests.
 **Units**: milliseconds 
 
 **Default**: 60000 (1 minute)
+
+**Restart required**: no
 
 ---
 
@@ -866,7 +1018,7 @@ Period of the quota manager's GC timer.
 
 **Default**: 30000 (30 seconds)
 
-
+**Restart required**: yes
 
 ---
 
@@ -877,6 +1029,8 @@ Timeout to wait for leader election.
 **Units**: milliseconds
 
 **Default**: 5000
+
+**Restart required**: no
 
 --------------------------------------------------------------------------------
 
@@ -890,6 +1044,8 @@ Interval of reports sent to clients from the metrics reporter.
 
 **Default**: 86400000 (24 hours)
 
+**Restart required**: no
+
 ---
 
 ### metrics_reporter_tick_interval
@@ -899,6 +1055,8 @@ Tick timer interval for capturing metrics.
 **Units**: milliseconds
 
 **Default**: 60000 (1 minute)
+
+**Restart required**: no
 
 --------------------------------------------------------------------------------
 
@@ -912,6 +1070,8 @@ Raft election timeout.
 
 **Default**: 1500
 
+**Restart required**: yes
+
 ---
 
 ### full_raft_configuration_recovery_pattern
@@ -921,6 +1081,8 @@ Recover raft configurations on start for NTPs that match this pattern.
 **Type**: string, or list of strings
 
 **Default**: {} (empty)
+
+**Restart required**: yes
 
 ---
 
@@ -936,6 +1098,8 @@ Number of consecutive failed heartbeat responses before forcibly closing an unre
 
 **Range**: [0, ...]
 
+**Restart required**: yes
+
 ---
 
 ### raft_heartbeat_interval_ms
@@ -945,6 +1109,8 @@ Period of raft leader heartbeat.
 **Units**: milliseconds
 
 **Default**: 150
+
+**Restart required**: no
 
 ---
 
@@ -956,6 +1122,8 @@ Timeout duration of raft leader heartbeat RPC.
 
 **Default**: 3000
 
+**Restart required**: no
+
 ---
 
 ### raft_io_timeout_ms
@@ -965,6 +1133,8 @@ Timeout duration for raft I/O.
 **Units**: milliseconds
 
 **Default**: 10000 (10 seconds)
+
+**Restart required**: yes
 
 ---
 
@@ -977,6 +1147,8 @@ Maximum number of concurrent requests per follower.
 **Units**: number of concurrent requests per follower
 
 **Default**: 16
+
+**Restart required**: yes
 
 ---
 
@@ -992,6 +1164,8 @@ Maximum amount of memory available for raft follower recovery. If `null`, defaul
 
 **Range**: [32 MiB, ...]
 
+**Restart required**: no
+
 ---
 
 ### raft_recovery_default_read_size
@@ -1006,6 +1180,8 @@ Default size of a read issued during raft follower recovery.
 
 **Range**: [128, 5 MiB]
 
+**Restart required**: no
+
 ---
 
 ### raft_replicate_batch_window_size
@@ -1017,6 +1193,8 @@ Maximum size of a batch for raft replication.
 **Units**: bytes
 
 **Default**: 1048576 (1 MiB)
+
+**Restart required**: yes
 
 ---
 
@@ -1036,6 +1214,8 @@ For details, see [seastar::smp_service_group_config](https://docs.seastar.io/mas
 
 **Default**: null
 
+**Restart required**: yes
+
 ---
 
 ### raft_timeout_now_timeout_ms
@@ -1045,6 +1225,8 @@ Timeout of the raft `timeout now` RPC request.
 **Units**: milliseconds
 
 **Default**: 1000
+
+**Restart required**: no
 
 ---
 
@@ -1056,6 +1238,8 @@ Timeout waiting for follower recovery when transferring leadership.
 
 **Default**: 10000 (10 seconds)
 
+**Restart required**: no
+
 ---
 
 ### recovery_append_timeout_ms
@@ -1065,6 +1249,8 @@ Timeout for raft's append entries RPC.
 **Units**: milliseconds
 
 **Default**: 5000
+
+**Restart required**: yes
 
 --------------------------------------------------------------------------------
 
@@ -1080,6 +1266,8 @@ Capacity of an abort index segment.
 
 **Default**: 50000
 
+**Restart required**: yes
+
 ---
 
 ### append_chunk_size
@@ -1093,6 +1281,8 @@ Size of direct-write operations to disk.
 **Default**: 16384 (16 KiB)
 
 **Range**: [4096, 32 MiB]. Must be 4096-byte aligned. 
+
+**Restart required**: yes
 
 ---
 
@@ -1108,6 +1298,8 @@ Size of a compacted log segment.
 
 **Range**: [1 MiB, ...]
 
+**Restart required**: no
+
 ---
 
 ### compaction_ctrl_backlog_size
@@ -1122,6 +1314,8 @@ Size of the compaction backlog of the backlog controller. If `null` (empty), def
 
 **Range**: [1 MiB, ...]
 
+**Restart required**: yes
+
 ---
 
 ### compaction_ctrl_d_coeff
@@ -1131,6 +1325,8 @@ Derivative coefficient for compaction PID controller.
 **Type**: double
 
 **Default**: 0.2
+
+**Restart required**: yes
 
 ---
 
@@ -1144,6 +1340,8 @@ Integral coefficient for compaction PID controller.
 
 **Range**: [0.0, ...]
 
+**Restart required**: yes
+
 ---
 
 ### compaction_ctrl_max_shares
@@ -1155,6 +1353,8 @@ Maximum number of I/O and CPU shares that the compaction process can use.
 **Units**: number of shares
 
 **Default**: 1000
+
+**Restart required**: yes
 
 ---
 
@@ -1168,6 +1368,8 @@ Minimum number of I/O and CPU shares that the compaction process can use.
 
 **Default**: 10
 
+**Restart required**: yes
+
 ---
 
 ### compaction_ctrl_p_coeff
@@ -1180,6 +1382,8 @@ Proportional coefficient for compaction PID controller. Must be negative to decr
 
 **Range**: [..., 0.0)
 
+**Restart required**: yes
+
 ---
 
 ### compaction_ctrl_update_interval_ms
@@ -1189,6 +1393,8 @@ Sampling interval of the compaction PID controller.
 **Units**: milliseconds
 
 **Default**: 30000 (30 seconds)
+
+**Restart required**: yes
 
 ---
 
@@ -1200,6 +1406,8 @@ Flag to disable the batch cache in log manager.
 
 **Default**: false
 
+**Restart required**: yes
+
 ---
 
 ### kvstore_flush_interval
@@ -1209,6 +1417,8 @@ Flush interval of the key-value store.
 **Units**: milliseconds
 
 **Default**: 10
+
+**Restart required**: no
 
 ---
 
@@ -1221,6 +1431,8 @@ Maximum size of a segment of the key-value store.
 **Units**: bytes
 
 **Default**: 16777216 (16 MiB)
+
+**Restart required**: yes
 
 ---
 
@@ -1236,13 +1448,13 @@ Default size of log segment. Per topic, it is superseded by topic property `segm
 
 **Range**: [1 MiB, ...]
 
+**Restart required**: no
+
 ---
 
 ### log_segment_size_max
 
-Upper limit of topic `segment.bytes`. Higher values are clamped to this limit. 
-
-If `null`, no limit is applied.
+Upper limit of topic `segment.bytes`. Higher values are clamped to this limit. If `null`, no limit is applied.
 
 **Type**: unsigned 64-bit integer
 
@@ -1250,19 +1462,21 @@ If `null`, no limit is applied.
 
 **Default**: null (no limit applied)
 
+**Restart required**: no
+
 ---
 
 ### log_segment_size_min
 
-Lower limit of topic `segment.bytes`. Lower values are clamped to this limit. 
-
-If `null`, no limit is applied.
+Lower limit of topic `segment.bytes`. Lower values are clamped to this limit. If `null`, no limit is applied.
 
 **Type**: unsigned 64-bit integer
 
 **Units**: bytes
 
 **Default**: 1048576 (1 MiB)
+
+**Restart required**: no
 
 ---
 
@@ -1280,6 +1494,8 @@ Applying segment size jitter is a good defensive measure to space out the overhe
 
 **Range**: [0, 99]
 
+**Restart required**: yes
+
 ---
 
 ### max_compacted_log_segment_size
@@ -1292,6 +1508,8 @@ Max compacted segment size after consolidation.
 
 **Default**: 5368709120 (5 GiB)
 
+**Restart required**: no
+
 ---
 
 ### readers_cache_eviction_timeout_ms
@@ -1302,7 +1520,7 @@ Duration after which inactive readers are evicted from the cache of readers.
 
 **Default**: 30000 (30 seconds)
 
-
+**Restart required**: yes
 
 ---
 
@@ -1316,6 +1534,8 @@ Minimum amount of free memory maintained by the batch cache.
 
 **Default**: 67108864 (64 MiB)
 
+**Restart required**: yes
+
 ---
 
 ### reclaim_growth_window
@@ -1328,6 +1548,8 @@ Starting from the last point in time when memory was reclaimed from the batch ca
 
 **Range**: <= [reclaim_stable_window](#reclaim_stable_window)
 
+**Restart required**: yes
+
 ---
 
 ### reclaim_max_size
@@ -1338,6 +1560,8 @@ Maximum batch cache reclaim size.
 
 **Default**: 4194304 (4 MiB)
 
+**Restart required**: yes
+
 ---
 
 ### reclaim_min_size
@@ -1347,6 +1571,8 @@ Minimum batch cache reclaim size.
 **Units**: bytes
 
 **Default**: 131072 (128 KiB)
+
+**Restart required**: yes
 
 ---
 
@@ -1360,6 +1586,8 @@ If the duration since the last time memory was reclaimed has been longer than th
 
 **Range**: >= [reclaim_growth_window](#reclaim_growth_window)
 
+**Restart required**: yes
+
 ---
 
 ### release_cache_on_segment_roll
@@ -1369,6 +1597,8 @@ Flag for whether to release cache when a full segment is rolled.
 **Type**: boolean
 
 **Default**: false
+
+**Restart required**: no
 
 ---
 
@@ -1380,6 +1610,8 @@ Timeout for append entry's RPCs issued while replicating entries.
 
 **Default**: 3000
 
+**Restart required**: yes
+
 ---
 
 ### segment_appender_flush_timeout_ms
@@ -1389,6 +1621,8 @@ Maximum duration until buffered data is written.
 **Units**: milliseconds
 
 **Default**: 1000
+
+**Restart required**: no
 
 ---
 
@@ -1404,6 +1638,8 @@ Size of a file allocation (_f_ allocation) step of a segment.
 
 **Range**: [4096, 1 GiB]. Must be 4096-byte aligned.
 
+**Restart required**: no
+
 ---
 
 ### storage_compaction_index_memory
@@ -1417,6 +1653,8 @@ Maximum number of bytes that may be used on each shard (CPU core) by compaction 
 **Default**: 134217728 (128 MiB)
 
 **Range**: [16 MiB, 100 GiB]
+
+**Restart required**: no
 
 ---
 
@@ -1432,6 +1670,8 @@ Maximum number of partition logs that are replayed concurrently on startup or fl
 
 **Range**: [128, ...]
 
+**Restart required**: no
+
 ---
 
 ### storage_min_free_bytes
@@ -1446,6 +1686,8 @@ Threshold of minimum amount of free space before rejecting producers.
 
 **Range**: [10 MiB, ...]
 
+**Restart required**: no
+
 ---
 
 ### storage_read_buffer_size
@@ -1458,6 +1700,8 @@ Size of a read buffer (one per in-flight read, one per log segment).
 
 **Default**: 131072 (128 KiB)
 
+**Restart required**: yes
+
 ---
 
 ### storage_read_readahead_count
@@ -1469,6 +1713,8 @@ Number of read-ahead reads when reading from a segment.
 **Units**: number of reads
 
 **Default**: 10
+
+**Restart required**: yes
 
 ---
 
@@ -1484,6 +1730,8 @@ The threshold of free storage (in bytes of free storage) below which a low stora
 
 **Range**: [0, ...]
 
+**Restart required**: no
+
 ---
 
 ### storage_space_alert_free_threshold_percent
@@ -1497,6 +1745,8 @@ The threshold of free storage (in percentage of total storage that is free) belo
 **Default**: 5
 
 **Range**: [0, 50]
+
+**Restart required**: no
 
 ---
 
@@ -1512,6 +1762,8 @@ Target bytes to replay from disk on startup after a clean shutdown. Controls the
 
 **Range**: [128 MiB, 1 TiB]
 
+**Restart required**: no
+
 ---
 
 ### zstd_decompress_workspace_bytes
@@ -1524,7 +1776,7 @@ Size of the Zstandard (zstd) compression algorithm's memory buffer (workspace) i
 
 **Default**: 8388608 (8 MiB)
 
-
+**Restart required**: yes
 
 --------------------------------------------------------------------------------
 
@@ -1538,7 +1790,7 @@ Time to wait for entries replication in controller log when executing alter topi
 
 **Default**: 5000
 
- 
+**Restart required**: no
 
 ---
 
@@ -1549,6 +1801,8 @@ Timeout to wait for new topic creation.
 **Units**: milliseconds
 
 **Default**: 2000
+
+**Restart required**: no
 
 ---
 
@@ -1564,6 +1818,8 @@ The number of file descriptors reserved for topics per partition.
 
 **Range**: [1, 1000]
 
+**Restart required**: no
+
 ---
 
 ### topic_memory_per_partition
@@ -1577,6 +1833,8 @@ The amount of memory reserved for topics per partition.
 **Default**: 1048576 (1 MiB)
 
 **Range**: [1, 100 MiB]
+
+**Restart required**: no
 
 ---
 
@@ -1592,6 +1850,8 @@ Maximum number of partitions which may be allocated per shard (CPU core).
 
 **Range**: [16, 131072]
 
+**Restart required**: no
+
 ---
 
 ### topic_partitions_reserve_shard0
@@ -1606,6 +1866,8 @@ Reserved partition slots on shard (CPU core) 0 on each node. If this is >= [topi
 
 **Range**: [0, 131072]
 
+**Restart required**: no
+
 -----------------------------------------------------------------------------------
 
 ## Transaction properties
@@ -1618,6 +1880,8 @@ Timer timeout to check for and abort inactive transactions.
 
 **Default**: 10000 (10 seconds)
 
+**Restart required**: yes
+
 ---
 
 ### transaction_coordinator_log_segment_size
@@ -1629,6 +1893,8 @@ Size of the log segment of the Kafka broker's transaction coordinator.
 **Units**: bytes
 
 **Default**: 1073741824 (1 GiB)
+
+**Restart required**: no
 
 --------------------------------------------------------------------------------
 
@@ -1646,6 +1912,8 @@ Maximum size of one topic read in coprocessing mode.
 
 **Default**: 32 KB
 
+**Restart required**: yes
+
 ---
 
 ### coproc_max_inflight_bytes
@@ -1657,6 +1925,8 @@ Maximum size of inflight data when sending to the Wasm engine.
 **Units**: bytes
 
 **Default**: 10485760 (10 MiB)
+
+**Restart required**: yes
 
 ---
 
@@ -1670,6 +1940,8 @@ Maximum size of input logs in memory.
 
 **Default**: 655360 (640 KiB)
 
+**Restart required**: yes
+
 ---
 
 ### coproc_offset_flush_interval_ms
@@ -1679,6 +1951,8 @@ Interval for which all coprocessor offsets are flushed to disk.
 **Units**: milliseconds
 
 **Default**: 300000 (5 minutes)
+
+**Restart required**: yes
 
 ----------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1020 .

Review deadline: Fri Jan 13

Added 'Restart required' for tunable properties, as specified by `needs_restart` meta data in https://github.com/redpanda-data/redpanda/blob/dev/src/v/config/configuration.cc (where unspecified/default is `needs_restart::yes`).

Preview: https://deploy-preview-1021--redpanda-documentation.netlify.app/docs/platform/reference/tunable-properties/

@jcsp @vuldin need an SME review, at minimum a spot-check of some properties.