### PR TITLE
cluster_config: Kerberos support

### DIFF
--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -468,7 +468,7 @@ The location of the Kerberos keytab file for Redpanda.
 
 ### sasl_kerberos_principal
 
-The primary of the Kerberos Service Principal Name (SPN) for Redpanda".
+The primary of the Kerberos Service Principal Name (SPN) for Redpanda.
 
 **Type**: string
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -442,6 +442,68 @@ Internal RPC TCP send buffer size. If `null` (the default value), no buffer size
 
 ---
 
+### sasl_kerberos_config
+
+The location of the Kerberos krb5.conf file for Redpanda.
+
+**Type**: string
+
+**Default**: `/etc/krb5.conf`
+
+**Restart required**: no
+
+---
+
+### sasl_kerberos_keytab
+
+The location of the Kerberos keytab file for Redpanda.
+
+**Type**: string
+
+**Default**: `/var/lib/redpanda/redpanda.keytab`
+
+**Restart required**: no
+
+---
+
+### sasl_kerberos_principal
+
+The primary of the Kerberos Service Principal Name (SPN) for Redpanda".
+
+**Type**: string
+
+**Default**: `redpanda`
+
+**Restart required**: no
+
+---
+
+### sasl_kerberos_principal_mapping
+
+Rules for mapping Kerberos Principal Names to Redpanda User Principals.
+
+**Type**: array of string
+
+**Default**: `["DEFAULT"]`
+
+**Restart required**: no
+
+---
+
+### sasl_mechanisms
+
+A list of supported SASL mechanisms. `SCRAM` and `GSSAPI` are allowed.
+
+**Type**: array of string
+
+**Default**: `["SCRAM"]`
+
+**Valid values**: `"SCRAM"`, `"GSSAPI"`
+
+**Restart required**: no
+
+---
+
 ### target_quota_byte_rate
 
 Target quota byte rate.

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -444,7 +444,7 @@ Internal RPC TCP send buffer size. If `null` (the default value), no buffer size
 
 ### sasl_kerberos_config
 
-The location of the Kerberos krb5.conf file for Redpanda.
+The location of the Kerberos `krb5.conf` file for Redpanda.
 
 **Type**: string
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -480,7 +480,7 @@ The primary of the Kerberos Service Principal Name (SPN) for Redpanda".
 
 ### sasl_kerberos_principal_mapping
 
-Rules for mapping Kerberos Principal Names to Redpanda User Principals.
+Rules for mapping Kerberos principal names to Redpanda user principals.
 
 **Type**: array of string
 


### PR DESCRIPTION
Fix #1172 

Is this the right place to document these? I notice that `kafka_mtls_principal_mapping_rules` and `kafka_enable_authorization` are also missing from here.

Signed-off-by: Ben Pope <ben@redpanda.com>