### PR TITLE
docs:#1218 update ABS feedback from Beta 

### DIFF
--- a/docs/manage/tiered-storage.mdx
+++ b/docs/manage/tiered-storage.mdx
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 :::info
-This feature requires an [Enterprise license](../../get-started/licenses). To upgrade, contact [Redpanda sales](https://redpanda.com/try-redpanda?section=enterprise-cloud).
+This feature requires an [Enterprise license](../../get-started/licenses). To upgrade, contact [Redpanda sales](https://redpanda.com/try-redpanda?section=enterprise-trial).
 :::
 
 Tiered Storage helps to lower storage costs by offloading log segments to cloud storage. You can specify the amount of storage you want to retain in local storage. You don't need to specify which log segments you want to move, because Redpanda moves them automatically based on cluster-level configuration properties. Tiered Storage indexes where data is offloaded, so it can retrieve the data when you need it.

--- a/docs/manage/tiered-storage.mdx
+++ b/docs/manage/tiered-storage.mdx
@@ -16,7 +16,7 @@ This feature requires an [Enterprise license](../../get-started/licenses). To up
 
 Tiered Storage helps to lower storage costs by offloading log segments to cloud storage. You can specify the amount of storage you want to retain in local storage. You don't need to specify which log segments you want to move, because Redpanda moves them automatically based on cluster-level configuration properties. Tiered Storage indexes where data is offloaded, so it can retrieve the data when you need it.
 
-Redpanda natively supports Tiered Storage with Amazon S3, Google Cloud Storage (GCS), and Microsoft Azure Blob Storage (ABS). 
+Redpanda natively supports Tiered Storage with Amazon S3, Google Cloud Storage (GCS), and Microsoft Azure Blob Storage (ABS). Migrating topics from one cloud provider to another is not supported. 
 
 :::caution
 Do not use Tiered Storage with [data transforms](../../labs/data-transform), which is a lab feature in technical preview. Lab features are not supported for production usage.
@@ -125,12 +125,10 @@ To configure access to Azure Blob Storage with shared keys:
    cloud_storage_azure_storage_account: <azure_account_name>
    cloud_storage_azure_container: <redpanda_container_name>
    ```
-   Replace `<variables>` with your own values.
-
+   Replace `<variables>` with your own values. 
 
 - For additional properties, see [Tiered Storage configuration properties](../tiered-storage#tiered-storage-configuration-properties).
-  
-- For more information about shared key authentication, see the [Azure documentation](https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key).
+- See the Microsoft documentation for information about Azure network security and how to [grant access from an internet IP range](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json&tabs=azure-portal#grant-access-from-an-internet-ip-range) or for more information about [shared key authentication](https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key). 
 
 
   </TabItem>

--- a/versioned_docs/version-22.3/manage/tiered-storage.mdx
+++ b/versioned_docs/version-22.3/manage/tiered-storage.mdx
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 :::info
-This feature requires an [Enterprise license](../../get-started/licenses). To upgrade, contact [Redpanda sales](https://redpanda.com/try-redpanda?section=enterprise-cloud).
+This feature requires an [Enterprise license](../../get-started/licenses). To upgrade, contact [Redpanda sales](https://redpanda.com/try-redpanda?section=enterprise-trial).
 :::
 
 Tiered Storage helps to lower storage costs by offloading log segments to cloud storage. You can specify the amount of local storage you want to retain in local storage. You don't need to specify which log segments you want to move because Redpanda moves them automatically based on cluster-level configuration properties. Redpanda Tiered Storage indexes where data is offloaded, so it can retrieve the data when you need it.


### PR DESCRIPTION
resolves #1218 

To address feedback from Beta customers, this adds: 
- Redpanda natively supports Tiered Storage with Amazon S3, Google Cloud Storage (GCS), and Microsoft Azure Blob Storage (ABS). Migrating topics from one cloud provider to another is not supported.
- See the Microsoft documentation for information about Azure network security and how to [grant access from an internet IP range](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json&tabs=azure-portal#grant-access-from-an-internet-ip-range) or for more information about [shared key authentication](https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key).
- @JakeSCahill is publishing a separate page specific to Tiered Storage for Kubernetes. After he merges that, I'll link to it from this file. 

preview:
https://deploy-preview-1223--redpanda-documentation.netlify.app/docs/beta/manage/tiered-storage/