### PR TITLE
Change Github wrong link to helm Artifact hub

### DIFF
--- a/docs/platform/security/kubernetes-tls.mdx
+++ b/docs/platform/security/kubernetes-tls.mdx
@@ -23,7 +23,7 @@ This page uses the recommended Redpanda Helm chart for configuring TLS. For info
 
 By default, the Redpanda Helm chart uses cert-manager to create self-signed certificates. To enable TLS, enable it when installing or upgrading Redpanda with the Helm chart.
 
-See [GitHub](https://github.com/redpanda-data/helm-charts/blob/main/redpanda/values.yaml) for the default values.
+See [Artifact Hub](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values) for the default values.
 
 ### Prerequisites
 

--- a/versioned_docs/version-22.2/platform/security/kubernetes-tls.mdx
+++ b/versioned_docs/version-22.2/platform/security/kubernetes-tls.mdx
@@ -20,7 +20,7 @@ This page uses the recommended `redpanda` Helm chart for configuring TLS. For in
 
 By default, the Redpanda Helm chart uses cert-manager to create self-signed certificates. To enable TLS, enable it when installing or upgrading Redpanda with the Helm chart.
 
-See [GitHub](https://github.com/redpanda-data/helm-charts/blob/main/redpanda/values.yaml) for the default values.
+See [Artifact Hub](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values) for the default values.
 
 ### Prerequisites
 


### PR DESCRIPTION
The modal in Artifact hub is more user friendly and should be more stable.