### PR TITLE
AKS nodes need external IP added for NodePort

### DIFF
--- a/modules/manage/pages/kubernetes/networking/configure-external-access-nodeport.adoc
+++ b/modules/manage/pages/kubernetes/networking/configure-external-access-nodeport.adoc
@@ -17,7 +17,7 @@ To expose your Redpanda cluster externally through a NodePort Service, you must 
 * Install xref:get-started:rpk-install.adoc[rpk] on your local machine so that you can test connections to your Redpanda cluster from outside Kubernetes.
 * Review the xref:deploy:deployment-option/self-hosted/kubernetes/kubernetes-best-practices.adoc[best practices].
 * Understand xref:./networking-and-connectivity.adoc[Kubernetes networking for Redpanda].
-* Make sure that your Kubernetes cluster is accessible through your desired node port range. You may need to edit your inbound firewall rules.
+* Make sure that your Kubernetes cluster is accessible through your desired node port range. For example, with AWS EKS you need to edit your inbound firewall rules. And with Azure AKS, you will need to [enable public IPs](https://learn.microsoft.com/en-us/azure/aks/use-node-public-ips) on nodes in your node pool.
 
 == Use the default Redpanda subdomains
 


### PR DESCRIPTION
The Azure UI doesn't give the option to add an external IP to nodes, so it's likely that many people trying to use NodePorts for external access will fail. This PR mentions this is the case and links to instructions for how to resolve this.