### PR TITLE
Add missing import for tab and tabs library

### DIFF
--- a/docs/platform/deploy/kubernetes-tune-workers.mdx
+++ b/docs/platform/deploy/kubernetes-tune-workers.mdx
@@ -9,6 +9,8 @@ tags:
     <meta name="description" content="To get the best performance from your hardware, set Redpanda to production mode and run the auto-tuning tool. The auto-tuning tool identifies your hardware configuration and tunes itself to give you the best performance."/>
 </head>
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import Versions from '@site/docs/platform/shared/versions.mdx'
 
 To get the best performance from your hardware, set Redpanda to production mode on each worker node and run the auto-tuning tool. The auto-tuning tool identifies the hardware configuration on your worker node and optimizes the Linux kernel to give you the best performance.


### PR DESCRIPTION
The following site display both option https://docs.redpanda.com/docs/platform/deploy/kubernetes-tune-workers/#install-redpanda

The tabs was defined, but we missed the include.

![Screenshot 2023-01-16 at 12 50 41](https://user-images.githubusercontent.com/22834495/212671821-fce62a00-60e9-44c2-853f-5e74f79c3e47.png)
