### PR TITLE
vpc-peering: add matching region requirements

### DIFF
--- a/docs/deploy/deployment-option/cloud/vpc-peering.mdx
+++ b/docs/deploy/deployment-option/cloud/vpc-peering.mdx
@@ -17,7 +17,8 @@ When you select a network for deploying your Redpanda Dedicated cluster, you hav
 
 ## Prerequisites
 
-Before you set up a peering connection in the Redpanda Cloud UI, you must have a VPC for Redpanda's VPC to connect to. If you do not already have a VPC, log in to the AWS VPC Console and create one.
+* **VPC network** - Before you set up a peering connection in the Redpanda Cloud UI, you must have a VPC in your own account for Redpanda's VPC to connect to. If you do not already have a VPC, log in to the AWS VPC Console and create one.
+* **Matching Region** - VPC peering connections can only be established between your and Redpanda VPC networks created in the **same region**. We don't support Inter-Region VPC peering connections.
 
 :::tip
 Consider adding `rp` at the beginning of the VPC name to indicate that this VPC is for deploying a Redpanda cluster.

--- a/versioned_docs/version-22.2/cloud/vpc-peering.mdx
+++ b/versioned_docs/version-22.2/cloud/vpc-peering.mdx
@@ -18,7 +18,8 @@ When you select a network for deploying your Redpanda Dedicated cluster, you hav
 
 ## Prerequisites
 
-Before you set up a peering connection in the Redpanda Cloud UI, you must have a VPC for Redpanda's VPC to connect to. If you do not already have a VPC, log in to the AWS VPC Console and create one.
+* **VPC network** - Before you set up a peering connection in the Redpanda Cloud UI, you must have a VPC in your own account for Redpanda's VPC to connect to. If you do not already have a VPC, log in to the AWS VPC Console and create one.
+* **Matching Region** - VPC peering connections can only be established between your and Redpanda VPC networks created in the **same region**. We don't support Inter-Region VPC peering connections.
 
 :::tip
 Consider adding `rp` at the beginning of the VPC name to indicate that this VPC is for deploying a Redpanda cluster.

--- a/versioned_docs/version-22.3/deploy/deployment-option/cloud/vpc-peering.mdx
+++ b/versioned_docs/version-22.3/deploy/deployment-option/cloud/vpc-peering.mdx
@@ -18,7 +18,7 @@ When you select a network for deploying your Redpanda Dedicated cluster, you hav
 ## Prerequisites
 
 * **VPC network** - Before you set up a peering connection in the Redpanda Cloud UI, you must have a VPC in your own account for Redpanda's VPC to connect to. If you do not already have a VPC, log in to the AWS VPC Console and create one.
-* **Matching Region** - VPC peering connection can only be established between your and Redpanda VPC networks created in the **same region**. We don't support Inter-Region VPC peering connections.
+* **Matching Region** - VPC peering connections can only be established between your and Redpanda VPC networks created in the **same region**. We don't support Inter-Region VPC peering connections.
 
 :::tip
 Consider adding `rp` at the beginning of the VPC name to indicate that this VPC is for deploying a Redpanda cluster.

--- a/versioned_docs/version-22.3/deploy/deployment-option/cloud/vpc-peering.mdx
+++ b/versioned_docs/version-22.3/deploy/deployment-option/cloud/vpc-peering.mdx
@@ -17,7 +17,8 @@ When you select a network for deploying your Redpanda Dedicated cluster, you hav
 
 ## Prerequisites
 
-Before you set up a peering connection in the Redpanda Cloud UI, you must have a VPC for Redpanda's VPC to connect to. If you do not already have a VPC, log in to the AWS VPC Console and create one.
+* **VPC network** - Before you set up a peering connection in the Redpanda Cloud UI, you must have a VPC in your own account for Redpanda's VPC to connect to. If you do not already have a VPC, log in to the AWS VPC Console and create one.
+* **Matching Region** - VPC peering connection can only be established between your and Redpanda VPC networks created in the **same region**. We don't support Inter-Region VPC peering connections.
 
 :::tip
 Consider adding `rp` at the beginning of the VPC name to indicate that this VPC is for deploying a Redpanda cluster.


### PR DESCRIPTION
VPC peering connection can only be created between customer's and Redpanda VPC networks residing in the same region. Add this information to the prerequisities section of the VPC peering doc.

Ref: https://github.com/redpanda-data/cloudv2/issues/4396