### PR TITLE
console: Provide more precise docs for jwtSecret

### DIFF
--- a/docs/manage/security/console/authentication.mdx
+++ b/docs/manage/security/console/authentication.mdx
@@ -27,9 +27,22 @@ to add Google login support looks like this:
 ```yaml
 login:
   enabled: true
-  # jwtSecret is a secret that is used to sign and encrypt the JSON Web tokens
-  # that are used by the backend for session management.
-  jwtSecret: abcadsdadasdasdas
+
+  # jwtSecret is the secret key you must use to sign and encrypt the JSON 
+  # web token used to store user sessions. This secret key is 
+  # critical for the security of Redpanda Console's authentication and 
+  # authorization system. Use a long, complex key with a combination of 
+  # numbers, letters, and special characters. While you must use a minimum of 
+  # 10 characters, Redpanda recommends using more than 32 
+  # characters. For additional security, use a different secret key for 
+  # each environment. jwtSecret can be securely generated with the following 
+  # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
+  #
+  # If you update this secret key, any users who are 
+  # already logged into Redpanda Console will be logged out and will have 
+  # to log in again.
+  jwtSecret: ""
+
   google:
     enabled: true
     clientId: redacted.apps.googleusercontent.com

--- a/docs/manage/security/console/generic-oidc.mdx
+++ b/docs/manage/security/console/generic-oidc.mdx
@@ -22,10 +22,19 @@ and then provide this application's credentials in the configuration:
 login:
   enabled: true
 
-  # jwtSecret is a random string of at least 10 characters that must be the same for all Console instances. 
-  # This string is used to sign and validate the user session JSON Web Tokens (JWT). 
-  # If this string changes, logged-in Console users will be logged out and will have to initiate a 
-  # new session by logging in again.
+  # jwtSecret is the secret key you must use to sign and encrypt the JSON 
+  # web token used to store user sessions. This secret key is 
+  # critical for the security of Redpanda Console's authentication and 
+  # authorization system. Use a long, complex key with a combination of 
+  # numbers, letters, and special characters. While you must use a minimum of 
+  # 10 characters, Redpanda recommends using more than 32 
+  # characters. For additional security, use a different secret key for 
+  # each environment. jwtSecret can be securely generated with the following 
+  # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
+  #
+  # If you update this secret key, any users who are 
+  # already logged into Redpanda Console will be logged out and will have 
+  # to log in again.
   jwtSecret: ""
 
   oidc:

--- a/docs/manage/security/console/github.mdx
+++ b/docs/manage/security/console/github.mdx
@@ -35,10 +35,19 @@ Below configurations assume that you want to host Redpanda Console so that it wo
 login:
   enabled: true
 
-  # jwtSecret is a random string of at least 10 characters that must be the same for all Console instances. 
-  # This string is used to sign and validate the user session JSON Web Tokens (JWT). 
-  # If this string changes, logged-in Console users will be logged out and will have to initiate a 
-  # new session by logging in again.
+  # jwtSecret is the secret key you must use to sign and encrypt the JSON 
+  # web token used to store user sessions. This secret key is 
+  # critical for the security of Redpanda Console's authentication and 
+  # authorization system. Use a long, complex key with a combination of 
+  # numbers, letters, and special characters. While you must use a minimum of 
+  # 10 characters, Redpanda recommends using more than 32 
+  # characters. For additional security, use a different secret key for 
+  # each environment. jwtSecret can be securely generated with the following 
+  # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
+  #
+  # If you update this secret key, any users who are 
+  # already logged into Redpanda Console will be logged out and will have 
+  # to log in again.
   jwtSecret: ""
 
   github:

--- a/docs/manage/security/console/google.mdx
+++ b/docs/manage/security/console/google.mdx
@@ -33,10 +33,19 @@ The following configurations are based on the assumption that you want to host R
 login:
   enabled: true
 
-  # jwtSecret is a random string of at least 10 characters that must be the same for all Console instances. 
-  # This string is used to sign and validate the user session JSON Web Tokens (JWT). 
-  # If this string changes, logged-in Console users will be logged out and will have to initiate a 
-  # new session by logging in again.
+  # jwtSecret is the secret key you must use to sign and encrypt the JSON 
+  # web token used to store user sessions. This secret key is 
+  # critical for the security of Redpanda Console's authentication and 
+  # authorization system. Use a long, complex key with a combination of 
+  # numbers, letters, and special characters. While you must use a minimum of 
+  # 10 characters, Redpanda recommends using more than 32 
+  # characters. For additional security, use a different secret key for 
+  # each environment. jwtSecret can be securely generated with the following 
+  # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
+  #
+  # If you update this secret key, any users who are 
+  # already logged into Redpanda Console will be logged out and will have 
+  # to log in again.
   jwtSecret: ""
 
   google:

--- a/docs/manage/security/console/okta.mdx
+++ b/docs/manage/security/console/okta.mdx
@@ -37,10 +37,19 @@ Put the following credentials into your Redpanda Console configuration:
 login:
   enabled: true
 
-  # jwtSecret is a random string of at least 10 characters that must be the same for all Console instances. 
-  # This string is used to sign and validate the user session JSON Web Tokens (JWT). 
-  # If this string changes, logged-in Console users will be logged out and will have to initiate a 
-  # new session by logging in again.
+  # jwtSecret is the secret key you must use to sign and encrypt the JSON 
+  # web token used to store user sessions. This secret key is 
+  # critical for the security of Redpanda Console's authentication and 
+  # authorization system. Use a long, complex key with a combination of 
+  # numbers, letters, and special characters. While you must use a minimum of 
+  # 10 characters, Redpanda recommends using more than 32 
+  # characters. For additional security, use a different secret key for 
+  # each environment. jwtSecret can be securely generated with the following 
+  # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
+  #
+  # If you update this secret key, any users who are 
+  # already logged into Redpanda Console will be logged out and will have 
+  # to log in again.
   jwtSecret: ""
 
   okta:

--- a/docs/reference/console/config.mdx
+++ b/docs/reference/console/config.mdx
@@ -266,14 +266,25 @@ licenseFilepath:
 # This feature requires an Enterprise license.
 login:
   enabled: false
-  # jwtSecret is a secret string that signs and encrypts
-  # the JSON Web tokens used by the backend for session management.
-  jwtSecret: redacted
-# Redpanda Console stores users' session data in cookies with no fixed size.
-# Because some browsers enforce maximum size limits on cookies, 
-# you can enable useCookieChunking to split a single big cookie into multiple smaller ones.
-# When useCookieChunking is enabled, cookies are kept below 4KiB, 
-# which is a maximum size limit that is set by most browsers.
+  # jwtSecret is the secret key you must use to sign and encrypt the JSON 
+  # web token used to store user sessions. This secret key is 
+  # critical for the security of Redpanda Console's authentication and 
+  # authorization system. Use a long, complex key with a combination of 
+  # numbers, letters, and special characters. While you must use a minimum of 
+  # 10 characters, Redpanda recommends using more than 32 
+  # characters. For additional security, use a different secret key for 
+  # each environment. jwtSecret can be securely generated with the following 
+  # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
+  #
+  # If you update this secret key, any users who are 
+  # already logged into Redpanda Console will be logged out and will have 
+  # to log in again.
+  jwtSecret: ""
+  # Redpanda Console stores users' session data in cookies with no fixed size.
+  # Because some browsers enforce a maximum size limit on cookies, 
+  # you can enable useCookieChunking to split a single big cookie into multiple 
+  # smaller ones. When you enable useCookieChunking, cookies are kept below 4KiB, 
+  # which is a maximum size limit set by most browsers.
   useCookieChunking: false
   google:
     enabled: false


### PR DESCRIPTION
This PR aims to improve the documentation around the `login.jwtSecret` configuration in Console which is important from a security standpoint. The goal is to inform the user about it's importance as well as having a single consistent documentation for the property.