### PR TITLE
Workaround fix for TOC of Deploy for production page 

### DIFF
--- a/docs/deploy/deployment-option/self-hosted/manual/production/production-deployment.mdx
+++ b/docs/deploy/deployment-option/self-hosted/manual/production/production-deployment.mdx
@@ -10,10 +10,10 @@ title: Deploy for Production
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-To start deploying for production, follow the guide for your deployment type:
+To start deploying for production, choose the guide for your deployment type:
 
 - [**Default deployment**](#default-deployment) - use default supported deployment tools.
-- [**Custom deployment**](#custom-deployment) - use custom deployment tools.
+- [**Custom deployment**](#custom-deployment) - use custom unsupported deployment tools.
 
 ---
 
@@ -199,7 +199,7 @@ rpk topic create panda
 
 ## Custom deployment
 
-Redpanda supports several deployment tools for setting up a cluster:
+This section provides information for creating your own automation for deploying Redpanda clusters without using any of the tools that Redpanda supports for setting up a cluster:
 
 - Ansible Playbook
 - Helm Chart
@@ -208,10 +208,6 @@ Redpanda supports several deployment tools for setting up a cluster:
 :::tip
 Redpanda strongly recommends using one of these supported deployment tools. See [Automate Deploying for Production](../../production/production-deployment-automation).
 :::
-
-This section provides information for anyone creating their own 
-automation for deploying Redpanda clusters; that is, anyone not using one
-of these supported tools.
 
 ### Configure bootstrapping
 

--- a/docs/deploy/deployment-option/self-hosted/manual/production/production-deployment.mdx
+++ b/docs/deploy/deployment-option/self-hosted/manual/production/production-deployment.mdx
@@ -10,15 +10,22 @@ title: Deploy for Production
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs>
-<TabItem value="defaultDeploy" label="Default Deployment" default>
+To start deploying for production, follow the guide for your deployment type:
+
+- [**Default deployment**](#default-deployment) - use default supported deployment tools.
+- [**Custom deployment**](#custom-deployment) - use custom deployment tools.
+
+---
+
+## Default deployment
+
 This section describes how to set up a production cluster of Redpanda.
 
 See also:
 - [Manage Disk Space](../../../../../../manage/cluster-maintenance/disk-utilization) for guidelines on cluster creation
 - [Redpanda Quickstart](../../../../../../get-started/quick-start/quick-start-docker) to try out Redpanda
 
-## Prepare infrastructure
+### Prepare infrastructure
 
 Provision hardware according to these requirements:
 
@@ -37,7 +44,7 @@ Provision hardware according to these requirements:
 You can [use Terraform to deploy Redpanda](../../production/production-deployment-automation).
 :::
 
-## Install Redpanda
+### Install Redpanda
 
 Install Redpanda on each system you want to be part of your cluster. There are binaries available for Fedora/RedHat or Debian systems.
 
@@ -67,7 +74,7 @@ sudo -E bash && sudo apt install redpanda -y
 </Tabs>
 
 
-## Install Redpanda Console
+### Install Redpanda Console
 
 Redpanda Console is a developer-friendly web UI for managing and debugging your Redpanda cluster and your applications.
 
@@ -93,7 +100,7 @@ sudo -E bash && sudo apt-get install redpanda-console -y
 </Tabs>
 
 
-## Set Redpanda to production mode
+### Set Redpanda to production mode
 
 By default, Redpanda is installed in development mode, which turns off hardware optimization.
 
@@ -129,7 +136,7 @@ sudo rpk iotune # takes 10mins
 
 :::
 
-## Start Redpanda
+### Start Redpanda
 
 Configure Redpanda using the [`rpk redpanda config bootstrap`](../../../../../../reference/rpk/rpk-redpanda/rpk-redpanda-config-bootstrap) command, then start Redpanda: 
 
@@ -154,7 +161,7 @@ When a Redpanda cluster starts, it instantiates a controller Raft group with all
 - It's possible to change the seed nodes for a short period of time after a cluster has been created. For example, you may want to designate one additional broker as a seed node to increase availability. To do this without cluster downtime, add the new broker to [`seed_servers`](../../../../../../reference/node-properties/) and restart Redpanda to apply the change on a broker-by-broker basis.
 :::
 
-## Start Redpanda Console
+### Start Redpanda Console
 
 1. Start Redpanda Console:
 
@@ -168,7 +175,7 @@ When a Redpanda cluster starts, it instantiates a controller Raft group with all
   sudo systemctl status redpanda-console
   ```
 
-## Verify the installation
+### Verify the installation
 
 To verify that the Redpanda cluster is up and running, check the logs:
 
@@ -190,18 +197,8 @@ rpk topic create panda
 
 ---
 
-## Next steps
+## Custom deployment
 
-If clients will connect from a different subnet, see [Configuring Listeners](../../../../../../manage/security/listener-configuration).
-
-## Suggested reading
-
-- [Redpanda Cluster Configuration](../../../../../../manage/cluster-maintenance/configuration)
-- [Redpanda Console configuration](../../../../../../reference/console/config)
-- [Working with Schema Registry](../../../../../../manage/schema-registry)
-
-</TabItem>
-<TabItem value="customDeploy" label="Custom Deployment" default>
 Redpanda supports several deployment tools for setting up a cluster:
 
 - Ansible Playbook
@@ -212,11 +209,11 @@ Redpanda supports several deployment tools for setting up a cluster:
 Redpanda strongly recommends using one of these supported deployment tools. See [Automate Deploying for Production](../../production/production-deployment-automation).
 :::
 
-This page provides information for anyone creating their own 
+This section provides information for anyone creating their own 
 automation for deploying Redpanda clusters; that is, anyone not using one
 of these supported tools.
 
-## Configure bootstrapping
+### Configure bootstrapping
 
 Redpanda cluster configuration is written with the Admin API and
 the `rpk cluster config` CLIs.
@@ -240,7 +237,7 @@ superusers:
 
 With this configuration, the Admin API is not accessible until you bootstrap a user account.
 
-## Bootstrap a user account
+### Bootstrap a user account
 
 When using username/password authentication, it's helpful to be able to create one user before the cluster starts for the first time.
 
@@ -253,7 +250,7 @@ when starting Redpanda for the first time. The value has the format
 set up authentication using cluster configuration.
 :::
 
-## Secure the Admin API
+### Secure the Admin API
 
 The Admin API is used to create SASL user accounts and ACLs, so it's
 important to think about how you secure it when creating a cluster.
@@ -269,7 +266,7 @@ important to think about how you secure it when creating a cluster.
   authentication. You probably still want to enable TLS on the Admin API
   endpoint to protect credentials in flight.
 
-## Configure the seed servers
+### Configure the seed servers
 
 Seed servers help new nodes join a cluster by directing requests from newly-started nodes to an existing cluster. The [seed_servers](../../../../../../reference/node-properties#seed_servers) node configuration property controls how Redpanda finds its peers when initially forming a cluster. It is dependent on the [empty_seed_starts_cluster](../../../../../../reference/node-properties#empty_seed_starts_cluster) node configuration property.
 
@@ -292,7 +289,7 @@ to erase a node's drive and restart it. However, in some environments (like when
 and nodes may find their data volumes erased. For such environments, Redpanda recommends setting `empty_seed_starts_cluster` to false and designating a set of seed nodes such that they couldn't lose their storage simultaneously.
 :::
 
-## Configure node IDs 
+### Configure node IDs 
 
 Redpanda automatically generates unique node IDs for each new node. This means that you don't need to include node IDs in configuration files or worry about policies on `node_id` re-use. 
 
@@ -302,7 +299,7 @@ If you choose to assign node IDs, make sure to use a fresh `node_id` each time y
 Never reuse node IDs, even for nodes that have been decommissioned and restarted empty. Doing so can result in an inconsistent state.
 :::
 
-## Upgrade considerations
+### Upgrade considerations
 
 Deployment automation should place each node into maintenance mode and wait for it to drain leaderships before restarting it with a newer version of Redpanda. For information about how to drive a rolling upgrade of a Redpanda cluster, see [Node Maintenance Mode](../../../../../../manage/node-management).
 
@@ -310,6 +307,15 @@ Rolling restarts preserve high availability and reduce
 risk during upgrades. Check the cluster's health after upgrading each node. Rolling
 back an upgrade to an earlier feature release is only supported until the last node
 has been updated, so it's important to identify any issues before that point.
-</TabItem>
-</Tabs>
 
+---
+
+## Next steps
+
+If clients will connect from a different subnet, see [Configuring Listeners](../../../../../../manage/security/listener-configuration).
+
+## Suggested reading
+
+- [Redpanda Cluster Configuration](../../../../../../manage/cluster-maintenance/configuration)
+- [Redpanda Console configuration](../../../../../../reference/console/config)
+- [Working with Schema Registry](../../../../../../manage/schema-registry)

--- a/versioned_docs/version-22.3/deploy/deployment-option/self-hosted/manual/production/production-deployment.mdx
+++ b/versioned_docs/version-22.3/deploy/deployment-option/self-hosted/manual/production/production-deployment.mdx
@@ -4,21 +4,28 @@ title: Deploy for Production
 
 <head>
     <meta name="title" content="Deploy for Production | Redpanda Docs"/>
-    <meta name="description" content="Steps to deploy a Redpanda production cluster."/>
+    <meta name="description" content="Steps to deploy a Redpanda production cluster"/>
 </head>
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs>
-<TabItem value="defaultDeploy" label="Default Deployment" default>
+To start deploying for production, choose the guide for your deployment type:
+
+- [**Default deployment**](#default-deployment) - use default supported deployment tools.
+- [**Custom deployment**](#custom-deployment) - use custom unsupported deployment tools.
+
+---
+
+## Default deployment
+
 This section describes how to set up a production cluster of Redpanda.
 
 See also:
 - [Manage Disk Space](../../../../../../manage/cluster-maintenance/disk-utilization) for guidelines on cluster creation
 - [Redpanda Quickstart](../../../../../../get-started/quick-start/quick-start-docker) to try out Redpanda
 
-## Prepare infrastructure
+### Prepare infrastructure
 
 Provision hardware according to these requirements:
 
@@ -37,7 +44,7 @@ Provision hardware according to these requirements:
 You can [use Terraform to deploy Redpanda](../../production/production-deployment-automation).
 :::
 
-## Install Redpanda
+### Install Redpanda
 
 Install Redpanda on each system you want to be part of your cluster. There are binaries available for Fedora/RedHat or Debian systems.
 
@@ -67,7 +74,7 @@ sudo -E bash && sudo apt install redpanda -y
 </Tabs>
 
 
-## Install Redpanda Console
+### Install Redpanda Console
 
 Redpanda Console is a developer-friendly web UI for managing and debugging your Redpanda cluster and your applications.
 
@@ -93,7 +100,7 @@ sudo -E bash && sudo apt-get install redpanda-console -y
 </Tabs>
 
 
-## Set Redpanda to production mode
+### Set Redpanda to production mode
 
 By default, Redpanda is installed in development mode, which turns off hardware optimization.
 
@@ -129,7 +136,7 @@ sudo rpk iotune # takes 10mins
 
 :::
 
-## Start Redpanda
+### Start Redpanda
 
 Configure Redpanda using the [`rpk redpanda config bootstrap`](../../../../../../reference/rpk/rpk-redpanda/rpk-redpanda-config-bootstrap) command, then start Redpanda: 
 
@@ -154,7 +161,7 @@ When a Redpanda cluster starts, it instantiates a controller Raft group with all
 - It's possible to change the seed nodes for a short period of time after a cluster has been created. For example, you may want to designate one additional broker as a seed node to increase availability. To do this without cluster downtime, add the new broker to [`seed_servers`](../../../../../../reference/node-properties/) and restart Redpanda to apply the change on a broker-by-broker basis.
 :::
 
-## Start Redpanda Console
+### Start Redpanda Console
 
 1. Start Redpanda Console:
 
@@ -168,7 +175,7 @@ When a Redpanda cluster starts, it instantiates a controller Raft group with all
   sudo systemctl status redpanda-console
   ```
 
-## Verify the installation
+### Verify the installation
 
 To verify that the Redpanda cluster is up and running, check the logs:
 
@@ -190,19 +197,9 @@ rpk topic create panda
 
 ---
 
-## Next steps
+## Custom deployment
 
-If clients will connect from a different subnet, see [Configuring Listeners](../../../../../../manage/security/listener-configuration).
-
-## Suggested reading
-
-- [Redpanda Cluster Configuration](../../../../../../manage/cluster-maintenance/configuration)
-- [Redpanda Console configuration](../../../../../../reference/console/config)
-- [Working with Schema Registry](../../../../../../manage/schema-registry)
-
-</TabItem>
-<TabItem value="customDeploy" label="Custom Deployment" default>
-Redpanda supports several deployment tools for setting up a cluster:
+This section provides information for creating your own automation for deploying Redpanda clusters without using any of the tools that Redpanda supports for setting up a cluster:
 
 - Ansible Playbook
 - Helm Chart
@@ -212,11 +209,7 @@ Redpanda supports several deployment tools for setting up a cluster:
 Redpanda strongly recommends using one of these supported deployment tools. See [Automate Deploying for Production](../../production/production-deployment-automation).
 :::
 
-This page provides information for anyone creating their own 
-automation for deploying Redpanda clusters; that is, anyone not using one
-of these supported tools.
-
-## Configure bootstrapping
+### Configure bootstrapping
 
 Redpanda cluster configuration is written with the Admin API and
 the `rpk cluster config` CLIs.
@@ -240,7 +233,7 @@ superusers:
 
 With this configuration, the Admin API is not accessible until you bootstrap a user account.
 
-## Bootstrap a user account
+### Bootstrap a user account
 
 When using username/password authentication, it's helpful to be able to create one user before the cluster starts for the first time.
 
@@ -253,7 +246,7 @@ when starting Redpanda for the first time. The value has the format
 set up authentication using cluster configuration.
 :::
 
-## Secure the Admin API
+### Secure the Admin API
 
 The Admin API is used to create SASL user accounts and ACLs, so it's
 important to think about how you secure it when creating a cluster.
@@ -269,7 +262,7 @@ important to think about how you secure it when creating a cluster.
   authentication. You probably still want to enable TLS on the Admin API
   endpoint to protect credentials in flight.
 
-## Configure the seed servers
+### Configure the seed servers
 
 Seed servers help new nodes join a cluster by directing requests from newly-started nodes to an existing cluster. The [seed_servers](../../../../../../reference/node-properties#seed_servers) node configuration property controls how Redpanda finds its peers when initially forming a cluster. It is dependent on the [empty_seed_starts_cluster](../../../../../../reference/node-properties#empty_seed_starts_cluster) node configuration property.
 
@@ -292,7 +285,7 @@ to erase a node's drive and restart it. However, in some environments (like when
 and nodes may find their data volumes erased. For such environments, Redpanda recommends setting `empty_seed_starts_cluster` to false and designating a set of seed nodes such that they couldn't lose their storage simultaneously.
 :::
 
-## Configure node IDs 
+### Configure node IDs 
 
 Redpanda automatically generates unique node IDs for each new node. This means that you don't need to include node IDs in configuration files or worry about policies on `node_id` re-use. 
 
@@ -302,7 +295,7 @@ If you choose to assign node IDs, make sure to use a fresh `node_id` each time y
 Never reuse node IDs, even for nodes that have been decommissioned and restarted empty. Doing so can result in an inconsistent state.
 :::
 
-## Upgrade considerations
+### Upgrade considerations
 
 Deployment automation should place each node into maintenance mode and wait for it to drain leaderships before restarting it with a newer version of Redpanda. For information about how to drive a rolling upgrade of a Redpanda cluster, see [Node Maintenance Mode](../../../../../../manage/node-management).
 
@@ -310,6 +303,15 @@ Rolling restarts preserve high availability and reduce
 risk during upgrades. Check the cluster's health after upgrading each node. Rolling
 back an upgrade to an earlier feature release is only supported until the last node
 has been updated, so it's important to identify any issues before that point.
-</TabItem>
-</Tabs>
 
+---
+
+## Next steps
+
+If clients will connect from a different subnet, see [Configuring Listeners](../../../../../../manage/security/listener-configuration).
+
+## Suggested reading
+
+- [Redpanda Cluster Configuration](../../../../../../manage/cluster-maintenance/configuration)
+- [Redpanda Console configuration](../../../../../../reference/console/config)
+- [Working with Schema Registry](../../../../../../manage/schema-registry)


### PR DESCRIPTION
Fixes:
- #1118 

Preview:
- Updated both [23.1's Deploy for production page](https://deploy-preview-1244--redpanda-documentation.netlify.app/docs/beta/deploy/deployment-option/self-hosted/manual/production/production-deployment/) and [22.3's page](https://deploy-preview-1244--redpanda-documentation.netlify.app/docs/deploy/deployment-option/self-hosted/manual/production/production-deployment/), moved tabbed content into separate headings. 

Future task:
- Fix root cause in Docusaurus of linking from TOC to disabled tabs
