### PR TITLE
console: Add Azure & Keycloak docs

### DIFF
--- a/docs/manage/security/console/authentication.mdx
+++ b/docs/manage/security/console/authentication.mdx
@@ -9,7 +9,7 @@ title: Authentication
   />
   <meta
     name="description"
-    content="Configure authentication with external identity providers such as Google, GitHub or Okta in Redpanda Console."
+    content="Configure authentication with external identity providers in Redpanda Console."
   />
 </head>
 
@@ -17,7 +17,7 @@ title: Authentication
 This feature requires an [Enterprise license](../../../../get-started/licenses). To upgrade, contact [Redpanda sales](https://redpanda.com/try-redpanda?section=enterprise-cloud).
 :::
 
-Redpanda Console supports authentication via OAuth 2.0 or OIDC for external identity providers, such as:
+Redpanda Console supports authentication using OAuth 2.0 or OIDC for external identity providers, such as:
 
 - [AzureAD](../azure-ad)
 - [Google](../google)
@@ -27,9 +27,9 @@ Redpanda Console supports authentication via OAuth 2.0 or OIDC for external iden
 - [Generic OIDC](../generic-oidc)
 
 You can use one or more login providers at the same time. To enable SSO authentication,
-you must create an OAuth application for your organization first. Visit the respective
-documentation page for guidance to setup your desired identity provider in Console.
-Afterwards you can configure your identity provider in Redpanda Console by providing the
+you must create an OAuth application for your organization first. Refer to the respective
+documentation page for guidance to set up your desired identity provider in Redpanda Console.
+Afterwards, you can configure your identity provider in Redpanda Console by providing the
 clientId and clientSecret in the configuration block for your provider. The configuration
 to add Google login support looks like this:
 
@@ -48,14 +48,14 @@ login:
   # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
   #
   # If you update this secret key, any users who are
-  # already logged into Redpanda Console will be logged out and will have
+  # already logged in to Redpanda Console will be logged out and will have
   # to log in again.
   jwtSecret: ""
 
   google:
     enabled: true
     clientId: redacted.apps.googleusercontent.com
-    clientSecret: redacted # can be set via environment variable
+    clientSecret: redacted # can be set with an environment variable
     # The directory config is optional. You have to configure it if you want to use
     # Google groups in your RBAC role bindings.
     # directory:
@@ -65,7 +65,6 @@ login:
     #  targetPrincipal: admin@mycompany.com
 ```
 
-By default, users don't have any permissions in Redpanda Console. This also includes permission
-to login at all. Thus authentication and authorization must always be used together.
-Continue with the authorization configuration by reading the RBAC-based [authorization
+By default, users don't have any permissions in Redpanda Console, including permission
+to log in. After you set up authentication, continue with the authorization configuration by reading the RBAC-based [authorization
 concept](../authorization).

--- a/docs/manage/security/console/authentication.mdx
+++ b/docs/manage/security/console/authentication.mdx
@@ -3,8 +3,14 @@ title: Authentication
 ---
 
 <head>
-    <meta name="title" content="SSO Authentication in Redpanda Console | Redpanda Docs"/>
-    <meta name="description" content="Configure authentication with external identity providers such as Google, GitHub or Okta in Redpanda Console."/>
+  <meta
+    name="title"
+    content="SSO Authentication in Redpanda Console | Redpanda Docs"
+  />
+  <meta
+    name="description"
+    content="Configure authentication with external identity providers such as Google, GitHub or Okta in Redpanda Console."
+  />
 </head>
 
 :::info
@@ -12,12 +18,15 @@ This feature requires an [Enterprise license](../../../../get-started/licenses).
 :::
 
 Redpanda Console supports authentication via OAuth 2.0 or OIDC for external identity providers, such as:
+
+- [AzureAD](../azure-ad)
 - [Google](../google)
 - [GitHub](../github)
+- [Keycloak](../keycloak)
 - [Okta](../okta)
 - [Generic OIDC](../generic-oidc)
 
-You can use one or more login providers at the same time. To enable SSO authentication 
+You can use one or more login providers at the same time. To enable SSO authentication
 you must create an OAuth application for your organization first. Visit the respective
 documentation page for guidance to setup your desired identity provider in Console.
 Afterwards you can configure your identity provider in Redpanda Console by providing the
@@ -28,18 +37,18 @@ to add Google login support looks like this:
 login:
   enabled: true
 
-  # jwtSecret is the secret key you must use to sign and encrypt the JSON 
-  # web token used to store user sessions. This secret key is 
-  # critical for the security of Redpanda Console's authentication and 
-  # authorization system. Use a long, complex key with a combination of 
-  # numbers, letters, and special characters. While you must use a minimum of 
-  # 10 characters, Redpanda recommends using more than 32 
-  # characters. For additional security, use a different secret key for 
-  # each environment. jwtSecret can be securely generated with the following 
+  # jwtSecret is the secret key you must use to sign and encrypt the JSON
+  # web token used to store user sessions. This secret key is
+  # critical for the security of Redpanda Console's authentication and
+  # authorization system. Use a long, complex key with a combination of
+  # numbers, letters, and special characters. While you must use a minimum of
+  # 10 characters, Redpanda recommends using more than 32
+  # characters. For additional security, use a different secret key for
+  # each environment. jwtSecret can be securely generated with the following
   # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
   #
-  # If you update this secret key, any users who are 
-  # already logged into Redpanda Console will be logged out and will have 
+  # If you update this secret key, any users who are
+  # already logged into Redpanda Console will be logged out and will have
   # to log in again.
   jwtSecret: ""
 

--- a/docs/manage/security/console/authentication.mdx
+++ b/docs/manage/security/console/authentication.mdx
@@ -26,7 +26,7 @@ Redpanda Console supports authentication via OAuth 2.0 or OIDC for external iden
 - [Okta](../okta)
 - [Generic OIDC](../generic-oidc)
 
-You can use one or more login providers at the same time. To enable SSO authentication
+You can use one or more login providers at the same time. To enable SSO authentication,
 you must create an OAuth application for your organization first. Visit the respective
 documentation page for guidance to setup your desired identity provider in Console.
 Afterwards you can configure your identity provider in Redpanda Console by providing the

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -4,7 +4,7 @@ title: Azure AD SSO Setup
 
 <head>
     <meta name="title" content="Azure AD SSO Authentication in Redpanda Console | Redpanda Docs"/>
-    <meta name="description" content="Configure authentication with external identity providers such as Google, GitHub or Okta in Redpanda Console."/>
+    <meta name="description" content="Configure authentication with external identity providers in Redpanda Console."/>
 </head>
 
 :::info

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -11,15 +11,23 @@ title: Azure AD SSO Setup
 This feature requires an [Enterprise license](../../../../get-started/licenses). To upgrade, contact [Redpanda sales](https://redpanda.com/try-redpanda?section=enterprise-cloud).
 :::
 
-Integrating Redpanda Console with Azure AD allows your users to use their Azure AD identities to sign-in to Console.
+Integrating Redpanda Console with Azure AD allows your users to use their Azure AD identities to sign in to Redpanda Console.
 This guide assumes you already have an Azure AD account and permissions to create Applications within your directory.
 
 ## Create an OpenID connect application
 
-TODO: Write text, possibly refer to: https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings
+Begin by registering your app in the Azure Portal. Provide the following information:
+
+* Display name
+* Supported account types that can access the API (choose single tenant, multi-tenant, or personal accounts)
+* Redirect URI (select `Web` as the platform)
+
+After the app is registered, the overview page opens. This page contains the client ID and client secret, which you paste into the `redpanda-console-config.yaml file`.
+
+For more information, see the Microsoft documentation for [configuring an OpenID connect provider](https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings).
 
 :::note
-Below configurations assume that you want to host Redpanda Console so that it would be accessible via
+The configurations below assume that you want to host Redpanda Console so it is accessible at
 `https://console.yourcompany.com`.
 :::
 
@@ -35,14 +43,14 @@ login:
   # web token used to store user sessions. This secret key is
   # critical for the security of Redpanda Console's authentication and
   # authorization system. Use a long, complex key with a combination of
-  # numbers, letters, and special characters. While you must use a minimum of
-  # 10 characters, Redpanda recommends using more than 32
+  # numbers, letters, and special characters. The minimum number of
+  # characters is 10, but Redpanda recommends using more than 32
   # characters. For additional security, use a different secret key for
-  # each environment. jwtSecret can be securely generated with the following
+  # each environment. To securely generate a jwtSecret key, run the following
   # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
   #
   # If you update this secret key, any users who are
-  # already logged into Redpanda Console will be logged out and will have
+  # already logged in to Redpanda Console will be logged out and will have
   # to log in again.
   jwtSecret: ""
 
@@ -51,12 +59,12 @@ login:
     # ProviderURL must be specified in the following format:
     # https://login.microsoftonline.com/{tenantId}/v2.0 .
     # To get this URL, browse to the registered app in your 
-    # Azure Portal, click the "Endpoints" tab. A drawer 
-    # should open with several links. The link below 
+    # Azure Portal and click the "Endpoints" tab. A drawer 
+    # opens with several links. The link below 
     # "OpenID Connect metadata document" contains the 
-    # provider URL, however you must trim the suffix 
+    # provider URL; however, you must trim the suffix 
     # "/.well-known/openid-configuration" so that it 
-    # matches the expected format as shown above.
+    # matches the expected format.
     providerUrl: ""
 
     clientId: ""

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -5,6 +5,7 @@ title: Azure AD SSO Setup
 <head>
     <meta name="title" content="Azure AD SSO Authentication in Redpanda Console | Redpanda Docs"/>
     <meta name="description" content="Configure authentication with external identity providers in Redpanda Console."/>
+    <link rel="canonical" href="https://docs.redpanda.com/docs/manage/security/console/azure-ad" />
 </head>
 
 :::info
@@ -13,44 +14,23 @@ This feature requires an [Enterprise license](../../../../get-started/licenses).
 
 By integrating Redpanda Console with Azure AD, your users can sign in to Redpanda Console using their Azure AD login credentials.
 
-These instructions assume you already have an Azure AD account and permissions to create applications within your directory.
+## Prerequisites
+
+You must have:
+
+- An [Azure AD account](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/sign-up-organization) and permissions to create applications within your directory.
+
+- An OpenID Connect (OIDC) provider](https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings) configured for your Azure AD account.
 
 ## Create an OpenID connect application
 
-In the Azure Portal, register your app and generate a client secret.
-
-### Register your app
-
-To register your application, log in to the Azure Portal and provide the following information:
-
-* **Display name** - Choose a descriptive name for your specific Redpanda Console deployment (for example Console Analytics Prod)
-* **Supported account types** - Select the types of accounts that can access the API (choose single tenant, multi-tenant, or personal accounts). If you are unsure, click "Help me choose...".
-* **Redirect URIs** Select Web as the platform and enter `https://console.<your-company>.com/login/callbacks/azure-ad` in the text box. Replace `<your-company>.com` with your company's domain name.
+In the Azure Portal, register your app and generate a client secret. For details, see the [Microsoft Azure documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-credentials).
 
 :::note
-The redirect URI is based on the assumption that you host Redpanda Console so it is accessible from
-`https://console.<your-company>.com`.
+Set the redirect URI to the URI where Redpanda Console is hosted.
 :::
 
 After the app is registered, a summary page opens. This page displays a list of **Essentials**, which you will need when you edit the `redpanda-console-config.yaml file`.
-
-For detailed instructions, see the Microsoft documentation for [configuring an OpenID connect provider](https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings).
-
-### Generate the client secret
-
-Redpanda Console requires a client secret to validate the connection request from the redirect URI. To generate a client secret:
-
-1. In the **Essentials** section of the summary page, click **Add a certificate or secret** next to **Client credentials**.
-
-2. On the **Certificates & secrets** page, select the **Client secrets** tab.
-
-3. Click **New client secret**.
-
-4. In the **Add a client secret** pane, enter a description that identifies the app associated with the client secret.
-
-5. Choose a time period that determines when the client secret will expire; for example, 180 days.
-
-When the client secret is generated successfully, it appears under the **Client secrets** tab with its description, expiration date, value, and secret ID.
 
 :::important
 Copy the client secret value into the `redpanda-console-config.yaml` file before you leave the **Certificates and secrets** page. After you navigate away from the page, only the first few characters of the client secret value are displayed and you won't be able to copy the value into the configuration file.

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -41,7 +41,7 @@ Redpanda Console requires a client secret to validate the connection request fro
 
 3. Click **New client secret**.
 
-4. In the "Add a client secret" pane, enter a description that identifies the app associated with the client secret.
+4. In the **Add a client secret** pane, enter a description that identifies the app associated with the client secret.
 
 5. Choose a time period that determines when the client secret will expire; for example, 180 days.
 
@@ -110,7 +110,7 @@ login:
     #    the email propagated)
     userIdentifyingClaimKey: "oid"
 
-    # The directory config is only required if you want to use 
+    # The directory configuration is only required if you want to use 
     # Azure AD groups in your role bindings, as described 
     # in the next section.
     # directory:
@@ -120,7 +120,7 @@ login:
 ## RBAC Azure AD groups sync
 
 You can bind roles to Azure groups from your organization by providing the `tenantId` in the directory configuration and adding API permissions to your client application. To retrieve the `tenantId`, go to
-your registered application in the Azure Active Directory portal. The "Directory (tenant) ID" is listed
+your registered application in the Azure Active Directory portal. The **Directory (tenant) ID** is listed
 along with other configurations in the **Essentials** section.
 
 ```yaml
@@ -132,13 +132,13 @@ login:
 
 If you specify the `tenantId`, Redpanda Console will send a request to the Microsoft Graph API to retrieve the memberships
 for the specified groups. In order for the Microsoft Graph API to grant the request, the client must have the appropriate permissions. In your AzureAD application,
-go to "API permissions" and add the following permissions:
+go to **API permissions** and add the following permissions:
 
-* "Group.Read.All"
-* "User.Read.All"
-* "Directory.Read.All"
+* **Group.Read.All**
+* **User.Read.All**
+* **Directory.Read.All**
 
-Next, grant admin consent for the default directory by clicking "Grant admin constent for Default Directory".
+Next, grant admin consent for the default directory by clicking **Grant admin consent for Default Directory**.
 
 ## Define role-bindings
 

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -27,7 +27,7 @@ For more information, see the Microsoft documentation for [configuring an OpenID
 After the app is registered, the overview page opens. This page contains the client ID and client secret, which you paste into the `redpanda-console-config.yaml file`.
 
 :::note
-The configurations below assume that you want to host Redpanda Console so it is accessible at
+The following configurations assume that you want to host Redpanda Console so it is accessible at
 `https://console.<your-company>.com`.
 :::
 

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -25,7 +25,12 @@ To register your application, log in to the Azure Portal and provide the followi
 
 * **Display name** - Choose a descriptive name for your specific Redpanda Console deployment (for example Console Analytics Prod)
 * **Supported account types** - Select the types of accounts that can access the API (choose single tenant, multi-tenant, or personal accounts). If you are unsure, click "Help me choose...".
-* **Redirect URIs** Select Web as the platform and enter `https://console.<yourcompany>.com/login/callbacks/azure-ad` in the text box. Replace `<your-company>.com` with your company's domain name.
+* **Redirect URIs** Select Web as the platform and enter `https://console.<your-company>.com/login/callbacks/azure-ad` in the text box. Replace `<your-company>.com` with your company's domain name.
+
+:::note
+The redirect URI is based on the assumption that you host Redpanda Console so it is accessible from
+`https://console.<your-company>.com`.
+:::
 
 After the app is registered, a summary page opens. This page displays a list of **Essentials**, which you will need when you edit the `redpanda-console-config.yaml file`.
 
@@ -54,11 +59,6 @@ Copy the client secret value into the `redpanda-console-config.yaml` file before
 ## Edit the console configuration file
 
 Edit the console configuration file associated with your deployment method and incorporate the details from your client application. For example, Kubernetes deployments use the `values.yaml` file. Linux deployments use the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`.
-
-:::note
-The following configurations are based on the assumption that you host Redpanda Console so it is accessible from
-`https://console.<your-company>.com`.
-:::
 
 ```yaml
 login:

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -1,5 +1,5 @@
 ---
-title: Azure AD SSO Setup
+title: Azure AD SSO Authentication in Redpanda Console
 ---
 
 <head>
@@ -20,21 +20,19 @@ You must have:
 
 - An [Azure AD account](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/sign-up-organization) and permissions to create applications within your directory.
 
-- An OpenID Connect (OIDC) provider](https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings) configured for your Azure AD account.
+- A registered OIDC application with Azure AD configured as the OpenID Connect (OIDC) provider. For instructions, see the [Microsoft documentation](https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings).
+
+  When you register the application, you need to:
+
+    - Enter a name for the application.
+
+    - Select a supported account type. For details, see the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+
+    - Set the redirect URI to a domain where Redpanda Console is hosted followed by the `/login/callbacks/azure-ad` path. For example, `https://console.<your-company>.com/login/callbacks/azure-ad` or `https://localhost:8080/login/callbacks/azure-ad`.
 
   :::note
-  Set the redirect URI to the domain where Redpanda Console is hosted followed by the `/login/callbacks/azure-ad` path. For example, `https://console.<your-company>.com/login/callbacks/azure-ad`
+  When you configure the identity provider, make a note of the client ID and client secret. You must add these credentials to the [console configuration file](#edit-the-console-configuration-file) so that Repanda Console can establish communication with Azure AD.
   :::
-
-## Create an OpenID connect application
-
-In the Azure Portal, register your app and generate a client secret. For details, see the [Microsoft Azure documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-credentials).
-
-After the app is registered, a summary page opens. This page displays a list of **Essentials**, which you will need when you edit the `redpanda-console-config.yaml file`.
-
-:::important
-Copy the client secret value into the `redpanda-console-config.yaml` file before you leave the **Certificates and secrets** page. After you navigate away from the page, only the first few characters of the client secret value are displayed and you won't be able to copy the value into the configuration file.
-:::
 
 ## Edit the console configuration file
 

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -22,15 +22,15 @@ You must have:
 
 - A registered OIDC application with Azure AD configured as the OpenID Connect (OIDC) provider. For instructions, see the [Microsoft documentation](https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings).
 
-  When you register the application, you need to:
+  When you register the application, provide the following inputs when you are asked for them:
 
-    - Enter a name for the application.
+    - **Name**: Enter a name for the application
 
-    - Select a supported account type. For details, see the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+    - **Supported account types**: Select a supported account type. For details, see the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
 
-    - Set the redirect URI to a domain where Redpanda Console is hosted followed by the `/login/callbacks/azure-ad` path. For example, `https://console.<your-company>.com/login/callbacks/azure-ad` or `https://localhost:8080/login/callbacks/azure-ad`.
+    - **Redirect URI**: Enter the domain where Redpanda Console is hosted followed by the `/login/callbacks/azure-ad` path. For example, `https://console.<your-company>.com/login/callbacks/azure-ad` or `https://localhost:8080/login/callbacks/azure-ad`.
 
-  :::note
+  :::info
   When you configure the identity provider, make a note of the client ID and client secret. You must add these credentials to the [console configuration file](#edit-the-console-configuration-file) so that Repanda Console can establish communication with Azure AD.
   :::
 

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -22,13 +22,13 @@ You must have:
 
 - An OpenID Connect (OIDC) provider](https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings) configured for your Azure AD account.
 
+  :::note
+  Set the redirect URI to the domain where Redpanda Console is hosted followed by the `/login/callbacks/azure-ad` path. For example, `https://console.<your-company>.com/login/callbacks/azure-ad`
+  :::
+
 ## Create an OpenID connect application
 
 In the Azure Portal, register your app and generate a client secret. For details, see the [Microsoft Azure documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-credentials).
-
-:::note
-Set the redirect URI to the domain where Redpanda Console is hosted followed by the `/login/callbacks/azure-ad` path. For example, `https://console.<your-company>.com/login/callbacks/azure-ad`
-:::
 
 After the app is registered, a summary page opens. This page displays a list of **Essentials**, which you will need when you edit the `redpanda-console-config.yaml file`.
 

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -1,0 +1,132 @@
+---
+title: Azure AD SSO Setup
+---
+
+<head>
+    <meta name="title" content="Azure AD SSO Authentication in Redpanda Console | Redpanda Docs"/>
+    <meta name="description" content="Configure authentication with external identity providers such as Google, GitHub or Okta in Redpanda Console."/>
+</head>
+
+:::info
+This feature requires an [Enterprise license](../../../../get-started/licenses). To upgrade, contact [Redpanda sales](https://redpanda.com/try-redpanda?section=enterprise-cloud).
+:::
+
+Integrating Redpanda Console with Azure AD allows your users to use their Azure AD identities to sign-in to Console.
+This guide assumes you already have an Azure AD account and permissions to create Applications within your directory.
+
+## Create an OpenID connect application
+
+TODO: Write text, possibly refer to: https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings
+
+:::note
+Below configurations assume that you want to host Redpanda Console so that it would be accessible via
+`https://console.yourcompany.com`.
+:::
+
+- **Name:** Any descriptive name for your specific Console deployment (for example Console Analytics Prod)
+- **Supported account types** Select an option that matches your needs. If you are unsure, click "Help me choose...".
+- **Redirect URIs** Web / `https://console.yourcompany.com/login/callbacks/azure-ad`
+
+```yaml
+login:
+  enabled: true
+
+  # jwtSecret is the secret key you must use to sign and encrypt the JSON
+  # web token used to store user sessions. This secret key is
+  # critical for the security of Redpanda Console's authentication and
+  # authorization system. Use a long, complex key with a combination of
+  # numbers, letters, and special characters. While you must use a minimum of
+  # 10 characters, Redpanda recommends using more than 32
+  # characters. For additional security, use a different secret key for
+  # each environment. jwtSecret can be securely generated with the following
+  # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
+  #
+  # If you update this secret key, any users who are
+  # already logged into Redpanda Console will be logged out and will have
+  # to log in again.
+  jwtSecret: ""
+
+  azureAd:
+    enabled: true
+    # ProviderURL must be specified in the following format:
+    # https://login.microsoftonline.com/{tenantId}/v2.0 .
+    # To get this URL, browse to the registered app in your 
+    # Azure Portal, click the "Endpoints" tab. A drawer 
+    # should open with several links. The link below 
+    # "OpenID Connect metadata document" contains the 
+    # provider URL, however you must trim the suffix 
+    # "/.well-known/openid-configuration" so that it 
+    # matches the expected format as shown above.
+    providerUrl: ""
+
+    clientId: ""
+    clientSecret: ""
+
+    #  userIdentifyingClaimKey is a relevant property if you want 
+    #  to use a different claim key to identify users in the 
+    #  role binding. By default, we will use the 'oid' claim key,
+    #  which resolves to the unique user ID within the identity 
+    #  provider. This means that you must provide the oid 
+    #  identifier in the roleBindings as 'name' as well. 
+    #  Other common options are:
+    #  - upn (unique principal name - you need to add the upn 
+    #    claim as a claim for id tokens in your Azure AD application)
+    #  - email (under certain conditions there's no value for 
+    #    the email propagated)
+    userIdentifyingClaimKey: "oid"
+
+    # The directory config is only required if you want to use 
+    # Azure AD groups in your role bindings. Described further
+    # in the next section.
+    # directory:
+    #   tenantId: ""
+```
+
+## RBAC Azure AD groups sync
+
+If you want to bind roles to Azure groups from your organization you have to provide the `tenantId` in the
+directory configuration and add API permissions to your client application. To retrieve the `tenantId` go to
+your registered application in the Azure Active Directory portal. The "Directory (tenant) ID" is listed
+along other configurations in the essentials section.
+
+```yaml
+login:
+  azureAd:
+    directory:
+      tenantId: ""
+```
+
+If you specify the `tenantId` Console will talk to the Microsoft Graph API to retrieve the memberships
+for the specified groups. Therefore the client needs the apropriate permissions. In your AzureAD application
+head to "API permissions" and add permissions for "Group.Read.All", "User.Read.All" and "Directory.Read.All".
+Then also grant admin consent for the default directory by clicking the "Grant admin constent for Default Directory"
+button.
+
+## Define role-bindings
+
+When you set up the GitHub login configuration, you can bind GitHub users or groups to roles. Following is a sample
+role binding:
+
+```yaml
+roleBindings:
+  - metadata:
+      name: Developers
+    subjects:
+      - kind: group
+        provider: AzureAD
+        # Name for group always refers to the group's oid.
+        name: ef0dd5b8-93c3-4a4f-9d90-cba243973d32
+      - kind: user
+        provider: AzureAD
+        # Name refers to the user's OID.
+        # This is dependent on your userIdentifyingClaimKey
+        # configuration. If you use `email` as claim key
+        # you should use the email address instead here.
+        name: c86fdb3f-b0f4-4b0b-9be3-ddf56f48b62f
+    roleName: editor
+```
+
+:::note
+The resolved group memberships will also include transitive members. Thus, you can
+create nested groups and refer these in your role bindings.
+:::

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -18,22 +18,20 @@ This guide assumes you already have an Azure AD account and permissions to creat
 
 Begin by registering your app in the Azure Portal. Provide the following information:
 
-* Display name
-* Supported account types that can access the API (choose single tenant, multi-tenant, or personal accounts)
-* Redirect URI (select `Web` as the platform)
-
-After the app is registered, the overview page opens. This page contains the client ID and client secret, which you paste into the `redpanda-console-config.yaml file`.
+* **Display name** - Choose a descriptive name for your specific Redpanda Console deployment (for example Console Analytics Prod)
+* **Supported account types** - Select the types of accounts that can access the API (choose single tenant, multi-tenant, or personal accounts). If you are unsure, click "Help me choose...".
+* **Redirect URIs** Select Web as the platform and enter `https://console.<yourcompany>.com/login/callbacks/azure-ad` in the text box. Replace `<your-company>.com` with your company's domain name.
 
 For more information, see the Microsoft documentation for [configuring an OpenID connect provider](https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings).
 
+After the app is registered, the overview page opens. This page contains the client ID and client secret, which you paste into the `redpanda-console-config.yaml file`.
+
 :::note
 The configurations below assume that you want to host Redpanda Console so it is accessible at
-`https://console.yourcompany.com`.
+`https://console.<your-company>.com`.
 :::
 
-- **Name:** Any descriptive name for your specific Console deployment (for example Console Analytics Prod)
-- **Supported account types** Select an option that matches your needs. If you are unsure, click "Help me choose...".
-- **Redirect URIs** Web / `https://console.yourcompany.com/login/callbacks/azure-ad`
+Edit the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`, and make the following changes:
 
 ```yaml
 login:
@@ -46,7 +44,9 @@ login:
   # numbers, letters, and special characters. The minimum number of
   # characters is 10, but Redpanda recommends using more than 32
   # characters. For additional security, use a different secret key for
-  # each environment. To securely generate a jwtSecret key, run the following
+  # each environment.
+  #
+  # To securely generate a jwtSecret key, run the following
   # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
   #
   # If you update this secret key, any users who are
@@ -92,10 +92,9 @@ login:
 
 ## RBAC Azure AD groups sync
 
-If you want to bind roles to Azure groups from your organization you have to provide the `tenantId` in the
-directory configuration and add API permissions to your client application. To retrieve the `tenantId` go to
+You can bind roles to Azure groups from your organization by providing the `tenantId` in the directory configuration and adding API permissions to your client application. To retrieve the `tenantId`, go to
 your registered application in the Azure Active Directory portal. The "Directory (tenant) ID" is listed
-along other configurations in the essentials section.
+along with uother configurations in the **Essentials** section.
 
 ```yaml
 login:
@@ -104,15 +103,19 @@ login:
       tenantId: ""
 ```
 
-If you specify the `tenantId` Console will talk to the Microsoft Graph API to retrieve the memberships
-for the specified groups. Therefore the client needs the apropriate permissions. In your AzureAD application
-head to "API permissions" and add permissions for "Group.Read.All", "User.Read.All" and "Directory.Read.All".
-Then also grant admin consent for the default directory by clicking the "Grant admin constent for Default Directory"
-button.
+If you specify the `tenantId`, Redpanda Console will talk to the Microsoft Graph API to retrieve the memberships
+for the specified groups. Therefore, the client needs the appropriate permissions. In your AzureAD application,
+go to "API permissions" and add the following permissions:
+
+* "Group.Read.All"
+* "User.Read.All"
+* "Directory.Read.All"
+
+Next, grant admin consent for the default directory by clicking "Grant admin constent for Default Directory".
 
 ## Define role-bindings
 
-When you set up the GitHub login configuration, you can bind GitHub users or groups to roles. Following is a sample
+When you set up the Azure AD login configuration, you can bind Azure AD users or groups to roles. Following is a sample
 role binding:
 
 ```yaml
@@ -122,19 +125,18 @@ roleBindings:
     subjects:
       - kind: group
         provider: AzureAD
-        # Name for group always refers to the group's oid.
+        # Name for group refers to the group's oid.
         name: ef0dd5b8-93c3-4a4f-9d90-cba243973d32
       - kind: user
         provider: AzureAD
         # Name refers to the user's OID.
-        # This is dependent on your userIdentifyingClaimKey
-        # configuration. If you use `email` as claim key
-        # you should use the email address instead here.
+        # This depends on your userIdentifyingClaimKey
+        # configuration. For example, if you use `email` as the claim key,
+        # use the email address for the name.
         name: c86fdb3f-b0f4-4b0b-9be3-ddf56f48b62f
     roleName: editor
 ```
 
 :::note
-The resolved group memberships will also include transitive members. Thus, you can
-create nested groups and refer these in your role bindings.
+The resolved group memberships will also include transitive members. This allows you to create nested groups and refer to them in your role bindings.
 :::

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -56,7 +56,7 @@ Copy the client secret value into the `redpanda-console-config.yaml` file before
 Edit the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`, and incorporate the details from your app registration.
 
 :::note
-The following configurations are based on hosting Redpanda Console so it is accessible from
+The following configurations are based on the assumption that you host Redpanda Console so it is accessible from
 `https://console.<your-company>.com`.
 :::
 

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -11,27 +11,54 @@ title: Azure AD SSO Setup
 This feature requires an [Enterprise license](../../../../get-started/licenses). To upgrade, contact [Redpanda sales](https://redpanda.com/try-redpanda?section=enterprise-cloud).
 :::
 
-Integrating Redpanda Console with Azure AD allows your users to use their Azure AD identities to sign in to Redpanda Console.
-This guide assumes you already have an Azure AD account and permissions to create Applications within your directory.
+By integrating Redpanda Console with Azure AD, your users can sign in to Redpanda Console using their Azure AD login credentials.
+
+These instructions assume you already have an Azure AD account and permissions to create Applications within your directory.
 
 ## Create an OpenID connect application
 
-Begin by registering your app in the Azure Portal. Provide the following information:
+In the Azure Portal, register your app and generate a client secret.
+
+### Register your app
+
+To register your application, log in to the Azure Portal and provide the following information:
 
 * **Display name** - Choose a descriptive name for your specific Redpanda Console deployment (for example Console Analytics Prod)
 * **Supported account types** - Select the types of accounts that can access the API (choose single tenant, multi-tenant, or personal accounts). If you are unsure, click "Help me choose...".
 * **Redirect URIs** Select Web as the platform and enter `https://console.<yourcompany>.com/login/callbacks/azure-ad` in the text box. Replace `<your-company>.com` with your company's domain name.
 
-For more information, see the Microsoft documentation for [configuring an OpenID connect provider](https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings).
+After the app is registered, a summary page opens. This page displays a list of **Essentials**, which you will need when you edit the `redpanda-console-config.yaml file`.
 
-After the app is registered, the overview page opens. This page contains the client ID and client secret, which you paste into the `redpanda-console-config.yaml file`.
+For detailed instructions, see the Microsoft documentation for [configuring an OpenID connect provider](https://learn.microsoft.com/en-us/power-apps/maker/portals/configure/configure-openid-settings).
+
+### Generate the client secret
+
+Redpanda Console requires a client secret to validate the connection request from the redirect URI. To generate a client secret:
+
+1. In the **Essentials** section of the summary page, click **Add a certificate or secret** next to **Client credentials**.
+
+2. On the **Certificates & secrets** page, select the **Client secrets** tab.
+
+3. Click **New client secret**.
+
+4. In the "Add a client secret" pane, enter a description that identifies the app associated with the client secret.
+
+5. Choose a time period that determines when the client secret will expire; for example, 180 days.
+
+When the client secret is generated successfully, it appears under the **Client secrets** tab with its description, expiration date, value, and secret ID.
+
+:::important
+Copy the client secret value into the `redpanda-console-config.yaml` file before you leave the **Certificates and secrets** page. After you navigate away from the page, only the first few characters of the client secret value are displayed and you won't be able to copy the value into the configuration file.
+:::
+
+## Edit the console configuration file
+
+Edit the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`, and incorporate the details from your app registration.
 
 :::note
 The following configurations assume that you want to host Redpanda Console so it is accessible at
 `https://console.<your-company>.com`.
 :::
-
-Edit the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`, and make the following changes:
 
 ```yaml
 login:
@@ -70,9 +97,9 @@ login:
     clientId: ""
     clientSecret: ""
 
-    #  userIdentifyingClaimKey is a relevant property if you want 
+    #  userIdentifyingClaimKey is only needed when you want 
     #  to use a different claim key to identify users in the 
-    #  role binding. By default, we will use the 'oid' claim key,
+    #  role binding. By default, Redpanda uses the 'oid' claim key,
     #  which resolves to the unique user ID within the identity 
     #  provider. This means that you must provide the oid 
     #  identifier in the roleBindings as 'name' as well. 
@@ -84,7 +111,7 @@ login:
     userIdentifyingClaimKey: "oid"
 
     # The directory config is only required if you want to use 
-    # Azure AD groups in your role bindings. Described further
+    # Azure AD groups in your role bindings, as described 
     # in the next section.
     # directory:
     #   tenantId: ""
@@ -94,7 +121,7 @@ login:
 
 You can bind roles to Azure groups from your organization by providing the `tenantId` in the directory configuration and adding API permissions to your client application. To retrieve the `tenantId`, go to
 your registered application in the Azure Active Directory portal. The "Directory (tenant) ID" is listed
-along with uother configurations in the **Essentials** section.
+along with other configurations in the **Essentials** section.
 
 ```yaml
 login:
@@ -103,8 +130,8 @@ login:
       tenantId: ""
 ```
 
-If you specify the `tenantId`, Redpanda Console will talk to the Microsoft Graph API to retrieve the memberships
-for the specified groups. Therefore, the client needs the appropriate permissions. In your AzureAD application,
+If you specify the `tenantId`, Redpanda Console will send a request to the Microsoft Graph API to retrieve the memberships
+for the specified groups. In order for the Microsoft Graph API to grant the request, the client must have the appropriate permissions. In your AzureAD application,
 go to "API permissions" and add the following permissions:
 
 * "Group.Read.All"
@@ -138,5 +165,5 @@ roleBindings:
 ```
 
 :::note
-The resolved group memberships will also include transitive members. This allows you to create nested groups and refer to them in your role bindings.
+The resolved group memberships can also include transitive members. This allows you to create nested groups and refer to them in your role bindings.
 :::

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -27,7 +27,7 @@ You must have:
 In the Azure Portal, register your app and generate a client secret. For details, see the [Microsoft Azure documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-credentials).
 
 :::note
-Set the redirect URI to the URI where Redpanda Console is hosted.
+Set the redirect URI to the domain where Redpanda Console is hosted followed by the `/login/callbacks/azure-ad` path. For example, `https://console.<your-company>.com/login/callbacks/azure-ad`
 :::
 
 After the app is registered, a summary page opens. This page displays a list of **Essentials**, which you will need when you edit the `redpanda-console-config.yaml file`.

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -53,7 +53,7 @@ Copy the client secret value into the `redpanda-console-config.yaml` file before
 
 ## Edit the console configuration file
 
-Edit the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`, and incorporate the details from your app registration.
+Edit the console configuration file associated with your deployment method and incorporate the details from your client application. For example, Kubernetes deployments use the `values.yaml` file. Linux deployments use the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`.
 
 :::note
 The following configurations are based on the assumption that you host Redpanda Console so it is accessible from

--- a/docs/manage/security/console/azure-ad.mdx
+++ b/docs/manage/security/console/azure-ad.mdx
@@ -13,7 +13,7 @@ This feature requires an [Enterprise license](../../../../get-started/licenses).
 
 By integrating Redpanda Console with Azure AD, your users can sign in to Redpanda Console using their Azure AD login credentials.
 
-These instructions assume you already have an Azure AD account and permissions to create Applications within your directory.
+These instructions assume you already have an Azure AD account and permissions to create applications within your directory.
 
 ## Create an OpenID connect application
 
@@ -56,7 +56,7 @@ Copy the client secret value into the `redpanda-console-config.yaml` file before
 Edit the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`, and incorporate the details from your app registration.
 
 :::note
-The following configurations assume that you want to host Redpanda Console so it is accessible at
+The following configurations are based on hosting Redpanda Console so it is accessible from
 `https://console.<your-company>.com`.
 :::
 
@@ -89,7 +89,7 @@ login:
     # Azure Portal and click the "Endpoints" tab. A drawer 
     # opens with several links. The link below 
     # "OpenID Connect metadata document" contains the 
-    # provider URL; however, you must trim the suffix 
+    # provider URL; however, you must remove the suffix 
     # "/.well-known/openid-configuration" so that it 
     # matches the expected format.
     providerUrl: ""

--- a/docs/manage/security/console/generic-oidc.mdx
+++ b/docs/manage/security/console/generic-oidc.mdx
@@ -12,11 +12,20 @@ This feature requires an [Enterprise license](../../../../get-started/licenses).
 :::
 
 If you would like to integrate an OpenID Connect (OIDC) compatible identity provider that is not yet natively supported in Console,
-you can configure the generic OIDC provider. To do so, you first have to create an OAuth application in your identity provider
+you can configure the generic OIDC provider. To do so, create an OAuth application in your identity provider
 and then provide this application's credentials in the configuration:
 
 - **Application type:** Web application
-- **Authorized redirect URI:** `https://console.yourcompany.com/login/callbacks/oidc`
+- **Authorized redirect URI:** `https://console.<your-company>.com/login/callbacks/oidc`. Replace `<your-company>.com` with your company's domain name.
+
+:::note
+The redirect URI is based on the assumption that you host Redpanda Console so it is accessible from
+`https://console.<your-company>.com`.
+:::
+
+## Edit the console configuration file
+
+Edit the console configuration file associated with your deployment method and incorporate the details from your client application. For example, Kubernetes deployments use the `values.yaml` file. Linux deployments use the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`.
 
 ```yaml
 login:

--- a/docs/manage/security/console/generic-oidc.mdx
+++ b/docs/manage/security/console/generic-oidc.mdx
@@ -26,14 +26,14 @@ login:
   # web token used to store user sessions. This secret key is 
   # critical for the security of Redpanda Console's authentication and 
   # authorization system. Use a long, complex key with a combination of 
-  # numbers, letters, and special characters. While you must use a minimum of 
-  # 10 characters, Redpanda recommends using more than 32 
+  # numbers, letters, and special characters. The minimum number of
+  # characters is 10, but Redpanda recommends using more than 32
   # characters. For additional security, use a different secret key for 
   # each environment. jwtSecret can be securely generated with the following 
   # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
   #
   # If you update this secret key, any users who are 
-  # already logged into Redpanda Console will be logged out and will have 
+  # already logged in to Redpanda Console will be logged out and will have 
   # to log in again.
   jwtSecret: ""
 

--- a/docs/manage/security/console/github.mdx
+++ b/docs/manage/security/console/github.mdx
@@ -22,14 +22,18 @@ organization you have admin access to. As you create the GitHub OAuth app, provi
 when you are asked for them:
 
 :::note
-Below configurations assume that you want to host Redpanda Console so that it would be accessible via
-`https://console.yourcompany.com`.
+The following configurations are based on the assumption that you want to host Redpanda Console so it is accessible from
+`https://console.<your-company>.com`.
 :::
 
-- **Application name:** Any descriptive name for your specific Console deployment (for example Console Analytics Prod)
-- **Homepage URL:** `https://console.yourcompany.com`
-- **Authorization callback URL:** `https://console.yourcompany.com/login/callbacks/github`
+- **Application name:** Choose a descriptive name for your specific Console deployment (for example Console Analytics Prod)
+- **Homepage URL:** `https://console.<your-company>.com`
+- **Authorization callback URL:** `https://console.<your-company>.com/login/callbacks/github`
 - **Enable device flow:** False / Not selected
+
+## Edit the console configuration file
+
+Edit the console configuration file associated with your deployment method and incorporate the details from your client application. For example, Kubernetes deployments use the `values.yaml` file. Linux deployments use the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`.
 
 ```yaml
 login:

--- a/docs/manage/security/console/github.mdx
+++ b/docs/manage/security/console/github.mdx
@@ -18,8 +18,8 @@ This guide assumes you already have a GitHub account and permissions to create A
 
 Follow this [GitHub guide](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) to create
 an OAuth application at GitHub. You can create the OAuth application either under your personal account or under any
-organization you have admin access to. As you follow the guide to create the GitHub OAuth app, use the following inputs
-when you are asked for it:
+organization you have admin access to. As you create the GitHub OAuth app, provide the following inputs
+when you are asked for them:
 
 :::note
 Below configurations assume that you want to host Redpanda Console so that it would be accessible via
@@ -39,14 +39,14 @@ login:
   # web token used to store user sessions. This secret key is 
   # critical for the security of Redpanda Console's authentication and 
   # authorization system. Use a long, complex key with a combination of 
-  # numbers, letters, and special characters. While you must use a minimum of 
-  # 10 characters, Redpanda recommends using more than 32 
+  # numbers, letters, and special characters. The minimum number of
+  # characters is 10, but Redpanda recommends using more than 32
   # characters. For additional security, use a different secret key for 
   # each environment. jwtSecret can be securely generated with the following 
   # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
   #
   # If you update this secret key, any users who are 
-  # already logged into Redpanda Console will be logged out and will have 
+  # already logged in to Redpanda Console will be logged out and will have 
   # to log in again.
   jwtSecret: ""
 

--- a/docs/manage/security/console/github.mdx
+++ b/docs/manage/security/console/github.mdx
@@ -14,7 +14,9 @@ This feature requires an [Enterprise license](../../../../get-started/licenses).
 Integrating Redpanda Console with GitHub allows your users to use their GitHub identities to sign-in to Console.
 This guide assumes you already have a GitHub account and permissions to create Applications within your organization.
 
-## Create an OpenID connect application
+## Prerequisites
+
+You must create an OpenID Connect (OIDC) application for your GitHub account.
 
 Follow this [GitHub guide](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) to create
 an OAuth application at GitHub. You can create the OAuth application either under your personal account or under any

--- a/docs/manage/security/console/google.mdx
+++ b/docs/manage/security/console/google.mdx
@@ -17,12 +17,12 @@ This guide assumes you already have a Google account to set up the OAuth applica
 ## Create an OpenID connect application
 
 Follow this [Google guide](https://developers.google.com/identity/protocols/oauth2/openid-connect#appsetup) to create
-an OAuth application. Use the following inputs
+an OAuth application. Provide the following inputs
 when you are asked for them:
 
 - **Application name:** Choose a descriptive name for your specific Redpanda Console deployment (for example Console Analytics Prod)
 - **Application type:** Web application
-- **Authorized redirect URI:** `https://console.yourcompany.com/login/callbacks/google`
+- **Authorized redirect URI:** `https://console.<your-company>.com/login/callbacks/google`
 
 ## Edit the console configuration file
 
@@ -41,14 +41,14 @@ login:
   # web token used to store user sessions. This secret key is 
   # critical for the security of Redpanda Console's authentication and 
   # authorization system. Use a long, complex key with a combination of 
-  # numbers, letters, and special characters. While you must use a minimum of 
-  # 10 characters, Redpanda recommends using more than 32 
+  # numbers, letters, and special characters. The minimum number of
+  # characters is 10, but Redpanda recommends using more than 32
   # characters. For additional security, use a different secret key for 
   # each environment. jwtSecret can be securely generated with the following 
   # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
   #
   # If you update this secret key, any users who are 
-  # already logged into Redpanda Console will be logged out and will have 
+  # already logged in to Redpanda Console will be logged out and will have 
   # to log in again.
   jwtSecret: ""
 

--- a/docs/manage/security/console/google.mdx
+++ b/docs/manage/security/console/google.mdx
@@ -56,7 +56,7 @@ login:
     enabled: true
     clientId: ""
     # ClientSecret is sensitive. You can also provide this config by setting
-    # the environment variable LOGIN_GOOGLE_CLIENTSECRET
+    # the environment variable LOGIN_GOOGLE_CLIENTSECRET.
     clientSecret: ""
     # The directory config is only required if you want to use Google
     # groups in your role bindings. This is described further in the next section.

--- a/docs/manage/security/console/google.mdx
+++ b/docs/manage/security/console/google.mdx
@@ -14,7 +14,9 @@ This feature requires an [Enterprise license](../../../../get-started/licenses).
 Integrating Redpanda Console with Google allows your users to use their Google identities to sign in to Console.
 This guide assumes you already have a Google account to set up the OAuth application.
 
-## Create an OpenID connect application
+## Prerequisites
+
+You must create an OpenID Connect (OIDC) application for your Google account.
 
 Follow this [Google guide](https://developers.google.com/identity/protocols/oauth2/openid-connect#appsetup) to create
 an OAuth application. Provide the following inputs

--- a/docs/manage/security/console/google.mdx
+++ b/docs/manage/security/console/google.mdx
@@ -12,22 +12,26 @@ This feature requires an [Enterprise license](../../../../get-started/licenses).
 :::
 
 Integrating Redpanda Console with Google allows your users to use their Google identities to sign in to Console.
-This guide assumes you already have a Google account to setup the OAuth application.
+This guide assumes you already have a Google account to set up the OAuth application.
 
 ## Create an OpenID connect application
 
 Follow this [Google guide](https://developers.google.com/identity/protocols/oauth2/openid-connect#appsetup) to create
-an OAuth application at Google. As you follow the guide to create the OAuth app, use the following inputs
-when you are asked for it:
+an OAuth application. Use the following inputs
+when you are asked for them:
 
-:::note
-The following configurations are based on the assumption that you want to host Redpanda Console so that it would be accessible using
-`https://console.yourcompany.com`.
-:::
-
-- **Application name:** Any descriptive name for your specific Console deployment (for example Console Analytics Prod)
+- **Application name:** Choose a descriptive name for your specific Redpanda Console deployment (for example Console Analytics Prod)
 - **Application type:** Web application
 - **Authorized redirect URI:** `https://console.yourcompany.com/login/callbacks/google`
+
+## Edit the console configuration file
+
+Edit the console configuration file associated with your deployment method and incorporate the details from your client application. For example, Kubernetes deployments use the `values.yaml` file. Linux deployments use the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`.
+
+:::note
+The following configurations are based on the assumption that you want to host Redpanda Console so it is accessible from
+`https://console.<your-company>.com`.
+:::
 
 ```yaml
 login:
@@ -51,11 +55,11 @@ login:
   google:
     enabled: true
     clientId: ""
-    # ClientSecret is sensitive. You can provide this config also via the
+    # ClientSecret is sensitive. You can also provide this config by setting
     # the environment variable LOGIN_GOOGLE_CLIENTSECRET
     clientSecret: ""
     # The directory config is only required if you want to use Google
-    # groups in your role bindings. Described further in the next section.
+    # groups in your role bindings. This is described further in the next section.
     # directory:
     #   serviceAccountFilepath: ""
     #   targetPrincipal: ""
@@ -63,14 +67,14 @@ login:
 
 ## RBAC Google groups sync
 
-If you want to bind roles to Google groups from a workspace organization you have to set up a service account, so that Redpanda Console can retrieve groups
+To bind roles to Google groups from a workspace organization, you must set up a service account so Redpanda Console can retrieve groups
 and their memberships using the Google Workspace API. Follow this [guide](https://developers.google.com/admin-sdk/directory/v1/guides/delegation) 
-to create the required service account and to delegate domain-wide authority to it. Make sure to create and download the service account key in JSON
-format.
+to create the required service account and to delegate domain-wide authority to it. Create and download the service account key in JSON
+format and mount the JSON file so it is available to Console. Specify
+the filepath to the JSON file in the Redpanda Console configuration file so it can be loaded at startup.
 
-You need to make the service account key (a JSON file) available to Console by mounting the file. The Console configuration expects you to specify
-the filepath to the JSON file so that it can be loaded at startup. Because only Google users with access to the Admin APIs have access to Google's
-Admin SDK Directory API, it is required that the service account impersonates such a user. Specify which user the service account shall impersonate
+Because only Google users with access to the Admin APIs have access to Google's
+Admin SDK Directory API, the service account must impersonate this user. Specify which user the service account will impersonate
 by setting the `targetPrincipal` to this user's email address.
 
 ```yaml
@@ -108,6 +112,6 @@ roleBindings:
 
 :::note
 Group memberships will be resolved proactively in order to support nested groups. If the service account doesn't have permissions
-to resolve a certain group memberships, it will be printed in the logs. Group memberships will be cached for 15 minutes before
-they will be refreshed.
+to resolve a certain group membership, a message is printed in the logs. Group memberships are cached for 15 minutes before
+they are refreshed.
 :::

--- a/docs/manage/security/console/google.mdx
+++ b/docs/manage/security/console/google.mdx
@@ -24,14 +24,14 @@ when you are asked for them:
 - **Application type:** Web application
 - **Authorized redirect URI:** `https://console.<your-company>.com/login/callbacks/google`
 
+:::note
+The redirect URI is based on the assumption that you want to host Redpanda Console so it is accessible from
+`https://console.<your-company>.com`.
+:::
+
 ## Edit the console configuration file
 
 Edit the console configuration file associated with your deployment method and incorporate the details from your client application. For example, Kubernetes deployments use the `values.yaml` file. Linux deployments use the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`.
-
-:::note
-The following configurations are based on the assumption that you want to host Redpanda Console so it is accessible from
-`https://console.<your-company>.com`.
-:::
 
 ```yaml
 login:

--- a/docs/manage/security/console/index.mdx
+++ b/docs/manage/security/console/index.mdx
@@ -3,23 +3,31 @@ title: Redpanda Console Security
 ---
 
 <head>
-    <meta name="title" content="Redpanda Console Security | Redpanda Docs"/>
-    <meta name="description" content="Redpanda Console Security."/>
+  <meta name="title" content="Redpanda Console Security | Redpanda Docs" />
+  <meta name="description" content="Redpanda Console Security." />
 </head>
 
+- [Azure AD](../console/azure-ad)
+
+  Integrating Redpanda Console with Azure AD allows your users to use their Azure AD identities to sign-in to Console.
+
 - [GitHub SSO Setup](../console/github)
-  
-    Integrating Redpanda Console with GitHub allows your users to use their GitHub identities to sign-in to Console.
+
+  Integrating Redpanda Console with GitHub allows your users to use their GitHub identities to sign-in to Console.
 
 - [Google SSO Setup](../console/google)
 
-    Integrating Redpanda Console with Google allows your users to use their Google identities to sign in to Console.
+  Integrating Redpanda Console with Google allows your users to use their Google identities to sign in to Console.
+
+- [Keycloak](../console/keycloak)
+
+  Integrating Redpanda Console with Keycloak allows your users to use their Keycloak identities to sign-in to Console.
 
 - [Okta SSO Setup](../console/okta)
 
-    Integrating Redpanda Console with Okta allows your users to use their Okta identities to sign in to Redpanda Console.
+  Integrating Redpanda Console with Okta allows your users to use their Okta identities to sign in to Redpanda Console.
 
 - [Generic OIDC](../console/generic-oidc)
 
-    If you would like to integrate an OpenID Connect (OIDC) compatible identity provider that is not yet natively supported in Console,
-    you can configure the generic OIDC provider.
+  If you would like to integrate an OpenID Connect (OIDC) compatible identity provider that is not yet natively supported in Console,
+  you can configure the generic OIDC provider.

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -4,7 +4,7 @@ title: Keycloak SSO Setup
 
 <head>
     <meta name="title" content="Keycloak SSO Authentication in Redpanda Console | Redpanda Docs"/>
-    <meta name="description" content="Configure authentication with external identity providers such as Google, GitHub or Okta in Redpanda Console."/>
+    <meta name="description" content="Configure authentication with external identity providers in Redpanda Console."/>
 </head>
 
 :::info
@@ -17,7 +17,11 @@ By integrating Redpanda Console with Keycloak, your users can sign in to Redpand
 
 Install Keycloak and create a super admin user account, which has the necessary permissions for setting up the OAuth application.
 
-Create at least one realm for managing and authenticating a specific group of users.
+(Optional) Create at least one realm for managing and authenticating a specific group of users.
+
+:::note
+You can use the master realm, or you can create a realm for managing and authenticating a specific group of users.
+:::
 
 ## Create an OpenID connect application
 

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -38,7 +38,7 @@ Create at least one realm for managing and authenticating a specific group of us
 
 7. In **Valid redirect URIs**, enter the URI where users are redirected after they log in successfully.
 
-    For example, if users access Redpanda Console from `https://console.<your-company>.com`, enter the following URI and replace <your-company> with the actual URI:
+    For example, if users access Redpanda Console from `https://console.<your-company>.com`, enter the following URI and replace `<your-company>` with the actual URI:
 
     ```
     https://console.<your-company>.com/login/callbacks/keycloak

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -5,6 +5,7 @@ title: Keycloak SSO Setup
 <head>
     <meta name="title" content="Keycloak SSO Authentication in Redpanda Console | Redpanda Docs"/>
     <meta name="description" content="Configure authentication with external identity providers in Redpanda Console."/>
+    <link rel="canonical" href="https://docs.redpanda.com/docs/manage/security/console/keycloak" />
 </head>
 
 :::info
@@ -15,58 +16,20 @@ By integrating Redpanda Console with Keycloak, your users can sign in to Redpand
 
 ## Prerequisites
 
-Install Keycloak and create a super admin user account, which has the necessary permissions for setting up the OAuth application.
+You must:
+
+- Install Keycloak and create a super admin user account, which has the necessary permissions for setting up the OAuth application. For details, see the [Keyclock documentation](https://www.keycloak.org/guides).
+- Create an OpenID Connect (OIDC) client. For details, see the [Keyclock documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-oidc-client_server_administration_guide).
+
+  :::note
+  - Set the valid redirect URIs to the URI where Redpanda Console is hosted.
+  - Copy the client ID and client secret. The console configuration file uses these credentials to establish communication with Keycloak.
+  :::
 
 (Optional) Create at least one realm for managing and authenticating a specific group of users.
 
 :::note
 You can use the master realm, or you can create a realm for managing and authenticating a specific group of users.
-:::
-
-## Create an OpenID connect application
-
-1. Log in to the Keycloak Admin Console.
-
-2. Select the realm where you want to create a client. 
-
-    Clients are applications and services that request user authentication.
-
-3. In the navigation pane, select **Clients**.
-
-4. On the **Clients** page, click **Create client**.
-    The **General Settings** page opens.
-
-5. In **Client ID**, enter a name for your console application, then click **Next**.
-    The **Capability config** page opens.
-
-6. Enable **Client authentication**, then click **Next**.
-    The **Login settings** page opens.
-
-7. In **Valid redirect URIs**, enter the URI where users are redirected after they log in successfully.
-
-    For example, if users access Redpanda Console from `https://console.<your-company>.com`, enter the following URI and replace `<your-company>` with the actual URI:
-
-    ```
-    https://console.<your-company>.com/login/callbacks/keycloak
-    ```
-
-    If you host Redpanda Console on your local machine, for example, you would use the following URI instead:
-    
-    ```
-    https://localhost:8080/login/callbacks/keycloak`
-    ```
-
-8. Click **Save**.
-    A summary page opens.
-
-9. Click the **Credentials** tab.
-
-10. In **Client Authenticator**, select **Client Id and Secret**, then click **Save**.
-
-11. Copy the **Client secret**, which is automatically generated.
-
-:::info
-The console configuration file uses the client secret, which is basically a password, to establish communication with Keycloak.
 :::
 
 ## Edit the console configuration file

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -18,9 +18,9 @@ By integrating Redpanda Console with Keycloak, your users can sign in to Redpand
 
 You must:
 
-- Install Keycloak and create a super admin user account, which has permissions for setting up an OAuth application. For details, see the [Keyclock documentation](https://www.keycloak.org/guides).
+- Install Keycloak and create a super admin user account, which has permissions for setting up an OAuth application. For details, see the [Keycloak documentation](https://www.keycloak.org/guides).
 
-- Create an OpenID Connect (OIDC) client. For details, see the [Keyclock documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-oidc-client_server_administration_guide).
+- Create an OpenID Connect (OIDC) client. For details, see the [Keycloak documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-oidc-client_server_administration_guide).
 
   Provide the following inputs when you are asked for them:
 

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -1,5 +1,5 @@
 ---
-title: Keycloak SSO Setup
+title: Keycloak SSO Authentication in Redpanda Console
 ---
 
 <head>
@@ -18,19 +18,25 @@ By integrating Redpanda Console with Keycloak, your users can sign in to Redpand
 
 You must:
 
-- Install Keycloak and create a super admin user account, which has the necessary permissions for setting up the OAuth application. For details, see the [Keyclock documentation](https://www.keycloak.org/guides).
-- Create an OpenID Connect (OIDC) client. For details, see the [Keyclock documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-oidc-client_server_administration_guide).
+- Install Keycloak and create a super admin user account, which has permissions for setting up an OAuth application. For details, see the [Keyclock documentation](https://www.keycloak.org/guides).
 
-  :::note
-  - Set the valid redirect URIs to the domain where Redpanda Console is hosted followed by the `/login/callbacks/keycloak` path. For example, `https://console.<your-company>.com/login/callbacks/keycloak`
-  - Copy the client ID and client secret. The console configuration file uses these credentials to establish communication with Keycloak.
-  :::
+- Create an OpenID Connect (OIDC) client. For details, see the [Keyclock documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-oidc-client_server_administration_guide). You'll need to:
 
-(Optional) Create at least one realm for managing and authenticating a specific group of users.
+  - Leave Client type set to OpenID Connect.
 
-:::note
-You can use the master realm, or you can create a realm for managing and authenticating a specific group of users.
-:::
+  - Enter a alphanumeric Client ID that the Keycloak database can use to identify the client.
+
+  - Enter any name for the client.
+
+  - Set the valid redirect URI in **Access Settings** to the domain where Redpanda Console is hosted followed by the `/login/callbacks/keycloak` path. For example, `https://console.<your-company>.com/login/callbacks/keycloak` or `https://localhost:8080/login/callbacks/keycloak`.
+
+  - Copy the client ID and client secret. The [console configuration file](#edit-the-console-configuration-file) uses these credentials to establish communication with Keycloak.
+
+  - (Optional) Create at least one realm for managing and authenticating a specific group of users.
+
+    :::note
+    You can use the master realm, or you can create a realm for managing and authenticating a specific group of users.
+    :::
 
 ## Edit the console configuration file
 
@@ -63,8 +69,8 @@ login:
     clientId: ""
     clientSecret: ""
 
-    # The directory configuration is only required if you want to 
-    # use Keycloak groups in your role bindings. 
+    # The directory configuration is only required if you want to
+    # use Keycloak groups in your role bindings.
     # This is described further in the next section.
     # directory:
     #   adminUser: ""

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -22,7 +22,7 @@ You must:
 - Create an OpenID Connect (OIDC) client. For details, see the [Keyclock documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-oidc-client_server_administration_guide).
 
   :::note
-  - Set the valid redirect URIs to the URI where Redpanda Console is hosted.
+  - Set the valid redirect URIs to the domain where Redpanda Console is hosted followed by the `/login/callbacks/keycloak` path. For example, `https://console.<your-company>.com/login/callbacks/keycloak`
   - Copy the client ID and client secret. The console configuration file uses these credentials to establish communication with Keycloak.
   :::
 

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -1,0 +1,95 @@
+---
+title: Keycloak SSO Setup
+---
+
+<head>
+    <meta name="title" content="Keycloak SSO Authentication in Redpanda Console | Redpanda Docs"/>
+    <meta name="description" content="Configure authentication with external identity providers such as Google, GitHub or Okta in Redpanda Console."/>
+</head>
+
+:::info
+This feature requires an [Enterprise license](../../../../get-started/licenses). To upgrade, contact [Redpanda sales](https://redpanda.com/try-redpanda?section=enterprise-cloud).
+:::
+
+Integrating Redpanda Console with Keycloak allows your users to use their Keycloak identities to sign-in to Console.
+This guide assumes you already have a Keycloak admin account to setup the OAuth application.
+
+## Create an OpenID connect application
+
+TODO: Describe how to create the application in Keycloak.
+
+:::note
+The following configurations are based on the assumption that you want to host Redpanda Console so that it would be accessible using
+`https://console.yourcompany.com`.
+:::
+
+- **Application name:** Any descriptive name for your specific Console deployment (for example Console Analytics Prod)
+- **Application type:** Web application
+- **Authorized redirect URI:** `https://console.yourcompany.com/login/callbacks/keycloak`
+
+```yaml
+login:
+  enabled: true
+
+  # jwtSecret is the secret key you must use to sign and encrypt the JSON
+  # web token used to store user sessions. This secret key is
+  # critical for the security of Redpanda Console's authentication and
+  # authorization system. Use a long, complex key with a combination of
+  # numbers, letters, and special characters. While you must use a minimum of
+  # 10 characters, Redpanda recommends using more than 32
+  # characters. For additional security, use a different secret key for
+  # each environment. jwtSecret can be securely generated with the following
+  # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
+  #
+  # If you update this secret key, any users who are
+  # already logged into Redpanda Console will be logged out and will have
+  # to log in again.
+  jwtSecret: ""
+
+  keycloak:
+    enabled: true
+    url: https://keycloak.internal.company.com
+    realm: master
+
+    clientId: ""
+    clientSecret: ""
+
+    # The directory config is only required if you want to 
+    # use Keycloak groups in your role bindings. 
+    # Described further in the next section.
+    # directory:
+    #   adminUser: ""
+    #   adminPassword: ""
+```
+
+## RBAC Keycloak groups sync
+
+If you want to bind roles to Keycloak groups you need to specifcy admin user credentials. These credentials
+are used to resolve group memberships when communicating with Keycloak's API.
+
+```yaml
+login:
+  keycloak:
+    directory:
+      adminUser: ""
+      adminPassword: ""
+```
+
+## Define role-bindings
+
+When you set up the Keycloak login configuration, you can bind Keycloak users or groups to roles. Following is a sample
+role binding:
+
+```yaml
+roleBindings:
+  - metadata:
+      name: Developers
+    subjects:
+      - kind: group
+        provider: Keycloak
+        name: 55e999ff-7923-4750-b2e1-7387768958a0 # Group ID
+      - kind: user
+        provider: Keycloak
+        name: martin # Keycloak login / username
+    roleName: editor
+```

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -69,7 +69,7 @@ The `redpanda-console-config.yaml` file uses the client secret to establish comm
 
 ## Edit the console configuration file
 
-Edit the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`, and incorporate the details from your client application.
+Edit the console configuration file associated with your deployment method and incorporate the details from your client application. For example, Kubernetes deployments use the `values.yaml` file. Linux deployments use the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`.
 
 :::note
 The following configurations are based on the assumption that you host Redpanda Console so it is accessible from

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -73,11 +73,6 @@ The console configuration file uses the client secret, which is basically a pass
 
 Edit the console configuration file associated with your deployment method and incorporate the details from your client application. For example, Kubernetes deployments use the `values.yaml` file. Linux deployments use the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`.
 
-:::note
-The following configurations are based on the assumption that you host Redpanda Console so it is accessible from
-`https://console.<your-company>.com`.
-:::
-
 ```yaml
 login:
   enabled: true

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -19,7 +19,7 @@ This guide assumes you already have a Keycloak admin account to setup the OAuth 
 TODO: Describe how to create the application in Keycloak.
 
 :::note
-The following configurations are based on the assumption that you want to host Redpanda Console so that it would be accessible using
+The following configurations assume that you want to host Redpanda Console so it is accessible at
 `https://console.yourcompany.com`.
 :::
 
@@ -54,9 +54,9 @@ login:
     clientId: ""
     clientSecret: ""
 
-    # The directory config is only required if you want to 
+    # The directory configuration is only required if you want to 
     # use Keycloak groups in your role bindings. 
-    # Described further in the next section.
+    # This is described further in the next section.
     # directory:
     #   adminUser: ""
     #   adminPassword: ""
@@ -64,7 +64,7 @@ login:
 
 ## RBAC Keycloak groups sync
 
-If you want to bind roles to Keycloak groups you need to specifcy admin user credentials. These credentials
+To bind roles to Keycloak groups, you need to specify admin user credentials. These credentials
 are used to resolve group memberships when communicating with Keycloak's API.
 
 ```yaml

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -27,7 +27,9 @@ You can use the master realm, or you can create a realm for managing and authent
 
 1. Log in to the Keycloak Admin Console.
 
-2. Select the realm where you want to create a client (clients are applications and services that request user authentication).
+2. Select the realm where you want to create a client. 
+
+    Clients are applications and services that request user authentication.
 
 3. In the navigation pane, select **Clients**.
 
@@ -64,7 +66,7 @@ You can use the master realm, or you can create a realm for managing and authent
 11. Copy the **Client secret**, which is automatically generated.
 
 :::info
-The `redpanda-console-config.yaml` file uses the client secret to establish communication with Keycloak.
+The console configuration file uses the client secret, which is basically a password, to establish communication with Keycloak.
 :::
 
 ## Edit the console configuration file
@@ -84,21 +86,21 @@ login:
   # web token used to store user sessions. This secret key is
   # critical for the security of Redpanda Console's authentication and
   # authorization system. Use a long, complex key with a combination of
-  # numbers, letters, and special characters. While you must use a minimum of
-  # 10 characters, Redpanda recommends using more than 32
+  # numbers, letters, and special characters. The minimum number of
+  # characters is 10, but Redpanda recommends using more than 32
   # characters. For additional security, use a different secret key for
   # each environment. jwtSecret can be securely generated with the following
   # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
   #
   # If you update this secret key, any users who are
-  # already logged into Redpanda Console will be logged out and will have
+  # already logged in to Redpanda Console will be logged out and will have
   # to log in again.
   jwtSecret: ""
 
   keycloak:
     enabled: true
     url: https://keycloak.internal.company.com
-    realm: <realm-name> # Replace this placeholder with the actual realm name.
+    realm: <realm-name> # Replace <realm-name> with the actual realm name.
 
     clientId: ""
     clientSecret: ""
@@ -113,8 +115,7 @@ login:
 
 ## RBAC Keycloak groups sync
 
-To bind roles to Keycloak groups, you need to specify admin user credentials. These credentials
-are used to resolve group memberships when communicating with Keycloak's API.
+To bind roles to Keycloak groups, you must specify admin user credentials, which are used to resolve group memberships when communicating with Keycloak's API. These credentials must be the same ones that are used to log in to the Keycloak admin panel, and they must be associated with the realm where the group memberships will be resolved.
 
 ```yaml
 login:

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -20,23 +20,27 @@ You must:
 
 - Install Keycloak and create a super admin user account, which has permissions for setting up an OAuth application. For details, see the [Keyclock documentation](https://www.keycloak.org/guides).
 
-- Create an OpenID Connect (OIDC) client. For details, see the [Keyclock documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-oidc-client_server_administration_guide). You'll need to:
+- Create an OpenID Connect (OIDC) client. For details, see the [Keyclock documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-oidc-client_server_administration_guide).
 
-  - Leave Client type set to OpenID Connect.
+  Provide the following inputs when you are asked for them:
 
-  - Enter a alphanumeric Client ID that the Keycloak database can use to identify the client.
+    - **Client type**: OpenID Connect
 
-  - Enter any name for the client.
+    - **Client ID**: Enter a alphanumeric that the Keycloak database can use to identify the client
 
-  - Set the valid redirect URI in **Access Settings** to the domain where Redpanda Console is hosted followed by the `/login/callbacks/keycloak` path. For example, `https://console.<your-company>.com/login/callbacks/keycloak` or `https://localhost:8080/login/callbacks/keycloak`.
+    - **Name**: Enter any name for the client
 
-  - Copy the client ID and client secret. The [console configuration file](#edit-the-console-configuration-file) uses these credentials to establish communication with Keycloak.
+    - **Valid Redirect URIs**: Enter the domain where Redpanda Console is hosted followed by the `/login/callbacks/keycloak` path. For example, `https://console.<your-company>.com/login/callbacks/keycloak` or `https://localhost:8080/login/callbacks/keycloak`.
 
-  - (Optional) Create at least one realm for managing and authenticating a specific group of users.
+    - (Optional) Create at least one realm for managing and authenticating a specific group of users
 
-    :::note
-    You can use the master realm, or you can create a realm for managing and authenticating a specific group of users.
-    :::
+      :::note
+      You can use the master realm, or you can create a realm for managing and authenticating a specific group of users.
+      :::
+
+  :::info
+  Copy the client ID and client secret. The [console configuration file](#edit-the-console-configuration-file) uses these credentials to establish communication with Keycloak.
+  :::
 
 ## Edit the console configuration file
 

--- a/docs/manage/security/console/keycloak.mdx
+++ b/docs/manage/security/console/keycloak.mdx
@@ -11,21 +11,66 @@ title: Keycloak SSO Setup
 This feature requires an [Enterprise license](../../../../get-started/licenses). To upgrade, contact [Redpanda sales](https://redpanda.com/try-redpanda?section=enterprise-cloud).
 :::
 
-Integrating Redpanda Console with Keycloak allows your users to use their Keycloak identities to sign-in to Console.
-This guide assumes you already have a Keycloak admin account to setup the OAuth application.
+By integrating Redpanda Console with Keycloak, your users can sign in to Redpanda Console using their Keycloak login credentials.
+
+## Prerequisites
+
+Install Keycloak and create a super admin user account, which has the necessary permissions for setting up the OAuth application.
+
+Create at least one realm for managing and authenticating a specific group of users.
 
 ## Create an OpenID connect application
 
-TODO: Describe how to create the application in Keycloak.
+1. Log in to the Keycloak Admin Console.
 
-:::note
-The following configurations assume that you want to host Redpanda Console so it is accessible at
-`https://console.yourcompany.com`.
+2. Select the realm where you want to create a client (clients are applications and services that request user authentication).
+
+3. In the navigation pane, select **Clients**.
+
+4. On the **Clients** page, click **Create client**.
+    The **General Settings** page opens.
+
+5. In **Client ID**, enter a name for your console application, then click **Next**.
+    The **Capability config** page opens.
+
+6. Enable **Client authentication**, then click **Next**.
+    The **Login settings** page opens.
+
+7. In **Valid redirect URIs**, enter the URI where users are redirected after they log in successfully.
+
+    For example, if users access Redpanda Console from `https://console.<your-company>.com`, enter the following URI and replace <your-company> with the actual URI:
+
+    ```
+    https://console.<your-company>.com/login/callbacks/keycloak
+    ```
+
+    If you host Redpanda Console on your local machine, for example, you would use the following URI instead:
+    
+    ```
+    https://localhost:8080/login/callbacks/keycloak`
+    ```
+
+8. Click **Save**.
+    A summary page opens.
+
+9. Click the **Credentials** tab.
+
+10. In **Client Authenticator**, select **Client Id and Secret**, then click **Save**.
+
+11. Copy the **Client secret**, which is automatically generated.
+
+:::info
+The `redpanda-console-config.yaml` file uses the client secret to establish communication with Keycloak.
 :::
 
-- **Application name:** Any descriptive name for your specific Console deployment (for example Console Analytics Prod)
-- **Application type:** Web application
-- **Authorized redirect URI:** `https://console.yourcompany.com/login/callbacks/keycloak`
+## Edit the console configuration file
+
+Edit the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`, and incorporate the details from your client application.
+
+:::note
+The following configurations are based on the assumption that you host Redpanda Console so it is accessible from
+`https://console.<your-company>.com`.
+:::
 
 ```yaml
 login:
@@ -49,7 +94,7 @@ login:
   keycloak:
     enabled: true
     url: https://keycloak.internal.company.com
-    realm: master
+    realm: <realm-name> # Replace this placeholder with the actual realm name.
 
     clientId: ""
     clientSecret: ""

--- a/docs/manage/security/console/okta.mdx
+++ b/docs/manage/security/console/okta.mdx
@@ -49,14 +49,14 @@ login:
   # web token used to store user sessions. This secret key is 
   # critical for the security of Redpanda Console's authentication and 
   # authorization system. Use a long, complex key with a combination of 
-  # numbers, letters, and special characters. While you must use a minimum of 
-  # 10 characters, Redpanda recommends using more than 32 
+  # numbers, letters, and special characters. The minimum number of
+  # characters is 10, but Redpanda recommends using more than 32
   # characters. For additional security, use a different secret key for 
   # each environment. jwtSecret can be securely generated with the following 
   # command: LC_ALL=C tr -dc '[:alnum:]' < /dev/random | head -c32
   #
   # If you update this secret key, any users who are 
-  # already logged into Redpanda Console will be logged out and will have 
+  # already logged in to Redpanda Console will be logged out and will have 
   # to log in again.
   jwtSecret: ""
 

--- a/docs/manage/security/console/okta.mdx
+++ b/docs/manage/security/console/okta.mdx
@@ -30,8 +30,16 @@ The following configurations are based on the assumption that you want to host R
 - **Sign-in method:** OIDC - Open ID Connect / Application type: Web Application
 - **Assignments:** Select groups that shall be able to use Redpanda Console (authorization can be made more granular using Redpanda Console's RBAC system)
 
-When you create the Okta application you should be able to access the application's client credentials (client ID and client secret).
-Put the following credentials into your Redpanda Console configuration:
+## Edit the console configuration file
+
+Edit the console configuration file associated with your deployment method and incorporate the details from your client application. For example, Kubernetes deployments use the `values.yaml` file. Linux deployments use the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`.
+
+When you create the Okta application, you should be able to retrieve the application's client ID and client secret and put them in your Redpanda Console configuration.
+
+:::note
+The following configurations are based on the assumption that you host Redpanda Console so it is accessible from
+`https://console.<your-company>.com`.
+:::
 
 ```yaml
 login:
@@ -54,21 +62,21 @@ login:
 
   okta:
     enabled: true
-    # URL to the OIDC endpoint, e.g. "https://yourcompany.com.okta.com"
+    # URL to the OIDC endpoint; for example, "https://<your-company>.com.okta.com"
     url: ""
     clientId: ""
-    # ClientSecret is sensitive. You can provide this config also via the
-    # the environment variable LOGIN_OKTA_CLIENTSECRET
+    # ClientSecret is sensitive. You can also provide this config by setting
+    # the environment variable LOGIN_OKTA_CLIENTSECRET.
     clientSecret: ""
     # The directory config is only required if you want to use Okta
-    # groups in your role bindings. Described further in the next section.
+    # groups in your role bindings. This is described further in the next section.
     # directory:
     #   apiToken: ""
 ```
 
 ## RBAC Okta groups sync
 
-If you want to bind roles to Okta groups, you must set up an API token in Okta so that Redpanda Console can retrieve groups
+To bind roles to Okta groups, you must set up an API token in Okta so that Redpanda Console can retrieve groups
 and their memberships using the Okta API. To create an API token, refer to the [Okta guide](https://developer.okta.com/docs/guides/create-an-api-token/main/).
 After completing the steps in the guide, insert the created API token into the configuration:
 

--- a/docs/manage/security/console/okta.mdx
+++ b/docs/manage/security/console/okta.mdx
@@ -22,24 +22,19 @@ when prompted:
 
 :::note
 The following configurations are based on the assumption that you want to host Redpanda Console so that it is accessible using
-`https://console.yourcompany.com`.
+`https://console.<your-company>.com`.
 :::
 
-- **Redirect URI:** `https://console.yourcompany.com/login/callbacks/okta`
-- **Logout Redirect URI:** `https://console.yourcompany.com`
+- **Redirect URI:** `https://console.<your-company>.com/login/callbacks/okta`
+- **Logout Redirect URI:** `https://console.<your-company>.com`
 - **Sign-in method:** OIDC - Open ID Connect / Application type: Web Application
-- **Assignments:** Select groups that shall be able to use Redpanda Console (authorization can be made more granular using Redpanda Console's RBAC system)
+- **Assignments:** Select groups that are authorized to use Redpanda Console (authorization can be made more granular using Redpanda Console's RBAC system)
 
 ## Edit the console configuration file
 
 Edit the console configuration file associated with your deployment method and incorporate the details from your client application. For example, Kubernetes deployments use the `values.yaml` file. Linux deployments use the `redpanda-console-config.yaml` file, which is in `/etc/redpanda`.
 
 When you create the Okta application, you should be able to retrieve the application's client ID and client secret and put them in your Redpanda Console configuration.
-
-:::note
-The following configurations are based on the assumption that you host Redpanda Console so it is accessible from
-`https://console.<your-company>.com`.
-:::
 
 ```yaml
 login:

--- a/sidebars.js
+++ b/sidebars.js
@@ -393,8 +393,18 @@ module.exports = {
                       },
                       {
                         "type": "doc",
+                        "label": "Azure AD",
+                        "id": "manage/security/console/azure-ad"
+                      },
+                      {
+                        "type": "doc",
                         "label": "GitHub",
                         "id": "manage/security/console/github"
+                      },
+                      {
+                        "type": "doc",
+                        "label": "Generic OIDC",
+                        "id": "manage/security/console/generic-oidc"
                       },
                       {
                         "type": "doc",
@@ -403,14 +413,14 @@ module.exports = {
                       },
                       {
                         "type": "doc",
-                        "label": "Okta",
-                        "id": "manage/security/console/okta"
+                        "label": "Keycloak",
+                        "id": "manage/security/console/keycloak"
                       },
                       {
                         "type": "doc",
-                        "label": "Generic OIDC",
-                        "id": "manage/security/console/generic-oidc"
-                      }
+                        "label": "Okta",
+                        "id": "manage/security/console/okta"
+                      },
                     ]
                   },
                   "manage/security/iam-roles",


### PR DESCRIPTION
This PR adds Azure AD & Keycloak documentation for the upcoming Console release. It's still missing content that describes how to create the OIDC application in the respective identity provider. I asked Anne to help here and I'll meet with her next week to show how it's done. 

Resolves #1481 