### PR TITLE
Improve backport automation

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -40,10 +40,14 @@ jobs:
 
           BRANCHES=""
           if [[ $BACKPORT_LABELS == "backport to all versions" ]]; then
-            BRANCHES="v/23.1,v/22.3,v/22.2"
+              # Fetch all branches with 'v/' prefix from GitHub API
+              ALL_BRANCHES=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/branches | jq -r '.[].name' | grep '^v/')
+              BRANCHES=$(echo "$ALL_BRANCHES" | tr '\n' ',')
+              BRANCHES=${BRANCHES::-1}  # Removing the trailing comma
           else
-            VERSIONS=$(echo "$BACKPORT_LABELS" | grep -o 'v/[0-9]\+\.[0-9]\+')
-            BRANCHES="${BRANCHES:+$BRANCHES,}$VERSIONS"
+            BRANCH_NAMES=$(echo "$BACKPORT_LABELS" | grep -o 'backport to v/[0-9]\+\.[0-9]\+' | sed -e 's/backport to //')
+            BRANCHES=$(echo "$BRANCH_NAMES" | tr '\n' ',')
+            BRANCHES=${BRANCHES::-1}  # Removing the trailing comma
           fi
 
           # Convert BRANCHES into a valid JSON array


### PR DESCRIPTION
- Finds all `v/*` branches to backport when the `backport to all versions` label is applied instead of us hardcoding the versions.
- Allows us to define multiple labels to backport to specific versions instead of a single label.

For example, a combination of the following:

- `backport to v/23.1`
- `backport to v/22.3`
- `backport to 21.11`

Would attempt to cherry-pick a commit to the v/23.1, v/22.3, and v/21.11 branches.