### PR TITLE
Include double dash syntax for `rpk cluster config set`

### DIFF
--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-set.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-set.adoc
@@ -39,13 +39,13 @@ help' for detail or '-X list' for terser detail.
 
 [NOTE]
 ====
-Setting parameters to non-number values (such as string values with a `-`) can be problematic for some terminals due to how POSIX flags are parsed from the command. For example, this command may not work from some terminals:
+Setting properties to non-number values (such as setting string values with `-`) can be problematic for some terminals due to how POSIX flags are parsed. For example, the following command may not work from some terminals:
 
 ```
 rpk cluster config set delete_retention_ms -1
 ```
 
-This can be resolved by using an alternate syntax that includes a `--` to disable parsing for all subsequent characters:
+Workaround: Use `--` to disable parsing for all subsequent characters. For example:
 
 ```
 rpk cluster config set -- delete_retention_ms -1

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-set.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-set.adoc
@@ -37,3 +37,17 @@ help' for detail or '-X list' for terser detail.
 |-v, --verbose |- |Enable verbose logging.
 |===
 
+[NOTE]
+====
+Setting parameters to non-number values (such as string values with a `-`) can be problematic for some terminals due to how POSIX flags are parsed from the command. For example, this command may not work from some terminals:
+
+```
+rpk cluster config set delete_retention_ms -1
+```
+
+This can be resolved by using an alternate syntax that includes a `--` to disable parsing for all subsequent characters:
+
+```
+rpk cluster config set -- delete_retention_ms -1
+```
+====


### PR DESCRIPTION
Setting a cluster parameter to `-1` doesn't work in most cases:

```
> rpk cluster config set delete_retention_ms "-1"
Error: unknown shorthand flag: '1' in -1
```

But a workaround is to use the double dash syntax, which this PR includes in our docs.