### PR TITLE
Add redpanda admin api config

### DIFF
--- a/modules/reference/pages/console/config.adoc
+++ b/modules/reference/pages/console/config.adoc
@@ -152,6 +152,18 @@ kafka:
   #   maxRetryInterval 60s
   #   backoffMultiplier: 2
 
+# redpanda:
+#   adminApi:
+#     enabled: false
+#     urls: []
+#     username: ""
+#     password: ""
+#     tls:
+#       enabled: false
+#       caFilepath: ""
+#       certFilepath: ""
+#       keyFilepath: ""
+
 # connect:
 #   enabled: false
 #   # An empty array for clusters is the default, but you have to specify at least one cluster, as soon as


### PR DESCRIPTION
Re-add redpanda admin api config documentation. It used to be there, but got removed somehow.