### PR TITLE
Limit width of code-blocks to prevent wraparound of TOC

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -77,19 +77,6 @@
   width: 100%;
 }
 
-.container code {
-  max-width: 100%;
-}
-
-code > span > span {
-    white-space: pre-wrap;
-}
-
-.container code > span {
-  display: block;
-}
-
-
 html[data-theme='dark'] {
   --ifm-toc-border-color: var(--v-black);
 }
@@ -149,6 +136,13 @@ div .admonition-content > ul > li > a {
   display: block;
   overflow-x: auto;
   white-space: nowrap;
+  }  
+}
+
+/* Prevent right-nav TOC from appearing below footer */
+@media screen and (max-width: 1008px)  {
+  [class*='stickyToc']{
+    display: none;
   }
 }
 
@@ -279,7 +273,19 @@ code {
 }
 .container code {
   background: var(--v-gray3);
+  overflow-x: auto;
+  white-space: nowrap;
+  max-width: 50vmax;
 }
+
+code > span > span {
+  white-space: pre-wrap;
+}
+
+.container code > span {
+display: block;
+}
+
 .container code span:not(.comment) {
   
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -131,6 +131,17 @@ div .admonition-content > ul > li > a {
   margin-top: 0;
 }
 
+/* Don't wrap right-nav TOC in main-doc container when screen width > 996px */ 
+[class*=docMainContainer] .container .row {
+  flex-wrap: nowrap;
+}
+
+@media screen and (max-width: 996px)  {
+  [class*=docMainContainer] .container .row {
+    flex-wrap: wrap;
+  }
+}
+
 @media screen and (max-width: 966px)  {
   table{
   display: block;
@@ -139,12 +150,6 @@ div .admonition-content > ul > li > a {
   }  
 }
 
-/* Prevent right-nav TOC from appearing below footer */
-@media screen and (max-width: 1008px)  {
-  [class*='stickyToc']{
-    display: none;
-  }
-}
 
 table tr td {
   text-align: left !important;


### PR DESCRIPTION
Fixes:
- #1210 

The specific goal of this PR is to prevent code blocks with long, unbroken strings from forcing the right-nav TOC off the visible screen.

Previews of pages that previously had code blocks so wide that they pushed the right-nav TOC to the bottom:
- https://deploy-preview-1224--redpanda-documentation.netlify.app/docs/manage/security/encryption/
- https://deploy-preview-1224--redpanda-documentation.netlify.app/docs/develop/http-proxy/