### PR TITLE
Admin API - Add new function for CPU profiling

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -1014,6 +1014,28 @@ paths:
         200:
           description: Stop self-test success
           content: {}
+  /debug/cpu_profile:
+    get:
+      operationId: get_cpu_profile
+      tags:
+      - Debugging
+      summary: Get samples from CPU profiler 
+      responses:
+        200:
+          description: CPU profile
+          content:
+            application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/cpu_profile_sample' 
+    parameters: 
+      - name: shard
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64  
   /cloud_storage/initiate_topic_scan_and_recovery:
     get:
       tags:
@@ -4433,6 +4455,17 @@ components:
           type: string
           description: Warning that arose during test execution
       description: Result set from a single self_test run
+    cpu_profile_sample:
+      type: object
+      properties:
+        user_backtrace:
+          type: string
+          description: User backtrace
+        occurrences:
+          type: integer
+          format: int64
+          description: Number of times this backtrace has occurred
+      description: CPU profile sample
     init_recovery_result:
       type: object
       properties:

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -1029,6 +1029,14 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/cpu_profile_shard_sample' 
+        400:
+          description: Invalid request
+          content:
+            application/json:
+              schema: 
+                oneOf:
+                  - $ref: '#/components/schemas/shard_error' 
+                  - $ref: '#/components/schemas/wait_ms_error'           
     parameters: 
       - name: shard
         in: query
@@ -1036,6 +1044,12 @@ paths:
         schema:
           type: integer
           format: int64  
+      - name: wait_ms
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64 
   /cloud_storage/initiate_topic_scan_and_recovery:
     get:
       tags:
@@ -4529,6 +4543,25 @@ components:
     cancel_all_partitions_reconfigurations:
       type: object
       description: TBD
+    shard_error:
+      type: object
+      properties: 
+        message:
+          type: string
+          example: "Invalid shard ID, check shard limit"
+        code: 
+          type: integer
+          example: 400
+    wait_ms_error:
+      type: object
+      properties: 
+        message:
+          type: string
+          example: "wait_ms must be between 1ms and 15min"
+        code: 
+          type: integer
+          example: 400
+
 
 tags:
   - name: Clusters

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -1028,7 +1028,7 @@ paths:
                 schema:
                   type: array
                   items:
-                    $ref: '#/components/schemas/cpu_profile_sample' 
+                    $ref: '#/components/schemas/cpu_profile_shard_sample' 
     parameters: 
       - name: shard
         in: query
@@ -4455,6 +4455,23 @@ components:
           type: string
           description: Warning that arose during test execution
       description: Result set from a single self_test run
+    cpu_profile_shard_sample:
+      type: object
+      properties:
+        shard_id:
+          type: integer
+          format: int64
+          description: Shard from which the sample originated
+        dropped_samples:
+          type: integer
+          format: int64
+          description: Number of samples that had to be dropped due to space limitations
+        samples:
+          type: array
+          description: CPU profile samples
+          items: 
+            $ref: "#/components/schemas/cpu_profile_sample"
+      description: CPU profile shard sample
     cpu_profile_sample:
       type: object
       properties:


### PR DESCRIPTION
New Admin API endpoint to query CPU profiler for troubleshooting purposes. See deploy preview: [Admin API GET /debug/cpu_profile](https://deploy-preview-100--redpanda-docs-preview.netlify.app/api/admin-api.html#tag/Debugging/operation/get_cpu_profile)

Closes: https://github.com/redpanda-data/documentation-private/issues/1983 