### PR TITLE
Beta banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,7 +89,7 @@ module.exports = {
           lastVersion: '22.3',
           versions: {
             current: {
-              label: 'Beta 🚧',
+              label: '23.1 Beta 🚧',
               banner: 'unreleased',
               path: '/beta'
             },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,7 +89,7 @@ module.exports = {
           lastVersion: '22.3',
           versions: {
             current: {
-              label: '23.1 Beta 🚧',
+              label: '23.1 Beta',
               banner: 'unreleased',
               path: '/beta'
             },

--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -22,7 +22,8 @@ function UnreleasedVersionLabel({siteTitle, versionMetadata}) {
         versionLabel: <b>{versionMetadata.label}</b>,
       }}>
       {
-        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
+        "This is unreleased documentation for {siteTitle} {versionLabel} version. "+{"\n"} +"To provide feedback on {siteTitle} {versionLabel} version, see the announcement in [Redpanda Community](https://redpandacommunity.slack.com/archives/C01AJDUT88N/p1675453479074339)."
+        
       }
     </Translate>
   );
@@ -37,7 +38,7 @@ function UnmaintainedVersionLabel({siteTitle, versionMetadata}) {
         versionLabel: <b>{versionMetadata.label}</b>,
       }}>
       {
-        ''
+        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
       }
     </Translate>
   );

--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -20,10 +20,14 @@ function UnreleasedVersionLabel({siteTitle, versionMetadata}) {
       values={{
         siteTitle,
         versionLabel: <b>{versionMetadata.label}</b>,
+        releaseAnnouncement: (
+           <p>
+            To access a preview and provide feedback, see the announcement in <a href="https://redpandacommunity.slack.com/archives/C01AJDUT88N/p1675453479074339">Redpanda Community</a>.
+          </p>
+        ),
       }}>
       {
-        "This is unreleased documentation for {siteTitle} {versionLabel} version. "+{"\n"} +"To provide feedback on {siteTitle} {versionLabel} version, see the announcement in [Redpanda Community](https://redpandacommunity.slack.com/archives/C01AJDUT88N/p1675453479074339)."
-        
+        'This is unreleased documentation for {siteTitle} {versionLabel} version. {releaseAnnouncement}'
       }
     </Translate>
   );

--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -22,12 +22,12 @@ function UnreleasedVersionLabel({siteTitle, versionMetadata}) {
         versionLabel: <b>{versionMetadata.label}</b>,
         releaseAnnouncement: (
            <p>
-            To access a preview and provide feedback, see the announcement in <a href="https://redpandacommunity.slack.com/archives/C01AJDUT88N/p1675453479074339">Redpanda Community</a>.
+            See the announcement for <b>{versionMetadata.label}</b> in <a href="https://redpandacommunity.slack.com/archives/C01AJDUT88N/p1675453479074339">Redpanda Community</a>.
           </p>
         ),
       }}>
       {
-        'This is unreleased documentation for {siteTitle} {versionLabel} version. {releaseAnnouncement}'
+        'This is unreleased documentation for Redpanda {versionLabel}. {releaseAnnouncement}'
       }
     </Translate>
   );


### PR DESCRIPTION
Updated unreleased (Beta) version banner with version number (23.1) and link to announcement in Redpanda Community.

Preview:
- https://deploy-preview-1184--redpanda-documentation.netlify.app/docs/beta/home/