### PR TITLE
Mark v22.2 as end of life

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -6,6 +6,7 @@ nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
+    page-eol: true
     full-version: 22.2.13
     latest-release-commit: '177befb'
     supported-kubernetes-version: 1.21


### PR DESCRIPTION
Support for v22.2 ended in August 2023.