### PR TITLE
Clarify public_metrics and metrics export different metrics for 22.2

### DIFF
--- a/versioned_docs/version-22.2/cluster-administration/monitoring.mdx
+++ b/versioned_docs/version-22.2/cluster-administration/monitoring.mdx
@@ -10,6 +10,14 @@ You can monitor the health of your system to optimize performance. The most usef
 
 For information about the original metrics available on `:9644/metrics`, see [Internal Metrics](../../reference/internal-metrics).
 
+:::note notes
+The `/public_metrics` endpoint exports different metrics than the `/metrics` endpoint.
+
+Use `/public_metrics` for your primary dashboards for system health.
+
+Use `/metrics` for detailed analysis and debugging.
+:::
+
 ## Configure Prometheus
 
 [Prometheus](https://prometheus.io/) is a systems monitoring and alerting tool. It collects and stores metrics as time-series data identified by metric name and key/value pairs. Redpanda exports Prometheus metrics on `:9644/public_metrics`. To generate the configuration on an existing Prometheus instance, run:

--- a/versioned_docs/version-22.2/reference/internal-metrics.mdx
+++ b/versioned_docs/version-22.2/reference/internal-metrics.mdx
@@ -11,6 +11,14 @@ This page describes the original metrics available on `<node ip>:9644/metrics`. 
 
 For information about the latest metrics available on `:9644/public_metrics`, see [Monitoring](../../cluster-administration/monitoring).
 
+:::note notes
+The `/public_metrics` endpoint exports different metrics than the `/metrics` endpoint.
+
+Use `/public_metrics` for your primary dashboards for system health.
+
+Use `/metrics` for detailed analysis and debugging.
+:::
+
 ## Configure Prometheus: internal metrics
 
 [Prometheus](https://prometheus.io/) is a systems monitoring and alerting tool. It collects and stores metrics as time-series data identified by metric name and key/value pairs. 


### PR DESCRIPTION
Fixes:
- #967 

Previews:
- 22.2: updated [public metrics](https://deploy-preview-1145--redpanda-documentation.netlify.app/docs/22.2/cluster-administration/monitoring/) and [internal metrics](https://deploy-preview-1145--redpanda-documentation.netlify.app/docs/22.2/reference/internal-metrics/) pages with note
- (22.3: previously resolved by #1059)

