### PR TITLE
Use `latest` connectors image version in owl-shop example

### DIFF
--- a/versioned_docs/version-22.3/reference/docker-compose.mdx
+++ b/versioned_docs/version-22.3/reference/docker-compose.mdx
@@ -105,7 +105,7 @@ services:
       - redpanda
 
   connect:
-    image: docker.redpanda.com/redpandadata/connectors:1.0.0-dev-dff1c57
+    image: docker.redpanda.com/redpandadata/connectors:latest
     hostname: connect
     container_name: connect
     networks:


### PR DESCRIPTION
The version `redpandadata/connectors:1.0.0-dev-dff1c57` used in the doc does not exist so the container from the example does not work.