### PR TITLE
add cloud beta tag

### DIFF
--- a/modules/ROOT/partials/attributes.yml
+++ b/modules/ROOT/partials/attributes.yml
@@ -20,3 +20,4 @@ badge-perf-iops: 'image:https://img.shields.io/badge/Performance-IOPS-yellow.svg
 badge-perf-storage: 'image:https://img.shields.io/badge/Performance-Storage-yellow.svg[]'
 badge-deprecated: 'image:https://img.shields.io/badge/-Deprecated-red.svg[]'
 badge-tech-preview: 'image:https://img.shields.io/badge/Technical%20Preview-Version%2023.2.x-red.svg[Technical Preview]'
+badge-cloud-beta: 'image:https://img.shields.io/badge/Cloud%20Beta-red.svg[Cloud Beta]'


### PR DESCRIPTION
Add a cloud beta tag

Usage: `{badge-cloud-beta}`

Resolves https://github.com/redpanda-data/documentation-private/issues/2089

Preview: https://img.shields.io/badge/Cloud%20Beta-red.svg