### PR TITLE
[Draft] Suggested improvements to docs/home page and hero section

### DIFF
--- a/docs/home/homepage.js
+++ b/docs/home/homepage.js
@@ -43,7 +43,7 @@ const FeatureList = [
     image: require('../../static/img/console-icon.png').default,
     description: (
       <>
-        Use the Redpanda Console dashboard to administer clusters and get visibility into your data streams.
+         Administer clusters and explore data streams with the Redpanda Console dashboard.
       </>
     ),
     url: '/docs/get-started/quick-start/quick-start-docker',
@@ -139,17 +139,23 @@ const FooterMenuList = [
 
 export default function HomepageFeatures() {
   return (
+    <>
+    <section className={styles.banner}>
+    </section>
     <section className={styles.features}>
-      <Grid gap="2rem" minWidth="300px" title='Most Visited'>
+      <Grid gap="1rem" minWidth="300px" >
         {FeatureList.map((props, idx) => (
           <Feature key={idx} {...props} />
         ))}
       </Grid>
+    </section>
+    <section className={styles.highlights}>
       <Grid gap="3.85rem" minWidth="175px" title='Highlights'>
         {FooterMenuList.map((props, idx) => (
           <FooterMenu key={idx} {...props} />
         ))}
       </Grid>
-    </section >
+    </section>
+    </>
   );
 }

--- a/docs/home/homepage.module.css
+++ b/docs/home/homepage.module.css
@@ -2,7 +2,19 @@
 
 .features {
   display: flex;
-  align-items: center;
+  align-items: left;
+  padding: 0 0;
+  width: 100%;
+  flex-direction: column;
+}
+
+.features h2 {
+  margin: 0;
+}
+
+.highlights {
+  display: flex;
+  align-items: left;
   padding: 2rem 0;
   width: 100%;
   flex-direction: column;

--- a/docs/home/index.mdx
+++ b/docs/home/index.mdx
@@ -7,7 +7,7 @@ pagination_prev: null
 
 <head>
     <meta name="title" content="Redpanda Documentation"/>
-    <meta name="description" content="Redpanda Documentation"/>
+    <meta name="description" content="Learn concepts, follow guides, and lookup references in developer documentation for Redpanda Data."/>
 </head>
 
 import Homepage from './homepage';

--- a/src/components/Feature.module.css
+++ b/src/components/Feature.module.css
@@ -7,9 +7,7 @@ a.featureLink:hover h2,
 a.featureLink:focus h2 {
   text-decoration: underline;
 }
-a.featureLink:hover .featureBox {
-  border-color: var(--ifm-color-emphasis-600);
-}
+
 
 /* Component styles */
 .featureBox {
@@ -26,6 +24,19 @@ a.featureLink:hover .featureBox {
   padding: 1rem;
   align-content: flex-start;
   transition: 100ms ease all;
+  box-shadow: 0px 2px 4px 0 rgba(0, 0, 0, 0.2);
+}
+
+.featureBox p {
+  margin-bottom: 1rem;
+}
+
+.featureBox:hover {
+  box-shadow: 0px 3px 6px 0 rgba(0, 0, 0, 0.5);
+}
+
+.featureBox:active {
+  box-shadow: 0px 0px 0px 0 rgba(0, 0, 0, 0.2);
 }
 
 .featureImage {

--- a/src/components/FooterMenu.module.css
+++ b/src/components/FooterMenu.module.css
@@ -1,6 +1,12 @@
-div.MenuContainer {
+[data-theme='light'] div.MenuContainer {
     padding: 2rem;
     background: #F9FAFB;
+    box-shadow: 0px 3px 3px 0 rgba(0, 0, 0, 0.3);
+}
+
+[data-theme='dark'] div.MenuContainer {
+    padding: 2rem;
+    background: #3a3a3a;
 }
 
 ul.MenuList {

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -7,8 +7,8 @@ export default function Grid({
   children,
 }) {
   return (
-    <div className='container' style={{
-      'margin-top': '2.5rem',
+    <div style={{
+      'margin-top': '0.5rem',
     }}>
       <h2>{title}</h2>
       <div className="grid" style={{

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -471,3 +471,11 @@ h5 {
 [class*=iconExternalLink] {
   display: none;
 }
+
+.markdown h1 {
+  font-size: 2.4em;
+}
+
+.markdown h1:first-child {
+  margin-bottom: 0.7rem;
+}

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -195,6 +195,11 @@ export default function DocItemLayout({ children }) {
   const { editUrl } = metadata;
   const [show, setShow] = useState(false);
   const [positiveFeedback, setPositiveFeedback] = useState(true);
+  let isDocsHome = false
+  if(typeof window !== 'undefined') {
+    const docsHomeUrlPattern = /\/docs\/[A-Za-z0-9.\/]*home/
+    isDocsHome = docsHomeUrlPattern.test(window.location.href);
+  }
   // Hide the feedback thumbs in the Toc when the user reaches the bottom of the page.
   useEffect(() => {
     document.addEventListener('scroll', function(e){
@@ -217,8 +222,8 @@ export default function DocItemLayout({ children }) {
         <DocVersionBanner />
         <div className={styles.docItemContainer}>
           <article>
-            <DocBreadcrumbs />
-            <DocVersionBadge />
+            {!isDocsHome && <DocBreadcrumbs />}
+            {!isDocsHome && <DocVersionBadge />}
             {docTOC.mobile}
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />

--- a/versioned_docs/version-22.3/home/homepage.js
+++ b/versioned_docs/version-22.3/home/homepage.js
@@ -43,7 +43,7 @@ const FeatureList = [
     image: require('../../../static/img/console-icon.png').default,
     description: (
       <>
-        Use the Redpanda Console dashboard to administer clusters and get visibility into your data streams.
+        Administer clusters and explore data streams with the Redpanda Console dashboard.
       </>
     ),
     url: '/docs/get-started/quick-start/quick-start-docker',
@@ -139,17 +139,21 @@ const FooterMenuList = [
 
 export default function HomepageFeatures() {
   return (
+    <>
     <section className={styles.features}>
-      <Grid gap="2rem" minWidth="300px" title='Most Visited'>
+      <Grid gap="2rem" minWidth="300px">
         {FeatureList.map((props, idx) => (
           <Feature key={idx} {...props} />
         ))}
       </Grid>
+    </section>
+    <section className={styles.highlights}>
       <Grid gap="3.85rem" minWidth="175px" title='Highlights'>
         {FooterMenuList.map((props, idx) => (
           <FooterMenu key={idx} {...props} />
         ))}
       </Grid>
     </section >
+    </>
   );
 }

--- a/versioned_docs/version-22.3/home/homepage.module.css
+++ b/versioned_docs/version-22.3/home/homepage.module.css
@@ -2,8 +2,20 @@
 
 .features {
   display: flex;
-  align-items: center;
-  padding: 2rem 0;
+  align-items: left;
+  padding: 0 0;
+  width: 100%;
+  flex-direction: column;
+}
+
+.features h2 {
+  margin: 0;
+}
+
+.highlights {
+  display: flex;
+  align-items: left;
+  padding: 1rem 0;
   width: 100%;
   flex-direction: column;
 }

--- a/versioned_docs/version-22.3/home/index.mdx
+++ b/versioned_docs/version-22.3/home/index.mdx
@@ -7,7 +7,7 @@ pagination_prev: null
 
 <head>
     <meta name="title" content="Redpanda Documentation"/>
-    <meta name="description" content="Redpanda Documentation"/>
+    <meta name="description" content="Learn concepts, follow guides, and lookup references in developer documentation for Redpanda Data."/>
 </head>
 
 import Homepage from './homepage';


### PR DESCRIPTION
[Draft PR, Do Not Merge, Comments Welcomed]

Implemented suggestions to improve look-and-feel of the new Docs home landing pages:
- Minimized non-interactive elements: removed white-space margins, reduced title font size, removed breadcrumbs and version label.
- Left-aligned title and tiles.
- Changed dark-mode background-color of Highlights tiles.
- Added shadows to tiles.
- Edited tile text.

Preview:
- https://deploy-preview-1214--redpanda-documentation.netlify.app/