### PR TITLE
New metrics records produced consumed

### DIFF
--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -37,11 +37,9 @@ If this is the last record received by the cluster, then the cluster is up-to-da
 
 ---
 
-=== vectorized_cluster_partition_last_stable_offset
+=== vectorized_cluster_partition_schema_id_validation_records_failed
 
-Last stable offset.
-
-If this is the last record received by the cluster, then the cluster is up-to-date and ready for maintenance.
+Number of records that failed schema ID validation.
 
 ---
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -37,6 +37,14 @@ If this is the last record received by the cluster, then the cluster is up-to-da
 
 ---
 
+=== vectorized_cluster_partition_last_stable_offset
+
+Last stable offset.
+
+If this is the last record received by the cluster, then the cluster is up-to-date and ready for maintenance.
+
+---
+
 === vectorized_io_queue_delay
 
 Total delay time in the queue.

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -387,6 +387,16 @@ Bandwidth available for partition movement, in bytes per sec.
 
 === Topic metrics
 
+---
+
+=== redpanda_cluster_partition_schema_id_validation_records_failed
+
+Number of records that failed schema ID validation.
+
+*Type*:  counter
+
+---
+
 === redpanda_kafka_partitions
 
 Configured number of partitions for a topic.
@@ -396,6 +406,22 @@ Configured number of partitions for a topic.
 *Labels*:
 -`redpanda_namespace`
 -`redpanda_topic`
+
+---
+
+=== redpanda_kafka_records_fetched_total
+
+Total number of records fetched.
+
+*Type*: counter
+
+---
+
+=== redpanda_kafka_records_produced_total
+
+Total number of records produced.
+
+*Type*: counter
 
 ---
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -112,7 +112,7 @@ Number of unavailable partitions (the partitions that lack quorum among their re
 
 ---
 
-=== Infrastructure metrics
+== Infrastructure metrics
 
 === redpanda_cpu_busy_seconds_total
 
@@ -283,7 +283,7 @@ Total CPU runtime (uptime) in seconds.
 
 ---
 
-=== Raft metrics
+== Raft metrics
 
 === redpanda_node_status_rpcs_received
 
@@ -309,7 +309,7 @@ Number of timed out node status RPCs from a node.
 
 ---
 
-=== Service metrics
+== Service metrics
 
 === redpanda_pandaproxy_request_latency_seconds
 
@@ -339,7 +339,7 @@ Latency of the request indicated by the label in the Schema Registry. The measur
 
 ---
 
-=== Partition metrics
+== Partition metrics
 
 === redpanda_kafka_max_offset
 
@@ -385,7 +385,7 @@ Bandwidth available for partition movement, in bytes per sec.
 
 ---
 
-=== Topic metrics
+== Topic metrics
 
 ---
 
@@ -465,7 +465,7 @@ Number of leadership changes across all partitions of a given topic.
 
 ---
 
-=== Broker metrics
+== Broker metrics
 
 === redpanda_kafka_request_latency_seconds
 
@@ -479,7 +479,7 @@ Latency of produce/consume requests per broker. This duration measures from when
 
 ---
 
-=== Consumer group metrics
+== Consumer group metrics
 
 === redpanda_kafka_consumer_group_committed_offset
 
@@ -519,7 +519,7 @@ Number of topics in a consumer group.
 
 ---
 
-=== REST proxy metrics
+== REST proxy metrics
 
 === redpanda_rest_proxy_request_errors_total
 
@@ -541,7 +541,7 @@ Internal latency of REST proxy requests.
 
 ---
 
-=== Application metrics
+== Application metrics
 
 === redpanda_application_build
 
@@ -564,7 +564,7 @@ Redpanda application uptime in seconds.
 
 ---
 
-=== Cloud metrics
+== Cloud metrics
 
 === redpanda_cloud_client_backoff
 


### PR DESCRIPTION
Add new metrics to https://docs.redpanda.com/current/reference/internal-metrics-reference/ and https://docs.redpanda.com/current/reference/public-metrics-reference/.

Also change section headings (e.g. https://docs.redpanda.com/current/reference/public-metrics-reference/#infrastructure-metrics) to H2 as most of them are currently H3, same level as the metrics. Changing to H2 will probably nest the metrics under the correct section heading and also make it easier for readers to navigate .

Fixes https://github.com/redpanda-data/documentation-private/issues/2020.