### PR TITLE
Change listener name that public certificate is refering to

### DIFF
--- a/modules/manage/pages/kubernetes/security/kubernetes-tls.adoc
+++ b/modules/manage/pages/kubernetes/security/kubernetes-tls.adoc
@@ -213,7 +213,7 @@ spec:
     tls:
       enabled: true
       certs:
-        default:
+        external:
           issuerRef:
             name: <issuer-name>
             kind: <issuer>
@@ -240,7 +240,7 @@ Helm::
 tls:
   enabled: true
   certs:
-    default:
+    external:
       issuerRef:
         name: <issuer-name>
         kind: <issuer>
@@ -259,9 +259,9 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
   --set tls.enabled=true \
-  --set tls.certs.default.issuerRef.name=<issuer-name> \
-  --set tls.certs.default.issuerRef.kind=<issuer> \
-  --set tls.certs.default.caEnabled=false \
+  --set tls.certs.external.issuerRef.name=<issuer-name> \
+  --set tls.certs.external.issuerRef.kind=<issuer> \
+  --set tls.certs.external.caEnabled=false \
   --set external.domain=<custom-domain>
 ```
 ====
@@ -348,6 +348,9 @@ kubectl create secret generic <secret-name> \
 ```
 +
 NOTE: When using certificates issued by public certificate authorities (CAs), you don't need to provide the `ca.crt` file in the Secret. Public CAs are already trusted by default in most systems and web browsers. The trust chain is built into the operating system or web browser, which includes the root certificates of well-known CAs.
++
++
+NOTE: When external secret is created for internal (`default`) listeners, it must follow the internal, to Kubernetes, DNS naming scheme like ``*.Service-Name.Namespace.svc.cluster.local` where `Service-Name` should be replaced by headless service and `Namespace` by the name of the namespace where Redpanda cluster is being deployed
 +
 Replace the `<path>` placeholders with the paths to your certificate files.
 +


### PR DESCRIPTION
Our documentation correctly describe the process to configure external cert manager cluster issuer to create public certificate. Unfortunately if user follows exact naming scheme, then Redpanda cluster deployment will not work as public certificate does not follow internal to Kubernetes cluster DNS naming scheme.

By default helm chart defines 2 listeners `default` and `external`. User can change those names. Those names are used to reference what TLS definition is assigned to them.

https://github.com/redpanda-data/helm-charts/issues/829#issuecomment-1787144184