### PR TITLE
Minor edits to Migrate with MirrorMaker 2 doc

### DIFF
--- a/modules/upgrade/pages/migrate/data-migration.adoc
+++ b/modules/upgrade/pages/migrate/data-migration.adoc
@@ -2,9 +2,7 @@
 :description: Use MirrorMaker 2 to replicate data between Redpanda clusters.
 :page-aliases: data-management:data-migration.adoc, manage:data-migration.adoc
 
-When you want to migrate data from Kafka or replicate data between Redpanda clusters, you can use the MirrorMaker 2 (MM2) tool bundled in the Kafka download package.
-
-This section describes the process of configuring MirrorMaker 2 to replicate data from one Redpanda cluster to another.
+When you want to migrate data from Kafka or replicate data between Redpanda clusters, you can use the MirrorMaker 2 (MM2) tool bundled in the Kafka download package. This section describes the process of configuring MirrorMaker 2 to replicate data from one Redpanda cluster to another.
 
 MirrorMaker 2 reads a configuration file that specifies the connection details for the Redpanda clusters, as well as other options.
 After you start MirrorMaker 2, the data migration continues according to the configuration at launch time until you shutdown the MirrorMaker 2 process.

--- a/modules/upgrade/pages/migrate/data-migration.adoc
+++ b/modules/upgrade/pages/migrate/data-migration.adoc
@@ -61,7 +61,6 @@ cat << EOF > mm2.properties
 clusters = <cluster_name_1>, <cluster_name_2>
 
 // Assign IP addresses to the cluster names
-// <cluster>.bootstrap.servers may also be a comma-separated list of bootstrap hosts, if the cluster has several
 <cluster_name_1>.bootstrap.servers = <cluster_1_ip>:9092
 <cluster_name_2>.bootstrap.servers = <cluster_2_ip>:9092
 

--- a/modules/upgrade/pages/migrate/data-migration.adoc
+++ b/modules/upgrade/pages/migrate/data-migration.adoc
@@ -2,14 +2,14 @@
 :description: Migrate external data to Redpanda with MirrorMaker 2.
 :page-aliases: data-management:data-migration.adoc, manage:data-migration.adoc
 
-When you want to migrate data from Kafka or replicate data between Redpanda clusters, you can use the MirrorMaker 2 (MM2) tool bundled in the https://kafka.apache.org/downloads[Kafka download package^].
+When you want to migrate data from Kafka or replicate data between Redpanda clusters, you can use the MirrorMaker 2 (MM2) tool bundled in the Kafka download package.
 
 This section describes the process of configuring MirrorMaker 2 to replicate data from one Redpanda cluster to another.
 
 MirrorMaker 2 reads a configuration file that specifies the connection details for the Redpanda clusters, as well as other options.
 After you start MirrorMaker 2, the data migration continues according to the configuration at launch time until you shutdown the MirrorMaker 2 process.
 
-For details on MirrorMaker 2 and its options, see the https://kafka.apache.org/documentation/#georeplication[Kafka documentation^].
+See the https://kafka.apache.org/downloads[Kafka downloads page^] for download instructions, and the https://kafka.apache.org/documentation/#georeplication[Kafka documentation^] for details on cross-cluster data mirroring with MirrorMaker 2.
 
 == Prerequisites
 

--- a/modules/upgrade/pages/migrate/data-migration.adoc
+++ b/modules/upgrade/pages/migrate/data-migration.adoc
@@ -61,6 +61,7 @@ cat << EOF > mm2.properties
 clusters = <cluster_name_1>, <cluster_name_2>
 
 // Assign IP addresses to the cluster names
+// <cluster>.bootstrap.servers may also be a comma-separated list of bootstrap hosts, if the cluster has several
 <cluster_name_1>.bootstrap.servers = <cluster_1_ip>:9092
 <cluster_name_2>.bootstrap.servers = <cluster_2_ip>:9092
 

--- a/modules/upgrade/pages/migrate/data-migration.adoc
+++ b/modules/upgrade/pages/migrate/data-migration.adoc
@@ -65,8 +65,8 @@ cat << EOF > mm2.properties
 clusters = <cluster_name_1>, <cluster_name_2>
 
 // Assign IP addresses to the cluster names
-<cluster_name_1>.bootstrap.servers = <cluster_1>_cluster_ip>:9092
-<cluster_name_2>.bootstrap.servers = <cluster_2>_cluster_ip>:9092
+<cluster_name_1>.bootstrap.servers = <cluster_1_ip>:9092
+<cluster_name_2>.bootstrap.servers = <cluster_2_ip>:9092
 
 // Set replication for all topics from Redpanda 1 to Redpanda 2
 <cluster_name_1>-><cluster_name_2>.enabled = true

--- a/modules/upgrade/pages/migrate/data-migration.adoc
+++ b/modules/upgrade/pages/migrate/data-migration.adoc
@@ -1,5 +1,5 @@
 = Migrate Data to Redpanda with MirrorMaker 2
-:description: Migrate external data to Redpanda with MirrorMaker 2.
+:description: Use MirrorMaker 2 to replicate data between Redpanda clusters.
 :page-aliases: data-management:data-migration.adoc, manage:data-migration.adoc
 
 When you want to migrate data from Kafka or replicate data between Redpanda clusters, you can use the MirrorMaker 2 (MM2) tool bundled in the Kafka download package.

--- a/modules/upgrade/pages/migrate/data-migration.adoc
+++ b/modules/upgrade/pages/migrate/data-migration.adoc
@@ -2,9 +2,7 @@
 :description: Migrate external data to Redpanda with MirrorMaker 2.
 :page-aliases: data-management:data-migration.adoc, manage:data-migration.adoc
 
-One of the more elegant aspects of Redpanda is that it is compatible with the xref:develop:kafka-clients.adoc[Kafka API and ecosystem].
-So when you want to migrate data from Kafka or replicate data between Redpanda clusters,
-the MirrorMaker 2 (MM2) tool bundled in the https://kafka.apache.org/downloads[Kafka download package^] is a natural solution.
+When you want to migrate data from Kafka or replicate data between Redpanda clusters, you can use the MirrorMaker 2 (MM2) tool bundled in the https://kafka.apache.org/downloads[Kafka download package^].
 
 This section describes the process of configuring MirrorMaker 2 to replicate data from one Redpanda cluster to another.
 


### PR DESCRIPTION
- Fix typo with connection details placeholder
- Also edited the opening paragraph to make it more succinct and a bit less "marketing" sounding. I did end up removing the link to the [Kafka compatibility](https://docs.redpanda.com/current/develop/kafka-clients/) page in the process though, so I'm open to modifying this PR to add it back in if that's better

Fixes https://github.com/redpanda-data/documentation-private/issues/1999