### PR TITLE
update log_segment_size default for v23.1

### DIFF
--- a/docs/deploy/deployment-option/self-hosted/manual/sizing.mdx
+++ b/docs/deploy/deployment-option/self-hosted/manual/sizing.mdx
@@ -131,7 +131,7 @@ Tiered Storage can be combined with local storage to provide infinite data reten
 
 Ideally, a cluster should be sized such that the cluster's local storage can service the majority of its consumers within a normal amount of lag, with Tiered Storage used to service any slow readers (for example, in the event of some downstream failure). 
 
-When Tiered Storage is enabled on a topic, it immediately copies closed log segments into the configured storage bucket or container. The default log segment size is set to one GB, so by default, a topic’s object store lags approximately one GB behind the local copy. 
+When Tiered Storage is enabled on a topic, it immediately copies closed log segments into the configured storage bucket or container. A topic’s object store thus lags behind the local copy by the default [log segment size](../../../../../reference/tunable-properties#log_segment_size).
 - You can lower `segment.bytes` to reduce this lag. This lets Redpanda archive smaller log segments more frequently, at the cost of increasing I/O and file count. 
 - You can also set an idle timeout to force Redpanda to periodically archive the contents of open log segments to object storage. This is useful if a topic’s write rate is low and log segments are kept open for long periods of time. 
 

--- a/docs/manage/cluster-maintenance/disk-utilization.mdx
+++ b/docs/manage/cluster-maintenance/disk-utilization.mdx
@@ -112,11 +112,11 @@ rpk topic alter-config <topic> --set segment.bytes=<segment_size>
  
 Compaction saves space by retaining only the last known value for each message key within the segment. The latest value for each key is preserved, and all older values are discarded. 
 
-When compaction is configured, topics take their size from `compacted_log_segment_size`. The `log_segment_size` property does not apply to compacted topics. 
+When compaction is configured, topics take their size from [compacted_log_segment_size](../../../reference/tunable-properties#compacted_log_segment_size). The [log_segment_size](../../../reference/tunable-properties#log_segment_size) property does not apply to compacted topics. 
 
 Setting a `segment.bytes` size on a topic applies whether the topic is compacted or not, and the `max_compacted_log_segment_size` property applies to compacted topics regardless of the other properties. It controls how many segments are merged together. For example, if you set `segment.bytes` to 128MB, but leave `max_compacted_log_segment_size` at 5GB, you get 128MB segments when they're written, but up to 5GB segments after compaction.
 
-Keep in mind that very large segments prevent compaction, and very small segments increase the risk of encountering resource limits. To calculate an upper limit on segment size, divide the disk size by the number of partitions. For example, if you have a 128 GB disk and 1000 partitions, the upper limit of the segment size is `134217728`. Default is `1073741824`. 
+Keep in mind that very large segments prevent compaction, and very small segments increase the risk of encountering resource limits. To calculate an upper limit on segment size, divide the disk size by the number of partitions. For example, if you have a 128 GB disk and 1000 partitions, the upper limit of the segment size is `134217728`. Compare your limit with the default [log_segment_size](../../../reference/tunable-properties#log_segment_size) and default [compacted_log_segment_size](../../../reference/tunable-properties#compacted_log_segment_size). 
 
 For details about how to modify cluster configuration properties, see [Cluster configuration](../cluster-property-configuration). 
 

--- a/docs/manage/cluster-maintenance/disk-utilization.mdx
+++ b/docs/manage/cluster-maintenance/disk-utilization.mdx
@@ -31,9 +31,9 @@ Set retention properties at the topic level or the cluster level. If a value isn
 
 | Retention property | Cluster level | Topic level <br /> (overrides cluster configuration) |
 | ---               | ---                                                |  ---                                 |
-| Time-based        | `delete_retention_ms` <br /> Default - `604800000` | `retention.ms` <br /> No default     |
-| Size-based        | `retention_bytes`  <br /> Default - `null`         | `retention.bytes`  <br /> No default |
-| Segment size      | `log_segment_size`  <br /> Default - `1073741824`  | N/A                                  |
+| Time-based        | [delete_retention_ms](../../../reference/cluster-properties#delete_retention_ms) | `retention.ms` <br /> No default     |
+| Size-based        | [retention_bytes](../../../reference/cluster-properties#retention_bytes) | `retention.bytes`  <br /> No default |
+| Segment size      | [log_segment_size](../../../reference/tunable-properties#log_segment_size) | N/A                                  |
 
 Based on these properties, Redpanda runs a log cleanup process in the background. If you start to run out of disk space, adjust your retention properties to reduce the amount of disk space used. 
 
@@ -92,20 +92,20 @@ To set retention size for a single topic, use `retention.bytes`, which overrides
 
 ## Configure segment size
 
-The `log_segment_size` property specifies the size of each log segment.
+The [log_segment_size](../../../reference/tunable-properties#log_segment_size) property specifies the size of each log segment.
 
 To set `log_segment_size`:
 
 ```bash
-rpk cluster config set log_segment_size <segment_size>
+rpk cluster config set log_segment_size <segment-size>
 ```
 
 If you know which topics will receive more data, it's best to specify the size for each topic. 
 
-To configure log segment size on a topic: 
+To configure log segment size on a topic, `segment.bytes`: 
 
 ```bash
-rpk topic alter-config <topic> --set segment.bytes=<segment_size>
+rpk topic alter-config <topic> --set segment.bytes=<segment-size>
 ```
 
 ### Segment size for compacted segments

--- a/docs/reference/tunable-properties.mdx
+++ b/docs/reference/tunable-properties.mdx
@@ -1444,7 +1444,7 @@ Default size of log segment. Per topic, it is superseded by topic property `segm
 
 **Units**: bytes
 
-**Default**: 1073741824 (1 GiB)
+**Default**: 134217728 (128 MiB)
 
 **Range**: [1 MiB, ...]
 


### PR DESCRIPTION
Fixes: 
- #1016 

Preview: 
- https://deploy-preview-1082--redpanda-documentation.netlify.app/docs/reference/tunable-properties/#log_segment_size