### PR TITLE
Updated IAM requirements for placement groups

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/security/authorization/cloud-iam-policies.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/authorization/cloud-iam-policies.adoc
@@ -49,6 +49,9 @@ statement {
      "autoscaling:DescribeInstanceRefreshes",
      "autoscaling:DescribeLaunchConfigurations",
      "iam:CreateServiceLinkedRole",
+     "ec2:CreatePlacementGroup",
+     "ec2:DeletePlacementGroup",
+     "ec2:DescribePlacementGroups"
    ]
    resources = [
      "*",


### PR DESCRIPTION
Placement groups have been added for single-zone AWS deployments.  Updated list of IAM permissions for this feature.