### PR TITLE
Add disable partition endpoints to Admin API

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -977,7 +977,7 @@ paths:
   /cluster/partitions/{namespace}/{topic}:
     post:
       summary: Disable/enable all partitions of a topic
-      description: "Disable or enable all partitions of a topic. To disable, use `disabled: true` in request body. To enable, use `disabled: false`."
+      description: "Disable or enable all partitions of a topic. To disable, use `{'disabled': true}` in request body. To enable, use `{'disabled': false}`."
       operationId: post_cluster_partitions_topic
       parameters: 
         - name: namespace
@@ -995,7 +995,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/disable_enable_partitions'
-        required: false 
+        required: true 
       responses: 
         200:
           description: Partitions disabled or enabled successfully
@@ -1017,12 +1017,11 @@ paths:
           required: true
           schema: 
             type: string
-      requestBody: 
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/disable_enable_partitions'
-        required: false  
+        - name: disabled
+          in: query 
+          required: false
+          schema: 
+            type: boolean
       responses: 
         200:
           description: Topic partitions metadata
@@ -1037,7 +1036,7 @@ paths:
   /cluster/partitions/{namespace}/{topic}/{partition}:
     post: 
       summary: Disable/enable a single partition
-      description: "Disable or enable a single partition. To disable, use `disabled: true` in request body. To enable, use `disabled: false`."
+      description: "Disable or enable a single partition. To disable, use `{'disabled': true}` in request body. To enable, use `{'disabled': false}`."
       operationId: post_cluster_partitions_topic_partition
       parameters: 
         - name: namespace
@@ -1061,7 +1060,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/disable_enable_partitions'
-        required: false  
+        required: true  
       responses: 
         200:
           description: Individual partition disabled or enabled successfully
@@ -4096,10 +4095,6 @@ components:
     cluster_partition:
       type: object
       properties:
-        leader_id:
-          type: integer
-          description: Node ID of the leader broker
-          format: int64
         ns:
           type: string
           description: namespace

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -947,6 +947,127 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/cluster_health_overview'
+  /cluster/partitions:
+    get: 
+      summary: Get cluster-level metadata for all partitions in cluster
+      description: Get cluster-level metadata for all partitions in cluster.
+      operationId: get_cluster_partitions
+      parameters: 
+        - name: disabled
+          in: query 
+          required: false
+          schema:
+            type: boolean
+        - name: with_internal
+          in: query
+          required: false
+          schema: 
+            type: boolean
+      responses:
+        200:
+          description: Partition metadata
+          content: 
+            application/json:
+              schema: 
+                type: array
+                items:
+                  $ref: '#/components/schemas/cluster_partition'
+      tags: 
+        -  Partitions    
+  /cluster/partitions/{namespace}/{topic}:
+    post:
+      summary: Disable/enable all partitions of a topic
+      description: "Disable or enable all partitions of a topic. To disable, use `disabled: true` in request body. To enable, use `disabled: false`."
+      operationId: post_cluster_partitions_topic
+      parameters: 
+        - name: namespace
+          in: path
+          required: true
+          schema: 
+            type: string
+        - name: topic
+          in: path
+          required: true
+          schema: 
+            type: string
+      requestBody: 
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/disable_enable_partitions'
+        required: false 
+      responses: 
+        200:
+          description: Partitions disabled or enabled successfully
+          content: {}
+      tags: 
+        -  Partitions 
+    get:
+      summary: Get cluster-level metadata for all partitions in topic
+      description: Get cluster-level metadata for all partitions in topic.
+      operationId: get_cluster_partitions_topic
+      parameters: 
+        - name: namespace
+          in: path
+          required: true
+          schema: 
+            type: string
+        - name: topic
+          in: path
+          required: true
+          schema: 
+            type: string
+      requestBody: 
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/disable_enable_partitions'
+        required: false  
+      responses: 
+        200:
+          description: Topic partitions metadata
+          content: 
+            application/json:
+              schema: 
+                type: array
+                items:
+                  $ref: '#/components/schemas/cluster_partition'
+      tags: 
+        -  Partitions 
+  /cluster/partitions/{namespace}/{topic}/{partition}:
+    post: 
+      summary: Disable/enable a single partition
+      description: "Disable or enable a single partition. To disable, use `disabled: true` in request body. To enable, use `disabled: false`."
+      operationId: post_cluster_partitions_topic_partition
+      parameters: 
+        - name: namespace
+          in: path
+          required: true
+          schema: 
+            type: string
+        - name: topic
+          in: path
+          required: true
+          schema: 
+            type: string
+        - name: partition
+          in: path
+          required: true
+          schema: 
+            type: integer
+            format: int64
+      requestBody: 
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/disable_enable_partitions'
+        required: false  
+      responses: 
+        200:
+          description: Individual partition disabled or enabled successfully
+          content: {}
+      tags: 
+        -  Partitions 
   /cluster/partition_balancer/status:
     get:
       tags:
@@ -3972,6 +4093,32 @@ components:
           description: node id
           format: int64
       description: Replica assignment
+    cluster_partition:
+      type: object
+      properties:
+        leader_id:
+          type: integer
+          description: Node ID of the leader broker
+          format: int64
+        ns:
+          type: string
+          description: namespace
+        partition_id:
+          type: integer
+          description: partition
+          format: int64
+        replicas:
+          type: array
+          description: Replica assignments
+          items:
+            $ref: '#/components/schemas/assignment'
+        disabled:
+          type: boolean
+          description: Status
+        topic:
+          type: string
+          description: topic
+      description: Partition details
     partition:
       type: object
       properties:
@@ -4341,6 +4488,11 @@ components:
       properties:
         cluster_uuid:
           type: string
+    disable_enable_partitions:
+      type: object
+      properties:
+        disabled:
+          type: boolean
     controller_status:
       type: object
       properties:


### PR DESCRIPTION
Add the following endpoints:
- `GET /cluster/partitions`: [preview](https://deploy-preview-148--redpanda-docs-preview.netlify.app/api/admin-api.html#tag/Partitions/operation/get_cluster_partitions)
- `GET /cluster/partitions/{namespace}/{topic}`: [preview](https://deploy-preview-148--redpanda-docs-preview.netlify.app/api/admin-api.html#tag/Partitions/operation/get_cluster_partitions_topic)
- `POST /cluster/partitions/{namespace}/{topic}`: [preview](https://deploy-preview-148--redpanda-docs-preview.netlify.app/api/admin-api.html#tag/Partitions/operation/post_cluster_partitions_topic)
- `POST /cluster/partitions/{namespace}/{topic}/{partition}`: [preview](https://deploy-preview-148--redpanda-docs-preview.netlify.app/api/admin-api.html#tag/Partitions/operation/post_cluster_partitions_topic_partition)

Merge this PR before merging https://github.com/redpanda-data/docs/pull/113 as this adds Admin API documentation that will be referred to in the new recovery mode doc.