### PR TITLE
docs: update cert-manager used in quickstart guides to v1.12.2

### DIFF
--- a/docs/reference/redpanda-operator/kubernetes-external-connect.mdx
+++ b/docs/reference/redpanda-operator/kubernetes-external-connect.mdx
@@ -103,7 +103,7 @@ To use Helm to install cert-manager:
     cert-manager jetstack/cert-manager \
     --namespace cert-manager \
     --create-namespace \
-    --version v1.4.4 \
+    --version v1.12.2 \
     --set installCRDs=true
   ```
 

--- a/docs/reference/redpanda-operator/kubernetes-qs-cloud.mdx
+++ b/docs/reference/redpanda-operator/kubernetes-qs-cloud.mdx
@@ -213,7 +213,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.4.4 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/docs/reference/redpanda-operator/kubernetes-qs-local-access.mdx
+++ b/docs/reference/redpanda-operator/kubernetes-qs-local-access.mdx
@@ -87,7 +87,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.4.4 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/docs/reference/redpanda-operator/kubernetes-qs-minikube.mdx
+++ b/docs/reference/redpanda-operator/kubernetes-qs-minikube.mdx
@@ -78,7 +78,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.7.0 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-21.11/quickstart/kubernetes-qs-minikube.mdx
+++ b/versioned_docs/version-21.11/quickstart/kubernetes-qs-minikube.mdx
@@ -85,7 +85,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.7.0 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-22.1/deployment/kubernetes-external-connect.mdx
+++ b/versioned_docs/version-22.1/deployment/kubernetes-external-connect.mdx
@@ -110,7 +110,7 @@ We'll use Helm to install cert-manager:
     cert-manager jetstack/cert-manager \
     --namespace cert-manager \
     --create-namespace \
-    --version v1.4.4 \
+    --version v1.12.2 \
     --set installCRDs=true
   ```
 

--- a/versioned_docs/version-22.1/quickstart/kubernetes-qs-cloud.mdx
+++ b/versioned_docs/version-22.1/quickstart/kubernetes-qs-cloud.mdx
@@ -174,7 +174,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.4.4 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-22.1/quickstart/kubernetes-qs-local-access.mdx
+++ b/versioned_docs/version-22.1/quickstart/kubernetes-qs-local-access.mdx
@@ -100,7 +100,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.4.4 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-22.1/quickstart/kubernetes-qs-minikube.mdx
+++ b/versioned_docs/version-22.1/quickstart/kubernetes-qs-minikube.mdx
@@ -85,7 +85,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.7.0 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-22.2/reference/redpanda-operator/kubernetes-external-connect.mdx
+++ b/versioned_docs/version-22.2/reference/redpanda-operator/kubernetes-external-connect.mdx
@@ -103,7 +103,7 @@ To use Helm to install cert-manager:
     cert-manager jetstack/cert-manager \
     --namespace cert-manager \
     --create-namespace \
-    --version v1.4.4 \
+    --version v1.12.2 \
     --set installCRDs=true
   ```
 

--- a/versioned_docs/version-22.2/reference/redpanda-operator/kubernetes-qs-cloud.mdx
+++ b/versioned_docs/version-22.2/reference/redpanda-operator/kubernetes-qs-cloud.mdx
@@ -170,7 +170,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.4.4 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-22.2/reference/redpanda-operator/kubernetes-qs-local-access.mdx
+++ b/versioned_docs/version-22.2/reference/redpanda-operator/kubernetes-qs-local-access.mdx
@@ -87,7 +87,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.4.4 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-22.2/reference/redpanda-operator/kubernetes-qs-minikube.mdx
+++ b/versioned_docs/version-22.2/reference/redpanda-operator/kubernetes-qs-minikube.mdx
@@ -78,7 +78,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.7.0 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-22.3/reference/redpanda-operator/kubernetes-external-connect.mdx
+++ b/versioned_docs/version-22.3/reference/redpanda-operator/kubernetes-external-connect.mdx
@@ -103,7 +103,7 @@ To use Helm to install cert-manager:
     cert-manager jetstack/cert-manager \
     --namespace cert-manager \
     --create-namespace \
-    --version v1.4.4 \
+    --version v1.12.2 \
     --set installCRDs=true
   ```
 

--- a/versioned_docs/version-22.3/reference/redpanda-operator/kubernetes-qs-cloud.mdx
+++ b/versioned_docs/version-22.3/reference/redpanda-operator/kubernetes-qs-cloud.mdx
@@ -213,7 +213,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.4.4 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-22.3/reference/redpanda-operator/kubernetes-qs-local-access.mdx
+++ b/versioned_docs/version-22.3/reference/redpanda-operator/kubernetes-qs-local-access.mdx
@@ -87,7 +87,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.4.4 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-22.3/reference/redpanda-operator/kubernetes-qs-minikube.mdx
+++ b/versioned_docs/version-22.3/reference/redpanda-operator/kubernetes-qs-minikube.mdx
@@ -78,7 +78,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.7.0 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-23.2/reference/redpanda-operator/kubernetes-external-connect.mdx
+++ b/versioned_docs/version-23.2/reference/redpanda-operator/kubernetes-external-connect.mdx
@@ -103,7 +103,7 @@ To use Helm to install cert-manager:
     cert-manager jetstack/cert-manager \
     --namespace cert-manager \
     --create-namespace \
-    --version v1.4.4 \
+    --version v1.12.2 \
     --set installCRDs=true
   ```
 

--- a/versioned_docs/version-23.2/reference/redpanda-operator/kubernetes-qs-cloud.mdx
+++ b/versioned_docs/version-23.2/reference/redpanda-operator/kubernetes-qs-cloud.mdx
@@ -213,7 +213,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.4.4 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 

--- a/versioned_docs/version-23.2/reference/redpanda-operator/kubernetes-qs-local-access.mdx
+++ b/versioned_docs/version-23.2/reference/redpanda-operator/kubernetes-qs-local-access.mdx
@@ -87,7 +87,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.4.4 \
+  --version v1.12.2 \
   --set installCRDs=true
 ```
 


### PR DESCRIPTION
Update `cert-manager` used in quickstart guides from `v1.7.0` to `v1.12.2.` The current version is already E[OL since July 2022 and only supports K8s versions up to `1.23`, so it does not work with newer clusters.](https://cert-manager.io/docs/installation/supported-releases/)