### PR TITLE
Add mouseflow custom variables to track positive/negative feedback

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -169,7 +169,14 @@ module.exports = async () => {
             injectHtmlTags({content}) {
               return {
                 headTags:['<meta name="google-site-verification" content="QcL-pD81oJatgKXQ3Wquvk_Ku3RRtUljxKoMaicySQA" />'],
-                preBodyTags: [`<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WB2CSV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>`],
+                preBodyTags: [`<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WB2CSV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><script type="text/javascript"> 
+                window._mfq = window._mfq || []; 
+                (function() { 
+                   var mf = document.createElement("script"); mf.type = "text/javascript"; mf.defer = true; 
+                   mf.src = "//cdn.mouseflow.com/projects/4260ac2a-9c53-42f1-a6cf-c2942fbfc263.js"; 
+                   document.getElementsByTagName("head")[0].appendChild(mf); 
+                })(); 
+             </script>`],
               };
             },
           }

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -15,6 +15,13 @@ import BrowserOnly from "@docusaurus/BrowserOnly";
 import Icon from "@material-ui/core/Icon";
 import ContributionIcon from "../../../../static/img/contribution.svg";
 
+// Set mouseflow custom variable
+// (See https://help.mouseflow.com/en/articles/4312070-custom-variables)
+function setFeedbackType(type) {
+  window._mfq = window._mfq || [];
+  window._mfq.push(["setVariable", type, "true"]);
+}
+
 function createEditablePlaceholders () {
   const codeElements = document.querySelectorAll("pre > code");
 
@@ -338,7 +345,7 @@ export default function DocItemLayout({ children,
                   className={
                     styles.mailIcon + " " + styles.thumbsUpSeparator
                   }
-                  onClick={() => {setShow(true); setPositiveFeedback(true);}}
+                  onClick={() => {setShow(true); setPositiveFeedback(true); setFeedbackType("positive-feedback");}}
                 >
                   <Icon>thumb_up</Icon>
                 </button>
@@ -347,7 +354,7 @@ export default function DocItemLayout({ children,
                   className={
                     styles.mailIcon + " " + styles.thumbsUpSeparator
                   }
-                  onClick={() => {setShow(true); setPositiveFeedback(false);}}
+                  onClick={() => {setShow(true); setPositiveFeedback(false); setFeedbackType("negative-feedback");}}
                 >
                   <Icon>thumb_down</Icon>
                 </button>


### PR DESCRIPTION
Following [Mouseflow's Custom Variables guide](https://help.mouseflow.com/en/articles/4312070-custom-variables), added Mouseflow variables `positive-feedback` and `negative-feedback` that are set `true` when the thumbs-up and thumbs-down buttons are clicked, respectively.

Can now filter for and observe Mouseflow recordings where positive or negative feedback are clicked.