### PR TITLE
Advertised listener address updates

### DIFF
--- a/modules/get-started/pages/licenses.adoc
+++ b/modules/get-started/pages/licenses.adoc
@@ -53,10 +53,10 @@ To apply the license key to your cluster, run:
 
 `rpk cluster license set`
 
-Either provide a path to a file containing the license, or provide the license string inline. For example, assuming you use the default admin host/port of `0.0.0.0:9644`, run:
+Either provide a path to a file containing the license, or provide the license string inline. For example, assuming you use the default admin host/port of `10.0.0.1:9644`, run:
 
 ```bash
-rpk cluster license set --path <path-to-license-file> -X admin.hosts=0.0.0.0:9644
+rpk cluster license set --path <path-to-license-file> -X admin.hosts=10.0.0.1:9644
 ```
 
 Or:
@@ -141,7 +141,7 @@ If neither the path nor the license string are provided, Redpanda looks for the 
 
 To check the status of your current license, run:
 
-`rpk cluster license info -X admin.hosts=0.0.0.0:9644`
+`rpk cluster license info -X admin.hosts=10.0.0.1:9644`
 
 Redpanda sends warning messages in the cluster logs if you enable enterprise features without a valid license key.
 

--- a/modules/manage/pages/security/listener-configuration.adoc
+++ b/modules/manage/pages/security/listener-configuration.adoc
@@ -29,6 +29,8 @@ An address of `0.0.0.0` means that Redpanda listens on all interfaces.
 
 By default, the advertised address is the address the listener is bound to, but this is not usually an externally-routable address. Set the advertised address to an address the client can use to connect to the instance of Redpanda.
 
+NOTE: Any configuration option prefixed with `advertise_*` must have a real hostname or IP address, and must not be configured with `0.0.0.0`.
+
 If the client exists on another subnet, then it needs to know how to reach Redpanda. Do this by configuring the advertised address of the Kafka API in `redpanda.yaml`. For example, if Redpanda is running on the subnet `192.168.4.0/24` with IP address `192.168.4.1`, and the clients are running on the subnet `192.168.5.0/24`, then the client machine needs a gateway configured to route requests to `192.168.4.1`:
 
 [,yaml]

--- a/modules/manage/pages/security/listener-configuration.adoc
+++ b/modules/manage/pages/security/listener-configuration.adoc
@@ -29,7 +29,7 @@ An address of `0.0.0.0` means that Redpanda listens on all interfaces.
 
 By default, the advertised address is the address the listener is bound to, but this is not usually an externally-routable address. Set the advertised address to an address the client can use to connect to the instance of Redpanda.
 
-NOTE: Any configuration option prefixed with `advertise_*` must have a real hostname or IP address, and must not be configured with `0.0.0.0`.
+NOTE: Any configuration option prefixed with `advertise_*` must have a real hostname or IP address, and must not be configured with `0.0.0.0`. If `advertise_*` does not use a real hostname or IP address, or is configured with `0.0.0.0` then broker startup will fail validation.
 
 If the client exists on another subnet, then it needs to know how to reach Redpanda. Do this by configuring the advertised address of the Kafka API in `redpanda.yaml`. For example, if Redpanda is running on the subnet `192.168.4.0/24` with IP address `192.168.4.1`, and the clients are running on the subnet `192.168.5.0/24`, then the client machine needs a gateway configured to route requests to `192.168.4.1`:
 

--- a/modules/manage/pages/security/listener-configuration.adoc
+++ b/modules/manage/pages/security/listener-configuration.adoc
@@ -29,7 +29,7 @@ An address of `0.0.0.0` means that Redpanda listens on all interfaces.
 
 By default, the advertised address is the address the listener is bound to, but this is not usually an externally-routable address. Set the advertised address to an address the client can use to connect to the instance of Redpanda.
 
-NOTE: Any configuration option prefixed with `advertise_*` must have a real hostname or IP address, and must not be configured with `0.0.0.0`. If `advertise_*` does not use a real hostname or IP address, or is configured with `0.0.0.0` then broker startup will fail validation.
+NOTE: Ensure that any configuration option with the `advertise_*` prefix uses a valid hostname or IP address. Do not use `0.0.0.0`. Invalid configurations, including the use of `0.0.0.0`, will cause the broker to fail during startup validation.
 
 If the client exists on another subnet, then it needs to know how to reach Redpanda. Do this by configuring the advertised address of the Kafka API in `redpanda.yaml`. For example, if Redpanda is running on the subnet `192.168.4.0/24` with IP address `192.168.4.1`, and the clients are running on the subnet `192.168.5.0/24`, then the client machine needs a gateway configured to route requests to `192.168.4.1`:
 

--- a/modules/reference/pages/node-configuration-sample.adoc
+++ b/modules/reference/pages/node-configuration-sample.adoc
@@ -85,7 +85,7 @@ redpanda:
   # Address of RPC endpoint published to other cluster members.
   # Default: 0.0.0.0:33145
   advertised_rpc_api:
-    address: "0.0.0.0"
+    address: "127.0.0.1"
     port: 33145
 
   # Multiple listeners are also supported as per KIP-103.

--- a/modules/reference/pages/node-configuration-sample.adoc
+++ b/modules/reference/pages/node-configuration-sample.adoc
@@ -61,7 +61,8 @@ redpanda:
     truststore_file: ""
 
   # The IP address and port for the internal RPC server.
-  # Default: 127.0.0.0:33145
+  # Default should be a real IP address because this is configuring advertised_rpc_api, not rpc_server.
+  # Default: 127.0.0.1:33145
   rpc_server:
     address: "0.0.0.0"
     port: 33145
@@ -120,8 +121,9 @@ redpanda:
 
   # Multiple listeners are also supported as per KIP-103.
   # The names must match those in kafka_api
+  # Default should be a real IP address because this is configuring advertised_rpc_api, not rpc_server.
   advertised_kafka_api:
-  - address: 0.0.0.0
+  - address: 10.0.0.1
     name: internal
     port: 9092
   - address: redpanda-0.my.domain.com.
@@ -173,8 +175,9 @@ pandaproxy:
 
   # A list of address and port for the REST API to publish to client
   # Default: from pandaproxy_api
+  # Default should be a real IP address because this is configuring advertised_rpc_api, not rpc_server.
   advertised_pandaproxy_api:
-    - address: 0.0.0.0
+    - address: 10.0.0.1
       name: internal
       port: 8082
     - address: "redpanda-rest-0.my.domain.com."

--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-config-set.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-config-set.adoc
@@ -31,20 +31,20 @@ rpk redpanda config set redpanda.rpc_server '{address: 3.250.158.1, port: 9092}'
 You can set an entire array by wrapping all items with braces, or by using one struct:
 
 ----
-rpk redpanda config set redpanda.advertised_kafka_api '[{address: 0.0.0.0, port: 9092}]'
+rpk redpanda config set redpanda.advertised_kafka_api '[{address: 10.0.0.1, port: 9092}]'
 ----
 
 or
 
 ----
-rpk redpanda config set redpanda.advertised_kafka_api '{address: 0.0.0.0, port: 9092}'
+rpk redpanda config set redpanda.advertised_kafka_api '{address: 10.0.0.1, port: 9092}'
 ----
 
 Indexing can be used to set specific items in an array. You can index one past
 the end of an array to extend it:
 
 ----
-rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 0.0.0.0, port: 9092}'
+rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 10.0.0.1, port: 9092}'
 ----
 
 The json format can be used to set values as json:


### PR DESCRIPTION
Fixes Issue 2049

Preview changes:
https://deploy-preview-73--redpanda-docs-preview.netlify.app/current/get-started/licenses/#apply-a-license-key-to-redpanda

https://deploy-preview-73--redpanda-docs-preview.netlify.app/current/manage/security/listener-configuration/#advertise-a-listener

https://deploy-preview-73--redpanda-docs-preview.netlify.app/current/reference/node-configuration-sample/#sample-configuration

https://deploy-preview-73--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-redpanda/rpk-redpanda-config-set/#examples

@hcoyote : 
Re:  Additional info:

- Updated listener config content to reflect that redpanda core disallows (once https://github.com/redpanda-data/redpanda/pull/14179 is merged) setting the advertised_* addresses to 0.0.0.0 in https://github.com/redpanda-data/redpanda/issues/12395

As for: Additionally, we're looking to prevent this from being set in the Ansible configurations as well as an additional safeguard in https://github.com/redpanda-data/redpanda-ansible-collection/issues/58
I don't see a PR open/in progress, so will have to circle back with that update once the code is updated.