### PR TITLE
fix version of twmb/tlscfg

### DIFF
--- a/modules/develop/pages/guide-go-cloud.adoc
+++ b/modules/develop/pages/guide-go-cloud.adoc
@@ -45,7 +45,7 @@ go mod init com/redpanda/chat-room
 ----
 go get github.com/twmb/franz-go@v1.9.0
 go get github.com/google/uuid@v1.3.0
-go get github.com/twmb/tlscfg@v1.3.1
+go get github.com/twmb/tlscfg@v1.2.1
 ----
 
 == Create a topic

--- a/modules/develop/pages/guide-go.adoc
+++ b/modules/develop/pages/guide-go.adoc
@@ -46,7 +46,7 @@ go mod init com/redpanda/chat-room
 ----
 go get github.com/twmb/franz-go@v1.9.0
 go get github.com/google/uuid@v1.3.0
-go get github.com/twmb/tlscfg@v1.3.1
+go get github.com/twmb/tlscfg@v1.2.1
 ----
 
 == Create a topic

--- a/modules/develop/partials/chat-app.adoc
+++ b/modules/develop/partials/chat-app.adoc
@@ -77,7 +77,7 @@ go mod init com/redpanda/chat-room
 ----
 go get github.com/twmb/franz-go@v1.9.0
 go get github.com/google/uuid@v1.3.0
-go get github.com/twmb/tlscfg@v1.3.1
+go get github.com/twmb/tlscfg@v1.2.1
 ----
 endif::[]
 


### PR DESCRIPTION
Hi this is Q. I tried to make chat demo. But I got error when I tried to install tlscfg.

In twmb/tlscfg, there isn't v1.3.1
You can check its version in https://github.com/twmb/tlscfg/tags.
So I changes version v1.3.1 to v1.2.1 that latest version of tlscfg

Also I add newline to modules/develop/partials/chat-app.adoc.
