### PR TITLE
document retention_local_strict is true when upgrading

### DIFF
--- a/modules/manage/pages/cluster-maintenance/disk-utilization.adoc
+++ b/modules/manage/pages/cluster-maintenance/disk-utilization.adoc
@@ -231,6 +231,8 @@ A periodic housekeeping task in Redpanda performs compaction and removes data th
 
 * When `retention_local_strict` is false (default), the housekeeping process removes data above the configured consumable retention. This means that data usage is allowed to expand to occupy more of the log data reservation.
 * When `retention_local_strict` is true, the housekeeping process uses local retention settings to select what data to remove.
++
+NOTE: By default, `retention_local_strict` is set to false in new clusters and set to true in upgraded clusters.
 
 ==== 2: Trim to local retention
 

--- a/modules/manage/pages/cluster-maintenance/disk-utilization.adoc
+++ b/modules/manage/pages/cluster-maintenance/disk-utilization.adoc
@@ -232,7 +232,7 @@ A periodic housekeeping task in Redpanda performs compaction and removes data th
 * When `retention_local_strict` is false (default), the housekeeping process removes data above the configured consumable retention. This means that data usage is allowed to expand to occupy more of the log data reservation.
 * When `retention_local_strict` is true, the housekeeping process uses local retention settings to select what data to remove.
 +
-NOTE: By default, `retention_local_strict` is set to false in new clusters and set to true in upgraded clusters.
+NOTE: The `retention_local_strict` property is set to true in clusters upgraded from release 23.1 and earlier.
 
 ==== 2: Trim to local retention
 


### PR DESCRIPTION
fixes redpanda-data/documentation-private/issues/2011

This adds the following note:
The `retention_local_strict` property is set to true in clusters upgraded from release 23.1 and earlier.

preview: https://deploy-preview-28--redpanda-docs-preview.netlify.app/current/manage/cluster-maintenance/disk-utilization/#phases-of-data-removal

