### PR TITLE
Fix Netlify form submissions

### DIFF
--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -91,16 +91,16 @@ const MyModal = (props) => {
                     <div className={styles.radioButtons}>
                     <input type="hidden" name="form-name" value="feedbackForm"/>
                       <label>
-                        <input type="radio" name="easyToUnderstand" id="easyToUnderstand" value="understand" onChange={handleChange}/>
+                        <input type="radio" name="feedback" id="easyToUnderstand" value={easyRadio} onChange={handleChange}/>
                         <span className={styles.labelMargin} >{easyRadio}</span>
                       </label> <br />
                       
                       <label>
-                        <input type="radio" name="solvedProblem" id="solvedProblem" value="solved" onChange={handleChange}/>
+                        <input type="radio" name="feedback" id="solvedProblem" value={solvedRadio} onChange={handleChange}/>
                         <span className={styles.labelMargin}>{solvedRadio}</span>
                       </label><br />
                       <label>
-                        <input type="radio" name="other" id="other" value="other" onChange={handleChange} />
+                        <input type="radio" name="feedback" id="other" value="other" onChange={handleChange} />
                         <span className={styles.labelMargin}>{otherRadio}</span>
                       </label><br/>
                     </div>
@@ -114,7 +114,7 @@ const MyModal = (props) => {
                         <div className={styles.boxSizing + " " + styles.padding}>
                           {whatWeDo}
                         </div>
-                        <textarea id="otherText"  name="otherText"  rows="4"  cols="50"  placeholder="Please describe in more details your feedback." onChange={handleChange}></textarea>
+                        <textarea id="otherText"  name="otherText"  rows="4"  cols="50"  placeholder="Please describe in more details your feedback."></textarea>
                       </div>
                     )}
                 </div>

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -16,11 +16,26 @@ import Icon from "@material-ui/core/Icon";
 import ContributionIcon from "../../../../static/img/contribution.svg";
 import { useLocation } from 'react-router-dom';
 
+function encode(data) {
+  return Object.keys(data)
+    .map((key) => encodeURIComponent(key) + '=' + encodeURIComponent(data[key]))
+    .join('&')
+}
+
 
 const MyModal = (props) => {
   const [other, setOther] = useState(false);
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
   const [disableButton, setDisableButton] = useState(false);
+  const [formData, setFormData] = useState({})
+
+  const handleChange = (e) => {
+    setOther(false)
+    if (e.target.name=='other') setOther(true)
+    setFormData({ ...formData, [e.target.name]: e.target.value })
+    setDisableButton(true)
+  }
+
   let title,whatWeDo,easyRadio, solvedRadio,otherRadio;
   
   otherRadio = "Other";
@@ -45,15 +60,14 @@ const MyModal = (props) => {
     if (feedbackSubmitted) return;
 
     const myForm = event.target;
-    const formData = new FormData(myForm);
     
     fetch("/", {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
+      body: encode({
         'form-name': 'feedbackForm',
         ...formData
-      }).toString(),
+      })
     })
       .then(() => {
         console.log("Form successfully submitted")
@@ -77,16 +91,16 @@ const MyModal = (props) => {
                     <div className={styles.radioButtons}>
                     <input type="hidden" name="form-name" value="feedbackForm"/>
                       <label>
-                        <input type="radio" name="feedbackOptions" id="easyToUnderstand" value="understand" onChange={() => {setOther(false); setDisableButton(true);}} />
+                        <input type="radio" name="easyToUnderstand" id="easyToUnderstand" value="understand" onChange={handleChange}/>
                         <span className={styles.labelMargin} >{easyRadio}</span>
                       </label> <br />
                       
                       <label>
-                        <input type="radio" name="feedbackOptions" id="solvedProblem" value="solved"onChange={() => {setOther(false); setDisableButton(true);}}/>
+                        <input type="radio" name="solvedProblem" id="solvedProblem" value="solved" onChange={handleChange}/>
                         <span className={styles.labelMargin}>{solvedRadio}</span>
                       </label><br />
                       <label>
-                        <input type="radio" name="feedbackOptions" id="other" value="other" onChange={() => {setOther(true); setDisableButton(true);}} />
+                        <input type="radio" name="other" id="other" value="other" onChange={handleChange} />
                         <span className={styles.labelMargin}>{otherRadio}</span>
                       </label><br/>
                     </div>
@@ -94,13 +108,13 @@ const MyModal = (props) => {
                       If we can contact you with more questions, please enter your
                       email address:
                     </div>
-                    <input type="text" name="email" id="email" placeholder="email@example.com" className={styles.moreQuestions}/><br />
+                    <input type="text" name="email" id="email" onChange={handleChange} placeholder="email@example.com" className={styles.moreQuestions}/><br />
                     {other && (
                       <div>
                         <div className={styles.boxSizing + " " + styles.padding}>
                           {whatWeDo}
                         </div>
-                        <textarea id="otherText"  name="otherText"  rows="4"  cols="50"  placeholder="Please describe in more details your feedback."></textarea>
+                        <textarea id="otherText"  name="otherText"  rows="4"  cols="50"  placeholder="Please describe in more details your feedback." onChange={handleChange}></textarea>
                       </div>
                     )}
                 </div>

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -31,7 +31,7 @@ const MyModal = (props) => {
 
   const handleChange = (e) => {
     setOther(false)
-    if (e.target.name=='other') setOther(true)
+    if (e.target.value=='other') setOther(true)
     setFormData({ ...formData, [e.target.name]: e.target.value })
     setDisableButton(true)
   }

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -19,13 +19,9 @@ import { useLocation } from 'react-router-dom';
 
 const MyModal = (props) => {
   const [other, setOther] = useState(false);
-  const [feedbackSubmited, setfeedbackSubmited] = useState(false);
+  const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
   const [disableButton, setDisableButton] = useState(false);
   let title,whatWeDo,easyRadio, solvedRadio,otherRadio;
-  
-  if (!props.show) {
-    return null;
-  }
   
   otherRadio = "Other";
 
@@ -46,6 +42,8 @@ const MyModal = (props) => {
   const handleSubmit = (event) => {
     event.preventDefault();
 
+    if (feedbackSubmitted) return;
+
     const myForm = event.target;
     const formData = new FormData(myForm);
     
@@ -57,15 +55,19 @@ const MyModal = (props) => {
         ...formData
       }).toString(),
     })
-      .then(() => console.log("Form successfully submitted"))
+      .then(() => {
+        console.log("Form successfully submitted")
+        setFeedbackSubmitted(true)
+        setTimeout(props.onClose,30000)
+      })
       .catch((error) => alert(error));
   };
 
   return (
-    <form data-netlify="true" name="feedbackForm" method="POST" onSubmit={handleSubmit}>
-      <div className={styles.modal} onClick={props.onClose}>
+    <form className={`${props.show ? `${styles.modal}` : `${styles.hide}`}`} data-netlify="true" name="feedbackForm" method="POST" onSubmit={handleSubmit}>
+      <div onClick={props.onClose}>
           <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
-        {!feedbackSubmited ? (
+        {!feedbackSubmitted ? (
           <div>
               
                 <div className={styles.modalHeader}>
@@ -73,7 +75,7 @@ const MyModal = (props) => {
                 </div>
                 <div className={styles.modalBody}>
                     <div className={styles.radioButtons}>
-                    <input type="hidden" name="feedbackForm" value="feedbackForm"/>
+                    <input type="hidden" name="form-name" value="feedbackForm"/>
                       <label>
                         <input type="radio" name="feedbackOptions" id="easyToUnderstand" value="understand" onChange={() => {setOther(false); setDisableButton(true);}} />
                         <span className={styles.labelMargin} >{easyRadio}</span>
@@ -103,8 +105,8 @@ const MyModal = (props) => {
                     )}
                 </div>
                 <div className={styles.modalFooter}>
-                  {!feedbackSubmited &&
-                  <button type= "submit" onSubmit={() => {setfeedbackSubmited(true); setTimeout(props.onClose,30000)}} className={clsx("button", styles.submitButton)} disabled={!disableButton}>Submit</button>
+                {!feedbackSubmitted &&
+                  <button type= "submit" onSubmit={handleSubmit} className={clsx("button", styles.submitButton)} disabled={!disableButton}>Submit</button>
                 }
                   <button type ="button" onClick={props.onClose}  className={clsx("button", styles.closeButton)}>Close</button>
                 </div>
@@ -112,14 +114,12 @@ const MyModal = (props) => {
             </div>): 
             
             (<div className={styles.modalBody}>
-              <div className={styles.feedbackSubmited}>
-              <Icon className={styles.feedbackSubmitedIcon}>checkmark</Icon><br/>
+              <div className={styles.feedbackSubmitted}>
+              <Icon className={styles.feedbackSubmittedIcon}>checkmark</Icon><br/>
               Thank you for submitting your feedback.
               <button onClick={props.onClose}  className={clsx("button", styles.closeButton)}>Close</button>
               </div>
               
-              
-
             </div>)}
             
           </div>
@@ -161,7 +161,6 @@ export default function DocItemLayout({ children }) {
         <div className={styles.docItemContainer}>
           <article>
             <DocBreadcrumbs />
-            {console.log(useLocation())}
             {!(
               useLocation().pathname.includes("/docs/platform/deployment/cloud")
               ) 
@@ -173,64 +172,64 @@ export default function DocItemLayout({ children }) {
           {/* BEGIN COMPONENT SWIZZLING. Add link to repository.
            */}
           <section className={styles.issueLinkSeparator}>
+          <MyModal onClose={() => setShow(false)} show={show} positiveFeedback={positiveFeedback}></MyModal>
+          <div className="row">
+            <div>
+              
+            </div>
+            <div className={clsx("col", styles.feedBackSection + " " + styles.mailIcon)}>
+              <div>Was this page helpful?</div>
+
+              <div>
+                <button
+                  className={
+                    styles.mailIcon + " " + styles.thumbsUpSeparator
+                  }
+                  onClick={() => {setShow(true); setPositiveFeedback(true);}}
+                >
+                  <Icon>thumb_up</Icon>
+                </button>
+
+                <button
+                  className={
+                    styles.mailIcon + " " + styles.thumbsUpSeparator
+                  }
+                  onClick={() => {setShow(true); setPositiveFeedback(false);}}
+                >
+                  <Icon>thumb_down</Icon>
+                </button>
+              </div>
+            </div>
+            <div className="col">
+              <a href="https://redpanda.com/slack" alt="Slack Community"><Icon className={styles.mailIcon}>group</Icon> Ask in the community</a>
+            </div>
+            <div className="col">
             <BrowserOnly>
               {() => (
-                <div className="row">
-                  <div>
-                    
-                  </div>
-                  <div className={clsx("col", styles.feedBackSection + " " + styles.mailIcon)}>
-                    <div>Was this page helpful?</div>
-
-                    <div>
-                      <button
-                        className={
-                          styles.mailIcon + " " + styles.thumbsUpSeparator
-                        }
-                        onClick={() => {setShow(true); setPositiveFeedback(true);}}
-                      >
-                        <Icon>thumb_up</Icon>
-                      </button>
-
-                      <button
-                        className={
-                          styles.mailIcon + " " + styles.thumbsUpSeparator
-                        }
-                        onClick={() => {setShow(true); setPositiveFeedback(false);}}
-                      >
-                        <Icon>thumb_down</Icon>
-                      </button>
-                    </div>
-                  </div>
-                  <div className="col">
-                    <a href="https://redpanda.com/slack" alt="Slack Community"><Icon className={styles.mailIcon}>group</Icon> Ask in the community</a>
-                  </div>
-                  <div className="col">
-                    <a
-                      href={
-                        "mailto:rp-docs-feedback@redpanda.com?subject=Documentation Feedback&body=Doc url: " +
-                        window.location.href
-                      }
-                    >
-                      <Icon className={styles.mailIcon}>email</Icon>
-                      <span> Share your feedback</span>
-                    </a>
-                  </div>
-                  <div className={clsx("col", styles.reportIssueText)}>
-                    <a
-                      href={editUrl}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                      className={styles.contributionIcon}
-                    >
-                      <ContributionIcon />
-                      <span> Make a contribution</span>
-                    </a>
-                  </div>
-                  <MyModal onClose={() => setShow(false)} show={show} positiveFeedback={positiveFeedback} className={styles.mymodal}></MyModal>
-                </div>
+              <a
+                href={
+                  "mailto:rp-docs-feedback@redpanda.com?subject=Documentation Feedback&body=Doc url: " +
+                  window.location.href
+                }
+              >
+                <Icon className={styles.mailIcon}>email</Icon>
+                <span> Share your feedback</span>
+              </a>
               )}
-            </BrowserOnly>
+              </BrowserOnly>
+            </div>
+            <div className={clsx("col", styles.reportIssueText)}>
+              <a
+                href={editUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className={styles.contributionIcon}
+              >
+                <ContributionIcon />
+                <span> Make a contribution</span>
+              </a>
+            </div>
+          </div>
           </section>
           <DocItemPaginator />
         </div>

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -9,6 +9,25 @@
   }
 }
 
+.modal {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: var(--font);
+  font-size: 14px;
+  z-index: 1;
+}
+
+.hide {
+  display: none;
+}
+
 .issueLinkSeparator {
   border-top: 1px solid;
   margin-top: 30px;
@@ -38,20 +57,6 @@
 
 .thumbsUpSeparator {
   margin-right: 15px;
-}
-
-.modal {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font: var(--font);
-  font-size: 14px;
 }
 
 .modalContent {
@@ -176,12 +181,12 @@ input[type="text"]:focus {
   padding-top: 15px;
 }
 
-.feedbackSubmited {
+.feedbackSubmitted {
   text-align: center;
   font-size: 20px;
 }
 
-.feedbackSubmitedIcon {
+.feedbackSubmittedIcon {
   color: green;
   font-size: 150px !important;
 }


### PR DESCRIPTION
This PR allows us to submit feedback forms to Netlify.

- Fixed an issue with empty fields in Netlify submissions by saving each value to the state.
- Moved only essential browser-only content inside `<BrowserOnly>`. If forms are inside this component, Netlify can't detect them. The only part that needs to be in `<BrowserOnly>` is the link that accesses the `window` object.
- Removed the condition that doesn't render the form. We need Netlify to see the form when the site it built, but this condition was stopping the form from being rendered.
  ```
  if (!props.show) {
    return null;
  }
  ```
- Renamed the hidden input name to `form-name`. See https://docs.netlify.com/forms/setup/#work-with-javascript-rendered-forms
- Fixed some logic to get the success message to be displayed and to stop form resubmissions.
- Fixed typo.