### PR TITLE
docs: fix connectors image tag

### DIFF
--- a/docs/reference/docker-compose.mdx
+++ b/docs/reference/docker-compose.mdx
@@ -105,7 +105,7 @@ services:
       - redpanda
 
   connect:
-    image: docker.redpanda.com/redpandadata/connectors:1.0.0-dev-dff1c57
+    image: docker.redpanda.com/redpandadata/connectors:1.0.0-dev-bc9a905
     hostname: connect
     container_name: connect
     networks:


### PR DESCRIPTION
Fix this error using the last tag in the docker hub (1.0.0-dev-bc9a905)

Error response from daemon: manifest for docker.redpanda.com/redpandadata/connectors:1.0.0-dev-dff1c57 not found: manifest unknown: manifest unknown