### PR TITLE
Fix backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -40,10 +40,27 @@ jobs:
 
           BRANCHES=""
           if [[ $BACKPORT_LABELS == "backport to all versions" ]]; then
-              # Fetch all branches with 'v/' prefix from GitHub API
-              ALL_BRANCHES=$(curl -s -H "Authorization: token ${{ secrets.ACTIONS_BOT_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/branches | jq -r '.[].name' | grep '^v/')
+              PAGE=1
+              ALL_BRANCHES=""
+              
+              # Loop to fetch all branches with 'v/' prefix from the GitHub API
+              while : ; do
+                RAW_RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.ACTIONS_BOT_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/branches?per_page=100&page=$PAGE")
+            
+                if [[ $(echo "$RAW_RESPONSE" | jq '. | length') -eq 0 ]]; then
+                    break
+                fi
+            
+                PAGE_BRANCHES=$(echo "$RAW_RESPONSE" | jq -r '.[].name' | grep '^v/')
+            
+                ALL_BRANCHES+=$PAGE_BRANCHES$'\n'
+            
+                ((PAGE++))
+              done
+          
+              # Prepare the BRANCHES variable, remove trailing comma and newline
               BRANCHES=$(echo "$ALL_BRANCHES" | tr '\n' ',')
-              BRANCHES=${BRANCHES::-1}  # Removing the trailing comma
+              BRANCHES=${BRANCHES%,}  # Removing the trailing comma and newline
           else
             BRANCH_NAMES=$(echo "$BACKPORT_LABELS" | grep -o 'backport to v/[0-9]\+\.[0-9]\+' | sed -e 's/backport to //')
             BRANCHES=$(echo "$BRANCH_NAMES" | tr '\n' ',')


### PR DESCRIPTION
By default, the GitHub API returns 30 results per page. Since we have a lot of branches now (some stale), the `v/` branches to backport to were not appearing in the first page of results.

This PR increases the number of results per page to the max of 100 and checks all other pages: https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28

We must maintain our branches to avoid too many stale ones in the repo.