### PR TITLE
docs: copy recent merges into dev

### DIFF
--- a/docs/manage/cluster-maintenance/disk-utilization.mdx
+++ b/docs/manage/cluster-maintenance/disk-utilization.mdx
@@ -19,9 +19,9 @@ When a Redpanda node runs out of disk space, it terminates. This causes leader r
 
 ## Configure message retention
 
-Retention properties control how long messages are kept on disk before they're deleted or compacted. Setting message retention properties is the best way to prevent old messages from accumulating on disk to the point that the disk becomes full.
+By default, all topics on self-hosted Redpanda clusters keep the last 24 hours of data on local disk. Redpanda Cloud keeps the last 12 hours of data. However, if data is written fast enough to consume all disk space within the local retention time period, it's possible to exhaust local disk space, even when using Tiered Storage. You can adjust the default local storage size or time period, if required.
 
-You can configure retention properties to delete messages based on the following conditions:
+Retention properties control how long messages are kept on disk before they're deleted or compacted. Setting message retention properties is the best way to prevent old messages from accumulating on disk to the point that the disk becomes full. You can configure retention properties to delete messages based on the following conditions:
 
 * Message age is exceeded.
 * Aggregate message size in the topic is exceeded.
@@ -31,11 +31,18 @@ Set retention properties at the topic level or the cluster level. If a value isn
 
 | Retention property | Cluster level | Topic level <br /> (overrides cluster configuration) |
 | ---               | ---                                                |  ---                                 |
-| Time-based        | [delete_retention_ms](../../../reference/cluster-properties#delete_retention_ms) | `retention.ms` <br /> No default     |
-| Size-based        | [retention_bytes](../../../reference/cluster-properties#retention_bytes) | `retention.bytes`  <br /> No default |
-| Segment size      | [log_segment_size](../../../reference/tunable-properties#log_segment_size) | N/A                                  |
+| Time-based        | `delete_retention_ms` <br /> Default - `604800000` | `retention.ms` <br /> No default     |
+| Time-based (with Tiered Storage enabled)       | `retention_local_target_ms_default` <br /> Default - `86400000`| `retention.local.target.ms` <br /> No default     |
+| Size-based        | `retention_bytes`  <br /> Default - `null`         | `retention.bytes`  <br /> No default |
+| Size-based (with Tiered Storage enabled)       | `retention_local_target_bytes_default`  <br /> Default - `null`         | `retention.local.target.bytes`  <br /> No default |
+| Segment size      | `log_segment_size`  <br /> Default - `1073741824`  | `segment.bytes`  <br /> No default |
+
+Data expires from object storage following `retention.ms` or `retention.bytes`. For example, if `retention.bytes` is set to 10 GiB, then every partition in the topic has a limit of 10 GiB storage in the cloud. When `retention.bytes` is exceeded by data in object storage, the data in object storage is trimmed. With Tiered Storage enabled, data expires from local storage following `retention.local.target.ms` or `retention.local.target.bytes`. 
 
 Based on these properties, Redpanda runs a log cleanup process in the background. If you start to run out of disk space, adjust your retention properties to reduce the amount of disk space used. 
+
+See also: [Manage local capacity for Tiered Storage topics](../../tiered-storage/#manage-local-capacity-for-tiered-storage-topics)
+
 
 ### Set time-based retention
 
@@ -62,7 +69,7 @@ To set retention time for a single topic, use `retention.ms`, which overrides `d
   To minimize the likelihood of out-of-disk outages, set `delete_retention_ms` to `86400000`, which is one day. The default is `604800000`, which is one week.
 
 :::caution 
-Do not set `delete_retention_ms` to `-1` unless you're using [remote write with Tiered Storage](../../tiered-storage#remote-write) to upload segments to remote storage. Setting it to `-1` configures indefinite retention, which can fill disk space.  
+Do not set `delete_retention_ms` to `-1` unless you're using [remote write with Tiered Storage](../../tiered-storage#remote-write) to upload segments to object storage. Setting it to `-1` configures indefinite retention, which can fill disk space.  
 :::
 
 ### Set size-based retention
@@ -92,58 +99,33 @@ To set retention size for a single topic, use `retention.bytes`, which overrides
 
 ## Configure segment size
 
-The [log_segment_size](../../../reference/tunable-properties#log_segment_size) property specifies the size of each log segment.
+The `log_segment_size` property specifies the size of each log segment.
 
 To set `log_segment_size`:
 
 ```bash
-rpk cluster config set log_segment_size <segment-size>
+rpk cluster config set log_segment_size <segment_size>
 ```
 
 If you know which topics will receive more data, it's best to specify the size for each topic. 
 
-To configure log segment size on a topic, `segment.bytes`: 
+To configure log segment size on a topic: 
 
 ```bash
-rpk topic alter-config <topic> --set segment.bytes=<segment-size>
+rpk topic alter-config <topic> --set segment.bytes=<segment_size>
 ```
 
 ### Segment size for compacted segments
  
 Compaction saves space by retaining only the last known value for each message key within the segment. The latest value for each key is preserved, and all older values are discarded. 
 
-When compaction is configured, topics take their size from [compacted_log_segment_size](../../../reference/tunable-properties#compacted_log_segment_size). The [log_segment_size](../../../reference/tunable-properties#log_segment_size) property does not apply to compacted topics. 
+When compaction is configured, topics take their size from `compacted_log_segment_size`. The `log_segment_size` property does not apply to compacted topics. 
 
-Setting a `segment.bytes` size on a topic applies whether the topic is compacted or not, and the `max_compacted_log_segment_size` property applies to compacted topics regardless of the other properties. It controls how many segments are merged together. For example, if you set `segment.bytes` to 128MB, but leave `max_compacted_log_segment_size` at 5GB, you get 128MB segments when they're written, but up to 5GB segments after compaction.
+Setting a `segment.bytes` size on a topic applies whether the topic is compacted or not, and the `max_compacted_log_segment_size` property applies to compacted topics regardless of any other properties. The `max_compacted_log_segment_size` property controls how many segments are merged together. For example, if you set `segment.bytes` to 128 MB, but leave `max_compacted_log_segment_size` at 5 GB, then you get 128 MB segments when they're written, but up to 5 GB segments after compaction.
 
-Keep in mind that very large segments prevent compaction, and very small segments increase the risk of encountering resource limits. To calculate an upper limit on segment size, divide the disk size by the number of partitions. For example, if you have a 128 GB disk and 1000 partitions, the upper limit of the segment size is `134217728`. Compare your limit with the default [log_segment_size](../../../reference/tunable-properties#log_segment_size) and default [compacted_log_segment_size](../../../reference/tunable-properties#compacted_log_segment_size). 
+Keep in mind that very large segments prevent compaction, and very small segments increase the risk of encountering resource limits. To calculate an upper limit on segment size, divide the disk size by the number of partitions. For example, if you have a 128 GB disk and 1000 partitions, the upper limit of the segment size is `134217728`. Default is `1073741824`. 
 
 For details about how to modify cluster configuration properties, see [Cluster configuration](../cluster-property-configuration). 
-
-### Log rolling
-
-Writing data for a topic usually spans multiple log segments. An **active segment** of a topic is a log segment that is being written to. As data of a topic is written and an active segment becomes full (reaches `log_segment_size`), it's closed and changed to read-only mode, and a new segment is created, set to read-write mode, and becomes the active segment. **Log rolling** is the rotation between segments to create a new active segment.
-
-Log rolling can also be triggered by configurable timeouts. This is useful when topic retention limits need to be applied within a known fixed duration. A log rolling timeout starts from the first write to an active segment. When a timeout elapses before the segment is full, the segment is rolled. The timeouts are configured with cluster-level and topic-level properties:
-
-* [log_segment_ms](../../../reference/cluster-properties#log_segment_ms) (or `log.roll.ms`) is a cluster property that configures the default segment rolling timeout for all topics of a cluster.
-
-  To set `log_segment_ms` for all topics of a cluster for a duration in milliseconds:
-
-    ```bash
-    rpk cluster config set log_segment_ms <segment_ms_duration>
-    ```
-
-* `segment.ms` is a topic-level property that configures the default segment rolling timeout for one topic. It's not set by default. If set, it overrides `log_segment_ms`.
-
-  To set `segment.ms` for a topic: 
-
-    ```bash
-    rpk topic alter-config <topic> --set segment.ms=<segment_ms_duration>
-    ```
-
-* [log_segment_ms_min](../../../reference/tunable-properties#log_segment_ms_min) and [log_segment_ms_max](../../../reference/tunable-properties#log_segment_ms_max) are cluster-level properties that configure the lower and upper limits, respectively, of log rolling timeouts.
-
 
 ## Handle full disks
 

--- a/docs/manage/remote-read-replicas.mdx
+++ b/docs/manage/remote-read-replicas.mdx
@@ -30,11 +30,18 @@ You can create [Remote Read Replica](../remote-read-replicas) topics in a Redpan
 To create a Remote Read Replica topic in another region, consider using a [multi-region bucket](https://aws.amazon.com/s3/features/multi-region-access-points/) to simplify deployment and optimize performance. 
 :::
 
+## Create a topic with archival storage or Tiered Storage
+
+When cloud storage is enabled on a topic, Redpanda copies closed log segments to the configured object store. Log segments are closed when the value of [`log_segment_size`](../../reference/tunable-properties#log_segment_size) has been reached, so a topic’s object store lags behind the local copy. To reduce this lag in the data availability for the Remote Read Replica:
+
+- You can lower the value of `segment.bytes`. This lets Redpanda archive smaller log segments more frequently, at the cost of increasing I/O and file count. 
+- Self-hosted implementations can set an idle timeout with `cloud_storage_segment_max_upload_interval_sec` to force Redpanda to periodically archive the contents of open log segments to object storage. This is useful if a topic’s write rate is low and log segments are kept open for long periods of time. The appropriate interval may depend on your total partition count: a system with less partitions can handle a higher number of segments per partition. 
+
 ## Create a topic with remote storage
 
-Before you can create a Remote Read Replica, you must create a topic on the origin cluster, and set up a bucket or container for the topic's cloud storage. 
+Before you can create a Remote Read Replica, you must create a topic on the origin cluster, and set up a bucket for the topic's cloud object storage. 
 
-1. Create a bucket or container to store the original data.
+1. Create a bucket to store the original data.
 2. Create the original topic by running `rpk topic create <topic_name>`, and specifying the number of partitions and the number of replicas.
 3. Enable cloud storage on the origin cluster by running `rpk cluster config edit`, and then specify the following cluster configuration properties:
 
@@ -46,9 +53,6 @@ Before you can create a Remote Read Replica, you must create a topic on the orig
     | `cloud_storage_secret_key` | AWS or GCS secret key. <br/>Required for AWS and GCS authentication with access keys.  |
     | `cloud_storage_region` | Cloud storage region. <br/>Required for AWS and GCS. |
     | `cloud_storage_api_endpoint` | AWS or GCS API endpoint. <br/>- For AWS, this can be left blank. It’s generated automatically using the region and bucket. <br/>- For GCS, use `storage.googleapis.com`. |
-    | `cloud_storage_azure_container` | Azure container name. <br/>Required for ABS. |
-    | `cloud_storage_azure_storage_account` | Azure account name. <br/>Required for ABS. |
-    | `cloud_storage_azure_shared_key` | Azure shared key. <br/>Required for ABS. |
     | `cloud_storage_enable_remote_write` | When using archival storage or Tiered Storage on the origin cluster, set to `true` to enable data to be uploaded from Redpanda and written to cloud storage for all topics. <br/>To only enable data upload for a specific topic, set `cloud_storage_enable_remote_write: false` and run `rpk topic create <topic_name> -c redpanda.remote.write=true` when you create the topic. |
     | `cloud_storage_enable_remote_read` | When using Tiered Storage on the origin cluster, set to `true` to enable consumers to read from all topics in cloud storage. <br/>To enable consumers to only read from one topic, set `cloud_storage_enable_remote_read: false` and run `rpk topic create <topic_name> -c redpanda.remote.read=true` when you create the topic.
 
@@ -56,34 +60,27 @@ Before you can create a Remote Read Replica, you must create a topic on the orig
 
 To set up a Remote Read Replica topic on a separate remote cluster:
 
-1. Create a remote cluster for the Remote Read Replica topic. 
-   - If that's a multi-region bucket/container, you can create the read replica cluster in any region that has that bucket/container. 
-   - If that's a single-region bucket/container, the remote cluster must be in the same region as the bucket/container.
+1. Create a remote cluster for the Remote Read Replica topic.
+   - If that's a multi-region bucket, you can create the read replica cluster in any region that has that bucket. 
+   - If that's a single-region bucket, the remote cluster must be in the same region as the bucket.
 2. Run `rpk cluster config edit`, and then specify the following cluster configuration properties:
 
     | Property | Description |
     | :------  | :---------  |
     | `cloud_storage_enabled` | Must be set to `true` to enable cloud storage. |
-    | `cloud_storage_bucket: "none"` | No AWS or GCS bucket is needed for the remote cluster. |
+    | `cloud_storage_bucket: “none”` | No AWS or GCS bucket is needed for the remote cluster. |
     | `cloud_storage_access_key` | AWS or GCS access key. <br/>Required for AWS and GCS authentication with access keys. |
     | `cloud_storage_secret_key` | AWS or GCS secret key. <br/>Required for AWS and GCS authentication with access keys.  |
     | `cloud_storage_region` | Cloud storage region of the remote cluster. <br/>Required for AWS and GCS. |
     | `cloud_storage_api_endpoint` | AWS or GCS API endpoint. <br/>- For AWS, this can be left blank. It’s generated automatically using the region and bucket. <br/>- For GCS, use `storage.googleapis.com`. |
-    | `cloud_storage_azure_container` | Azure container name. <br/>Required for ABS. |
-    | `cloud_storage_azure_storage_account` | Azure account name. <br/>Required for ABS. |
-    | `cloud_storage_azure_shared_key` | Azure shared key. <br/>Required for ABS. |
 
 3. Create the Remote Read Replica topic by running `rpk topic create <topic_name> -c redpanda.remote.readreplica=<bucket_name>`. 
    
-    For `<topic_name>`, use the same name as the original topic. For `<bucket_name>`, use the bucket specified in the `cloud_storage_bucket` property for the origin cluster.
+   For `<topic_name>`, use the same name as the original topic. For `<bucket_name>`, use the bucket specified in the `cloud_storage_bucket` property for the origin cluster.
 
-    :::note
-    Using `redpanda.remote.readreplica` with `redpanda.remote.read` or `redpanda.remote.write` results in an error. This could happen if you configure a topic with Remote Read Replica binding; for example:
-
-    ```bash
-    rpk topic create topic1 -p 32 -r 3 -c redpanda.remote.read=true -c redpanda.remote.write=false -c redpanda.remote.readreplica=bucket
-    ```
-    :::
+   :::note
+   Do not use `redpanda.remote.read` or `redpanda.remote.write` with `redpanda.remote.readreplica`. Redpanda ignores the values for remote read and remote write properties on read replica topics. 
+   :::
 
 ## Reduce lag in data availability
 


### PR DESCRIPTION
Because I'd started #1222 and #1231 before v23.1 was published, their dev branches went into v22.3. I merged these 2 PRs last week but they only went into v23.1. This PR updates those same 2 files in dev (v23.1). 