### PR TITLE
fix version and dependency of golang chat demo

### DIFF
--- a/modules/develop/pages/guide-go-cloud.adoc
+++ b/modules/develop/pages/guide-go-cloud.adoc
@@ -43,9 +43,9 @@ go mod init com/redpanda/chat-room
 +
 [,bash]
 ----
-go get github.com/twmb/franz-go@v1.9.0
+go get github.com/twmb/franz-go@v1.15.0
+go get github.com/twmb/franz-go/pkg/kadm@v1.10.0
 go get github.com/google/uuid@v1.3.0
-go get github.com/twmb/tlscfg@v1.3.1
 ----
 
 == Create a topic

--- a/modules/develop/pages/guide-go.adoc
+++ b/modules/develop/pages/guide-go.adoc
@@ -44,9 +44,9 @@ go mod init com/redpanda/chat-room
 +
 [,bash]
 ----
-go get github.com/twmb/franz-go@v1.9.0
+go get github.com/twmb/franz-go@v1.15.0
+go get github.com/twmb/franz-go/pkg/kadm@v1.10.0
 go get github.com/google/uuid@v1.3.0
-go get github.com/twmb/tlscfg@v1.3.1
 ----
 
 == Create a topic


### PR DESCRIPTION
Hi this is JQ. As I send [PR#82](https://github.com/redpanda-data/docs/pull/82) before about version, I realized that I needed to change a dependency in this demo.
Please check my go mod file in demo.
https://github.com/Q00/redpanda-chat/blob/main/go.mod

This demo needs github.com/twmb/franz-go/pkg/kadm instead of github.com/twmb/tlscfg.
When I run `go mod tidy`, it removes github.com/twmb/tlscfg.