### PR TITLE
Switch owl-shop example to use yaml config.

### DIFF
--- a/docs/reference/docker-compose.mdx
+++ b/docs/reference/docker-compose.mdx
@@ -72,6 +72,12 @@ This `docker-compose.yml` file starts a single Redpanda broker, Redpanda Console
         - redpanda:/var/lib/redpanda/data
       networks:
         - redpanda_network
+      healthcheck:
+        test: ["CMD-SHELL", "rpk cluster health | grep -E 'Healthy:.+true' || exit 1"]
+        interval: 15s
+        timeout: 3s
+        retries: 5
+        start_period: 5s
 
     console:
       image: docker.redpanda.com/redpandadata/console:vVAR::CONSOLE_LATEST_VERSION
@@ -106,11 +112,18 @@ This `docker-compose.yml` file starts a single Redpanda broker, Redpanda Console
       networks:
         - redpanda_network
       # platform: 'linux/amd64'
+      entrypoint: /bin/sh
+      command: -c "echo \"$$OWLSHOP_CONFIG_FILE\" > /tmp/config.yml; /app/owlshop"
       environment:
-        - SHOP_KAFKA_BROKERS=redpanda:19092
-        - SHOP_KAFKA_TOPICREPLICATIONFACTOR=1
-        - SHOP_TRAFFIC_INTERVAL_RATE=1
-        - SHOP_TRAFFIC_INTERVAL_DURATION=0.1s
+        CONFIG_FILEPATH: /tmp/config.yml
+        OWLSHOP_CONFIG_FILE: |
+          shop:
+            requestRate: 1
+            interval: 0.1s
+            topicReplicationFactor: 1
+            topicPartitionCount: 1
+          kafka:
+            brokers: "redpanda:9092"
       depends_on:
         - redpanda
 
@@ -139,7 +152,7 @@ This `docker-compose.yml` file starts a single Redpanda broker, Redpanda Console
             offset.flush.interval.ms=1000
             producer.linger.ms=50
             producer.batch.size=131072
-        CONNECT_BOOTSTRAP_SERVERS: redpanda:19092
+        CONNECT_BOOTSTRAP_SERVERS: redpanda:9092
         CONNECT_GC_LOG_ENABLED: "false"
         CONNECT_HEAP_OPTS: -Xms512M -Xmx512M
         CONNECT_LOG_LEVEL: info

--- a/docs/reference/docker-compose.mdx
+++ b/docs/reference/docker-compose.mdx
@@ -108,7 +108,7 @@ This `docker-compose.yml` file starts a single Redpanda broker, Redpanda Console
         - redpanda
 
     owl-shop:
-      image: quay.io/cloudhut/owl-shop:latest
+      image: quay.io/cloudhut/owl-shop:sha-042112b
       networks:
         - redpanda_network
       # platform: 'linux/amd64'


### PR DESCRIPTION
Environment variables seem busted. Also adds a healthcheck for Redpanda as owlshop will fail fast and not retry to connect if the broker interface isn't ready.