### PR TITLE
fix kafka_quota_balancer_min_shard_throughput_ratio description

### DIFF
--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -604,7 +604,7 @@ The minimum value of the throughput quota a shard can get in the process of quot
 
 Both `kafka_quota_balancer_min_shard_throughput_ratio` and [kafka_quota_balancer_min_shard_throughput_bps](#kafka_quota_balancer_min_shard_throughput_bps) can be specified at the same time. In this case, the balancer will not decrease the effective shard quota below the largest bps value of each of these two properties.
 
-If set to `0.0`, the minimum is disabled. If set to greater than `1.0 / <number-of-shards>`, where each shard is supposed to have allocated more than an equal share of total quota, then the balancer won't be able to rebalance quota without violating this ratio, consequently precluding the balancer from adjusting shards' quotas.
+If set to `0.0`, the minimum is disabled. If set to `1.0`, then the balancer won't be able to rebalance quota without violating this ratio, consequently precluding the balancer from adjusting shards' quotas.
 
 **Type**: double
 


### PR DESCRIPTION
Fixed the description of the kafka_quota_balancer_min_shard_throughput_ratio property: https://deploy-preview-1258--redpanda-documentation.netlify.app/docs/beta/reference/cluster-properties/#kafka_quota_balancer_min_shard_throughput_ratio