### PR TITLE
clarify adopting not deploying

### DIFF
--- a/docs/upgrade/migrate/kubernetes/helm-to-operator.mdx
+++ b/docs/upgrade/migrate/kubernetes/helm-to-operator.mdx
@@ -64,13 +64,13 @@ To migrate to the latest Redpanda Operator and use it to manage your Helm deploy
   For details on the structure and configuration options of the Redpanda custom resource, refer to the [Redpanda Operator CRD reference](../../../../reference/crd#redpandaclusterspec).
   :::
 
-1. Deploy the Redpanda cluster by creating an instance of the Redpanda custom resource in the same namespace as the Redpanda Operator:
+1. Adopt the Redpanda cluster by creating an instance of the Redpanda custom resource in the same namespace as the Redpanda Operator:
 
   ```bash
   kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
   ```
 
-1. Wait for the Redpanda resource to be successfully deployed:
+1. Wait for the Redpanda resource to successfully reach a "deployed" state:
 
   ```bash
   kubectl get redpanda --namespace <namespace> --watch

--- a/docs/upgrade/migrate/kubernetes/helm-to-operator.mdx
+++ b/docs/upgrade/migrate/kubernetes/helm-to-operator.mdx
@@ -70,7 +70,7 @@ To migrate to the latest Redpanda Operator and use it to manage your Helm deploy
   kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
   ```
 
-1. Wait for the Redpanda resource to successfully reach a "deployed" state:
+1. Wait for the Redpanda resource to successfully reach a `deployed` state:
 
   ```bash
   kubectl get redpanda --namespace <namespace> --watch


### PR DESCRIPTION
@mattschumpert pointed out to me that this read as if he was replacing his Redpanda cluster instead of adopting it into the operator.

Soften the wording to make it clearer.