### PR TITLE
Update permissions required for redpanda-agent in customer managed

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/vpc-byo-gcp.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/vpc-byo-gcp.adoc
@@ -204,6 +204,7 @@ cat << EOT > redpanda-agent.role
     "iam.serviceAccounts.getIamPolicy",
     "resourcemanager.projects.get",
     "resourcemanager.projects.getIamPolicy",
+    "serviceusage.services.list",
     "storage.buckets.get",
     "storage.buckets.getIamPolicy",
   ],


### PR DESCRIPTION
Add `serviceusage.services.list` which enables the redpanda agent to determine which GCP APIs have been enabled.