### PR TITLE
docs:#887 add "Configuring Topics"

### DIFF
--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -50,7 +50,7 @@ For example, suppose you plan to create a consumer group with 10 consumers. To c
 rpk topic create xyz -p 10
 ```
 
-### Choosing the replication factor
+### Choose the replication factor
 
 Replicas are copies of partitions that are distributed across different nodes, so if one node goes down, other nodes still have a copy of the data. The default replication factor in the cluster configuration is set to 1.
 

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -102,6 +102,14 @@ Suppose you configure a topic using the default cleanup policy `delete`, and you
 rpk topic alter-config [TOPICS…] —-set cleanup.policy=compact
 ```
 
+### Removing a configuration setting
+
+You can remove a configuration that overrides the default setting, and the setting will use the default value again. For example, suppose you altered the cleanup policy to use `compact` instead of the default, `delete`. Now you want to return the policy setting to the default. To remove the configuration setting `cleanup.policy=compact`, run `rpk topic alter-config` with the `--delete` flag as shown:
+
+```
+rpk topic alter-config [TOPICS...] --delete cleanup.policy
+```
+
 ## Listing topic configuration settings
 
 You can display all the configuration settings for a topic by running:

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -158,7 +158,7 @@ PARTITIONS  3
 REPLICAS    3
 ```
 
-## Deleting a topic
+## Delete a topic
 
 After you’re done with a topic, you can delete it by running:
 

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -28,7 +28,9 @@ These default settings are best suited to a one-node cluster in a development en
 
 Creating a topic can be as simple as specifying a name for your topic on the command line. For example, to create a topic named `xyz`:
 
-`rpk topic create xyz`
+```
+rpk topic create xyz
+```
 
 This command creates a topic named `xyz` with one partition and one replica, since these are the default values set in the cluster configuration file.
 
@@ -44,17 +46,21 @@ As a general rule, select a number of partitions that corresponds to the maximum
 
 For example, suppose you plan to create a consumer group with 10 consumers. To create a topic “xyz” with 10 partitions:
 
-`rpk topic create xyz -p 10`
+```
+rpk topic create xyz -p 10
+```
 
 ### Choosing the replication factor
 
-Replicas are copies that are distributed across different nodes, so if one node goes down, you still have other nodes with a copy of the data. The default replication factor in the cluster configuration is set to 1.
+Replicas are copies of partitions that are distributed across different nodes, so if one node goes down, other nodes still have a copy of the data. The default replication factor in the cluster configuration is set to 1.
 
 By choosing a replication factor greater than 1, you ensure that each partition has a copy of its data on at least one other node. One replica acts as the leader, and the other replicas are followers.
 
 To specify a replication factor of 3 for topic “xyz”:
 
-`rpk topic create xyz -r 3`
+```
+rpk topic create xyz -r 3
+```
 
 :::note
 The replication factor must be an odd number. Redpanda Data recommends a replication factor of 3 for most use cases.
@@ -68,7 +74,9 @@ After you create a topic, you can update the topic property settings for all new
 
 You can add partitions to a topic after you create it. For example, suppose you added nodes to your cluster, and you want to take advantage of the additional processing power. To increase the number of partitions for existing topics, run:
 
-`rpk topic add-partitions [TOPICS...] --num [#]`
+```
+rpk topic add-partitions [TOPICS...] --num [#]
+```
 
 Note that `--num <#>` is the number of partitions to _add_, not the total number of partitions.
 
@@ -76,10 +84,12 @@ Note that `--num <#>` is the number of partitions to _add_, not the total number
 
 Suppose you configure a topic with the default replication factor of 1 (which is specified in the cluster properties configuration file). Now you want to change the replication factor to 3, so you can have two backups of topic data in case a broker goes down. To set the replication factor to 3 for all new data written to a topic, run:
 
-`rpk topic alter-config [TOPICS...] --set replication.factor=3`
+```
+rpk topic alter-config [TOPICS...] --set replication.factor=3
+```
 
 :::note
-The replication factor should not exceed the number of Redpanda brokers.
+The replication factor can't exceed the number of Redpanda brokers. If you try to set a replication factor greater than the number of brokers, the request is rejected.
 :::
 
 ### Changing the cleanup policy
@@ -88,13 +98,17 @@ The cleanup policy determines how to clean up the partition log files when they 
 
 Suppose you configure a topic using the default cleanup policy `delete`, and you want to change the policy to `compact`. Run the `rpk topic alter-config` command as shown:
 
-`rpk topic alter-config [TOPICS…] —-set cleanup.policy=compact`
+```
+rpk topic alter-config [TOPICS…] —-set cleanup.policy=compact
+```
 
 ## Listing topic configuration settings
 
 You can display all the configuration settings for a topic by running:
 
-`rpk topic describe <topic-name> -c`
+```
+rpk topic describe <topic-name> -c
+```
 
 The `-c` flag limits the command output to just the topic configurations. This command is useful for checking the default configuration settings before you make any changes, and for verifying changes after you make them.
 
@@ -140,16 +154,22 @@ REPLICAS    3
 
 After you’re done with a topic, you can delete it by running:
 
-`rpk topic delete <topic-name>`
+```
+rpk topic delete <topic-name>
+```
 
 When a topic is deleted, its underlying data is deleted, too.
 
 To delete multiple topics at a time, provide a space-separated list. For example:
 
-`rpk topic delete topic1 topic2`
+```
+rpk topic delete topic1 topic2
+```
 
-You can also use the `-r` flag to specify one or more regular expressions, and any topic names that match the pattern you specify will be deleted. The following command deletes any topics whose names start with “f” and any whose names end with “r”:
+You can also use the `-r` flag to specify one or more regular expressions; then, any topic names that match the pattern you specify will be deleted. The following command deletes any topics whose names start with “f” and any whose names end with “r”:
 
-`rpk topic  delete -r '^f.*' '.*r$'`
+```
+rpk topic  delete -r '^f.*' '.*r$'
+```
 
 Note that the first regular expression starts with the `^` symbol, and the last ends with the `$` symbol. This requirement helps prevent accidental deletions.

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -22,7 +22,7 @@ The following table shows the topic property settings listed in the cluster conf
  | `log_message_timestamp_type` | CreateTime                | `message.timestamp.type`  |
  | `kafka_batch_max_bytes`      | 1048576 bytes (1 MiB)     | `max.message.bytes`       |
 
-These default settings are best suited to a one-node cluster in a development environment. To learn how to modify the default values in the configuration file, see [Configure Cluster Properties](../../manage/cluster-maintenance/cluster-property-configuration). Even if you set default values that work for most topics, you may still want to change some properties for a specific topic.
+These default settings are best suited to a one-broker cluster in a development environment. To learn how to modify the default values in the configuration file, see [Configure Cluster Properties](../../manage/cluster-maintenance/cluster-property-configuration). Even if you set default values that work for most topics, you may still want to change some properties for a specific topic.
 
 ## Create a topic
 
@@ -41,7 +41,7 @@ But suppose you want to create a topic with different values for these settings.
 A partition acts as a log file where topic data is written. Dividing topics into partitions allows producers to write messages in parallel and consumers to read messages in parallel. The higher the number of partitions, the greater the throughput.
 
 :::tip
-As a general rule, select a number of partitions that corresponds to the maximum number of consumers in a consumer group that will consume the data.
+As a general rule, select a number of partitions that corresponds to the maximum number of consumers in any consumer group that will consume the data.
 :::
 
 For example, suppose you plan to create a consumer group with 10 consumers. To create topic `xyz` with 10 partitions:
@@ -52,9 +52,9 @@ rpk topic create xyz -p 10
 
 ### Choose the replication factor
 
-Replicas are copies of partitions that are distributed across different nodes, so if one node goes down, other nodes still have a copy of the data. The default replication factor in the cluster configuration is set to 1.
+Replicas are copies of partitions that are distributed across different brokers, so if one broker goes down, other brokers still have a copy of the data. The default replication factor in the cluster configuration is set to 1.
 
-By choosing a replication factor greater than 1, you ensure that each partition has a copy of its data on at least one other node. One replica acts as the leader, and the other replicas are followers.
+By choosing a replication factor greater than 1, you ensure that each partition has a copy of its data on at least one other broker. One replica acts as the leader, and the other replicas are followers.
 
 To specify a replication factor of 3 for topic “xyz”:
 
@@ -68,11 +68,11 @@ The replication factor must be an odd number. Redpanda Data recommends a replica
 
 ## Update topic configurations
 
-After you create a topic, you can update the topic property settings for all new data written to that topic. For example, you can add partitions, change the replication factor, or change a configuration setting like the cleanup policy.
+After you create a topic, you can update the topic property settings for all new data written to it. For example, you can add partitions, change the replication factor, or change a configuration setting like the cleanup policy.
 
 ### Add partitions
 
-You can add partitions to a topic after you create it. For example, suppose you added nodes to your cluster, and you want to take advantage of the additional processing power. To increase the number of partitions for existing topics, run:
+You can assign a certain number of partitions when you create a topic, and add partitions later. For example, suppose you add brokers to your cluster, and you want to take advantage of the additional processing power. To increase the number of partitions for existing topics, run:
 
 ```
 rpk topic add-partitions [TOPICS...] --num [#]
@@ -94,7 +94,11 @@ The replication factor can't exceed the number of Redpanda brokers. If you try t
 
 ### Change the cleanup policy
 
-The cleanup policy determines how to clean up the partition log files when they reach a certain size - by deleting data based on age or log size, by compacting the data and only keeping the latest values for each key, or by using a combination of deletion and compaction.
+The cleanup policy determines how to clean up the partition log files when they reach a certain size:
+
+* `delete` deletes data based on age or log size.
+* `compact` compacts the data by only keeping the latest values for each KEY.
+* `compact,delete` combines both methods.
 
 Suppose you configure a topic using the default cleanup policy `delete`, and you want to change the policy to `compact`. Run the `rpk topic alter-config` command as shown:
 
@@ -112,7 +116,7 @@ rpk topic alter-config [TOPICS...] --delete cleanup.policy
 
 ## List topic configuration settings
 
-You can display all the configuration settings for a topic by running:
+To display all the configuration settings for a topic, run:
 
 ```
 rpk topic describe <topic-name> -c
@@ -120,7 +124,7 @@ rpk topic describe <topic-name> -c
 
 The `-c` flag limits the command output to just the topic configurations. This command is useful for checking the default configuration settings before you make any changes, and for verifying changes after you make them.
 
-The following command output is displayed after running `rpk topic describe test-topic`, where `test-topic` was created with default settings:
+The following command output displays after running `rpk topic describe test-topic`, where `test-topic` was created with default settings:
 
 ```
 rpk topic describe test_topic
@@ -160,7 +164,7 @@ REPLICAS    3
 
 ## Delete a topic
 
-After you’re done with a topic, you can delete it by running:
+To delete a topic, run:
 
 ```
 rpk topic delete <topic-name>
@@ -168,13 +172,13 @@ rpk topic delete <topic-name>
 
 When a topic is deleted, its underlying data is deleted, too.
 
-To delete multiple topics at a time, provide a space-separated list. For example:
+To delete multiple topics at a time, provide a space-separated list. For example, to delete two topics named `topic1` and `topic2`, run:
 
 ```
 rpk topic delete topic1 topic2
 ```
 
-You can also use the `-r` flag to specify one or more regular expressions; then, any topic names that match the pattern you specify will be deleted. The following command deletes any topics whose names start with “f” and any whose names end with “r”:
+You can also use the `-r` flag to specify one or more regular expressions; then, any topic names that match the pattern you specify are deleted. For example, to delete topics with names that start with “f” and end with “r”, run:
 
 ```
 rpk topic  delete -r '^f.*' '.*r$'

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -70,7 +70,7 @@ The replication factor must be an odd number. Redpanda Data recommends a replica
 
 After you create a topic, you can update the topic property settings for all new data written to that topic. For example, you can add partitions, change the replication factor, or change a configuration setting like the cleanup policy.
 
-### Adding partitions
+### Add partitions
 
 You can add partitions to a topic after you create it. For example, suppose you added nodes to your cluster, and you want to take advantage of the additional processing power. To increase the number of partitions for existing topics, run:
 

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -92,7 +92,7 @@ rpk topic alter-config [TOPICS...] --set replication.factor=3
 The replication factor can't exceed the number of Redpanda brokers. If you try to set a replication factor greater than the number of brokers, the request is rejected.
 :::
 
-### Changing the cleanup policy
+### Change the cleanup policy
 
 The cleanup policy determines how to clean up the partition log files when they reach a certain size - by deleting data based on age or log size, by compacting the data and only keeping the latest values for each key, or by using a combination of deletion and compaction.
 

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -82,7 +82,7 @@ Note that `--num <#>` is the number of partitions to _add_, not the total number
 
 ### Change the replication factor
 
-Suppose you configure a topic with the default replication factor of 1 (which is specified in the cluster properties configuration file). Now you want to change the replication factor to 3, so you can have two backups of topic data in case a broker goes down. To set the replication factor to 3 for all new data written to a topic, run:
+Suppose you create a topic with the default replication factor of 1 (which is specified in the cluster properties configuration file). Now you want to change the replication factor to 3, so you can have two backups of topic data in case a broker goes down. To set the replication factor to 3 for all new data written to the topic, run:
 
 ```
 rpk topic alter-config [TOPICS...] --set replication.factor=3

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -80,7 +80,7 @@ rpk topic add-partitions [TOPICS...] --num [#]
 
 Note that `--num <#>` is the number of partitions to _add_, not the total number of partitions.
 
-### Changing the replication factor
+### Change the replication factor
 
 Suppose you configure a topic with the default replication factor of 1 (which is specified in the cluster properties configuration file). Now you want to change the replication factor to 3, so you can have two backups of topic data in case a broker goes down. To set the replication factor to 3 for all new data written to a topic, run:
 

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -24,7 +24,7 @@ The following table shows the topic property settings listed in the cluster conf
 
 These default settings are best suited to a one-node cluster in a development environment. To modify the default values in the configuration file, see [Configure Cluster Properties](../../manage/cluster-maintenance/cluster-property-configuration) for instructions. Even if you set default values that work for most topics, you may still want to change some properties for a specific topic.
 
-## Creating a topic
+## Create a topic
 
 Creating a topic can be as simple as specifying a name for your topic on the command line. For example, to create a topic named `xyz`:
 

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -22,7 +22,7 @@ The following table shows the topic property settings listed in the cluster conf
  | `log_message_timestamp_type` | CreateTime                | `message.timestamp.type`  |
  | `kafka_batch_max_bytes`      | 1048576 bytes (1 MiB)     | `max.message.bytes`       |
 
-These default settings are best suited to a one-node cluster in a development environment. To modify the default values in the configuration file, see [Configure Cluster Properties](../../manage/cluster-maintenance/cluster-property-configuration) for instructions. Even if you set default values that work for most topics, you may still want to change some properties for a specific topic.
+These default settings are best suited to a one-node cluster in a development environment. To learn how to modify the default values in the configuration file, see [Configure Cluster Properties](../../manage/cluster-maintenance/cluster-property-configuration). Even if you set default values that work for most topics, you may still want to change some properties for a specific topic.
 
 ## Create a topic
 

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -38,7 +38,7 @@ But suppose you want to create a topic with different values for these settings.
 
 ### Choose the number of partitions
 
-A partition acts as a log file where topic data is written. Dividing topics into partitions allows producers to write messages in parallel, and consumers to read messages in parallel. The higher the number of partitions, the greater the throughput.
+A partition acts as a log file where topic data is written. Dividing topics into partitions allows producers to write messages in parallel and consumers to read messages in parallel. The higher the number of partitions, the greater the throughput.
 
 :::tip
 As a general rule, select a number of partitions that corresponds to the maximum number of consumers in a consumer group that will consume the data.

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -44,7 +44,7 @@ A partition acts as a log file where topic data is written. Dividing topics into
 As a general rule, select a number of partitions that corresponds to the maximum number of consumers in a consumer group that will consume the data.
 :::
 
-For example, suppose you plan to create a consumer group with 10 consumers. To create a topic “xyz” with 10 partitions:
+For example, suppose you plan to create a consumer group with 10 consumers. To create topic `xyz` with 10 partitions:
 
 ```
 rpk topic create xyz -p 10

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -1,0 +1,155 @@
+---
+title: Configure Topics
+---
+
+<head>
+    <meta name="title" content="Configure Topics | Redpanda Docs"/>
+    <meta name="description" content="Learn how to configure topics with Redpanda."/>
+</head>
+
+Topics provide a way to organize events in a data streaming platform. When you create a topic, the default topic settings from the cluster configuration file are applied, unless you specify a different setting on the command line.
+
+The following table shows the topic property settings listed in the cluster configuration file along with their default values, and the equivalent topic property names:
+ 
+ | Cluster property             | Default                   | Topic property            |
+ | :--------------------------- | :------------------------ | :------------------------ |
+ | `log_cleanup_policy`         | delete                    | `cleanup.policy`          |
+ | `retention_bytes`            | null (no limit)           | `retention.bytes`         |
+ | `delete_retention_ms`        | 604800000 ms (1 week)     | `retention.ms`            |
+ | `log_segment_ms`             | null (no limit)           | `segment.ms`              |
+ | `log_segment_size`           | 134217728 bytes (128 MiB) | `segment.bytes`           |
+ | `log_compression_type`       | producer                  | `compression.type`        |
+ | `log_message_timestamp_type` | CreateTime                | `message.timestamp.type`  |
+ | `kafka_batch_max_bytes`      | 1048576 bytes (1 MiB)     | `max.message.bytes`       |
+
+These default settings are best suited to a one-node cluster in a development environment. To modify the default values in the configuration file, see [Configure Cluster Properties](../../manage/cluster-maintenance/cluster-property-configuration) for instructions. Even if you set default values that work for most topics, you may still want to change some properties for a specific topic.
+
+## Creating a topic
+
+Creating a topic can be as simple as specifying a name for your topic on the command line. For example, to create a topic named `xyz`:
+
+`rpk topic create xyz`
+
+This command creates a topic named `xyz` with one partition and one replica, since these are the default values set in the cluster configuration file.
+
+But suppose you want to create a topic with different values for these settings. The guidelines in this section show you how to choose the number of partitions and replicas for your use case.
+
+### Choosing the number of partitions
+
+A partition acts as a log file where topic data is written. Dividing topics into partitions allows producers to write messages in parallel, and consumers to read messages in parallel. The higher the number of partitions, the greater the throughput.
+
+:::tip
+As a general rule, select a number of partitions that corresponds to the maximum number of consumers in a consumer group that will consume the data.
+:::
+
+For example, suppose you plan to create a consumer group with 10 consumers. To create a topic “xyz” with 10 partitions:
+
+`rpk topic create xyz -p 10`
+
+### Choosing the replication factor
+
+Replicas are copies that are distributed across different nodes, so if one node goes down, you still have other nodes with a copy of the data. The default replication factor in the cluster configuration is set to 1.
+
+By choosing a replication factor greater than 1, you ensure that each partition has a copy of its data on at least one other node. One replica acts as the leader, and the other replicas are followers.
+
+To specify a replication factor of 3 for topic “xyz”:
+
+`rpk topic create xyz -r 3`
+
+:::note
+The replication factor must be an odd number. Redpanda Data recommends a replication factor of 3 for most use cases.
+:::
+
+## Updating topic configurations
+
+After you create a topic, you can update the topic property settings for all new data written to that topic. For example, you can add partitions, change the replication factor, or change a configuration setting like the cleanup policy.
+
+### Adding partitions
+
+You can add partitions to a topic after you create it. For example, suppose you added nodes to your cluster, and you want to take advantage of the additional processing power. To increase the number of partitions for existing topics, run:
+
+`rpk topic add-partitions [TOPICS...] --num [#]`
+
+Note that `--num <#>` is the number of partitions to _add_, not the total number of partitions.
+
+### Changing the replication factor
+
+Suppose you configure a topic with the default replication factor of 1 (which is specified in the cluster properties configuration file). Now you want to change the replication factor to 3, so you can have two backups of topic data in case a broker goes down. To set the replication factor to 3 for all new data written to a topic, run:
+
+`rpk topic alter-config [TOPICS...] --set replication.factor=3`
+
+:::note
+The replication factor should not exceed the number of Redpanda brokers.
+:::
+
+### Changing the cleanup policy
+
+The cleanup policy determines how to clean up the partition log files when they reach a certain size - by deleting data based on age or log size, by compacting the data and only keeping the latest values for each key, or by using a combination of deletion and compaction.
+
+Suppose you configure a topic using the default cleanup policy `delete`, and you want to change the policy to `compact`. Run the `rpk topic alter-config` command as shown:
+
+`rpk topic alter-config [TOPICS…] —-set cleanup.policy=compact`
+
+## Listing topic configuration settings
+
+You can display all the configuration settings for a topic by running:
+
+`rpk topic describe <topic-name> -c`
+
+The `-c` flag limits the command output to just the topic configurations. This command is useful for checking the default configuration settings before you make any changes, and for verifying changes after you make them.
+
+The following command output is displayed after running `rpk topic describe test-topic`, where `test-topic` was created with default settings:
+
+```
+rpk topic describe test_topic
+SUMMARY
+=======
+NAME        test_topic
+PARTITIONS  1
+REPLICAS    1
+
+CONFIGS
+=======
+KEY                           VALUE                          SOURCE
+cleanup.policy                delete                         DYNAMIC_TOPIC_CONFIG
+compression.type              producer                       DEFAULT_CONFIG
+max.message.bytes             1048576                        DEFAULT_CONFIG
+message.timestamp.type        CreateTime                     DEFAULT_CONFIG
+redpanda.datapolicy           function_name:  script_name:   DEFAULT_CONFIG
+redpanda.remote.delete        true                           DEFAULT_CONFIG
+redpanda.remote.read          false                          DEFAULT_CONFIG
+redpanda.remote.write         false                          DEFAULT_CONFIG
+retention.bytes               -1                             DEFAULT_CONFIG
+retention.local.target.bytes  -1                             DEFAULT_CONFIG
+retention.local.target.ms     86400000                       DEFAULT_CONFIG
+retention.ms                  604800000                      DEFAULT_CONFIG
+segment.bytes                 1073741824                     DEFAULT_CONFIG
+```
+
+Now suppose you add two partitions, and increase the number of replicas to 3. The new command output confirms the changes in the `SUMMARY` section:
+
+```
+SUMMARY
+=======
+NAME        test_topic
+PARTITIONS  3
+REPLICAS    3
+```
+
+## Deleting a topic
+
+After you’re done with a topic, you can delete it by running:
+
+`rpk topic delete <topic-name>`
+
+When a topic is deleted, its underlying data is deleted, too.
+
+To delete multiple topics at a time, provide a space-separated list. For example:
+
+`rpk topic delete topic1 topic2`
+
+You can also use the `-r` flag to specify one or more regular expressions, and any topic names that match the pattern you specify will be deleted. The following command deletes any topics whose names start with “f” and any whose names end with “r”:
+
+`rpk topic  delete -r '^f.*' '.*r$'`
+
+Note that the first regular expression starts with the `^` symbol, and the last ends with the `$` symbol. This requirement helps prevent accidental deletions.

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -102,7 +102,7 @@ Suppose you configure a topic using the default cleanup policy `delete`, and you
 rpk topic alter-config [TOPICS…] —-set cleanup.policy=compact
 ```
 
-### Removing a configuration setting
+### Remove a configuration setting
 
 You can remove a configuration that overrides the default setting, and the setting will use the default value again. For example, suppose you altered the cleanup policy to use `compact` instead of the default, `delete`. Now you want to return the policy setting to the default. To remove the configuration setting `cleanup.policy=compact`, run `rpk topic alter-config` with the `--delete` flag as shown:
 

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -36,7 +36,7 @@ This command creates a topic named `xyz` with one partition and one replica, sin
 
 But suppose you want to create a topic with different values for these settings. The guidelines in this section show you how to choose the number of partitions and replicas for your use case.
 
-### Choosing the number of partitions
+### Choose the number of partitions
 
 A partition acts as a log file where topic data is written. Dividing topics into partitions allows producers to write messages in parallel, and consumers to read messages in parallel. The higher the number of partitions, the greater the throughput.
 

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -110,7 +110,7 @@ You can remove a configuration that overrides the default setting, and the setti
 rpk topic alter-config [TOPICS...] --delete cleanup.policy
 ```
 
-## Listing topic configuration settings
+## List topic configuration settings
 
 You can display all the configuration settings for a topic by running:
 

--- a/docs/develop/config-topics.mdx
+++ b/docs/develop/config-topics.mdx
@@ -66,7 +66,7 @@ rpk topic create xyz -r 3
 The replication factor must be an odd number. Redpanda Data recommends a replication factor of 3 for most use cases.
 :::
 
-## Updating topic configurations
+## Update topic configurations
 
 After you create a topic, you can update the topic property settings for all new data written to that topic. For example, you can add partitions, change the replication factor, or change a configuration setting like the cleanup policy.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -69,6 +69,7 @@ module.exports = {
         "develop/code-examples",
         "develop/guide-nodejs",
         "develop/http-proxy",
+        "develop/config-topics",
         {
           type: "category",
           label: "Produce Data",


### PR DESCRIPTION
Explains how to configure topics from the `rpk` command line. Offers guidance for determining the number of partitions to use, and a recommendation for the number of replicas. Also covers the `rpk topic delete` command and the `rpk topic describe` command.

Fixes #887 

Review deadline: Thursday, March 23, 2023.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204218351694977