### PR TITLE
docs: remove video thumbnails

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -145,6 +145,4 @@ include::shared:partial$suggested-reading.adoc[]
 
 include::shared:partial$suggested-video.adoc[]
 
-- YouTube - What is Redpanda BYOC? (3 mins)
-+
-video::gVlzsJAYT64[youtube,width=560,height=315]
+* https://www.youtube.com/watch?v=gVlzsJAYT64&ab_channel=RedpandaData[YouTube - What is Redpanda BYOC? (3 mins)^]

--- a/modules/develop/pages/consume-data/follower-fetching.adoc
+++ b/modules/develop/pages/consume-data/follower-fetching.adoc
@@ -26,6 +26,4 @@ To enable follower fetching in Redpanda, configure properties for the consumer a
 
 include::shared:partial$suggested-video.adoc[]
 
-* YouTube - Redpanda Office Hour: Follower Fetching (52 mins)
-+
-video::wV6gH5_yVaw[youtube,width=560,height=315]
+* https://www.youtube.com/watch?v=wV6gH5_yVaw&ab_channel=RedpandaData[YouTube - Redpanda Office Hour: Follower Fetching (52 mins)^]

--- a/modules/get-started/pages/architecture.adoc
+++ b/modules/get-started/pages/architecture.adoc
@@ -79,20 +79,10 @@ include::shared:partial$suggested-reading.adoc[]
 
 include::shared:partial$suggested-video.adoc[]
 
-* YouTube - Lightning Talk: Tiered Storage (11:39 mins)
-+
-video::3_Tmdvrp5sU[youtube,width=560,height=315]
+* https://www.youtube.com/watch?v=3_Tmdvrp5sU&ab_channel=RedpandaData[YouTube - Lightning Talk: Tiered Storage (11:39 mins)^]
 
+* https://www.youtube.com/watch?v=guoaxRJG8p8&ab_channel=RedpandaData[YouTube - Intro to Redpanda: Thread-per-core architecture in C++ (60 mins)^]
 
-* YouTube - Intro to Redpanda: Thread-per-core architecture in C++ (60 mins)
-+
-video::guoaxRJG8p8[youtube,width=560,height=315]
+* https://www.youtube.com/watch?v=UxM1mn1gwoc&ab_channel=RedpandaData[YouTube - Differences between Apache Kafka and Redpanda: Thread per Core Architecture (4:30 mins)^]
 
-
-* YouTube - Differences between Apache Kafka and Redpanda: Thread per Core Architecture (4:30 mins)
-+
-video::UxM1mn1gwoc[youtube,width=560,height=315]
-
-* YouTube - Common pitfalls for Redpanda beginners (44:35 mins)
-+
-video::CEVxZznqTDo[youtube,width=560,height=315]
+* https://www.youtube.com/watch?v=CEVxZznqTDo&ab_channel=RedpandaData[YouTube - Common pitfalls for Redpanda beginners (44:35 mins)^]

--- a/modules/get-started/pages/intro-to-events.adoc
+++ b/modules/get-started/pages/intro-to-events.adoc
@@ -84,6 +84,4 @@ include::shared:partial$suggested-reading.adoc[]
 
 include::shared:partial$suggested-video.adoc[]
 
-* YouTube - Redpanda in a Nutshell (6:36 mins)
-+
-video::FEVL8cLUFOc[youtube,width=560,height=315]
+* https://www.youtube.com/watch?v=FEVL8cLUFOc&ab_channel=RedpandaData[YouTube - Redpanda in a Nutshell (6:36 mins)^]


### PR DESCRIPTION
Resolves https://github.com/redpanda-data/documentation-private/issues/2010

Please check if we need to reduce the number of link in the architecture page. 

Preview: 

https://deploy-preview-48--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/cloud-overview
https://deploy-preview-48--redpanda-docs-preview.netlify.app/current/develop/consume-data/follower-fetching
https://deploy-preview-48--redpanda-docs-preview.netlify.app/current/get-started/architecture
https://deploy-preview-48--redpanda-docs-preview.netlify.app/current/get-started/intro-to-events


Architecture page
https://deploy-preview-48--redpanda-docs-preview.netlify.app/current/get-started/architecture