### PR TITLE
Admin API reference: partition recovery

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -3,7 +3,6 @@ info:
   title: Redpanda Admin API
   version: 1.0.0
   description: |
-  
     Use the Admin API to administer and manage Redpanda.
 
     ---
@@ -43,7 +42,7 @@ paths:
       responses:
         200:
           description: Brokers' configurations response
-          externalDocs: 
+          externalDocs:
             url: https://docs.redpanda.com/docs/reference/node-properties/
           content:
             application/json:
@@ -56,12 +55,12 @@ paths:
       tags:
       - Logging
       summary: Get loggers
-      description: List of all registered loggers. Each logger has its own configurable `log_level` that dictates how verbose logs are within their corresponding subsystems. 
+      description: List of all registered loggers. Each logger has its own configurable `log_level` that dictates how verbose logs are within their corresponding subsystems.
       operationId: get_loggers
       responses:
         200:
           description: Loggers response
-          content:  
+          content:
             application/json:
               schema:
                 type: array
@@ -95,12 +94,11 @@ paths:
           - trace
       - name: expires
         in: query
-        description: | 
+        description: |
           Duration, in seconds, that the logger is set to the specified log level, after which the level reverts to its previous value.
 
           * **Default value**: 600 (10 minutes)
           * **Valid values**: `0` (infinite duration) or greater
-  
         schema:
           type: number
       responses:
@@ -1019,7 +1017,7 @@ paths:
       operationId: get_cpu_profile
       tags:
       - Debugging
-      summary: Get samples from CPU profiler 
+      summary: Get samples from CPU profiler
       responses:
         200:
           description: CPU profile
@@ -1028,22 +1026,22 @@ paths:
                 schema:
                   type: array
                   items:
-                    $ref: '#/components/schemas/cpu_profile_shard_sample' 
+                    $ref: '#/components/schemas/cpu_profile_shard_sample'
         400:
           description: Invalid request
           content:
             application/json:
-              schema: 
+              schema:
                 oneOf:
-                  - $ref: '#/components/schemas/shard_error' 
-                  - $ref: '#/components/schemas/wait_ms_error'           
-    parameters: 
+                  - $ref: '#/components/schemas/shard_error'
+                  - $ref: '#/components/schemas/wait_ms_error'
+    parameters:
       - name: shard
         in: query
         required: false
         schema:
           type: integer
-          format: int64  
+          format: int64
       - name: wait_ms
         in: query
         required: false
@@ -1051,17 +1049,26 @@ paths:
           type: integer
           format: int64
   /debug/partitions/{namespace}/{topic}/{partition}/force_replicas:
-    post: 
-      tags: 
-      -  Debugging
+    post:
+      tags:
+      -  Partitions
       summary: Force update replicas
       operationId: force_update_partition_replicas
       description: Force update partition replicas
-      responses: 
+      responses:
         200:
           description: Replica update successful
           content: {}
-    parameters: 
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              description: Replica assignments
+              items:
+                $ref: '#/components/schemas/assignment'
+    parameters:
       - name: namespace
         in: path
         required: true
@@ -1071,12 +1078,12 @@ paths:
         in: path
         required: true
         schema:
-          type: string 
+          type: string
       - name: partition
-        in: path 
-        required: true 
-        schema: 
-          type: integer 
+        in: path
+        required: true
+        schema:
+          type: integer
           format: int64
   /cloud_storage/initiate_topic_scan_and_recovery:
     get:
@@ -4573,20 +4580,20 @@ components:
       description: TBD
     shard_error:
       type: object
-      properties: 
+      properties:
         message:
           type: string
           example: "Invalid shard ID, check shard limit"
-        code: 
+        code:
           type: integer
           example: 400
     wait_ms_error:
       type: object
-      properties: 
+      properties:
         message:
           type: string
           example: "wait_ms must be between 1ms and 15min"
-        code: 
+        code:
           type: integer
           example: 400
 
@@ -4595,7 +4602,7 @@ tags:
   - name: Clusters
     description: |
 
-      Configure a Redpanda cluster's properties. 
+      Configure a Redpanda cluster's properties.
 
   - name: Brokers
     description: |
@@ -4608,7 +4615,7 @@ tags:
       Manage partitions of a Redpanda cluster.
 
   - name: Tiered Storage
-    description: Manage 
+    description: Manage
   - name: Transactions
   - name: Users
     description: Manage SCRAM (Salted Challenge Response Authentication Mechanism) users.
@@ -4617,8 +4624,8 @@ tags:
   - name: Logging
     description: Get available loggers, and set log levels.
   - name: Debugging
-    description: | 
-      Debug a Redpanda cluster.  
+    description: |
+      Debug a Redpanda cluster.
 
       For details about debugging in the latest version of Redpanda version, see [Cluster Diagnostics](https://docs.redpanda.com/docs/manage/cluster-maintenance/cluster-diagnostics/).
   - name: Services

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -1055,7 +1055,7 @@ paths:
       tags: 
       -  Debugging
       summary: Force update replicas
-      operationId: force_update_replicas
+      operationId: force_update_partition_replicas
       description: Force update partition replicas
       responses: 
         200:

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -1049,7 +1049,35 @@ paths:
         required: false
         schema:
           type: integer
-          format: int64 
+          format: int64
+  /debug/partitions/{namespace}/{topic}/{partition}/force_replicas:
+    post: 
+      tags: 
+      -  Debugging
+      summary: Force update replicas
+      operationId: force_update_replicas
+      description: Force update partition replicas
+      responses: 
+        200:
+          description: Replica update successful
+          content: {}
+    parameters: 
+      - name: namespace
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: topic
+        in: path
+        required: true
+        schema:
+          type: string 
+      - name: partition
+        in: path 
+        required: true 
+        schema: 
+          type: integer 
+          format: int64
   /cloud_storage/initiate_topic_scan_and_recovery:
     get:
       tags:


### PR DESCRIPTION
Add new Admin API endpoint for feature referred to as partition recovery. This feature allows you to recover a "stuck" partition. Please refer to preview: https://deploy-preview-153--redpanda-docs-preview.netlify.app/api/admin-api.html#tag/Debugging/operation/force_update_partition_replicas

Partially resolves https://github.com/redpanda-data/documentation-private/issues/2105 (a separate PR to be opened to update content in `main`).