### PR TITLE
Document crash_loop_limit node configuration for 23.1

### DIFF
--- a/docs/manage/cluster-maintenance/configure-availability.mdx
+++ b/docs/manage/cluster-maintenance/configure-availability.mdx
@@ -1,0 +1,32 @@
+---
+title: Configure Availability 
+---
+
+<head>
+    <meta name="title" content="Configure Availability | Redpanda Docs"/>
+    <meta name="description" content="Guidelines for configuring Redpanda clusters for optimal availability."/>
+</head>
+
+import ConfigureAvailabilityIntro from './shared/_intro-configure-availability.mdx'
+
+<ConfigureAvailabilityIntro/>
+
+## Limit Client Connections
+
+A malicious Kafka client application may create many network connections to execute its attacks. A poorly configured application may also create an excessive number of connections. To mitigate the risk of a client creating too many connections and using too many system resources, you can configure a Redpanda cluster to impose limits on the number of created client connections for its Kafka protocol server nodes. 
+
+The following cluster properties limit the number of connections:
+
+- [kafka_connections_max](../../../reference/cluster-properties#kafka_connections_max): Similar to Kafka's `max.connections`, this property sets the maximum number of connections created by a node.
+- [kafka_connections_max_per_ip](../../../reference/cluster-properties#kafka_connections_max_per_ip): Similar to Kafka's `max.connections.per.ip`, this property sets the maximum number of connections created per IP address by a node.
+- [kafka_connections_max_overrides](../../../reference/cluster-properties#kafka_connections_max_overrides): A list of IP addresses for which [kafka_connections_max_per_ip](../../../reference/cluster-properties#kafka_connections_max_per_ip) is overridden and doesn't apply.
+
+Redpanda also provides properties to manage the rate of connection creation:
+
+- [kafka_connection_rate_limit](../../../reference/cluster-properties#kafka_connection_rate_limit): This property limits the maximum rate of connections created per second. It applies per CPU core.
+- [kafka_connection_rate_limit_overrides](../../../reference/cluster-properties#kafka_connection_rate_limit_overrides): A list of IP addresses for which [kafka_connection_rate_limit](../../../reference/cluster-properties#kafka_connection_rate_limit) is overridden and doesn't apply.
+
+:::note notes
+- These connection limit properties are disabled by default. You must manually enable them.
+- Typically, a client opens two or three connections, so the total number of connections is not equal to the number of clients. For example, to support 100 clients, you might set your connection limit to 300.
+:::

--- a/docs/manage/cluster-maintenance/configure-availability.mdx
+++ b/docs/manage/cluster-maintenance/configure-availability.mdx
@@ -11,7 +11,7 @@ import ConfigureAvailabilityIntro from './shared/_intro-configure-availability.m
 
 <ConfigureAvailabilityIntro/>
 
-## Limit Client Connections
+## Limit client connections
 
 A malicious Kafka client application may create many network connections to execute its attacks. A poorly configured application may also create an excessive number of connections. To mitigate the risk of a client creating too many connections and using too many system resources, you can configure a Redpanda cluster to impose limits on the number of created client connections for its Kafka protocol server nodes. 
 
@@ -29,4 +29,20 @@ Redpanda also provides properties to manage the rate of connection creation:
 :::note notes
 - These connection limit properties are disabled by default. You must manually enable them.
 - Typically, a client opens two or three connections, so the total number of connections is not equal to the number of clients. For example, to support 100 clients, you might set your connection limit to 300.
+:::
+
+## Prevent crash loops
+
+A Redpanda node creates a non-insignificant amount of log segments at startup. If a node were to crash after startup, and if it were to get stuck in a crash loop, it could eventually run low on disk space.
+
+To prevent infinite crash loops, the node property [crash_loop_limit](../../../reference/node-properties#crash_loop_limit) sets an upper limit on the number of consecutive crashes that can happen within one hour of each other. After `crash_loop_limit` is reached, a node cannot restart until its crash-tracking logic is reset by one of the following conditions:
+
+- The node configuration file, `redpanda.yaml`, is updated.
+- The `startup_log` file in the node's [data_directory](../../../reference/node-properties#data_directory) is manually deleted.
+- One hour elapses since the last crash.
+
+A node's crash-tracking logic is also reset by a clean shutdown.
+
+:::note 
+The limit property is disabled by default. You must manually enable it by setting it to a non-zero value.
 :::

--- a/docs/manage/cluster-maintenance/configure-availability.mdx
+++ b/docs/manage/cluster-maintenance/configure-availability.mdx
@@ -33,7 +33,7 @@ Redpanda also provides properties to manage the rate of connection creation:
 
 ## Prevent crash loops
 
-A Redpanda node creates a non-insignificant amount of log segments at startup. If a node were to crash after startup, and if it were to get stuck in a crash loop, it would produce progressively more state that uses more disk space and takes more time for each restart to process.  
+A Redpanda node may create a non-insignificant amount of log segments at startup. If a node were to crash after startup, and if it were to get stuck in a crash loop, it would produce progressively more state that uses more disk space and takes more time for each restart to process.  
 
 To prevent infinite crash loops, the node property [crash_loop_limit](../../../reference/node-properties#crash_loop_limit) sets an upper limit on the number of consecutive crashes that can happen within one hour of each other. Once it reaches the limit, a node cannot restart until its internal consecutive crash counter is reset to zero by one of the following conditions:
 

--- a/docs/manage/cluster-maintenance/configure-availability.mdx
+++ b/docs/manage/cluster-maintenance/configure-availability.mdx
@@ -33,16 +33,16 @@ Redpanda also provides properties to manage the rate of connection creation:
 
 ## Prevent crash loops
 
-A Redpanda node creates a non-insignificant amount of log segments at startup. If a node were to crash after startup, and if it were to get stuck in a crash loop, it could eventually run low on disk space.
+A Redpanda node creates a non-insignificant amount of log segments at startup. If a node were to crash after startup, and if it were to get stuck in a crash loop, it would produce progressively more state that uses more disk space and takes more time for each restart to process.  
 
-To prevent infinite crash loops, the node property [crash_loop_limit](../../../reference/node-properties#crash_loop_limit) sets an upper limit on the number of consecutive crashes that can happen within one hour of each other. After `crash_loop_limit` is reached, a node cannot restart until its crash-tracking logic is reset by one of the following conditions:
+To prevent infinite crash loops, the node property [crash_loop_limit](../../../reference/node-properties#crash_loop_limit) sets an upper limit on the number of consecutive crashes that can happen within one hour of each other. Once it reaches the limit, a node cannot restart until its internal consecutive crash counter is reset to zero by one of the following conditions:
 
 - The node configuration file, `redpanda.yaml`, is updated.
 - The `startup_log` file in the node's [data_directory](../../../reference/node-properties#data_directory) is manually deleted.
 - One hour elapses since the last crash.
+- The node is cleanly shut down. (This is not possible after `crash_loop_limit` has been reached and the node cannot be restarted.)
 
-A node's crash-tracking logic is also reset by a clean shutdown.
-
-:::note 
-The limit property is disabled by default. You must manually enable it by setting it to a non-zero value.
+:::note notes
+- The limit property is disabled by default. You must manually enable it by setting it to a non-zero value.
+- If the limit is less than two, the node will be blocked from restarting after every single crash, until one of the reset conditions is met.
 :::

--- a/docs/manage/cluster-maintenance/index.mdx
+++ b/docs/manage/cluster-maintenance/index.mdx
@@ -7,6 +7,8 @@ title: Cluster Maintenance
     <meta name="description" content="Cluster Maintenance"/>
 </head>
 
+import ConfigureAvailabilityIntro from './shared/_intro-configure-availability.mdx'
+
 - [Cluster Balancing](../cluster-maintenance/cluster-balancing)
 
     When a topic is created, Redpanda evenly distributes its partitions by sequentially allocating them to the node with the least number of partitions. By default, Redpanda provides leadership balancing and partition rebalancing when nodes are added or decommissioned. 
@@ -22,6 +24,10 @@ title: Cluster Maintenance
 - [Manage Disk Space](../cluster-maintenance/disk-utilization)
 
     Redpanda provides several ways to manage disk space to ensure the production stability of the cluster.
+
+- [Configure Availability](../cluster-maintenance/configure-availability)
+
+    <ConfigureAvailabilityIntro/>
 
 - [Cluster Properties](../cluster-maintenance/cluster-property-configuration)
 

--- a/docs/manage/cluster-maintenance/shared/_intro-configure-availability.mdx
+++ b/docs/manage/cluster-maintenance/shared/_intro-configure-availability.mdx
@@ -1,0 +1,1 @@
+Optimize the availability of your clusters by configuring and tuning Redpanda cluster properties.

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -320,7 +320,7 @@ Overrides the maximum connections per second for one core for the specified IP a
 
 ### kafka_connections_max
 
-Maximum number of Kafka client connections per broker. If `null`, the property is disabled.
+The maximum number of Kafka client connections per broker. If `null`, the property is disabled, and no limit is applied to the number of Kafka client connections.
 
 **Units**: number of Kafka client connections per broker
 
@@ -332,7 +332,7 @@ Maximum number of Kafka client connections per broker. If `null`, the property i
 
 ### kafka_connections_max_overrides
 
-A list of IP addresses for which Kafka client connection limits are overridden and don't apply. For example, `(['127.0.0.1:90', '50.20.1.1:40']).`
+A list of IP addresses that are exempt from the limit on Kafka client connections ([`kafka_connections_max_per_ip`](#kafka_connections_max_per_ip)). For example, `(['127.0.0.1:90', '50.20.1.1:40']).`
 
 **Default**: {} (empty list)
 
@@ -342,7 +342,7 @@ A list of IP addresses for which Kafka client connection limits are overridden a
 
 ### kafka_connections_max_per_ip
 
-Maximum number of Kafka client connections per IP address, per broker. If `null`, the property is disabled.
+The maximum number of Kafka client connections per IP address, per broker. If `null`, the property is disabled, and no limit is applied to the number of Kafka client connections.
 
 **Units**: number of Kafka client connections per IP address, per broker
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -318,6 +318,40 @@ Overrides the maximum connections per second for one core for the specified IP a
 
 ---
 
+### kafka_connections_max
+
+Maximum number of Kafka client connections per broker. If `null`, the property is disabled.
+
+**Units**: number of Kafka client connections per broker
+
+**Default**: null
+
+**Restart required**: no
+
+---
+
+### kafka_connections_max_overrides
+
+A list of IP addresses for which Kafka client connection limits are overridden and don't apply. For example, `(['127.0.0.1:90', '50.20.1.1:40']).`
+
+**Default**: {} (empty list)
+
+**Restart required**: no
+
+---
+
+### kafka_connections_max_per_ip
+
+Maximum number of Kafka client connections per IP address, per broker. If `null`, the property is disabled.
+
+**Units**: number of Kafka client connections per IP address, per broker
+
+**Default**: null
+
+**Restart required**: no
+
+---
+
 ### kafka_group_recovery_timeout_ms
 
 Kafka group recovery timeout.

--- a/docs/reference/node-properties.mdx
+++ b/docs/reference/node-properties.mdx
@@ -85,6 +85,24 @@ IP address and port for supervisor service.
 
 ---
 
+### crash_loop_limit
+
+A limit on the number of consecutive crashes (unclean shutdowns) of a node within a short duration of each other, after which the node cannot restart until its crash-tracking logic is reset. It prevents a node from getting stuck in an infinite cycle of crashes.
+
+If `null`, the property is disabled and no limit is applied.
+
+The crash-tracking logic is reset (to zero consecutive crashes) by any of the following conditions:
+- The node shuts down cleanly.
+- One hour elapses since the last crash.
+- The node configuration file, `redpanda.yaml`, is updated.
+- The `startup_log` file in the node's [data_directory](#data_directory) is manually deleted.
+
+**Units**: number of consecutive crashes of a node
+
+**Default**: null
+
+---
+
 ### dashboard_dir
 
 Path to the directory where the HTTP dashboard is located. 

--- a/docs/reference/node-properties.mdx
+++ b/docs/reference/node-properties.mdx
@@ -87,7 +87,7 @@ IP address and port for supervisor service.
 
 ### crash_loop_limit
 
-A limit on the number of consecutive crashes (unclean shutdowns) of a node within a short duration of each other, after which the node cannot restart until its crash-tracking logic is reset. It prevents a node from getting stuck in an infinite cycle of crashes.
+A limit on the number of consecutive times a broker can crash within one hour before its crash-tracking logic is reset. This limit prevents a broker from getting stuck in an infinite cycle of crashes.
 
 If `null`, the property is disabled and no limit is applied.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -336,6 +336,11 @@ module.exports = {
                   "manage/cluster-maintenance/disk-utilization",
                   {
                     type: "doc",
+                    label: "Configure Availability",
+                    id: "manage/cluster-maintenance/configure-availability",
+                  },
+                  {
+                    type: "doc",
                     label: "Cluster Properties",
                     id: "manage/cluster-maintenance/cluster-property-configuration",
                   },  


### PR DESCRIPTION
Fixes for 23.1:
- #1114 

Previews:
- [New Node property](https://deploy-preview-1131--redpanda-documentation.netlify.app/docs/reference/node-properties/#crash_loop_limit)
- [New section in Configure Availability topic](https://deploy-preview-1131--redpanda-documentation.netlify.app/docs/manage/cluster-maintenance/configure-availability/#prevent-crash-loops) (note: cherry-picked Configure Availability from dev)

Review deadline: Wed Feb 1
