### PR TITLE
Document group offset retention properties for v23.1

### DIFF
--- a/docs/reference/tunable-properties.mdx
+++ b/docs/reference/tunable-properties.mdx
@@ -826,6 +826,39 @@ Timeout to wait for new members to join a consumer group.
 
 ---
 
+### group_offset_retention_check_ms
+
+Period at which Redpanda checks for expired consumer group offsets.
+
+**Units**: milliseconds
+
+**Default**: 600000 (10 min)
+
+**Restart required**: no
+
+**Related properties**: 
+- [group_offset_retention_sec](#group_offset_retention_sec)
+- [legacy_group_offset_retention_enabled](#legacy_group_offset_retention_enabled)
+
+---
+
+### group_offset_retention_sec
+
+Retention duration of an offset for an empty consumer group. Once elapsed, an offset is considered to be expired and is discarded. If `null`, the property is disabled, and no retention duration is set.
+
+**Units**: seconds
+
+**Default**: 604800 (7 days)
+
+**Restart required**: no
+
+**Related properties**: 
+- [group_offset_retention_check_ms](#group_offset_retention_check_ms)
+- [legacy_group_offset_retention_enabled](#legacy_group_offset_retention_enabled)
+
+
+---
+
 ### group_topic_partitions
 
 Number of partitions in the internal group membership topic.
@@ -995,6 +1028,24 @@ Maximum size of the user-space receive buffer. If `null`, this limit is not appl
 **Range**: [512, 512 KiB]. Must be 4096-byte aligned.
 
 **Restart required**: yes
+
+---
+
+### legacy_group_offset_retention_enabled
+
+Flag to enable group offset retention for upgraded deployments of Redpanda. 
+
+Group offset retention is enabled by default in Redpanda versions 23.1 and later. To enable offset retention after upgrading from a version earlier than 23.1, set this property to `true`.
+
+**Type**: boolean
+
+**Default**: false
+
+**Restart required**: no
+
+**Related properties**: 
+- [group_offset_retention_sec](#group_offset_retention_sec)
+- [group_offset_retention_check_ms](#group_offset_retention_check_ms)
 
 ---
 

--- a/docs/reference/tunable-properties.mdx
+++ b/docs/reference/tunable-properties.mdx
@@ -844,7 +844,11 @@ Period at which Redpanda checks for expired consumer group offsets.
 
 ### group_offset_retention_sec
 
-Retention duration of an offset for an empty consumer group. Once elapsed, an offset is considered to be expired and is discarded. If `null`, the property is disabled, and no retention duration is set.
+The retention duration of consumer group offsets. Redpanda identifies offsets that are expired, based on this retention duration, and removes them to reclaim storage. For a consumer group, the retention timeout starts from when the group becomes empty by losing all its consumers; for a standalone consumer, the retention timeout starts from the time of the last commit. Once elapsed, an offset is considered to be expired and is discarded. 
+
+Redpanda periodically checks for expired offsets at the rate set by [group_offset_retention_check_ms](#group_offset_retention_check_ms). 
+
+If `null`, the automatic offset retention feature is disabled.
 
 **Units**: seconds
 
@@ -855,7 +859,6 @@ Retention duration of an offset for an empty consumer group. Once elapsed, an of
 **Related properties**: 
 - [group_offset_retention_check_ms](#group_offset_retention_check_ms)
 - [legacy_group_offset_retention_enabled](#legacy_group_offset_retention_enabled)
-
 
 ---
 
@@ -1033,9 +1036,15 @@ Maximum size of the user-space receive buffer. If `null`, this limit is not appl
 
 ### legacy_group_offset_retention_enabled
 
-Flag to enable group offset retention for upgraded deployments of Redpanda. 
+With group offset retention enabled by default starting in Redpanda version 23.1, this flag enables group offset retention for deployments of Redpanda upgraded from earlier versions. 
 
-Group offset retention is enabled by default in Redpanda versions 23.1 and later. To enable offset retention after upgrading from a version earlier than 23.1, set this property to `true`.
+For Redpanda versions **23.1 and later**, this flag has no effect.
+
+For Redpanda versions **earlier than 23.1**: 
+- In upgraded clusters, to enable group offset retention, both this flag must be `true` and [group_offset_retention_check_ms](#group_offset_retention_check_ms) must be non-null.
+- When legacy group offset retention is enabled:
+  - Only offsets that were committed or updated following the upgrade to 23.1 or later will be automatically collected. Offsets that were committed prior to upgrading to 23.1 or later will never be automatically deleted, and instead need to be manually removed using the Offset Delete API.
+  - The age of an offset is calculated based on when it was committed.
 
 **Type**: boolean
 

--- a/docs/reference/tunable-properties.mdx
+++ b/docs/reference/tunable-properties.mdx
@@ -1044,7 +1044,7 @@ For Redpanda versions **earlier than 23.1**:
 - In upgraded clusters, to enable group offset retention, both this flag must be `true` and [group_offset_retention_check_ms](#group_offset_retention_check_ms) must be non-null.
 - When legacy group offset retention is enabled:
   - Only offsets that were committed or updated following the upgrade to 23.1 or later will be automatically collected. Offsets that were committed prior to upgrading to 23.1 or later will never be automatically deleted, and instead need to be manually removed using the Offset Delete API.
-  - The age of an offset is calculated based on when it was committed.
+  - The age of an offset is calculated based on when it was committed (including commits prior to upgrading Redpanda), rather than when this flag was enabled. 
 
 **Type**: boolean
 

--- a/docs/reference/tunable-properties.mdx
+++ b/docs/reference/tunable-properties.mdx
@@ -1044,7 +1044,7 @@ For Redpanda versions **earlier than 23.1**:
 - In upgraded clusters, to enable group offset retention, this flag must be `true` and [group_offset_retention_check_ms](#group_offset_retention_check_ms) must be non-null.
 - When legacy group offset retention is enabled:
   - Only offsets that were committed or updated following the upgrade to 23.1 or later will be automatically collected. Offsets that were committed prior to upgrading to 23.1 or later will never be automatically deleted, and instead need to be manually removed using the Offset Delete API.
-  - The age of an offset is calculated based on when it was committed (including commits prior to upgrading Redpanda), rather than when this flag was enabled. 
+  - The age of an offset is calculated based on when it was committed rather than when this flag was enabled. 
 
 **Type**: boolean
 

--- a/docs/reference/tunable-properties.mdx
+++ b/docs/reference/tunable-properties.mdx
@@ -1041,7 +1041,7 @@ With group offset retention enabled by default starting in Redpanda version 23.1
 For Redpanda versions **23.1 and later**, this flag has no effect.
 
 For Redpanda versions **earlier than 23.1**: 
-- In upgraded clusters, to enable group offset retention, both this flag must be `true` and [group_offset_retention_check_ms](#group_offset_retention_check_ms) must be non-null.
+- In upgraded clusters, to enable group offset retention, this flag must be `true` and [group_offset_retention_check_ms](#group_offset_retention_check_ms) must be non-null.
 - When legacy group offset retention is enabled:
   - Only offsets that were committed or updated following the upgrade to 23.1 or later will be automatically collected. Offsets that were committed prior to upgrading to 23.1 or later will never be automatically deleted, and instead need to be manually removed using the Offset Delete API.
   - The age of an offset is calculated based on when it was committed (including commits prior to upgrading Redpanda), rather than when this flag was enabled. 


### PR DESCRIPTION
Review deadline: Fri Feb 10

Fixes:
- #1076 

Preview: 
- [New tunable properties](https://deploy-preview-1190--redpanda-documentation.netlify.app/docs/beta/reference/tunable-properties/#group_offset_retention_check_ms)

