### PR TITLE
rpk reference: clarify that debug bundle must run inside pod

### DIFF
--- a/docs/reference/rpk/rpk-debug/shared/_bundle-contents-k8s.mdx
+++ b/docs/reference/rpk/rpk-debug/shared/_bundle-contents-k8s.mdx
@@ -1,5 +1,5 @@
 :::note
-Redpanda collects some data from the Kubernetes API.
+rpk collects some data from the Kubernetes API. To do so, execute the rpk debug bundle command inside a Pod container that's running a Redpanda broker.
 To communicate with the Kubernetes API, Redpanda requires a ClusterRole attached to the default ServiceAccount for the Pods.
 The files and directories that are generated only when the ClusterRole exists are labeled **Requires ClusterRole**.
 :::

--- a/versioned_docs/version-23.2/reference/rpk/rpk-debug/shared/_bundle-contents-k8s.mdx
+++ b/versioned_docs/version-23.2/reference/rpk/rpk-debug/shared/_bundle-contents-k8s.mdx
@@ -1,5 +1,5 @@
 :::note
-Redpanda collects some data from the Kubernetes API.
+rpk collects some data from the Kubernetes API. To do so, execute the rpk debug bundle command inside a Pod container that's running a Redpanda broker.
 To communicate with the Kubernetes API, Redpanda requires a ClusterRole attached to the default ServiceAccount for the Pods.
 The files and directories that are generated only when the ClusterRole exists are labeled **Requires ClusterRole**.
 :::


### PR DESCRIPTION
During an internal conversation, we saw that we document this requirement: https://docs.redpanda.com/docs/manage/kubernetes/troubleshooting/diagnostics-bundle/#generate-a-diagnostics-bundle but not on this page.