### PR TITLE
Improve upgrade docs #1963

### DIFF
--- a/modules/manage/pages/kubernetes/security/sasl-kubernetes.adoc
+++ b/modules/manage/pages/kubernetes/security/sasl-kubernetes.adoc
@@ -52,7 +52,7 @@ Replace the following placeholders with your own values for the superuser:
 +
 [,bash]
 ----
-kubectl create secret generic redpanda-superusers -n redpanda --from-file=superusers.txt
+kubectl create secret generic redpanda-superusers --namespace <namespace> --from-file=superusers.txt
 ----
 
 . Enable SASL and create the superuser using your Secret:
@@ -89,6 +89,8 @@ Helm::
 --
 [tabs]
 ====
+--values::
++
 .`enable-sasl.yaml`
 [,yaml]
 ----

--- a/modules/upgrade/pages/k-rolling-upgrade.adoc
+++ b/modules/upgrade/pages/k-rolling-upgrade.adoc
@@ -338,7 +338,7 @@ The combination of the `--watch` and `--exit-when-healthy` flags tell rpk to mon
 +
 [cols="1m,1a,1a"]
 |===
-| Metric Name | Description Recommendations
+| Metric Name | Description |Recommendations
 
 | xref:reference:public-metrics-reference.adoc#redpanda_kafka_under_replicated_replicas[redpanda_kafka_under_replicated_replicas]
 | Measures the number of under-replicated Kafka replicas. Non-zero: Replication lagging. Zero: All replicas replicated.

--- a/modules/upgrade/pages/k-rolling-upgrade.adoc
+++ b/modules/upgrade/pages/k-rolling-upgrade.adoc
@@ -211,10 +211,9 @@ CLUSTER HEALTH OVERVIEW
 Healthy:                     true <1>
 Controller ID:               0
 All nodes:                   [0 1 2] <2>
-<3>
-Nodes down:                  []
-Leaderless partitions:       []
-Under-replicated partitions: []
+Nodes down:                  [] <3>
+Leaderless partitions:       [] <3>
+Under-replicated partitions: [] <3>
 ----
 <1> The cluster is either healthy (`true`) or unhealthy (`false`).
 <2> The node IDs of all brokers in the cluster.

--- a/modules/upgrade/pages/k-rolling-upgrade.adoc
+++ b/modules/upgrade/pages/k-rolling-upgrade.adoc
@@ -1,5 +1,5 @@
 = Upgrade Redpanda in Kubernetes
-:description: To benefit from Redpanda’s new features and enhancements, upgrade to the latest version. 
+:description: To benefit from Redpanda's new features and enhancements, upgrade to the latest version.
 :page-context-links: [{"name": "Linux", "to": "upgrade:rolling-upgrade.adoc" },{"name": "Kubernetes", "to": "upgrade:k-rolling-upgrade.adoc" } ]
 :page-aliases: manage:kubernetes/rolling-upgrade.adoc
 
@@ -15,13 +15,10 @@ include::partial$rolling-upgrades/important-upgrade-note.adoc[]
 * https://stedolan.github.io/jq/download/[jq^] for listing available versions.
 * An understanding of the <<impact-of-broker-restarts,impact of broker restarts>> on clients, node CPU, and any alerting systems you use.
 * Review incompatible changes in new versions:
-+
-|===
-| Version | Change
 
-|23.1
-| If remote read is disabled, and if the requested term falls below the local log's beginning, then Redpanda updates the Kafka handler to return the start offset of Redpanda's local log. In other words, if you request a value older than the lowest offset, Redpanda returns the lowest offset, not -1.
-|===
+=== Review incompatible changes
+
+Patch releases in https://github.com/redpanda-data/redpanda/discussions/9522[22.3.14^] and https://github.com/redpanda-data/redpanda/discussions/9523[23.1.2^] changed the behavior when remote read is disabled and the requested Raft term falls below the local log's beginning. In earlier versions, Redpanda returned an offset -1. With the patch, when you request a value older than the lowest offset, Redpanda returns the lowest offset, not -1.
 
 == Find a new version
 
@@ -108,11 +105,10 @@ Placing brokers into maintenance mode ensures a smooth upgrade of your cluster w
 
 When a broker is placed into maintenance mode, it reassigns its partition leadership to other brokers for all topics that have a replication factor greater than one.
 Reassigning partition leadership involves _draining_ leadership from the broker and _transferring_ that leadership to another broker.
-If you have topics with `replication.factor=1` and sufficient disk space, Redpanda Data recommends temporarily increasing the replication factor.
-This can help limit outages for these topics during the rolling upgrade. Do this before the upgrade to ensure there's time for the data to replicate to other brokers.
-For details, see xref:manage:data-migration.adoc#change-topic-replication-factor[Change topic replication factor].
 
-To perform a rolling upgrade:
+. Check for topics that have a replication factor greater than one.
++
+If you have topics with `replication.factor=1`, and if you have sufficient disk space, Redpanda Data recommends temporarily increasing the replication factor. This can help limit outages for these topics during the rolling upgrade. Do this before the upgrade to make sure there's time for the data to replicate to other brokers. For more information, see xref:manage:data-migration.adoc#change-topic-replication-factor[Change topic replication factor].
 
 . <<Deploy an upgraded StatefulSet>> with your desired Redpanda version.
 . <<Upgrade and restart the brokers>> separately, one after the other.
@@ -125,7 +121,7 @@ the `terminationGracePeriod` may not be long enough to allow maintenance mode to
 If maintenance mode does not finish before the Pod is deleted, you may lose data.
 After the `terminationGracePeriod`, the container is forcefully stopped using a `SIGKILL` command.
 
-It can be a challenge to determine the necessary value for the `terminationGracePeriod`. In common cases, 30 seconds should be sufficient.
+If you want to use `kubectl rollout restart`, it can be a challenge to determine the necessary value for the `terminationGracePeriod`. In common cases, 30 seconds should be sufficient.
 For large clusters, 90 seconds should be sufficient. You can test different values in a development environment. To configure the `terminationGracePeriod`,
 use the xref:reference:redpanda-helm-spec.adoc#statefulsetterminationgraceperiodseconds[`statefulset.terminationGracePeriodSeconds`] setting.
 ====
@@ -175,9 +171,88 @@ To upgrade the Redpanda brokers, you must do the following to each broker, one a
 TIP: Before placing a broker into maintenance mode, you may want to temporarily disable or ignore alerts related to under-replicated partitions.
 When a broker is taken offline during a restart, replicas can become under-replicated.
 
+. Check that all brokers are healthy:
++
+[tabs]
+====
+TLS Enabled::
++
+--
+
+```bash
+kubectl exec redpanda-0 --namespace <namespace> -c redpanda -- \
+  rpk cluster health \
+    -X admin.tls.enabled=true \
+    -X admin.tls.ca=<path-to-admin-api-ca-certificate> \
+    -X admin.hosts=<broker-url>:<admin-api-port>
+```
+
+--
+TLS Disabled::
++
+--
+
+```bash
+kubectl exec redpanda-0 --namespace <namespace> -c redpanda -- \
+  rpk cluster health \
+    -X admin.hosts=<broker-url>:<admin-api-port>
+```
+
+--
+====
++
+.Example output:
+[%collapsible]
+====
+[.no-copy]
+----
+CLUSTER HEALTH OVERVIEW
+=======================
+Healthy:                     true <1>
+Controller ID:               0
+All nodes:                   [0 1 2] <2>
+<3>
+Nodes down:                  []
+Leaderless partitions:       []
+Under-replicated partitions: []
+----
+<1> The cluster is either healthy (`true`) or unhealthy (`false`).
+<2> The node IDs of all brokers in the cluster.
+<3> If the cluster is unhealthy, these fields will contain data.
+====
+
+. Find the Pod that is running the broker with the ID that you want to upgrade:
++
+[,bash]
+----
+kubectl exec redpanda-0 --namespace <namespace> -c redpanda -- \
+  rpk cluster info \
+    -X brokers=<broker-url>:<kafka-api-port> \
+    --tls-enabled \
+    --tls-truststore <path-to-kafka-api-ca-certificate>
+----
++
+.Example output:
+[%collapsible]
+====
+[.no-copy]
+----
+BROKERS
+=======
+ID    HOST                                         PORT
+0     redpanda-0.redpanda.test.svc.cluster.local.  9093
+1*    redpanda-1.redpanda.test.svc.cluster.local.  9093
+2     redpanda-2.redpanda.test.svc.cluster.local.  9093
+----
+====
++
+Here, `redpanda-0` is running a broker with the ID `0`. In this example, the ordinal of the StatefulSet replica (`0` in `redpanda-0`) is the same as the broker's ID. However, this is not always the case.
+
 . Select a broker that has not been upgraded yet and place it into maintenance mode.
 +
-In this example, the command is executed on a Pod called `redpanda-0` in the `redpanda` namespace. The ordinal of the StatefulSet replica, `0` in this example, is the same as the broker's ID. This ID is used to enable maintenance mode on the broker: `rpk cluster maintenance enable 0`.
+In this example, the command is executed on a Pod called `redpanda-0`.
++
+TIP: You can execute the command on any Pod. It doesn't have to be the one with the ID that you want to place into maintenance mode.
 +
 [tabs]
 ====
@@ -220,6 +295,7 @@ Example output:
 ----
 NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
 0        true      true      false   1           0         1             0
+...
 ----
 
 . Wait until the cluster is healthy before continuing:
@@ -235,8 +311,11 @@ kubectl exec redpanda-0 --namespace <namespace> -c redpanda -- \
   rpk cluster health \
     -X admin.tls.enabled=true \
     -X admin.tls.ca=<path-to-admin-api-ca-certificate> \
-    -X admin.hosts=<broker-url>:<admin-api-port>
+    -X admin.hosts=<broker-url>:<admin-api-port> \
+    --watch --exit-when-healthy
 ```
++
+The combination of the `--watch` and `--exit-when-healthy` flags tell rpk to monitor the cluster health and exit only when the cluster is back in a healthy state.
 
 --
 TLS Disabled::
@@ -247,29 +326,48 @@ TLS Disabled::
 kubectl exec redpanda-0 --namespace <namespace> -c redpanda -- \
   rpk cluster health \
     -X admin.hosts=<broker-url>:<admin-api-port> \
+    --watch --exit-when-healthy
 ```
++
+The combination of the `--watch` and `--exit-when-healthy` flags tell rpk to monitor the cluster health and exit only when the cluster is back in a healthy state.
 
 --
 ====
+
+. Check the following xref:manage:kubernetes/monitor.adoc[metrics]:
 +
-.Expected output:
-[%collapsible]
-====
-[.no-copy]
-```
-CLUSTER HEALTH OVERVIEW
-=======================
-Healthy:               true
-Controller ID:         0
-All nodes:             [0 2 1]
-Nodes down:            []
-Leaderless partitions: []
-```
-====
+[cols="1m,1a,1a"]
+|===
+| Metric Name | Description Recommendations
+
+| xref:reference:public-metrics-reference.adoc#redpanda_kafka_under_replicated_replicas[redpanda_kafka_under_replicated_replicas]
+| Measures the number of under-replicated Kafka replicas. Non-zero: Replication lagging. Zero: All replicas replicated.
+| Pause upgrades if non-zero.
+
+| xref:reference:public-metrics-reference.adoc#redpanda_cluster_unavailable_partitions[redpanda_cluster_unavailable_partitions]
+| Represents the number of partitions that are currently unavailable. Value of zero indicates all partitions are available. Non-zero indicates the respective count of unavailable partitions.
+| Ensure metric shows zero unavailable partitions before restart.
+
+| xref:reference:public-metrics-reference.adoc#redpanda_kafka_request_bytes_total[redpanda_kafka_request_bytes_total]
+| Total bytes processed for Kafka requests.
+| Ensure produce and consume rate for each broker recovers to its pre-upgrade value before restart.
+
+| xref:reference:public-metrics-reference.adoc#redpanda_kafka_request_latency_seconds[redpanda_kafka_request_latency_seconds]
+| Latency for processing Kafka requests. Indicates the delay between a Kafka request being initiated and completed.
+| Ensure the p99 histogram value recovers to its pre-upgrade level before restart.
+
+| xref:reference:public-metrics-reference.adoc#redpanda_rpc_request_latency_seconds[redpanda_rpc_request_latency_seconds]
+| Latency for processing RPC requests. Shows the delay between an RPC request initiation and completion.
+| Ensure the p99 histogram value returns to its pre-upgrade level before restart.
+
+| xref:reference:public-metrics-reference.adoc#redpanda_cpu_busy_seconds_total[redpanda_cpu_busy_seconds_total]
+| CPU utilization for a given second. The value is a decimal between 0.0 and 1.0. A value of 1.0 means that the CPU was busy for the entire second, operating at 100% capacity. A value of 0.5 implies the CPU was busy for half the time (or 500 milliseconds) in the given second. A value of 0.0 indicates that the CPU was idle and not busy during the entire second.
+|If you're seeing high values consistently, investigate the reasons. It could be due to high traffic or other system bottlenecks.
+
+|===
 +
 [NOTE]
 ====
-You can also evaluate xref:manage:kubernetes/monitor.adoc[external metrics] to determine cluster health.
 If the cluster has any issues, take the broker out of maintenance mode by running the following command before proceeding with other operations,
 such as decommissioning or retrying the rolling upgrade:
 
@@ -278,7 +376,7 @@ rpk cluster maintenance disable <node-id>
 ```
 ====
 
-. Delete the Pod in which the broker was running:
+. Delete the Pod in which the broker in maintenance mode was running:
 +
 ```bash
 kubectl delete pod redpanda-0 --namespace <namespace>
@@ -390,7 +488,7 @@ REVISION	UPDATED                 	STATUS    	CHART          	APP VERSION	DESCRIP
 helm rollback redpanda <previous-revision> --namespace <namespace>
 ```
 
-. Verify that the cluster is healthy. If the cluster is unhealthy, the upgrade may still be in progress. Try waiting a few moments, then run the command again.
+. Verify that the cluster is healthy. If the cluster is unhealthy, the upgrade may still be in progress. The command exits when the cluster is healthy.
 +
 [tabs]
 ====
@@ -403,7 +501,8 @@ kubectl exec redpanda-0 --namespace <namespace> -c redpanda -- \
   rpk cluster health \
     -X admin.tls.enabled=true \
     -X admin.tls.ca=<path-to-admin-api-ca-certificate> \
-    -X admin.hosts=<broker-url>:<admin-api-port>
+    -X admin.hosts=<broker-url>:<admin-api-port> \
+    --watch --exit-when-healthy
 ```
 
 --
@@ -415,6 +514,7 @@ TLS Disabled::
 kubectl exec redpanda-0 --namespace <namespace> -c redpanda -- \
   rpk cluster health \
     -X admin.hosts=<broker-url>:<admin-api-port> \
+    --watch --exit-when-healthy
 ```
 
 --

--- a/modules/upgrade/pages/k-rolling-upgrade.adoc
+++ b/modules/upgrade/pages/k-rolling-upgrade.adoc
@@ -16,7 +16,7 @@ include::partial$rolling-upgrades/important-upgrade-note.adoc[]
 * An understanding of the <<impact-of-broker-restarts,impact of broker restarts>> on clients, node CPU, and any alerting systems you use.
 * Review incompatible changes in new versions:
 
-=== Review incompatible changes
+=== Review incompatible changes 
 
 Patch releases in https://github.com/redpanda-data/redpanda/discussions/9522[22.3.14^] and https://github.com/redpanda-data/redpanda/discussions/9523[23.1.2^] changed the behavior when remote read is disabled and the requested Raft term falls below the local log's beginning. In earlier versions, Redpanda returned an offset -1. With the patch, when you request a value older than the lowest offset, Redpanda returns the lowest offset, not -1.
 

--- a/modules/upgrade/pages/rolling-upgrade.adoc
+++ b/modules/upgrade/pages/rolling-upgrade.adoc
@@ -1,5 +1,5 @@
 = Upgrade Redpanda
-:description: To benefit from Redpanda’s new features and enhancements, upgrade to the latest version. 
+:description: To benefit from Redpanda's new features and enhancements, upgrade to the latest version.
 :page-context-links: [{"name": "Linux", "to": "upgrade:rolling-upgrade.adoc" },{"name": "Kubernetes", "to": "upgrade:k-rolling-upgrade.adoc" } ]
 :page-aliases: manage:cluster-maintenance/rolling-upgrade.adoc, \
 install-upgrade:rolling-upgrade.adoc, \
@@ -8,7 +8,7 @@ cluster-management:version-upgrade.adoc, \
 cluster-administration:version-upgrade.adoc, \
 reference:version-upgrade.adoc
 
-To benefit from Redpanda's new features and enhancements, upgrade to the latest version. Redpanda recommends that you perform a rolling upgrade on production clusters, which requires all brokers to be placed into maintenance mode and restarted separately, one after the other.
+To benefit from Redpanda's new features and enhancements, upgrade to the latest version. Redpanda Data recommends that you perform a rolling upgrade on production clusters, which requires all brokers to be placed into maintenance mode and restarted separately, one after the other.
 
 Redpanda platform version numbers follow the convention AB.C.D, where AB is the two digit year, C is the feature release, and D is the patch release. For example, version 22.3.1 indicates the first patch release on the third feature release of the year 2022. Patch releases include bug fixes and minor improvements, with no change to user-facing behavior. New and enhanced features are documented with each feature release.
 
@@ -19,11 +19,11 @@ include::partial$rolling-upgrades/important-upgrade-note.adoc[]
 * A running Redpanda cluster.
 * https://stedolan.github.io/jq/download/[jq^] for listing available versions.
 * An understanding of the <<impact-of-broker-restarts,impact of broker restarts>> on clients, node CPU, and any alerting systems you use.
-* Review incompatible changes in new versions:
+* Review incompatible changes in new versions.
 
 === Review incompatible changes
 
-Patches in https://github.com/redpanda-data/redpanda/discussions/9522[22.3.14^] and https://github.com/redpanda-data/redpanda/discussions/9523[23.1.2^] changed the behavior when remote read is disabled and the requested term falls below the local log's beginning. In earlier versions, Redpanda returned an offset -1. With the patch, when you request a value older than the lowest offset, Redpanda returns the lowest offset, not -1.
+Patch releases in https://github.com/redpanda-data/redpanda/discussions/9522[22.3.14^] and https://github.com/redpanda-data/redpanda/discussions/9523[23.1.2^] changed the behavior when remote read is disabled and the requested Raft term falls below the local log's beginning. In earlier versions, Redpanda returned an offset -1. With the patch, when you request a value older than the lowest offset, Redpanda returns the lowest offset, not -1.
 
 == Find a new version
 
@@ -91,17 +91,21 @@ include::partial$rolling-upgrades/restart-impact.adoc[leveloffset=+1]
 
 A rolling upgrade involves putting a broker into xref:manage:node-management.adoc[maintenance mode], upgrading the broker, taking the broker out of maintenance mode, and then repeating the process on the next broker in the cluster. Placing brokers into maintenance mode ensures a smooth upgrade of your cluster while reducing the risk of interruption or degradation in service.
 
-When a broker is placed into maintenance mode, it reassigns its partition leadership to other brokers for all topics that have a replication factor greater than one. Reassigning partition leadership involves _draining_ leadership from the broker and _transferring_ that leadership to another broker. If you have topics with `replication.factor=1`, and if you have sufficient disk space, Redpanda recommends temporarily increasing the replication factor. This can help limit outages for these topics during the rolling upgrade. Do this before the upgrade to make sure there's time for the data to replicate to other brokers. For more information, see xref:manage:data-migration.adoc#change-topic-replication-factor[Change topic replication factor].
+When a broker is placed into maintenance mode, it reassigns its partition leadership to other brokers for all topics that have a replication factor greater than one. Reassigning partition leadership involves _draining_ leadership from the broker and _transferring_ that leadership to another broker.
 
-To ensure that all brokers are active before upgrading, run:
+. Check for topics that have a replication factor greater than one.
++
+If you have topics with `replication.factor=1`, and if you have sufficient disk space, Redpanda Data recommends temporarily increasing the replication factor. This can help limit outages for these topics during the rolling upgrade. Do this before the upgrade to make sure there's time for the data to replicate to other brokers. For more information, see xref:manage:data-migration.adoc#change-topic-replication-factor[Change topic replication factor].
 
+. Ensure that all brokers are active before upgrading:
++
 [,bash]
 ----
 rpk redpanda admin brokers list
 ----
-
++
 All brokers should show `active` for `MEMBERSHIP-STATUS` and `true` for `IS-ALIVE`:
-
++
 .Example output
 [%collapsible]
 ====
@@ -127,20 +131,24 @@ NOTE: Redpanda started supporting xref:develop:consume-data/consumer-offsets.ado
 rpk cluster health
 ----
 +
-.Expected output:
+.Example output:
 [%collapsible]
 ====
 [.no-copy]
 ----
 CLUSTER HEALTH OVERVIEW
 =======================
-Healthy:                     true
+Healthy:                     true <1>
 Controller ID:               0
-All nodes:                   [0 1 2]
+All nodes:                   [0 1 2] <2>
+<3>
 Nodes down:                  []
 Leaderless partitions:       []
 Under-replicated partitions: []
 ----
+<1> The cluster is either healthy (`true`) or unhealthy (`false`).
+<2> The node IDs of all brokers in the cluster.
+<3> If the cluster is unhealthy, these fields will contain data.
 ====
 
 . Select a broker that has not been upgraded yet and place it into maintenance mode:
@@ -152,22 +160,12 @@ rpk cluster maintenance enable <node-id> --wait
 The `--wait` option tells the command to wait until a given broker, 0 in this example, finishes draining all partitions it originally served. After the partition draining completes, the command completes.
 +
 .Expected output:
-[%collapsible]
-====
++
 [.no-copy]
 ----
 Successfully enabled maintenance mode for node 0
 Waiting for node to drain...
-NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
-0        false     false     false   0           0         0             0
-0        false     false     false   0           0         0             0
-0        false     false     false   0           0         0             0
-0        false     false     false   0           0         0             0
-0        false     false     false   0           0         0             0
-0        false     false     false   0           0         0             0
-0        true      true      false   3           0         2             0
 ----
-====
 
 . Verify that the broker is in maintenance mode:
 +
@@ -185,29 +183,17 @@ NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
 1        false     false     false   0           0         0             0
 2        false     false     false   0           0         0             0
 ----
+
+The `Finished` column should read `true` for the broker that you put into maintenance mode.
 ====
 
-. Validate again the health of the cluster:
+. Validate the health of the cluster again:
 +
 ```bash
-rpk cluster health
+rpk cluster health --watch --exit-when-healthy
 ```
 +
-.Expected output:
-[%collapsible]
-====
-[.no-copy]
-----
-CLUSTER HEALTH OVERVIEW
-=======================
-Healthy:                     true
-Controller ID:               0
-All nodes:                   [0 1 2]
-Nodes down:                  []
-Leaderless partitions:       []
-Under-replicated partitions: []
-----
-====
+The combination of the `--watch` and `--exit-when-healthy` flags tell rpk to monitor the cluster health and exit only when the cluster is back in a healthy state.
 +
 [NOTE]
 ====
@@ -310,33 +296,39 @@ For installations from binary files, download the preferred version from the rel
 
 === Check metrics
 
-Check the following metrics before continuing with the upgrade:
+Before continuing with the upgrade, check these important metrics to make sure the cluster is healthy and working as expected.
 
-[options="header"]
+[cols="1m,1a,1a"]
 |===
-| Metric | Description
+| Metric Name | Description Recommendations
 
 | xref:reference:public-metrics-reference.adoc#redpanda_kafka_under_replicated_replicas[redpanda_kafka_under_replicated_replicas]
-| If this shows any non-zero value, then replication cannot catch up, and the upgrade should be paused.
+| Measures the number of under-replicated Kafka replicas. Non-zero: Replication lagging. Zero: All replicas replicated.
+| Pause upgrades if non-zero.
 
 | xref:reference:public-metrics-reference.adoc#redpanda_cluster_unavailable_partitions[redpanda_cluster_unavailable_partitions]
-| Before restart, wait for this to show zero unavailable partitions.
+| Represents the number of partitions that are currently unavailable. Value of zero indicates all partitions are available. Non-zero indicates the respective count of unavailable partitions.
+| Ensure metric shows zero unavailable partitions before restart.
 
 | xref:reference:public-metrics-reference.adoc#redpanda_kafka_request_bytes_total[redpanda_kafka_request_bytes_total]
-| Before restart, the produce and consume rate for each broker should recover to the pre-upgrade value.
+| Total bytes processed for Kafka requests.
+| Ensure produce and consume rate for each broker recovers to its pre-upgrade value before restart.
 
 | xref:reference:public-metrics-reference.adoc#redpanda_kafka_request_latency_seconds[redpanda_kafka_request_latency_seconds]
-| Before restart, the p99 histogram should recover to the pre-upgrade value.
+| Latency for processing Kafka requests. Indicates the delay between a Kafka request being initiated and completed.
+| Ensure the p99 histogram value recovers to its pre-upgrade level before restart.
 
 | xref:reference:public-metrics-reference.adoc#redpanda_rpc_request_latency_seconds[redpanda_rpc_request_latency_seconds]
-| Before restart, the p99 histogram should recover to the pre-upgrade value.
+| Latency for processing RPC requests. Shows the delay between an RPC request initiation and completion.
+| Ensure the p99 histogram value returns to its pre-upgrade level before restart.
 
 | xref:reference:public-metrics-reference.adoc#redpanda_cpu_busy_seconds_total[redpanda_cpu_busy_seconds_total]
-| Check the CPU utilization. The derivative gives you a 0.0-1.0 value for how much time the core was busy in a given second.
+| CPU utilization for a given second. The value is a decimal between 0.0 and 1.0. A value of 1.0 means that the CPU was busy for the entire second, operating at 100% capacity. A value of 0.5 implies the CPU was busy for half the time (or 500 milliseconds) in the given second. A value of 0.0 indicates that the CPU was idle and not busy during the entire second.
+|If you're seeing high values consistently, investigate the reasons. It could be due to high traffic or other system bottlenecks.
+
 |===
 
-
-=== Restart broker
+=== Restart the broker
 
 Restart the broker's Redpanda service with xref:reference:rpk/rpk-redpanda/rpk-redpanda-stop.adoc[`rpk redpanda stop`], then xref:reference:rpk/rpk-redpanda/rpk-redpanda-start.adoc[`rpk redpanda start`].
 

--- a/modules/upgrade/pages/rolling-upgrade.adoc
+++ b/modules/upgrade/pages/rolling-upgrade.adoc
@@ -141,10 +141,9 @@ CLUSTER HEALTH OVERVIEW
 Healthy:                     true <1>
 Controller ID:               0
 All nodes:                   [0 1 2] <2>
-<3>
-Nodes down:                  []
-Leaderless partitions:       []
-Under-replicated partitions: []
+Nodes down:                  [] <3>
+Leaderless partitions:       [] <3>
+Under-replicated partitions: [] <3>
 ----
 <1> The cluster is either healthy (`true`) or unhealthy (`false`).
 <2> The node IDs of all brokers in the cluster.

--- a/modules/upgrade/pages/rolling-upgrade.adoc
+++ b/modules/upgrade/pages/rolling-upgrade.adoc
@@ -300,7 +300,7 @@ Before continuing with the upgrade, check these important metrics to make sure t
 
 [cols="1m,1a,1a"]
 |===
-| Metric Name | Description Recommendations
+| Metric Name | Description |Recommendations
 
 | xref:reference:public-metrics-reference.adoc#redpanda_kafka_under_replicated_replicas[redpanda_kafka_under_replicated_replicas]
 | Measures the number of under-replicated Kafka replicas. Non-zero: Replication lagging. Zero: All replicas replicated.


### PR DESCRIPTION

Originally, this issue was to fix #1061, but we are closing this one as these metrics are now covered by the `rpk cluster health` command.

While researching the issue, I reviewed the content and decided it might be worth applying the following content improvements:

- Add the new `--watch` and `--exit-when-healthy` flags to the `rpk cluster health` commands after putting brokers in maintenance mode. The combination of these flags tells rpk to monitor the cluster health and exit only when the cluster is back in a healthy state.
- Improve the table of metrics to watch by including more detailed descriptions and recommendations depending on the current state.
- Add callouts to describe the output of the `rpk cluster health` command the first time it's used.

This PR also fixes a tabs formatting issue in the Kubernetes SASL docs.