### PR TITLE
Set single primary font (Patron) 

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -19,7 +19,7 @@
   --v-gray4: #F8F8F8;
   --v-green: #64C97B;
   --v-background: #FFFFFF;
-  --v-font: Inter, sans-serif;
+  --v-font: Patron, Inter, sans-serif;
   --v-font-mono: Inter,'Courier Prime', Courier, monospace;
 
   /* Color Variables */


### PR DESCRIPTION
https://github.com/redpanda-data/documentation/pull/1237 updated the font of the left nav to Patron, but the default font (--v-font) used by the body and right nav still has Inter as the primary font. The different fonts create an inconsistent appearance. 

This PR sets Patron as the primary --v-font (same as other font-family)