### PR TITLE
engine: Fix 404s for rpk reference parents

### DIFF
--- a/modules/reference/pages/rpk/rpk-acl/rpk-acl.adoc
+++ b/modules/reference/pages/rpk/rpk-acl/rpk-acl.adoc
@@ -1,5 +1,6 @@
 = rpk acl
-:description: rpk acl
+:description: These commands let you create SASL users and create, list, and delete ACLs.
+:page-aliases: reference:rpk/rpk-acl.adoc
 
 Manage ACLs and SASL users.
 

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud.adoc
@@ -1,5 +1,7 @@
 = rpk cloud
-:description: rpk cloud
+:description: These commands let you interact with Repanda Cloud.
+:page-aliases: reference:rpk/rpk-cloud.adoc
+
 
 Interact with Redpanda cloud.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster.adoc
@@ -1,5 +1,6 @@
 = rpk cluster
-:description: rpk cluster commands list
+:description: These commands let you interact with a Redpanda cluster.
+:page-aliases: reference:rpk/rpk-cluster.adoc
 
 Interact with a Redpanda cluster.
 

--- a/modules/reference/pages/rpk/rpk-container/rpk-container.adoc
+++ b/modules/reference/pages/rpk/rpk-container/rpk-container.adoc
@@ -1,5 +1,6 @@
 = rpk container
-:description: rpk Container commands list
+:description: These commands let you manage (start, stop, purge) a local container cluster.
+:page-aliases: features:guide-rpk-container.adoc, reference:rpk/rpk-container.adoc
 
 Manage a local container cluster.
 

--- a/modules/reference/pages/rpk/rpk-debug/rpk-debug.adoc
+++ b/modules/reference/pages/rpk/rpk-debug/rpk-debug.adoc
@@ -1,5 +1,6 @@
 = rpk debug
-:description: rpk debug list
+:description: These commands let you debug the local Redpanda process and collect a diagnostics bundle.
+:page-aliases: reference:rpk/rpk-debug.adoc
 
 Debug the local Redpanda process
 

--- a/modules/reference/pages/rpk/rpk-generate/rpk-generate.adoc
+++ b/modules/reference/pages/rpk/rpk-generate/rpk-generate.adoc
@@ -1,5 +1,8 @@
 = rpk generate
-:description: rpk generate list
+:description: These commands let you generate a configuration template for related services.
+:page-aliases: reference:rpk/rpk-generate.adoc
+
+== rpk generate
 
 Generate a configuration template for related services.
 

--- a/modules/reference/pages/rpk/rpk-group/rpk-group.adoc
+++ b/modules/reference/pages/rpk/rpk-group/rpk-group.adoc
@@ -1,5 +1,6 @@
 = rpk group
-:description: rpk group list
+:description: These commands let you describe, list, and delete consumer groups and manage their offsets.
+:page-aliases: reference:rpk/rpk-group.adoc
 
 Describe, list, and delete consumer groups and manage their offsets.
 

--- a/modules/reference/pages/rpk/rpk-plugin/rpk-plugin.adoc
+++ b/modules/reference/pages/rpk/rpk-plugin/rpk-plugin.adoc
@@ -1,5 +1,6 @@
 = rpk plugin
-:description: rpk plugin
+:description: pass:q[These commands let you list, download, update, and remove `rpk` plugins.]
+:page-aliases: reference:rpk/rpk-plugin.adoc
 
 List, download, update, and remove `rpk` plugins.
 Plugins augment `rpk` with new commands.

--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda.adoc
@@ -1,7 +1,6 @@
 = rpk redpanda
-:description: rpk redpanda list
-
-Interact with a local Redpanda process.
+:description: These commands let you interact with (start, stop, tune) a local Redpanda process.
+:page-aliases: reference:rpk/rpk-redpanda.adoc
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic.adoc
@@ -1,5 +1,6 @@
 = rpk topic
-:description: rpk topic
+:description: These commands let you manage your topics, including creating, producing, and consuming new messages.
+:page-aliases: reference:rpk/rpk-topic.adoc
 
 You can use `rpk topic` to manage your topics, create new messages and consume them.
 


### PR DESCRIPTION
(cherry picked from commit 59cff705dab042fc2b2aeaba97485365039da5cb)