### PR TITLE
Document missing tunable and cluster properties in 23.1

### DIFF
--- a/docs/manage/schema-registry.mdx
+++ b/docs/manage/schema-registry.mdx
@@ -48,6 +48,8 @@ Redpanda built the schema registry directly into the Redpanda binary. The schema
 
 Every broker allows mutating REST calls, so there is no need to configure leadership or failover strategies. Schema are stored in a compacted topic, and the registry uses optimistic concurrency control at the topic level to detect and avoid collisions.
 
+Schema registry publishes its records' metadata to an internal topic, `_schemas`, as its backend store. By default, `_schemas` is protected from deletion and configuration changes by Kafka clients (see the [kafka_nodelete_topics](../../reference/cluster-properties#kafka_nodelete_topics) cluster property).
+
 ## Use schema registry
 
 The following examples cover the basic functionality of the Redpanda schema registry based on an example Avro schema called `sensor_sample`. This schema contains fields that represent a measurement from a sensor for the value of the `sensor` topic, as defined below.

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -541,7 +541,8 @@ A list of topics that are protected from deletion and configuration changes by K
 **Restart required**: no
 
 **Related topics**:
-- [Consumer offsets](../../develop/consume-data/consumer-offsets)
+- [Consumer Offsets](../../develop/consume-data/consumer-offsets)
+- [Schema Registry](../../manage/schema-registry)
 
 ---
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -292,7 +292,7 @@ Enable rack-aware replica assignment.
 Mode of [partition balancing](../../manage/cluster-maintenance/cluster-balancing#partition-balancing) for a cluster.
 
 Available modes:
-- `node_add`: partition balancing happens when a node is added
+- `node_add`: partition balancing happens when a node is added.
 - `continuous`: partition balancing happens automatically to maintain optimal performance and availability, based on continuous monitoring for node failures and high disk usage. This option requires an [Enterprise license](../../get-started/licenses).  
 - `off`: partition balancing is disabled. This option is not recommended for production clusters.
 
@@ -316,7 +316,7 @@ When a node is unavailable for at least this timeout duration, it triggers Redpa
 
 ### partition_autobalancing_max_disk_usage_percent
 
-When the disk usage of a node exceeds this threshold, it triggers Redpanda to moving partitions off of the node.
+When the disk usage of a node exceeds this threshold, it triggers Redpanda to move partitions off of the node.
 
 **Units**: percent of disk used
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -330,7 +330,7 @@ When the disk usage of a node exceeds this threshold, it triggers Redpanda to mo
 
 ### kafka_admin_topic_api_rate
 
-Target quota rate for partition mutations per [default_window_sec](../tunable-properties#default_window_sec). It's an optional property; if `null`, the property is disabled.
+Target quota rate for partition mutations per [default_window_sec](../tunable-properties#default_window_sec). If `null`, the property is disabled, and no quota rate is applied.
 
 **Units**: partition mutations per default_window_second
 
@@ -860,7 +860,7 @@ Target quota byte rate.
 
 ### target_fetch_quota_byte_rate
 
-Target fetch-size quota byte rate. It's an optional property; if `null`, the property is disabled.
+Target fetch-size quota byte rate. If `null`, the property is disabled, and no quota byte rate is applied.
 
 **Units**: bytes per second
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -534,19 +534,22 @@ Principal mapping rules for mTLS authentication on the Kafka API. If `null`, the
 
 ### kafka_nodelete_topics
 
-A list of topics that are not deleted by the Kafka API. Set by default to a list of Redpanda internal topics.
+A list of topics that are protected from deletion and configuration changes by Kafka clients. Set by default to a list of Redpanda internal topics.
 
-**Default**: {"__audit", "__consumer_offsets", "__redpanda_e2e_probe", "__schemas"}
+**Default**: `['__audit', '__consumer_offsets', '__redpanda_e2e_probe', '__schemas']`
 
 **Restart required**: no
+
+**Related topics**:
+- [Consumer offsets](../../develop/consume-data/consumer-offsets)
 
 ---
 
 ### kafka_noproduce_topics
 
-A list of topics that have no messages produced to them by the Kafka API. Set by default to a list of Redpanda internal topics.
+A list of topics that are protected from being produced to by Kafka clients. Set by default to a list of Redpanda internal topics.
 
-**Default**: {"__audit"}
+**Default**: `['__audit']`
 
 **Restart required**: no
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -522,7 +522,7 @@ Kafka group recovery timeout.
 
 ---
 
-## kafka_mtls_principal_mapping_rules
+### kafka_mtls_principal_mapping_rules
 
 Principal mapping rules for mTLS authentication on the Kafka API. If `null`, the property is disabled.
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -44,6 +44,51 @@ List of superuser usernames.
 
 ## Cloud storage properties
 
+
+### cloud_storage_azure_storage_account
+
+The name of the Azure storage account to use with Tiered Storage. If `null`, the property is disabled.
+
+**Type**: string
+
+**Default**: null
+
+**Restart required**: yes
+
+---
+
+### cloud_storage_azure_container
+
+The name of the Azure container to use with Tiered Storage. If `null`, the property is disabled.
+
+:::note
+The container must belong to [cloud_storage_azure_storage_account](#cloud_storage_azure_storage_account).
+:::
+
+**Type**: string
+
+**Default**: null
+
+**Restart required**: yes
+
+---
+
+### cloud_storage_azure_shared_key
+
+The shared key to be used for Azure Shared Key authentication with the Azure storage account configured by [cloud_storage_azure_storage_account](#cloud_storage_azure_storage_account).  If `null`, the property is disabled.
+
+:::note
+Redpanda expects this key string to be Base64 encoded.
+:::
+
+**Type**: string
+
+**Default**: null
+
+**Restart required**: yes
+
+---
+
 ### cloud_storage_access_key
 
 AWS or GCP access key.
@@ -206,6 +251,18 @@ Enable automatic partition rebalancing when new nodes are added.
 
 ---
 
+### enable_controller_log_rate_limiting
+
+Flag to enable limiting the write rate for the controller log.
+
+**Type**: boolean
+
+**Default**: false
+
+**Restart required**: no
+
+---
+
 ### enable_leader_balancer
 
 Enable automatic leadership rebalancing.
@@ -228,9 +285,96 @@ Enable rack-aware replica assignment.
 
 **Restart required**: no
 
+---
+
+### partition_autobalancing_mode
+
+Mode of [partition balancing](../../manage/cluster-maintenance/cluster-balancing#partition-balancing) for a cluster.
+
+Available modes:
+- `node_add`: partition balancing happens when a node is added
+- `continuous`: partition balancing happens automatically to maintain optimal performance and availability, based on continuous monitoring for node failures and high disk usage. This option requires an [Enterprise license](../../get-started/licenses).  
+- `off`: partition balancing is disabled. This option is not recommended for production clusters.
+
+**Default**: `node_add`
+
+**Restart required**: no
+
+---
+
+### partition_autobalancing_node_availability_timeout_sec
+
+When a node is unavailable for at least this timeout duration, it triggers Redpanda to move partitions off of the node.
+
+**Units**: seconds
+
+**Default**: 900 (15 min)
+
+**Restart required**: no
+
+---
+
+### partition_autobalancing_max_disk_usage_percent
+
+When the disk usage of a node exceeds this threshold, it triggers Redpanda to moving partitions off of the node.
+
+**Units**: percent of disk used
+
+**Default**: 80
+
+**Range**: [5, 100]
+
 -------------------------------------------------------------------------------
 
 ## Kafka API properties
+
+### kafka_admin_topic_api_rate
+
+Target quota rate for partition mutations per [default_window_sec](../tunable-properties#default_window_sec). It's an optional property; if `null`, the property is disabled.
+
+**Units**: partition mutations per default_window_second
+
+**Default**: null
+
+**Range**: [1, ...]
+
+**Restart required**: no
+
+---
+
+### kafka_client_group_byte_rate_quota
+
+A map specifying the produce-rate quota per client group. 
+
+The keys of the map:
+- `group_name`: name of a client group
+- `clients_prefix`: prefix to prepend to the name of each client belonging to the group specified by `group_name`
+- `quota`: produce-rate quota, in bytes per second
+
+An example: `([{'group_name': 'first_group','clients_prefix': 'group_1','quota': 10240}])`
+
+**Default**: {} (empty map)
+
+**Restart required**: no
+
+---
+
+### kafka_client_group_fetch_byte_rate_quota
+
+A map specifying the fetch-rate quota per client group. 
+
+The keys of the map:
+- `group_name`: name of a client group
+- `clients_prefix`: prefix to prepend to the name of each client belonging to the group specified by `group_name`
+- `quota`: fetch-rate quota, in bytes per second
+
+An example: `([{'group_name': 'first_group','clients_prefix': 'group_1','quota': 10240}])`
+
+**Default**: {} (empty map)
+
+**Restart required**: no
+
+---
 
 ### enable_idempotence
 
@@ -352,6 +496,20 @@ Maximum number of Kafka client connections per IP address, per broker. If `null`
 
 ---
 
+### kafka_enable_authorization
+
+Flag to require authorization for Kafka connections. If `null`, the property is disabled, and authorization is instead enabled by [enable_sasl](#enable_sasl). 
+
+**Type**: boolean
+
+**Default**: null
+
+**Related properties**:
+- [enable_sasl](#enable_sasl)
+- `kafka_api[].authentication_method`
+
+---
+
 ### kafka_group_recovery_timeout_ms
 
 Kafka group recovery timeout.
@@ -359,6 +517,36 @@ Kafka group recovery timeout.
 **Units**: milliseconds
 
 **Default**: 30000 (30 sec)
+
+**Restart required**: no
+
+---
+
+## kafka_mtls_principal_mapping_rules
+
+Principal mapping rules for mTLS authentication on the Kafka API. If `null`, the property is disabled. Replaces `kafka_api_tls.principal_mapping_rules` of Redpanda versions earlier than v22.2.1. 
+
+**Default**: null
+
+**Restart required**: no
+
+---
+
+### kafka_nodelete_topics
+
+A list of topics that are not deleted by the Kafka API. Set by default to a list of Redpanda internal topics.
+
+**Default**: {"__audit", "__consumer_offsets", "__redpanda_e2e_probe", "__schemas"}
+
+**Restart required**: no
+
+---
+
+### kafka_noproduce_topics
+
+A list of topics that have no messages produced to them by the Kafka API. Set by default to a list of Redpanda internal topics.
+
+**Default**: {"__audit"}
 
 **Restart required**: no
 
@@ -458,6 +646,31 @@ Time window used to average the current throughput measurement for the quota bal
 **Range**: [1, ...]
 
 **Restart required**: no
+
+---
+
+
+### kafka_rpc_server_tcp_recv_buf
+
+Size of the Kafka server TCP receive buffer. If `null`, the property is disabled.
+
+**Units**: bytes
+
+**Default**: null
+
+**Range**: [32 KiB, ...], aligned to 4096 bytes
+
+---
+
+### kafka_rpc_server_tcp_send_buf
+
+Size of the Kafka server TCP transmit buffer. If `null`, the property is disabled.
+
+**Units**: bytes
+
+**Default**: null
+
+**Range**: [32 KiB, ...], aligned to 4096 bytes
 
 ---
 
@@ -639,6 +852,18 @@ Target quota byte rate.
 
 **Restart required**: no
 
+---
+
+### target_fetch_quota_byte_rate
+
+Target fetch-size quota byte rate. It's an optional property; if `null`, the property is disabled.
+
+**Units**: bytes per second
+
+**Default**: null
+
+**Restart required**: no
+
 -------------------------------------------------------------------------------
 
 ## Metrics properties
@@ -762,6 +987,30 @@ Default timestamp type for topic messages (CreateTime or LogAppendTime).
 **Default**: `CreateTime`
 
 **Valid values**: `CreateTime`, `LogAppendTime`
+
+**Restart required**: no
+
+---
+
+### retention_local_target_bytes_default
+
+Local retention size target for partitions of topics with cloud storage write enabled. If `null`, the property is disabled.
+
+**Units**: bytes
+
+**Default**: null
+
+**Restart required**: no
+
+---
+
+### retention_local_target_ms_default
+
+Local retention time target for partitions of topics with cloud storage write enabled.
+
+**Units**: milliseconds
+
+**Default**: 86400000 (24 hours)
 
 **Restart required**: no
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -1001,7 +1001,7 @@ Default timestamp type for topic messages (CreateTime or LogAppendTime).
 Local retention size target for partitions of topics with cloud storage write enabled. If `null`, the property is disabled.
 
 :::note
-Both `retention_local_target_bytes_default` and `retention_local_target_ms_default` can be set, and the  limit that is reached earlier is applied.
+Both `retention_local_target_bytes_default` and `retention_local_target_ms_default` can be set. The limit that is reached earlier is applied.
 :::
 
 **Units**: bytes
@@ -1019,7 +1019,7 @@ Both `retention_local_target_bytes_default` and `retention_local_target_ms_defau
 Local retention time target for partitions of topics with cloud storage write enabled.
 
 :::note
-Both `retention_local_target_bytes_default` and `retention_local_target_ms_default` can be set, and the  limit that is reached earlier is applied.
+Both `retention_local_target_bytes_default` and `retention_local_target_ms_default` can be set. The limit that is reached earlier is applied.
 :::
 
 **Units**: milliseconds

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -524,7 +524,7 @@ Kafka group recovery timeout.
 
 ## kafka_mtls_principal_mapping_rules
 
-Principal mapping rules for mTLS authentication on the Kafka API. If `null`, the property is disabled. Replaces `kafka_api_tls.principal_mapping_rules` of Redpanda versions earlier than v22.2.1. 
+Principal mapping rules for mTLS authentication on the Kafka API. If `null`, the property is disabled.
 
 **Default**: null
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -1000,11 +1000,17 @@ Default timestamp type for topic messages (CreateTime or LogAppendTime).
 
 Local retention size target for partitions of topics with cloud storage write enabled. If `null`, the property is disabled.
 
+:::note
+Both `retention_local_target_bytes_default` and `retention_local_target_ms_default` can be set, and the  limit that is reached earlier is applied.
+:::
+
 **Units**: bytes
 
 **Default**: null
 
 **Restart required**: no
+
+**Related properties**: [retention_local_target_ms_default](#retention_local_target_ms_default)
 
 ---
 
@@ -1012,11 +1018,17 @@ Local retention size target for partitions of topics with cloud storage write en
 
 Local retention time target for partitions of topics with cloud storage write enabled.
 
+:::note
+Both `retention_local_target_bytes_default` and `retention_local_target_ms_default` can be set, and the  limit that is reached earlier is applied.
+:::
+
 **Units**: milliseconds
 
 **Default**: 86400000 (24 hours)
 
 **Restart required**: no
+
+**Related properties**: [retention_local_target_bytes_default](#retention_local_target_bytes_default)
 
 ---
 

--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -536,7 +536,7 @@ Principal mapping rules for mTLS authentication on the Kafka API. If `null`, the
 
 A list of topics that are protected from deletion and configuration changes by Kafka clients. Set by default to a list of Redpanda internal topics.
 
-**Default**: `['__audit', '__consumer_offsets', '__redpanda_e2e_probe', '__schemas']`
+**Default**: `['__audit', '__consumer_offsets', '__redpanda_e2e_probe', '_schemas']`
 
 **Restart required**: no
 

--- a/docs/reference/tunable-properties.mdx
+++ b/docs/reference/tunable-properties.mdx
@@ -108,6 +108,18 @@ Interval for cloud storage housekeeping tasks.
 
 ---
 
+### cloud_storage_idle_timeout_ms
+
+Timeout used to detect idle state of the cloud storage API. If no API requests are made for at least this timeout's duration, the cloud storage is considered idle.
+
+**Units**: milliseconds
+
+**Default**: 10000 (10 sec)
+
+**Restart required**: no
+
+---
+
 ### cloud_storage_initial_backoff_ms
 
 Initial backoff time for exponential backoff algorithm.
@@ -224,6 +236,18 @@ Interval at which the archival service runs reconciliation.
 
 ---
 
+### cloud_storage_recovery_temporary_retention_bytes_default
+
+The number of bytes of size-based retention for topics that are created during automated recovery of topics from cloud storage.
+
+**Units**: bytes
+
+**Default**: 1073741824 (1 GiB)
+
+**Restart required**: no
+
+---
+
 ### cloud_storage_segment_max_upload_interval_sec
 
 Duration that a segment can be kept in local storage without uploading it to remote storage. If `null`, defaults to infinite duration.
@@ -233,6 +257,30 @@ Duration that a segment can be kept in local storage without uploading it to rem
 **Default**: null (infinite duration)
 
 **Restart required**: yes
+
+---
+
+### cloud_storage_segment_size_target
+
+The desired segment size in cloud storage. If `null`, the property is disabled, and the segment size in cloud storage defaults to `segment.bytes`.
+
+**Units**: bytes
+
+**Default**: null
+
+**Restart required**: no
+
+---
+
+### cloud_storage_segment_size_min
+
+The minimum segment size in cloud storage. If `null`, the property is disabled, and the minimum segment size defaults to [cloud_storage_segment_size_target](#cloud_storage_segment_size_target)/2.
+
+**Units**: bytes
+
+**Default**: null
+
+**Restart required**: no
 
 ---
 
@@ -407,6 +455,20 @@ Maximum capacity of accumulated requests for the cluster controller's node manag
 **Restart required**: no
 
 **Related properties**: [rps_limit_node_management_operations](#rps_limit_node_management_operations) 
+
+---
+
+### controller_log_accummulation_rps_capacity_topic_operations
+
+Maximum capacity of accumulated requests for the cluster controller's topic management operations. If `null`, no maximum capacity is applied.
+
+**Type**: unsigned integer
+
+**Units**: number of requests
+
+**Default**: null
+
+**Restart required**: no
 
 ---
 
@@ -1811,6 +1873,18 @@ Target bytes to replay from disk on startup after a clean shutdown. Controls the
 **Default**: 10737418240 (10 GiB)
 
 **Range**: [128 MiB, 1 TiB]
+
+**Restart required**: no
+
+---
+
+### tx_log_stats_interval_s
+
+Period for which to log transmit (tx) statistics per partition.  Requires the tx logger's log-level to be at least `debug`.
+
+**Units**: seconds
+
+**Default**: 10
 
 **Restart required**: no
 


### PR DESCRIPTION
Review deadline: Tue Feb 14

Fixes:
- #1072 
- #1188 

Previews:
- Added rest of the [tunable properties](https://deploy-preview-1203--redpanda-documentation.netlify.app/docs/reference/tunable-properties/) and [cluster properties](https://deploy-preview-1203--redpanda-documentation.netlify.app/docs/reference/cluster-properties/) that are new in 23.1 or were previously supported but undocumented.

