### PR TITLE
Put build hook in secret

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,4 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger build
-      run: curl -X POST -d {} https://api.netlify.com/build_hooks/64e4681f196c14340d591f29
+      env:
+        BUILD_HOOK: ${{ secrets.BUILD_HOOK }}
+      run: curl -X POST -d {} $BUILD_HOOK


### PR DESCRIPTION
Stops builds from triggering on forked repos and protects our build hook