### PR TITLE
`continuous` autobalancing mode includes benefits of `node_add` mode

### DIFF
--- a/docs/reference/cluster-properties.mdx
+++ b/docs/reference/cluster-properties.mdx
@@ -293,7 +293,7 @@ Mode of [partition balancing](../../manage/cluster-maintenance/cluster-balancing
 
 Available modes:
 - `node_add`: partition balancing happens when a node is added.
-- `continuous`: partition balancing happens automatically to maintain optimal performance and availability, based on continuous monitoring for node failures and high disk usage. This option requires an [Enterprise license](../../get-started/licenses), and it is customized by [partition_autobalancing_node_availability_timeout_sec](#partition_autobalancing_node_availability_timeout_sec) and [partition_autobalancing_max_disk_usage_percent](#partition_autobalancing_max_disk_usage_percent) properties.
+- `continuous`: partition balancing happens automatically to maintain optimal performance and availability, based on continuous monitoring for node changes (same as `node_add`) and also high disk usage. This option requires an [Enterprise license](../../get-started/licenses), and it is customized by [partition_autobalancing_node_availability_timeout_sec](#partition_autobalancing_node_availability_timeout_sec) and [partition_autobalancing_max_disk_usage_percent](#partition_autobalancing_max_disk_usage_percent) properties.
 - `off`: partition balancing is disabled. This option is not recommended for production clusters.
 
 **Default**: `node_add`


### PR DESCRIPTION
I didn't realize `partition_autobalancing_mode` set to `continuous` would include all the benefits of `node_add`. This small change make this associated between these two values more clear.