### PR TITLE
add single source of truth for rpk

### DIFF
--- a/tools/gen-rpk-ascii.py
+++ b/tools/gen-rpk-ascii.py
@@ -1,0 +1,460 @@
+import subprocess
+import re
+import json
+import os
+import filecmp
+import difflib
+
+suggestedReadings = """
+
+---
+
+<SuggestedReading/>
+
+- [Introducing rpk container](https://redpanda.com/blog/rpk-container/)
+- [Getting started with rpk commands](https://redpanda.com/blog/getting-started-rpk/)
+"""
+
+
+cmd_dict = {}
+basic_commands_docker = ["docker","exec","-it"] 
+basic_commands_docker.append("rp-0") #modify to your cluster name
+rpk_basic_command = ["rpk"]
+
+def assert_period(s):return s if s.endswith('.') else s + '.'
+
+def escape_chars(s):
+    s = s.replace("redpanda.yaml", "`redpanda.yaml`")
+    s = s.replace("<IP>", "|IP|")
+    s = s.replace("<port>", "|port|")
+    s = s.replace("<name>", "|name|")
+    s = s.replace("<host>", "|host|")
+    s = s.replace("<storage type>", "|storage type|")
+    s = s.replace("<vm type>", "|vm type|")
+    s = s.replace("<vendor>", "|vendor|")
+    s = s.replace("<host:port>", "|host:port|")
+    s = s.replace("<tuner name>", "|tuner name|")
+    s = s.replace("./<timestamp>-bundle.zip", "./&lt;timestamp&gt;-bundle.zip")
+    return s
+
+def cmp_rpk_ascii(dir1, dir2, outdir=""):
+    if outdir:
+        for root1, _, files1 in os.walk(dir1):
+            for file1 in files1:
+                for root2, _, files2 in os.walk(dir2):
+                    for file2 in files2:
+                        if file1 == file2:
+                            file_path1 = os.path.join(root1, file1)
+                            file_path2 = os.path.join(root2, file2)
+                            
+                            if not filecmp.cmp(file_path1, file_path2, shallow=False):
+                                with open(file_path1, "r") as f1, open(file_path2, "r") as f2:
+                                    lines1 = f1.readlines()
+                                    lines2 = f2.readlines()
+                                
+                                diff = difflib.unified_diff(lines1, lines2, file_path1, file_path2)
+                                outfile = outdir + "/diff_" + os.path.basename(file_path1)
+                                with open(outfile, "w") as fo:
+                                    fo.write("\n".join(diff))
+                                    print("Wrote " + outfile)
+
+class Flag:
+    def __init__(self, value, type, explanation):
+        self.value = value
+        self.type = type
+        self.explanation = explanation
+
+
+# Execute a subprocess inside a Linux machine. If the command is multi level (ex. rpk acl create) is generates a bigger list
+def execute_process(commands):
+    if len(commands) > 0:
+        commands = commands[0].split(" ")
+    commands_to_execute = basic_commands_docker + rpk_basic_command + commands
+    commands_to_execute.append("-h")
+    process = subprocess.run(commands_to_execute, stdout=subprocess.PIPE)
+    return process.stdout.decode("utf-8")
+
+
+# Get the explanation written before the usage. Example:
+""" # rpk is the Redpanda CLI & toolbox.
+# Usage:
+#   rpk [command] """
+
+
+def get_explanation(process_line):
+    return process_line[: process_line.find("Usage")].rstrip("\n").strip()
+
+
+# Get the usage of the command. If it's initial command, look for available commands. If it's a final a command, then look for flags. Finally if neither are present, extract the usage. Example:
+""" Usage:
+  rpk [command]
+
+Available Commands:
+  acl         Manage ACLs and SASL users.
+  cluster     Interact with a Redpanda cluster.
+  container   Manage a local container cluster.
+  debug       Debug the local Redpanda process.
+  generate    Generate a configuration template for related services.
+  group       Describe, list, and delete consumer groups and manage their offsets.
+  help        Help about any command
+  iotune      Measure filesystem performance and create IO configuration file.
+  plugin      List, download, update, and remove rpk plugins.
+  redpanda    Interact with a local Redpanda process
+  topic       Create, delete, produce to and consume from Redpanda topics.
+  version     Check the current version.
+  wasm        Deploy and remove inline WASM engine scripts. """
+
+
+def get_usage(process_line):
+    if process_line.find("Available Commands:") != -1:
+        return process_line[
+            process_line.find("Usage") : process_line.find("Available Commands:")
+        ].rstrip("\n")
+    elif process_line.find("Flags:") != -1:
+        return process_line[
+            process_line.find("Usage") : process_line.find("Flags:")
+        ].rstrip("\n")
+    else:
+        return process_line[process_line.find("Usage") :].rstrip("\n")
+
+
+# Get lines for possible available commands. Example:
+""" Usage:
+  rpk [command]
+
+Available Commands:
+  acl         Manage ACLs and SASL users.
+  cluster     Interact with a Redpanda cluster.
+  container   Manage a local container cluster.
+  debug       Debug the local Redpanda process.
+  generate    Generate a configuration template for related services.
+  group       Describe, list, and delete consumer groups and manage their offsets.
+  help        Help about any command
+  iotune      Measure filesystem performance and create IO configuration file.
+  plugin      List, download, update, and remove rpk plugins.
+  redpanda    Interact with a local Redpanda process
+  topic       Create, delete, produce to and consume from Redpanda topics.
+  version     Check the current version.
+  wasm        Deploy and remove inline WASM engine scripts. """
+
+
+def get_commands(process_line):
+    if process_line.find('Use "rpk') != -1:
+        full_command = process_line[
+            process_line.find("Available Commands:") : process_line.find('Use "rpk')
+        ]
+    else:
+        full_command = process_line[process_line.find("Available Commands:") :]
+
+    commands = full_command[: full_command.find("Flags:")]
+    return commands.lstrip("Available Commands:")
+
+
+# Extract lines for the flags from a command. Example:
+""" Available Commands:
+  acl         Manage ACLs and SASL users.
+  cluster     Interact with a Redpanda cluster.
+  container   Manage a local container cluster.
+  debug       Debug the local Redpanda process.
+  generate    Generate a configuration template for related services.
+  group       Describe, list, and delete consumer groups and manage their offsets.
+  help        Help about any command
+  iotune      Measure filesystem performance and create IO configuration file.
+  plugin      List, download, update, and remove rpk plugins.
+  redpanda    Interact with a local Redpanda process
+  topic       Create, delete, produce to and consume from Redpanda topics.
+  version     Check the current version.
+  wasm        Deploy and remove inline WASM engine scripts.
+
+Flags:
+  -h, --help      help for rpk
+  -v, --verbose   Enable verbose logging (default: false).
+
+Use "rpk [command] --help" for more information about a command. """
+
+
+def extract_flags(process_line):
+    if process_line.find('Use "rpk') != -1:
+        return process_line[process_line.find("Flags:") : process_line.find('Use "rpk')]
+    else:
+        return process_line[process_line.find("Flags:") :]
+
+
+# Extract new commands (multilevel) or flags from the available ones. Example:
+"""   deploy      Deploy inline WASM function.
+  generate    Create an npm template project for inline WASM engine.
+  remove      Remove inline WASM function. """
+# or
+"""       --brokers strings         Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092' ). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+      --config string           Redpanda config file, if not set the file will be searched for in the default locations
+  -h, --help                    help for wasm
+      --password string         SASL password to be used for authentication.
+      --sasl-mechanism string   The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+      --tls-cert string         The certificate to be used for TLS authentication with the broker.
+      --tls-enabled             Enable TLS for the Kafka API (not necessary if specifying custom certs).
+      --tls-key string          The certificate key to be used for TLS authentication with the broker.
+      --tls-truststore string   The truststore to be used for TLS communication with the broker.
+      --user string             SASL user to be used for authentication. """
+
+
+def extract_new_commands(available, is_flag):
+    iterable_commands = []
+    mline = ""
+
+    for line in available.splitlines():
+        if not line:
+            if mline:
+                mline = mline.strip() 
+                iterable_commands.append(mline)
+                mline = ""
+            continue
+        if not is_flag:
+            if mline: 
+                mline = mline.strip()
+                iterable_commands.append(mline)
+                mline = ""
+            iterable_commands.append(line.split(" ")[2])
+        else:
+            if line.strip().startswith("-"):
+                if mline:
+                    mline = mline.strip() 
+                    iterable_commands.append(mline)
+                    mline = ""    
+                mline = line[line.find("-") :].strip()
+                continue
+            elif line[0] != " ":
+                if mline: 
+                    mline = mline.strip() 
+                    iterable_commands.append(mline)
+                    mline = ""
+                continue 
+            else:
+                mline += " " + line.strip()
+                continue
+    
+    if mline: 
+        mline = mline.strip() 
+        iterable_commands.append(mline.strip())
+
+    return iterable_commands
+
+
+# Extract flag value, explanation and type from a flag line. Example:
+"""--user string             SASL user to be used for authentication. """
+
+
+def extract_all_flag(line):
+    flag_set = []
+    for flag in line:
+        value = flag[: flag.find(" ")]
+        explanation = flag[flag.find(" ") :]
+        if value.find(",") != -1:
+            explanation = explanation.lstrip(" ")
+            value = value + " " + (explanation[: explanation.find(" ")])
+            explanation = explanation[explanation.find(" ") :]
+
+        if re.search(r"\bstring\b", explanation):
+            type = "string"
+            explanation = re.sub(r"\bstring\b", "", explanation)
+        elif re.search(r"\bstrings\b", flag):
+            type = "strings"
+            explanation = re.sub(r"\bstrings\b", "", explanation)
+        elif re.search(r"\bstringArray\b", flag):
+            type = "stringArray"
+            explanation = re.sub(r"\bstringArray\b", "", explanation)
+        elif re.search(r"\bint\b", flag):
+            type = "int"
+            explanation = re.sub(r"\bint\b", "", explanation)
+        elif re.search(r"\bint16\b", flag):
+            type = "int16"
+            explanation = re.sub(r"\bint16\b", "", explanation)
+        elif re.search(r"\bint32\b", flag):
+            type = "int32"
+            explanation = re.sub(r"\bint32\b", "", explanation)
+        elif re.search(r"\bint32Slice\b", flag):
+            type = "int32"
+            explanation = re.sub(r"\bint32Array\b", "", explanation)
+        elif re.search(r"\bduration\b", flag):
+            type = "duration"
+            explanation = re.sub(r"\bduration\b", "", explanation)
+        else:
+            type = "-"
+        explanation = assert_period(explanation.strip())
+        flag_set.append(Flag(value, type, explanation))
+    return flag_set
+
+# Build dictionary of commands
+def build_dict(cmd_dict, executed_command, explanation, usage, it_flags, flag_list):
+
+    cmd = {"description" : explanation, "usage" : usage, "flags" : {} }
+           
+    if it_flags:
+        for flag in flag_list:
+            cmd['flags'][flag.value] = { "type" : flag.type.strip(), "description" : flag.explanation}
+
+    cmd_dict[executed_command] = cmd
+    return cmd_dict
+
+
+def build_ascii(ascii_result, executed_command, explanation, usage, it_flags, flag_list, separate_files):
+
+    rpk_gen_dir = "gen/"
+    ascii_result += "= "+ executed_command
+    ascii_result += "\n:description: " + executed_command
+    ascii_result += "\n\n" + explanation
+
+    usage_val_start = usage.find("Usage:") + len("Usage:")
+    aliases_start = usage.find("Aliases:")
+    aliases_val_start = usage.find("Aliases:") + len("Aliases:")
+
+    usage_val = usage[usage_val_start:aliases_start] if aliases_start >= 0 else usage[usage_val_start:]
+
+    ascii_result += "\n\n== Usage"
+    ascii_result += """\n\n[,bash]\n"""
+    ascii_result += """----\n"""
+    ascii_result += usage_val.strip()
+    ascii_result += """\n----"""
+
+    if aliases_start >= 0:
+        ascii_result += "\n\n== Aliases"
+        ascii_result += """\n\n[,bash]\n"""
+        ascii_result += """----\n"""
+        ascii_result += usage[aliases_val_start:].strip()
+        ascii_result += """\n----"""
+
+    if it_flags:
+        ascii_result += """\n\n== Flags"""
+        ascii_result += """\n\n[cols="1m,1a,2a]"""
+        ascii_result += """\n|==="""
+        ascii_result += """\n|*Value* |*Type* |*Description*"""
+
+    for flag in flag_list:
+        ascii_result += """\n\n"""
+        ascii_result += "|`"+flag.value+"` |"
+        ascii_result += flag.type+" |"
+        ascii_result += flag.explanation
+
+    ascii_result += "\n|==="
+    filename = rpk_gen_dir + executed_command.replace(" ","-") + ".adoc"
+
+    # Check if directory exists, if not create it
+    if not os.path.exists(rpk_gen_dir):
+        os.makedirs(rpk_gen_dir)
+
+    # Check if file exists, if it does then delete it
+    if os.path.exists(filename):
+        os.remove(filename)
+
+    # Write to the file
+    with open(filename, "w") as filetowrite:
+        ascii_result = escape_chars(ascii_result)
+        filetowrite.write(ascii_result)
+
+    return ascii_result
+
+## run basic command first
+first_command = basic_commands_docker + rpk_basic_command + ["version"]
+print("Running ")
+print(" ".join(first_command))
+result = subprocess.run(first_command, stdout=subprocess.PIPE)
+rpk_version = result.stdout.decode('utf-8').strip(" \n")
+print("Redpanda version: " + rpk_version)
+
+result = execute_process([])
+
+explanation = get_explanation(result)
+
+usage = get_usage(result)
+
+full_command = get_commands(result)
+
+commands = full_command[: full_command.find("Flags:")]
+
+available_commmands = commands.lstrip("Available Commands:")
+it_commands = extract_new_commands(available_commmands, False)
+
+flags = extract_flags(result)
+available_flags = flags.lstrip("Flags:")
+
+it_flags = extract_new_commands(available_flags, True)
+flag_list = extract_all_flag(it_flags)
+
+md_result = """---
+title: rpk commands
+rpk_version: """ + rpk_version + """
+---
+
+`rpk` is Redpanda's command line interface (CLI) utility. rpk commands allow you to configure and manage Redpanda clusters, tune them for better performance, manage topics and groups, manage access control lists (ACLs).
+
+This section lists each rpk command in alphabetical order, along with a table of flags for that command. All descriptions are from the output of the `rpk <command> -–help` command.
+
+"""
+
+executed_command = "rpk"
+
+for command in it_commands:
+    result = execute_process([command])
+    executed_command = "rpk " + command
+
+    explanation = get_explanation(result)
+
+    usage = get_usage(result)
+
+    full_command = get_commands(result)
+
+    commands = full_command[: full_command.find("Flags:")]
+
+    available_commmands = commands.lstrip("Available Commands:")
+    new_commands = extract_new_commands(available_commmands, False)
+
+    flags = extract_flags(result)
+    available_flags = flags.lstrip("Flags:")
+
+    it_flags = extract_new_commands(available_flags, True)
+
+    flag_list = extract_all_flag(it_flags)
+
+    cmd_dict = build_dict(cmd_dict, executed_command, explanation, usage, it_flags, flag_list);
+
+    md_result = build_ascii(
+        "", executed_command, explanation, usage, it_flags, flag_list, True
+    )
+ 
+    index = it_commands.index(command) + 1
+    for new_command in new_commands:
+        it_commands.insert(index, command + " " + new_command)
+        index += 1
+
+cmd_dict['rpk_version'] = rpk_version
+json_object = json.dumps(cmd_dict, indent = 4) 
+
+md_result = md_result.replace(
+    """  rpk-<name>
+  rpk.ac-<name>""",
+    """```bash
+rpk-<name>
+rpk.ac-<name>
+```
+""",
+)
+
+
+
+md_result = md_result + suggestedReadings
+
+try:
+    json_path = "gen/json"
+    file = json_path + "/rpk-commands.json"
+    if not os.path.exists(json_path):
+        os.makedirs(json_path)
+    with open(file, "w") as filetowrite:
+        filetowrite.write(json_object)
+    print("The rpk commands have been successfully generated at",file)
+except Exception as e:
+    print("Error generating the rpk commands file " + e)
+
+dir1 = "docs/reference/rpk"
+dir2 = "gen"
+#outdir = "tools/rpk/diff"
+
+cmp_rpk_ascii(dir1, dir2)

--- a/tools/gen/22.3/json/rpk-commands.json
+++ b/tools/gen/22.3/json/rpk-commands.json
@@ -1,0 +1,4849 @@
+{
+    "rpk acl": {
+        "description": "Manage ACLs and SASL users.\r\n\r\nThis command space creates, lists, and deletes ACLs, as well as creates SASL\r\nusers. The help text below is specific to ACLs. To learn about SASL users,\r\ncheck the help text under the \"user\" command.\r\n\r\nWhen using SASL, ACLs allow or deny you access to certain requests. The\r\n\"create\", \"delete\", and \"list\" commands help you manage your ACLs.\r\n\r\nAn ACL is made up of five components:\r\n\r\n  * a principal (the user)\r\n  * a host the principal is allowed or denied requests from\r\n  * what resource to access (topic name, group ID, ...)\r\n  * the operation (read, write, ...)\r\n  * the permission: whether to allow or deny the above\r\n\r\nACL commands work on a multiplicative basis. If creating, specifying two\r\nprincipals and two permissions creates four ACLs: both permissions for the\r\nfirst principal, as well as both permissions for the second principal. Adding\r\ntwo resources further doubles the ACLs created.\r\n\r\nIt is recommended to be as specific as possible when granting ACLs. Granting\r\nmore ACLs than necessary per principal may inadvertently allow clients to do\r\nthings they should not, such as deleting topics or joining the wrong consumer\r\ngroup.\r\n\r\nPRINCIPALS\r\n\r\nAll ACLs require a principal. A principal is composed of two parts: the type\r\nand the name. Within Redpanda, only one type is supported, \"User\". The reason\r\nfor the prefix is that a potential future authorizer may add support for\r\nauthorizing by Group or anything else.\r\n\r\nWhen you create a user, you need to add ACLs for it before it can be used. You\r\ncan create / delete / list ACLs for that user with either \"User:bar\" or \"bar\"\r\nin the --allow-principal and --deny-principal flags. This command will add the\r\n\"User:\" prefix for you if it is missing. The wildcard '*' matches any user.\r\nCreating an ACL with user '*' grants or denies the permission for all users.\r\n\r\nHOSTS\r\n\r\nHosts can be seen as an extension of the principal, and effectively gate where\r\nthe principal can connect from. When creating ACLs, unless otherwise specified,\r\nthe default host is the wildcard '*' which allows or denies the principal from\r\nall hosts (where allow & deny are based on whether --allow-principal or\r\n--deny-principal is used). If specifying hosts, you must pair the --allow-host\r\nflag with the --allow-principal flag, and the --deny-host flag with the\r\n--deny-principal flag.\r\n\r\nRESOURCES\r\n\r\nA resource is what an ACL allows or denies access to. There are four resources\r\nwithin Redpanda: topics, groups, the cluster itself, and transactional IDs.\r\nNames for each of these resources can be specified with their respective flags.\r\n\r\nResources combine with the operation that is allowed or denied on that\r\nresource. The next section describes which operations are required for which\r\nrequests, and further fleshes out the concept of a resource.\r\n\r\nBy default, resources are specified on an exact name match (a \"literal\" match).\r\nThe --resource-pattern-type flag can be used to specify that a resource name is\r\n\"prefixed\", meaning to allow anything with the given prefix. A literal name of\r\n\"foo\" will match only the topic \"foo\", while the prefixed name of \"foo-\" will\r\nmatch both \"foo-bar\" and \"foo-baz\". The special wildcard resource name '*'\r\nmatches any name of the given resource type (--topic '*' matches all topics).\r\n\r\nOPERATIONS\r\n\r\nPairing with resources, operations are the actions that are allowed or denied.\r\nRedpanda has the following operations:\r\n\r\n    ALL                 Allows all operations below.\r\n    READ                Allows reading a given resource.\r\n    WRITE               Allows writing to a given resource.\r\n    CREATE              Allows creating a given resource.\r\n    DELETE              Allows deleting a given resource.\r\n    ALTER               Allows altering non-configurations.\r\n    DESCRIBE            Allows querying non-configurations.\r\n    DESCRIBE_CONFIGS    Allows describing configurations.\r\n    ALTER_CONFIGS       Allows altering configurations.\r\n\r\nCheck --help-operations to see which operations are required for which\r\nrequests. In flag form to set up a general producing/consuming client, you can\r\ninvoke 'rpk acl create' three times with the following (including your\r\n--allow-principal):\r\n\r\n    --operation write,read,describe --topic [topics]\r\n    --operation describe,read --group [group.id]\r\n    --operation describe,write --transactional-id [transactional.id]\r\n\r\nPERMISSIONS\r\n\r\nA client can be allowed access or denied access. By default, all permissions\r\nare denied. You only need to specifically deny a permission if you allow a wide\r\nset of permissions and then want to deny a specific permission in that set.\r\nYou could allow all operations, and then specifically deny writing to topics.\r\n\r\nMANAGEMENT\r\n\r\nCreating ACLs works on a specific ACL basis, but listing and deleting ACLs\r\nworks on filters. Filters allow matching many ACLs to be printed listed and\r\ndeleted at once. Because this can be risky for deleting, the delete command\r\nprompts for confirmation by default. More details and examples for creating,\r\nlisting, and deleting can be seen in each of the commands.\r\n\r\nUsing SASL requires setting \"enable_sasl: true\" in the redpanda section of your\r\nredpanda.yaml. User management is a separate, simpler concept that is\r\ndescribed in the user command.",
+        "usage": "Usage:\r\n  rpk acl [flags]\r\n  rpk acl [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for acl."
+            },
+            "--help-operations": {
+                "type": "-",
+                "description": "Print more help about ACL operations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl create": {
+        "description": "Create ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. Following the\r\nmultiplying effect of combining flags, the create command works on a\r\nstraightforward basis: every ACL combination is a created ACL.\r\n\r\nAs mentioned in the 'rpk acl' help text, if no host is specified, an allowed\r\nprincipal is allowed access from all hosts. The wildcard principal '*' allows\r\nall principals. At least one principal, one host, one resource, and one\r\noperation is required to create a single ACL.\r\n\r\nAllow all permissions to user bar on topic \"foo\" and group \"g\":\r\n    --allow-principal bar --operation all --topic foo --group g\r\nAllow read permissions to all users on topics biz and baz:\r\n    --allow-principal '*' --operation read --topic biz,baz\r\nAllow write permissions to user buzz to transactional id \"txn\":\r\n    --allow-principal User:buzz --operation write --transactional-id txn",
+        "usage": "Usage:\r\n  rpk acl create [flags]\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Hosts from which access will be granted (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Principals for which these permissions will be granted (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to grant ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Hosts from from access will be denied (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Principal for which these permissions will be denied (repeatable)."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to grant ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to grant (repeatable)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (literal or prefixed) (default \"literal\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to grant ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to grant ACLs for (repeatable)."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl delete": {
+        "description": "Delete ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. Delete flags work in a\r\nsimilar multiplying effect as creating ACLs, but delete is more advanced:\r\ndeletion works on a filter basis. Any unspecified flag defaults to matching\r\neverything (all operations, or all allowed principals, etc). To ensure that you\r\ndo not accidentally delete more than you intend, this command prints everything\r\nthat matches your input filters and prompts for a confirmation before the\r\ndelete request is issued. Anything matching more than 10 ACLs doubly confirms.\r\n\r\nAs mentioned, not specifying flags matches everything. If no resources are\r\nspecified, all resources are matched. If no operations are specified, all\r\noperations are matched. You can also opt in to matching everything with \"any\":\r\n--operation any matches any operation.\r\n\r\nThe --resource-pattern-type, defaulting to \"any\", configures how to filter\r\nresource names:\r\n  * \"any\" returns exact name matches of either prefixed or literal pattern type\r\n  * \"match\" returns wildcard matches, prefix patterns that match your input, and literal matches\r\n  * \"prefix\" returns prefix patterns that match your input (prefix \"fo\" matches \"foo\")\r\n  * \"literal\" returns exact name matches",
+        "usage": "Usage:\r\n  rpk acl delete [flags]\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Allowed host ACLs to remove (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Allowed principal ACLs to remove (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to remove ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Denied host ACLs to remove (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Denied principal ACLs to remove (repeatable)."
+            },
+            "-d, --dry": {
+                "type": "-",
+                "description": "Dry run: validate what would be deleted."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to remove ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to remove (repeatable)."
+            },
+            "-f, --print-filters": {
+                "type": "-",
+                "description": "Print the filters that were requested (failed filters are always printed)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (any, match, literal, or prefixed) (default \"any\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to remove ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to remove ACLs for (repeatable)."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl list": {
+        "description": "List ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. List flags work in a\r\nsimilar multiplying effect as creating ACLs, but list is more advanced:\r\nlisting works on a filter basis. Any unspecified flag defaults to matching\r\neverything (all operations, or all allowed principals, etc).\r\n\r\nAs mentioned, not specifying flags matches everything. If no resources are\r\nspecified, all resources are matched. If no operations are specified, all\r\noperations are matched. You can also opt in to matching everything with \"any\":\r\n--operation any matches any operation.\r\n\r\nThe --resource-pattern-type, defaulting to \"any\", configures how to filter\r\nresource names:\r\n  * \"any\" returns exact name matches of either prefixed or literal pattern type\r\n  * \"match\" returns wildcard matches, prefix patterns that match your input, and literal matches\r\n  * \"prefix\" returns prefix patterns that match your input (prefix \"fo\" matches \"foo\")\r\n  * \"literal\" returns exact name matches",
+        "usage": "Usage:\r\n  rpk acl list [flags]\r\n\r\nAliases:\r\n  list, ls, describe\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Allowed host ACLs to match (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Allowed principal ACLs to match (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to match ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Denied host ACLs to match (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Denied principal ACLs to match (repeatable)."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to match ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to match (repeatable)."
+            },
+            "-f, --print-filters": {
+                "type": "-",
+                "description": "Print the filters that were requested (failed filters are always printed)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (any, match, literal, or prefixed) (default \"any\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to match ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to match ACLs for (repeatable)."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl user": {
+        "description": "Manage SASL users.\r\n\r\nIf SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs\r\ncontrol what your user has access to. See 'rpk acl --help' for more information\r\nabout ACLs, and 'rpk acl user create --help' for more information about\r\ncreating SASL users. Using SASL requires setting \"enable_sasl: true\" in the\r\nredpanda section of your redpanda.yaml.",
+        "usage": "Usage:\r\n  rpk acl user [command]\r\n\r",
+        "flags": {
+            "--api-urls": {
+                "type": "strings",
+                "description": "The comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for user."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl user create": {
+        "description": "Create a SASL user.\r\n\r\nThis command creates a single SASL user with the given password, optionally\r\nwith a custom \"mechanism\". SASL consists of three parts: a username, a\r\npassword, and a mechanism. The mechanism determines which authentication flow\r\nthe client will use for this user/pass.\r\n\r\nRedpanda currently supports two mechanisms: SCRAM-SHA-256, the default, and\r\nSCRAM-SHA-512, which is the same flow but uses sha512 rather than sha256.\r\n\r\nUsing SASL requires setting \"enable_sasl: true\" in the redpanda section of your\r\nredpanda.yaml. Before a created SASL account can be used, you must also create\r\nACLs to grant the account access to certain resources in your cluster. See the\r\nacl help text for more info.",
+        "usage": "Usage:\r\n  rpk acl user create [USER] -p [PASS] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "--mechanism": {
+                "type": "string",
+                "description": "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive); not to be confused with the global flag --sasl-mechanism which is used for authenticating the rpk client (default \"scram-sha-256\")."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "strings",
+                "description": "The comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl user delete": {
+        "description": "Delete a SASL user.\r\n\r\nThis command deletes the specified SASL account from Redpanda. This does not\r\ndelete any ACLs that may exist for this user.",
+        "usage": "Usage:\r\n  rpk acl user delete [USER] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "strings",
+                "description": "The comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl user list": {
+        "description": "List SASL users",
+        "usage": "Usage:\r\n  rpk acl user list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "strings",
+                "description": "The comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud": {
+        "description": "Interact with Redpanda cloud",
+        "usage": "Usage:\r\n  rpk cloud [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for cloud."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud byoc": {
+        "description": "Manage a Redpanda cloud BYOC agent\r\n\r\nFor BYOC, Redpanda installs an agent service in your owned cluster. The agent\r\nthen proceeds to provision further infrastructure and eventually, a full\r\nRedpanda cluster.\r\n\r\nThe BYOC command runs Terraform to create and start the agent. You first need\r\na redpanda-id (or cluster ID); this is used to get the details of how your\r\nagent should be provisioned. You can create a BYOC cluster in our cloud UI\r\nand then come back to this command to complete the process.",
+        "usage": "Usage:\r\n  rpk cloud byoc [flags]\r\n  rpk cloud byoc [command]\r\n\r",
+        "flags": {
+            "--client-id": {
+                "type": "string",
+                "description": "The client ID of the organization in Redpanda Cloud."
+            },
+            "--client-secret": {
+                "type": "string",
+                "description": "The client secret of the organization in Redpanda Cloud."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for byoc."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud byoc install": {
+        "description": "Install the BYOC plugin\r\n\r\nThis command downloads the BYOC managed plugin if necessary. The plugin is\r\ninstalled by default if you try to run a non-install command, but this command\r\nexists if you want to download the plugin ahead of time.",
+        "usage": "Usage:\r\n  rpk cloud byoc install [flags]\r\n\r",
+        "flags": {
+            "--client-id": {
+                "type": "string",
+                "description": "The client ID of the organization in Redpanda Cloud."
+            },
+            "--client-secret": {
+                "type": "string",
+                "description": "The client secret of the organization in Redpanda Cloud."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for install."
+            },
+            "--redpanda-id": {
+                "type": "string",
+                "description": "The redpanda ID of the cluster you are creating."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud byoc uninstall": {
+        "description": "Uninstall the BYOC plugin\r\n\r\nThis command deletes your locally downloaded BYOC managed plugin if it exists.\r\nOften, you only need to download the plugin to create your cluster once, and\r\nthen you never need the plugin again. You can uninstall to save a small bit of\r\ndisk space.",
+        "usage": "Usage:\r\n  rpk cloud byoc uninstall [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for uninstall."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud login": {
+        "description": "Log in to the Redpanda cloud\r\n\r\nThis command checks for an existing token and, if present, ensures it is still\r\nvalid. If no token is found or the token is no longer valid, this command will\r\nlogin and save your token.\r\n\r\nYou may use any of the following methods to pass the cloud credentials to rpk:\r\n\r\nLogging in requires cloud credentials, which can be created in the Clients\r\ntab of the Users section in the Redpanda Cloud online interface. Client\r\ncredentials can be provided in three ways, in order of preference:\r\n\r\n* In $HOME/.config/rpk/__cloud.yaml, in 'client_id' and 'client_secret' fields\r\n* Through RPK_CLOUD_CLIENT_ID and RPK_CLOUD_CLIENT_SECRET environment variables\r\n* Through the --client-id and --client-secret flags\r\n\r\nIf none of these are provided, login will prompt you for the client ID and\r\nclient secret and will save them to the __cloud.yaml file. If you specify\r\nenvironment variables or flags, they will not be synced to the __cloud.yaml\r\nfile unless the --save flag is passed. The cloud authorization token is always \r\nsynced.",
+        "usage": "Usage:\r\n  rpk cloud login [flags]\r\n\r",
+        "flags": {
+            "--client-id": {
+                "type": "string",
+                "description": "The client ID of the organization in Redpanda Cloud."
+            },
+            "--client-secret": {
+                "type": "string",
+                "description": "The client secret of the organization in Redpanda Cloud."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for login."
+            },
+            "--save": {
+                "type": "-",
+                "description": "Save environment or flag specified client ID and client secret to the configuration file."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud logout": {
+        "description": "Log out from Redpanda cloud\r\n\r\nThis command deletes your cloud auth token. If you want to log out entirely and\r\nswitch to a different organization, you can use the --clear-credentials flag to\r\nadditionally clear your client ID and client secret.",
+        "usage": "Usage:\r\n  rpk cloud logout [flags]\r\n\r",
+        "flags": {
+            "-c, --clear-credentials": {
+                "type": "-",
+                "description": "Clear the client ID and client secret in addition to the auth token."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for logout."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster": {
+        "description": "Interact with a Redpanda cluster",
+        "usage": "Usage:\r\n  rpk cluster [command]\r\n\r",
+        "flags": {
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for cluster."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config": {
+        "description": "Interact with cluster configuration properties.\r\n\r\nCluster properties are redpanda settings which apply to all nodes in\r\nthe cluster.  These are separate to node properties, which are set with\r\n'rpk redpanda config'.\r\n\r\nUse the 'edit' subcommand to interactively modify the cluster configuration, or\r\n'export' and 'import' to write configuration to a file that can be edited and\r\nread back later.\r\n\r\nThese commands take an optional '--all' flag to include all properties including\r\nlow level tunables such as internal buffer sizes, that do not usually need\r\nto be changed during normal operations.  These properties generally require\r\nsome expertize to set safely, so if in doubt, avoid using '--all'.\r\n\r\nModified properties are propagated immediately to all nodes.  The 'status'\r\nsubcommand can be used to verify that all nodes are up to date, and identify\r\nany settings which were rejected by a node, for example if a node is running a\r\ndifferent redpanda version that does not recognize certain properties.",
+        "usage": "Usage:\r\n  rpk cluster config [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config edit": {
+        "description": "Edit cluster-wide configuration properties.\r\n\r\nThis command opens a text editor to modify the cluster's configuration.\r\n\r\nCluster properties are redpanda settings which apply to all nodes in\r\nthe cluster.  These are separate to node properties, which are set with\r\n'rpk redpanda config'.\r\n\r\nModified values are written back when the file is saved and the editor\r\nis closed.  Properties which are deleted are reset to their default\r\nvalues.\r\n\r\nBy default, low level tunables are excluded: use the '--all' flag\r\nto edit all properties including these tunables.",
+        "usage": "Usage:\r\n  rpk cluster config edit [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for edit."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config export": {
+        "description": "Export cluster configuration.\r\n\r\nWrites out a YAML representation of the cluster configuration to a file,\r\nsuitable for editing and later applying with the corresponding 'import'\r\ncommand.\r\n\r\nBy default, low level tunables are excluded: use the '--all' flag\r\nto include all properties including these low level tunables.",
+        "usage": "Usage:\r\n  rpk cluster config export [flags]\r\n\r",
+        "flags": {
+            "-f, --filename": {
+                "type": "string",
+                "description": "path to file to export to, e.g. './config.yml'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for export."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config force-reset": {
+        "description": "Forcibly clear a cluster configuration property on this node.\r\n\r\nThis command is not for general changes to cluster configuration: use this only\r\nwhen redpanda will not start due to a configuration issue.\r\n\r\nIf your cluster is working properly and you would like to reset a property\r\nto its default, you may use the 'set' command with an empty string, or\r\nuse the 'edit' command and delete the property's line.\r\n\r\nThis command erases a named property from an internal cache of the cluster\r\nconfiguration on the local node, so that on next startup redpanda will treat\r\nthe setting as if it was set to the default.\r\n\r\nWARNING: this should only be used when redpanda is not running.",
+        "usage": "Usage:\r\n  rpk cluster config force-reset [PROPERTY...] [flags]\r\n\r",
+        "flags": {
+            "--cache-file": {
+                "type": "string",
+                "description": "location of configuration cache file (defaults to redpanda data directory)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for force-reset."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config get": {
+        "description": "Get a cluster configuration property.\r\n\r\nThis command is provided for use in scripts.  For interactive editing, or bulk\r\noutput, use the 'edit' and 'export' commands respectively.",
+        "usage": "Usage:\r\n  rpk cluster config get <key> [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for get."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config import": {
+        "description": "Import cluster configuration from a file.\r\n\r\nImport configuration from a YAML file, usually generated with\r\ncorresponding 'export' command.  This downloads the current cluster\r\nconfiguration, calculates the difference with the YAML file, and\r\nupdates any properties that were changed.  If a property is removed\r\nfrom the YAML file, it is reset to its default value.",
+        "usage": "Usage:\r\n  rpk cluster config import [flags]\r\n\r",
+        "flags": {
+            "-f, --filename": {
+                "type": "string",
+                "description": "full path to file to import, e.g. '/tmp/config.yml'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for import."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config lint": {
+        "description": "Remove any deprecated content from redpanda.yaml.\r\n\r\nDeprecated content includes properties which were set via redpanda.yaml\r\nin earlier versions of redpanda, but are now managed via Redpanda's\r\ncentral configuration store (and via 'rpk cluster config edit').",
+        "usage": "Usage:\r\n  rpk cluster config lint [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for lint."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config set": {
+        "description": "Set a single cluster configuration property.\r\n\r\nThis command is provided for use in scripts.  For interactive editing, or bulk\r\nchanges, use the 'edit' and 'import' commands respectively.\r\n\r\nIf an empty string is given as the value, the property is reset to its default.",
+        "usage": "Usage:\r\n  rpk cluster config set <key> <value> [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config status": {
+        "description": "Get configuration status of redpanda nodes.\r\n\r\nFor each node, indicate whether a restart is required for settings to\r\ntake effect, and any settings that the node has identified as invalid\r\nor unknown properties.\r\n\r\nAdditionally show the version of cluster configuration that each node\r\nhas applied: under normal circumstances these should all be equal,\r\na lower number shows that a node is out of sync, perhaps because it\r\nis offline.",
+        "usage": "Usage:\r\n  rpk cluster config status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster health": {
+        "description": "Queries health overview.\r\n\r\nHealth overview is created based on the health reports collected periodically\r\nfrom all nodes in the cluster. A cluster is considered healthy when the\r\nfollowing conditions are met:\r\n\r\n* all cluster nodes are responding\r\n* all partitions have leaders\r\n* the cluster controller is present",
+        "usage": "Usage:\r\n  rpk cluster health [flags]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "-e, --exit-when-healthy": {
+                "type": "-",
+                "description": "When used with watch, exits after cluster is back in healthy state."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for health."
+            },
+            "-w, --watch": {
+                "type": "-",
+                "description": "Blocks and writes out all cluster health changes."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster license": {
+        "description": "Manage cluster license.",
+        "usage": "Usage:\r\n  rpk cluster license [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for license."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster license info": {
+        "description": "Retrieve license information:\r\n\r\n    Organization:    Organization the license was generated for.\r\n    Type:            Type of license: free, enterprise, etc.\r\n    Expires:         Expiration date of the license\r\n    Version:         License schema version.",
+        "usage": "Usage:\r\n  rpk cluster license info [flags]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (text, json) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for info."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster license set": {
+        "description": "Upload license to the cluster\r\n\r\nYou can either provide a path to a file containing the license:\r\n\r\n    rpk cluster license set --path /home/organization/redpanda.license\r\n\r\nOr inline the license string:\r\n\r\n    rpk cluster license set <license string>\r\n\r\nIf neither are present, rpk will look for the license in the\r\ndefault location '/etc/redpanda/redpanda.license'.",
+        "usage": "Usage:\r\n  rpk cluster license set [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--path": {
+                "type": "string",
+                "description": "Path to the license file."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster logdirs": {
+        "description": "Describe log directories on Redpanda brokers",
+        "usage": "Usage:\r\n  rpk cluster logdirs [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for logdirs."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster logdirs describe": {
+        "description": "Describe log directories on Redpanda brokers.\r\n\r\nThis command prints information about log directories on brokers, particularly,\r\nthe base directory that topics and partitions are located in, and the size of\r\ndata that has been written to the partitions. The size you see may not exactly\r\nmatch the size on disk as reported by du: Redpanda allocates files in chunks.\r\nThe chunks will show up in du, while the actual bytes so far written to the\r\nfile will show up in this command.\r\n\r\nThe directory returned is the root directory for partitions. Within Redpanda,\r\nthe partition data lives underneath the the returned root directory in\r\n\r\n    kafka/{topic}/{partition}_{revision}/\r\n\r\nwhere revision is a Redpanda internal concept.",
+        "usage": "Usage:\r\n  rpk cluster logdirs describe [flags]\r\n\r",
+        "flags": {
+            "--aggregate-into": {
+                "type": "string",
+                "description": "If non-empty, what column to aggregate into starting from the partition column (broker, dir, topic)."
+            },
+            "-b, --broker": {
+                "type": "int32",
+                "description": "If non-negative, the specific broker to describe (default -1)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "--sort-by-size": {
+                "type": "-",
+                "description": "If true, sort by size."
+            },
+            "--topics": {
+                "type": "strings",
+                "description": "Specific topics to describe."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster maintenance": {
+        "description": "Interact with cluster maintenance mode.\r\n\r\nMaintenance mode is a state that a node may be placed into in which the node\r\nmay be shutdown or restarted with minimal disruption to client workloads. The\r\nprimary use of maintenance mode is to perform a rolling upgrade in which each\r\nnode is placed into maintenance mode prior to upgrading the node.\r\n\r\nUse the 'enable' and 'disable' subcommands to place a node into maintenance mode\r\nor remove it, respectively. Only one node at a time may be in maintenance mode.\r\n\r\nWhen a node is placed into maintenance mode the following occurs:\r\n\r\nLeadership draining. All raft leadership is transferred to another eligible\r\nnode, and the node in maintenance mode rejects new leadership requests. By\r\ntransferring leadership off of the node in maintenance mode all client traffic\r\nand requests are directed to other nodes minimizing disruption to client\r\nworkloads when the node is shutdown.\r\n\r\nCurrently leadership is not transferred for partitions with one replica.",
+        "usage": "Usage:\r\n  rpk cluster maintenance [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for maintenance."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster maintenance disable": {
+        "description": "Disable maintenance mode for a node.",
+        "usage": "Usage:\r\n  rpk cluster maintenance disable <broker-id> [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for disable."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster maintenance enable": {
+        "description": "Enable maintenance mode for a node.\r\n\r\nThis command enables maintenance mode for the node with the specified ID. If a\r\nnode exists that is already in maintenance mode then an error will be returned.",
+        "usage": "Usage:\r\n  rpk cluster maintenance enable <node-id> [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for enable."
+            },
+            "-w, --wait": {
+                "type": "-",
+                "description": "Wait until node is drained."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster maintenance status": {
+        "description": "Report maintenance status.\r\n\r\nThis command reports maintenance status for each node in the cluster. The output\r\nis presented as a table with each row representing a node in the cluster.  The\r\noutput can be used to monitor the progress of node draining.\r\n\r\n   NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED\r\n   1        false     false     false   0           0         0             0\r\n\r\nField descriptions:\r\n\r\n        NODE-ID: the node ID\r\n       DRAINING: true if the node is actively draining leadership\r\n       FINISHED: leadership draining has completed\r\n         ERRORS: errors have been encountered while draining\r\n     PARTITIONS: number of partitions whose leadership has moved\r\n       ELIGIBLE: number of partitions with leadership eligible to move\r\n   TRANSFERRING: current active number of leadership transfers\r\n         FAILED: number of failed leadership transfers\r\n\r\nNotes:\r\n\r\n   - When errors are present further information will be available in the logs\r\n     for the corresponding node.\r\n\r\n   - Only partitions with more than one replica are eligible for leadership\r\n     transfer.",
+        "usage": "Usage:\r\n  rpk cluster maintenance status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster metadata": {
+        "description": "Request broker metadata.\r\n\r\nThe Kafka protocol's metadata contains information about brokers, topics, and\r\nthe cluster as a whole.\r\n\r\nThis command only runs if specific sections of metadata are requested. There\r\nare currently three sections: the cluster, the list of brokers, and the topics.\r\nIf no section is specified, this defaults to printing all sections.\r\n\r\nIf the topic section is requested, all topics are requested by default unless\r\nsome are manually specified as arguments. Expanded per-partition information\r\ncan be printed with the -d flag, and internal topics can be printed with the -i\r\nflag.\r\n\r\nIn the broker section, the controller node is suffixed with *.",
+        "usage": "Usage:\r\n  rpk cluster metadata [flags]\r\n\r\nAliases:\r\n  metadata, status, info\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for metadata."
+            },
+            "-b, --print-brokers": {
+                "type": "-",
+                "description": "Print brokers section."
+            },
+            "-c, --print-cluster": {
+                "type": "-",
+                "description": "Print cluster section."
+            },
+            "-d, --print-detailed-topics": {
+                "type": "-",
+                "description": "Print per-partition information for topics (implies -t)."
+            },
+            "-i, --print-internal-topics": {
+                "type": "-",
+                "description": "Print internal topics (if all topics requested, implies -t)."
+            },
+            "-t, --print-topics": {
+                "type": "-",
+                "description": "Print topics section (implied if any topics are specified)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster partitions": {
+        "description": "Manage cluster partitions",
+        "usage": "Usage:\r\n  rpk cluster partitions [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for partitions."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster partitions balancer-status": {
+        "description": "Queries cluster for partition balancer status:\r\n\r\nIf continuous partition balancing is enabled, redpanda will continuously\r\nreassign partitions from both unavailable nodes and from nodes using more disk\r\nspace than the configured limit.\r\n\r\nThis command can be used to monitor the partition balancer status.\r\n\r\nFIELDS\r\n\r\n    Status:                        Either off, ready, starting, in progress, or\r\n                                   stalled.\r\n    Seconds Since Last Tick:       The last time the partition balancer ran.\r\n    Current Reassignments Count:   Current number of partition reassignments in\r\n                                   progress.\r\n    Unavailable Nodes:             The nodes that have been unavailable after a\r\n                                   time set by the\r\n                                   \"partition_autobalancing_node_availability_timeout_sec\"\r\n                                   cluster property.\r\n    Over Disk Limit Nodes:         The nodes that surpassed the threshold of\r\n                                   used disk percentage specified in the\r\n                                   \"partition_autobalancing_max_disk_usage_percent\"\r\n                                   cluster property.\r\n\r\nBALANCER STATUS\r\n\r\n    off:          The balancer is disabled.\r\n    ready:        The balancer is active but there is nothing to do.\r\n    starting:     The balancer is starting but has not run yet.\r\n    in_progress:  The balancer is active and is in the process of scheduling\r\n                  partition movements.\r\n    stalled:      Violations have been detected and the balancer cannot correct\r\n                  them.\r\n\r\nSTALLED BALANCER\r\n\r\nA stalled balancer can occur for a few reasons and requires a bit of manual\r\ninvestigation. A few areas to investigate:\r\n\r\n* Are there are enough healthy nodes to which to move partitions? For example,\r\n  in a three node cluster, no movements are possible for partitions with three\r\n  replicas. You will see a stall every time there is a violation.\r\n\r\n* Does the cluster have sufficient space? If all nodes in the cluster are\r\n  utilizing more than 80% of their disk space, rebalancing cannot proceed.\r\n\r\n* Do all partitions have quorum? If the majority of a partition's replicas are\r\n  down, the partition cannot be moved.\r\n\r\n* Are any nodes in maintenance mode? Partitions are not moved if any node is in\r\n  maintenance mode.",
+        "usage": "Usage:\r\n  rpk cluster partitions balancer-status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for balancer-status."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster partitions movement-cancel": {
+        "description": "Cancel ongoing partition movements.\r\n\r\nBy default, this command cancels all the partition movements in the cluster. \r\nTo ensure that you do not accidentally cancel all partition movements, this \r\ncommand prompts users for confirmation before issuing the cancellation request. \r\nYou can use \"--no-confirm\" to disable the confirmation prompt:\r\n\r\n    rpk cluster partitions movement-cancel --no-confirm\r\n\r\nIf \"--node\" is set, this command will only stop the partition movements \r\noccurring in the specified node:\r\n\r\n    rpk cluster partitions movement-cancel --node 1",
+        "usage": "Usage:\r\n  rpk cluster partitions movement-cancel [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for movement-cancel."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "--node": {
+                "type": "int",
+                "description": "ID of a specific node on which to cancel ongoing partition movements (default -1)."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk container": {
+        "description": "Manage a local container cluster",
+        "usage": "Usage:\r\n  rpk container [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for container."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk container purge": {
+        "description": "Stop and remove an existing local container cluster's data",
+        "usage": "Usage:\r\n  rpk container purge [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for purge."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk container start": {
+        "description": "Start a local container cluster",
+        "usage": "Usage:\r\n  rpk container start [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "-n, --nodes": {
+                "type": "-",
+                "description": "uint     The number of nodes to start (default 1)."
+            },
+            "--retries": {
+                "type": "-",
+                "description": "uint   The amount of times to check for the cluster before considering it unstable and exiting. (default 10)."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk container stop": {
+        "description": "Stop an existing local container cluster",
+        "usage": "Usage:\r\n  rpk container stop [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk debug": {
+        "description": "Debug the local Redpanda process",
+        "usage": "Usage:\r\n  rpk debug [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for debug."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk debug bundle": {
+        "description": "'rpk debug bundle' collects environment data that can help debug and diagnose\r\nissues with a redpanda cluster, a broker, or the machine it's running on. It\r\nthen bundles the collected data into a zip file.\r\n\r\nThe following are the data sources that are bundled in the compressed file:\r\n\r\n - Kafka metadata: Broker configs, topic configs, start/committed/end offsets,\r\n   groups, group commits.\r\n\r\n - Data directory structure: A file describing the data directory's contents.\r\n\r\n - redpanda configuration: The redpanda configuration file (redpanda.yaml;\r\n   SASL credentials are stripped).\r\n\r\n - /proc/cpuinfo: CPU information like make, core count, cache, frequency.\r\n\r\n - /proc/interrupts: IRQ distribution across CPU cores.\r\n\r\n - Resource usage data: CPU usage percentage, free memory available for the\r\n   redpanda process.\r\n\r\n - Clock drift: The ntp clock delta (using pool.ntp.org as a reference) & round\r\n   trip time.\r\n\r\n - Kernel logs: The kernel logs ring buffer (syslog).\r\n\r\n - Broker metrics: The local broker's Prometheus metrics, fetched through its\r\n   admin API.\r\n\r\n - DNS: The DNS info as reported by 'dig', using the hosts in\r\n   /etc/resolv.conf.\r\n\r\n - Disk usage: The disk usage for the data directory, as output by 'du'.\r\n\r\n - redpanda logs: The redpanda logs written to journald. If --logs-since or\r\n   --logs-until are passed, then only the logs within the resulting time frame\r\n   will be included.\r\n\r\n - Socket info: The active sockets data output by 'ss'.\r\n\r\n - Running process info: As reported by 'top'.\r\n\r\n - Virtual memory stats: As reported by 'vmstat'.\r\n\r\n - Network config: As reported by 'ip addr'.\r\n\r\n - lspci: List the PCI buses and the devices connected to them.\r\n\r\n - dmidecode: The DMI table contents. Only included if this command is run\r\n   as root.",
+        "usage": "Usage:\r\n  rpk debug bundle [flags]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--admin-url": {
+                "type": "string",
+                "description": "The address to the broker's admin API. Defaults to the one in the config file."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for bundle."
+            },
+            "--logs-since": {
+                "type": "string",
+                "description": "Include log entries on or newer than the specified date. (journalctl date format, e.g. YYYY-MM-DD)."
+            },
+            "--logs-size-limit": {
+                "type": "string",
+                "description": "Read the logs until the given size is reached. Multipliers are also supported, e.g. 3MB, 1GiB (default \"100MiB\")."
+            },
+            "--logs-until": {
+                "type": "string",
+                "description": "Include log entries on or older than the specified date. (journalctl date format, e.g. YYYY-MM-DD)."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "How long to wait for child commands to execute (e.g. '30s', '1.5m') (default 10s)."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk generate": {
+        "description": "Generate a configuration template for related services",
+        "usage": "Usage:\r\n  rpk generate [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for generate."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk generate grafana-dashboard": {
+        "description": "Generate a Grafana dashboard for redpanda metrics",
+        "usage": "Usage:\r\n  rpk generate grafana-dashboard [flags]\r\n\r",
+        "flags": {
+            "--datasource": {
+                "type": "string",
+                "description": "The name of the Prometheus datasource as configured in your grafana instance."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for grafana-dashboard."
+            },
+            "--job-name": {
+                "type": "string",
+                "description": "The prometheus job name by which to identify the redpanda nodes (default \"redpanda\")."
+            },
+            "--metrics-endpoint": {
+                "type": "string",
+                "description": "The redpanda metrics endpoint where to get the metrics metadata. i.e. redpanda_host:9644/metrics (default \"http://localhost:9644/metrics\")."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk generate prometheus-config": {
+        "description": "Generate the Prometheus configuration to scrape redpanda nodes. This command's\r\noutput should be added to the 'scrape_configs' array in your Prometheus\r\ninstance's YAML config file.\r\n\r\nIf --seed-addr is passed, it will be used to discover the rest of the cluster\r\nhosts via Redpanda's Kafka API. If --node-addrs is passed, they will be used\r\ndirectly. Otherwise, 'rpk generate prometheus-conf' will read the redpanda\r\nconfig file and use the node IP configured there. --config may be passed to\r\nspecify an arbitrary config file.\r\n\r\nIf the node you want to scrape uses TLS, you can provide the TLS flags:\r\n--tls-key, --tls-cert, and --tls-truststore and rpk will generate the required\r\ntls_config section in the scrape configuration.",
+        "usage": "Usage:\r\n  rpk generate prometheus-config [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "The path to the redpanda config file."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for prometheus-config."
+            },
+            "--internal-metrics": {
+                "type": "-",
+                "description": "Include scrape config for internal metrics (/metrics)."
+            },
+            "--job-name": {
+                "type": "string",
+                "description": "The prometheus job name by which to identify the redpanda nodes (default \"redpanda\")."
+            },
+            "--node-addrs": {
+                "type": "strings",
+                "description": "A comma-delimited list of the addresses (<host>:<port>) of all the redpanda nodes in a cluster. The port must be the one configured for the nodes' admin API (9644 by default)."
+            },
+            "--seed-addr": {
+                "type": "string",
+                "description": "The URL of a redpanda node with which to discover the rest."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk generate shell-completion": {
+        "description": "Shell completion can help autocomplete rpk commands when you press tab.\r\n\r\n# Bash\r\n\r\nBash autocompletion relies on the bash-completion package. You can test if you\r\nhave this by running \"type _init_completion\", if you do not, you can install\r\nthe package through your package manager.\r\n\r\nIf you have bash-completion installed, and the command still fails, you likely\r\nneed to add the following line to your ~/.bashrc:\r\n\r\n    source /usr/share/bash-completion/bash_completion\r\n\r\nTo ensure autocompletion of rpk exists in all shell sessions, add the following\r\nto your ~/.bashrc:\r\n\r\n    command -v rpk >/dev/null && . <(rpk generate shell-completion bash)\r\n\r\nAlternatively, to globally enable rpk completion, you can run the following:\r\n\r\n    rpk generate shell-completion bash > /etc/bash_completion.d/rpk\r\n\r\n# Zsh\r\n\r\nTo enable autocompletion in any zsh session for any user, run this once:\r\n\r\n    rpk generate shell-completion zsh > \"${fpath[1]}/_rpk\"\r\n\r\nYou can also place that command in your ~/.zshrc to ensure that when you update\r\nrpk, you update autocompletion. If you initially require sudo to edit that\r\nfile, you can chmod it to be world writeable, after which you will always be\r\nable to update it from ~/.zshrc.\r\n\r\nIf shell completion is not already enabled in your zsh environment, also\r\nadd the following to your ~/.zshrc:\r\n\r\n    autoload -U compinit; compinit\r\n\r\n# Fish\r\n\r\nTo enable autocompletion in any fish session, run:\r\n\r\n    rpk generate shell-completion fish > ~/.config/fish/completions/rpk.fish",
+        "usage": "Usage:\r\n  rpk generate shell-completion [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for shell-completion."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group": {
+        "description": "Describe, list, and delete consumer groups and manage their offsets.\r\n\r\nConsumer groups allow you to horizontally scale consuming from topics. A\r\nnon-group consumer consumes all records from all partitions you assign it. In\r\ncontrast, consumer groups allow many consumers to coordinate and divide work.\r\nIf you have two members in a group consuming topics A and B, each with three\r\npartitions, then both members consume three partitions. If you add another\r\nmember to the group, then each of the three members will consume two\r\npartitions. This allows you to horizontally scale consuming of topics.\r\n\r\nThe unit of scaling is a single partition. If you add more consumers to a group\r\nthan there are are total partitions to consume, then some consumers will be\r\nidle. More commonly, you have many more partitions than consumer group members\r\nand each member consumes a chunk of available partitions. One scenario where\r\nyou may want more members than partitions is if you want active standby's to\r\ntake over load immediately if any consuming member dies.\r\n\r\nHow group members divide work is entirely client driven (the \"partition\r\nassignment strategy\" or \"balancer\" depending on the client). Brokers know\r\nnothing about how consumers are assigning partitions. A broker's role in group\r\nconsuming is to choose which member is the leader of a group, forward that\r\nmember's assignment to every other member, and ensure all members are alive\r\nthrough heartbeats.\r\n\r\nConsumers periodically commit their progress when consuming partitions. Through\r\nthese commits, you can monitor just how far behind a consumer is from the\r\nlatest messages in a partition. This is called \"lag\". Large lag implies that\r\nthe client is having problems, which could be from the server being too slow,\r\nor the client being oversubscribed in the number of partitions it is consuming,\r\nor the server being in a bad state that requires restarting or removing from\r\nthe server pool, and so on.\r\n\r\nYou can manually manage offsets for a group, which allows you to rewind or\r\nforward commits. If you notice that a recent deploy of your consumers had a\r\nbug, you may want to stop all members, rewind the commits to before the latest\r\ndeploy, and restart the members with a patch.\r\n\r\nThis command allows you to list all groups, describe a group (to view the\r\nmembers and their lag), and manage offsets.",
+        "usage": "Usage:\r\n  rpk group [command]\r\n\r\nAliases:\r\n  group, g\r\n\r",
+        "flags": {
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for group."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group delete": {
+        "description": "Delete groups from brokers.\r\n\r\nOlder versions of the Kafka protocol included a retention_millis field in\r\noffset commit requests. Group commits persisted for this retention and then\r\neventually expired. Once all commits for a group expired, the group would be\r\nconsidered deleted.\r\n\r\nThe retention field was removed because it proved problematic for infrequently\r\ncommitting consumers: the offsets could be expired for a group that was still\r\nactive. If clients use new enough versions of OffsetCommit (versions that have\r\nremoved the retention field), brokers expire offsets only when the group is\r\nempty for offset.retention.minutes. Redpanda does not currently support that\r\nconfiguration (see #2904), meaning offsets for empty groups expire only when\r\nthey are explicitly deleted.\r\n\r\nYou may want to delete groups to clean up offsets sooner than when they\r\nautomatically are cleaned up, such as when you create temporary groups for\r\nquick investigation or testing. This command helps you do that.",
+        "usage": "Usage:\r\n  rpk group delete [GROUPS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group describe": {
+        "description": "Describe group offset status & lag.\r\n\r\nThis command describes group members, calculates their lag, and prints detailed\r\ninformation about the members.",
+        "usage": "Usage:\r\n  rpk group describe [GROUPS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "-s, --print-summary": {
+                "type": "-",
+                "description": "Print only the group summary section."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group list": {
+        "description": "List all groups.\r\n\r\nThis command lists all groups currently known to Redpanda, including empty\r\ngroups that have not yet expired. The BROKER column is which broker node is the\r\ncoordinator for the group. This command can be used to track down unknown\r\ngroups, or to list groups that need to be cleaned up.",
+        "usage": "Usage:\r\n  rpk group list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group seek": {
+        "description": "Modify a group's current offsets.\r\n\r\nThis command allows you to modify a group's offsets. Sometimes, you may need to\r\nrewind a group if you had a mistaken deploy, or fast-forward a group if it is\r\nfalling behind on messages that can be skipped.\r\n\r\nThe --to option allows you to seek to the start of partitions, end of\r\npartitions, or after a specific timestamp. The default is to seek any topic\r\npreviously committed. Using --topics allows to you set commits for only the\r\nspecified topics; all other commits will remain untouched. Topics with no\r\ncommits will not be committed unless allowed with --allow-new-topics.\r\n\r\nThe --to-group option allows you to seek to commits that are in another group.\r\nThis is a merging operation: if g1 is consuming topics A and B, and g2 is\r\nconsuming only topic B, \"rpk group seek g1 --to-group g2\" will update g1's\r\ncommits for topic B only. The --topics flag can be used to further narrow which\r\ntopics are updated. Unlike --to, all non-filtered topics are committed, even\r\ntopics not yet being consumed, meaning --allow-new-topics is not needed.\r\n\r\nThe --to-file option allows to seek to offsets specified in a text file with\r\nthe following format:\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    ...\r\nEach line contains the topic, the partition, and the offset to seek to. As with\r\nthe prior options, --topics allows filtering which topics are updated. Similar\r\nto --to-group, all non-filtered topics are committed, even topics not yet being\r\nconsumed, meaning --allow-new-topics is not needed.\r\n\r\nThe --to, --to-group, and --to-file options are mutually exclusive. If you are\r\nnot authorized to describe or read some topics used in a group, you will not be\r\nable to modify offsets for those topics.\r\n\r\nEXAMPLES\r\n\r\nSeek group G to June 1st, 2021:\r\n    rpk group seek g --to 1622505600\r\n    or, rpk group seek g --to 1622505600000\r\n    or, rpk group seek g --to 1622505600000000000\r\nSeek group X to the commits of group Y topic foo:\r\n    rpk group seek X --to-group Y --topics foo\r\nSeek group G's topics foo, bar, and biz to the end:\r\n    rpk group seek G --to end --topics foo,bar,biz\r\nSeek group G to the beginning of a topic it was not previously consuming:\r\n    rpk group seek G --to start --topics foo --allow-new-topics",
+        "usage": "Usage:\r\n  rpk group seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ... [flags]\r\n\r",
+        "flags": {
+            "--allow-new-topics": {
+                "type": "-",
+                "description": "Allow seeking to new topics not currently consumed (implied with --to-group or --to-file)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for seek."
+            },
+            "--to": {
+                "type": "string",
+                "description": "Where to seek (start, end, unix second | millisecond | nanosecond)."
+            },
+            "--to-file": {
+                "type": "string",
+                "description": "Seek to offsets as specified in the file."
+            },
+            "--to-group": {
+                "type": "string",
+                "description": "Seek to the commits of another group."
+            },
+            "--topics": {
+                "type": "strings",
+                "description": "Only seek these topics, if any are specified."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk help": {
+        "description": "Help provides help for any command in the application.\r\nSimply type rpk help [path to command] for full details.",
+        "usage": "Usage:\r\n  rpk help [command] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "help for help."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk iotune": {
+        "description": "Measure filesystem performance and create IO configuration file",
+        "usage": "Usage:\r\n  rpk iotune [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--directories": {
+                "type": "strings",
+                "description": "List of directories to evaluate."
+            },
+            "--duration": {
+                "type": "duration",
+                "description": "Duration of tests.The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 10m0s)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for iotune."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt if the iotune file already exists."
+            },
+            "--out": {
+                "type": "string",
+                "description": "The file path where the IO config will be written (default \"/etc/redpanda/io-config.yaml\")."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time after -- to wait for iotune to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 1h0m0s)."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk plugin": {
+        "description": "List, download, update, and remove rpk plugins.\r\n\t\r\nPlugins augment rpk with new commands.\r\n\r\nFor a plugin to be used, it must be in $HOME/.local/bin or somewhere \r\ndiscoverable by rpk in your $PATH. All plugins follow a defined naming scheme:\r\n\r\n  .rpk-<name>\r\n  .rpk.ac-<name>\r\n\r\nAll plugins are prefixed with either .rpk- or .rpk.ac-. When rpk starts up, it\r\nsearches all directories in your $PATH for any executable binary that begins\r\nwith either of those prefixes. For any binary it finds, rpk adds a command for\r\nthat name to the rpk command space itself.\r\n\r\nNo plugin name can shadow an existing rpk command, and only one plugin can\r\nexist under a given name at once. Plugins are added to the rpk command space on\r\na first-seen basis. If you have two plugins rpk-foo, and the second is\r\ndiscovered later on in the $PATH directories, then only the first will be used.\r\nThe second will be ignored.\r\n\r\nPlugins that have an .rpk.ac- prefix indicate that they support the\r\n--help-autocomplete flag. If rpk sees this, rpk will exec the plugin with that\r\nflag when rpk starts up, and the plugin will return all commands it supports as\r\nwell as short and long help test for each command. Rpk uses this return to\r\nbuild a shadow command space within rpk itself so that it looks as if the\r\nplugin exists within rpk. This is particularly useful if you enable\r\nautocompletion.\r\n\r\nThe expected return for plugins from --help-autocomplete is an array of the\r\nfollowing:\r\n\r\n  type pluginHelp struct {\r\n          Path    string   `json:\"path,omitempty\"`\r\n          Short   string   `json:\"short,omitempty\"`\r\n          Long    string   `json:\"long,omitempty\"`\r\n          Example string   `json:\"example,omitempty\"`\r\n          Args    []string `json:\"args,omitempty\"`\r\n  }\r\n\r\nwhere \"path\" is an underscore delimited argument path to a command. For\r\nexample, \"foo_bar_baz\" corresponds to the command \"rpk foo bar baz\".",
+        "usage": "Usage:\r\n  rpk plugin [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for plugin."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk plugin install": {
+        "description": "Install an rpk plugin.\r\n\r\nAn rpk plugin must be saved in $HOME/.local/bin or in a directory that is in \r\nyour $PATH. By default, this command installs plugins to $HOME/.local/bin. This \r\ncan be overridden by specifying the --dir flag.\r\n\r\nIf --dir is not present, rpk will create $HOME/.local/bin if it does not exist.",
+        "usage": "Usage:\r\n  rpk plugin install [PLUGIN] [flags]\r\n\r\nAliases:\r\n  install, download\r\n\r",
+        "flags": {
+            "--dir": {
+                "type": "string",
+                "description": "Destination directory to save the installed plugin (defaults to $HOME/.local/bin) (default \"/var/lib/redpanda/.local/bin\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for install."
+            },
+            "-u, --update": {
+                "type": "-",
+                "description": "Update a locally installed plugin if it differs from the current remote version."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk plugin list": {
+        "description": "List all available plugins.\r\n\r\nBy default, this command fetches the remote manifest and prints plugins\r\navailable for download. Any plugin that is already downloaded is prefixed with\r\nan asterisk. If a locally installed plugin has a different sha256sum as the one\r\nspecified in the manifest, or if the sha256sum could not be calculated for the\r\nlocal plugin, an additional message is printed.\r\n\r\nYou can specify --local to print all locally installed plugins, as well as\r\nwhether you have \"shadowed\" plugins (the same plugin specified multiple times).",
+        "usage": "Usage:\r\n  rpk plugin list [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-l, --local": {
+                "type": "-",
+                "description": "List locally installed plugins and shadowed plugins."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk plugin uninstall": {
+        "description": "Uninstall / remove an existing local plugin.\r\n\r\nThis command lists locally installed plugins and removes the first plugin that\r\nmatches the requested removal. If --include-shadowed is specified, this command\r\nalso removes all shadowed plugins of the same name. To remove a command under a\r\nnested namespace (\"rpk foo bar\"), you can use \"foo_bar\".",
+        "usage": "Usage:\r\n  rpk plugin uninstall [NAME] [flags]\r\n\r\nAliases:\r\n  uninstall, rm\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for uninstall."
+            },
+            "--include-shadowed": {
+                "type": "-",
+                "description": "Also remove shadowed plugins that have the same name."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda": {
+        "description": "Interact with a local Redpanda process",
+        "usage": "Usage:\r\n  rpk redpanda [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for redpanda."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin": {
+        "description": "Talk to the Redpanda admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for admin."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin brokers": {
+        "description": "View and configure Redpanda brokers through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for brokers."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin brokers decommission": {
+        "description": "Decommission the given broker.\r\n\r\nDecommissioning a broker removes it from the cluster.\r\n\r\nA decommission request is sent to every broker in the cluster, only the cluster\r\nleader handles the request.\r\n\r\nFor safety on v22.x clusters, this command will not run if the requested \r\nbroker is in maintenance mode. As of v23.x, Redpanda supports \r\ndecommissioning a node that is currently in maintenance mode. If you are on \r\na v22.x cluster and need to bypass the maintenance mode check (perhaps your \r\ncluster is unreachable), use the hidden --force flag.",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers decommission [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for decommission."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin brokers decommission-status": {
+        "description": "Show the progress of a node decommissioning",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers decommission-status [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-d, --detailed": {
+                "type": "-",
+                "description": "Print how much data moved and remaining in bytes."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for decommission-status."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin brokers list": {
+        "description": "List the brokers in your cluster",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin brokers recommission": {
+        "description": "Recommission the given broker if is is still decommissioning.\r\n\r\nRecommissioning can stop an active decommission.\r\n\r\nOnce a broker is decommissioned, it cannot be recommissioned through this\r\ncommand.\r\n\r\nA recommission request is sent to every broker in the cluster, only\r\nthe cluster leader handles the request.",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers recommission [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for recommission."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin config": {
+        "description": "View or modify Redpanda configuration through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin config [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin config log-level": {
+        "description": "Manage a broker's log level",
+        "usage": "Usage:\r\n  rpk redpanda admin config log-level [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for log-level."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin config log-level set": {
+        "description": "Set broker logger's log level.\r\n\r\nThis command temporarily changes a broker logger's log level. Each Redpanda\r\nbroker has many loggers, and each can be individually changed. Any change\r\nto a logger persists for a limited amount of time, so as to ensure you do\r\nnot accidentally enable debug logging permanently.\r\n\r\nIt is optional to specify a logger; if you do not, this command will prompt\r\nfrom the set of available loggers.\r\n\r\nThe special logger \"all\" enables all loggers. Alternatively, you can specify\r\nmany loggers at once. To see all possible loggers, run the following command:\r\n\r\n  redpanda --help-loggers\r\n\r\nThis command accepts loggers that it does not know of to ensure you can\r\nindependently update your redpanda installations from rpk. The success or\r\nfailure of enabling each logger is individually printed.",
+        "usage": "Usage:\r\n  rpk redpanda admin config log-level set [LOGGERS...] [flags]\r\n\r",
+        "flags": {
+            "-e, --expiry-seconds": {
+                "type": "int",
+                "description": "seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown) (default 300)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--host": {
+                "type": "string",
+                "description": "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to."
+            },
+            "-l, --level": {
+                "type": "string",
+                "description": "log level to set (error, warn, info, debug, trace) (default \"debug\")."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin config print": {
+        "description": "Display the current Redpanda configuration",
+        "usage": "Usage:\r\n  rpk redpanda admin config print [flags]\r\n\r\nAliases:\r\n  print, dump, list, ls, display\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for print."
+            },
+            "--host": {
+                "type": "string",
+                "description": "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin partitions": {
+        "description": "View and configure Redpanda partitions through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin partitions [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for partitions."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin partitions list": {
+        "description": "List the partitions in a broker in the cluster",
+        "usage": "Usage:\r\n  rpk redpanda admin partitions list [BROKER ID] [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-l, --leader-only": {
+                "type": "-",
+                "description": "print the partitions on broker which are leaders."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda check": {
+        "description": "Check if system meets redpanda requirements",
+        "usage": "Usage:\r\n  rpk redpanda check [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for check."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum amount of time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 2s)."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda config": {
+        "description": "Edit configuration",
+        "usage": "Usage:\r\n  rpk redpanda config [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda config bootstrap": {
+        "description": "Initialize the configuration to bootstrap a cluster.\r\n\r\nThis command generates a redpanda.yaml configuration file to bootstrap a\r\ncluster. If you are modifying the configuration file further, it is recommended\r\nto first bootstrap and then modify. If the file already exists, this command\r\nwill set fields as requested by flags, and this may undo some of your earlier\r\nedits.\r\n\r\nThe --ips flag specifies seed servers (ips, ip:ports, or hostnames) that this\r\nbroker will use to form a cluster.\r\n\r\nBy default, redpanda expects your machine to have one private IP address, and\r\nredpanda will listen on it. If your machine has multiple private IP addresses,\r\nyou must use the --self flag to specify which ip redpanda should listen on.",
+        "usage": "Usage:\r\n  rpk redpanda config bootstrap [--self <ip>] [--ips <ip1,ip2,...>] [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default location."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for bootstrap."
+            },
+            "--ips": {
+                "type": "strings",
+                "description": "Comma-separated list of the seed node addresses or hostnames; at least three are recommended."
+            },
+            "--self": {
+                "type": "string",
+                "description": "Optional IP address for redpanda to listen on; if empty, defaults to a private address."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda config init": {
+        "description": "Init the node after install, by setting the node's UUID",
+        "usage": "Usage:\r\n  rpk redpanda config init [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default location."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for init."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda config set": {
+        "description": "Set configuration values, such as the redpanda node ID or the list of seed servers\r\n\r\nThis command modifies the redpanda.yaml you have locally on disk. The first\r\nargument is the key within the yaml representing a property / field that you\r\nwould like to set. Nested fields can be accessed through a dot:\r\n\r\n  rpk redpanda config set redpanda.developer_mode true\r\n\r\nThe default format is to parse the value as yaml. Individual specific fields\r\ncan be set, or full structs:\r\n\r\n  rpk redpanda config set rpk.tune_disk_irq true\r\n  rpk redpanda config set redpanda.rpc_server '{address: 3.250.158.1, port: 9092}'\r\n\r\nYou can set an entire array by wrapping all items with braces, or by using one\r\nstruct:\r\n\r\n  rpk redpanda config set redpanda.advertised_kafka_api '[{address: 0.0.0.0, port: 9092}]'\r\n  rpk redpanda config set redpanda.advertised_kafka_api '{address: 0.0.0.0, port: 9092}' # same\r\n\r\nIndexing can be used to set specific items in an array. You can index one past\r\nthe end of an array to extend it:\r\n\r\n  rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 0.0.0.0, port: 9092}'\r\n\r\nThe json format can be used to set values as json:\r\n\r\n  rpk redpanda config set redpanda.rpc_server '{\"address\":\"0.0.0.0\",\"port\":33145}' --format json",
+        "usage": "Usage:\r\n  rpk redpanda config set <key> <value> [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default location."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Format of the value (yaml/json) (default \"yaml\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda mode": {
+        "description": "Enable a default configuration mode",
+        "usage": "Usage:\r\n  rpk redpanda mode <mode> [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for mode."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda start": {
+        "description": "Start redpanda",
+        "usage": "Usage:\r\n  rpk redpanda start [flags]\r\n\r",
+        "flags": {
+            "--advertise-kafka-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Kafka addresses to advertise (<name>://<host>:<port>)."
+            },
+            "--advertise-pandaproxy-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Pandaproxy addresses to advertise (<name>://<host>:<port>)."
+            },
+            "--advertise-rpc-addr": {
+                "type": "string",
+                "description": "The advertised RPC address (<host>:<port>)."
+            },
+            "--check": {
+                "type": "-",
+                "description": "When set to false will disable system checking before starting redpanda (default true)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--install-dir": {
+                "type": "string",
+                "description": "Directory where redpanda has been installed."
+            },
+            "--kafka-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Kafka listener addresses to bind to (<name>://<host>:<port>)."
+            },
+            "--mode": {
+                "type": "string",
+                "description": "Mode sets well-known configuration properties for development or test environments; use --mode help for more info."
+            },
+            "--pandaproxy-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Pandaproxy listener addresses to bind to (<name>://<host>:<port>)."
+            },
+            "--rpc-addr": {
+                "type": "string",
+                "description": "The RPC address to bind to (<host>:<port>)."
+            },
+            "--schema-registry-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Schema Registry listener addresses to bind to (<name>://<host>:<port>)."
+            },
+            "-s, --seeds": {
+                "type": "strings",
+                "description": "A comma-separated list of seed node addresses (<host>[:<port>]) to connect to."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 10s)."
+            },
+            "--tune": {
+                "type": "-",
+                "description": "When present will enable tuning before starting redpanda."
+            },
+            "--well-known-io": {
+                "type": "string",
+                "description": "The cloud vendor and VM type, in the format <vendor>:<vm type>:<storage type>."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda stop": {
+        "description": "Stop a local redpanda process. 'rpk stop'\r\nfirst sends SIGINT, and waits for the specified timeout. Then, if redpanda\r\nhasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still\r\nrunning.",
+        "usage": "Usage:\r\n  rpk redpanda stop [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum amount of time to wait for redpanda to stop,after each signal is sent. The value passed is asequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 5s)."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda tune": {
+        "description": "Sets the OS parameters to tune system performance.\r\n\r\nAvailable tuners:\r\n\r\n  - all.\r\n  - swappiness\r\n  - transparent_hugepages\r\n  - coredump\r\n  - disk_irq\r\n  - disk_nomerges\r\n  - fstrim\r\n  - net\r\n  - aio_events\r\n  - disk_scheduler\r\n  - disk_write_cache\r\n  - cpu\r\n  - clocksource\r\n  - ballast_file\r\n\r\nTo learn more about a tuner, run 'rpk redpanda tune help <tuner name>'.",
+        "usage": "Usage:\r\n  rpk redpanda tune <list of elements to tune> [flags]\r\n  rpk redpanda tune [command]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--cpu-set": {
+                "type": "string",
+                "description": "Set of CPUs for tuner to use in cpuset(7) format if not specified tuner will use all available CPUs (default \"all\")."
+            },
+            "-r, --dirs": {
+                "type": "strings",
+                "description": "List of *data* directories or places to store data, i.e.: '/var/vectorized/redpanda/', usually your XFS filesystem on an NVMe SSD device."
+            },
+            "-d, --disks": {
+                "type": "strings",
+                "description": "Lists of devices to tune f.e. 'sda1'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for tune."
+            },
+            "-m, --mode": {
+                "type": "string",
+                "description": "Operation Mode: one of: [sq, sq_split, mq]."
+            },
+            "-n, --nic": {
+                "type": "strings",
+                "description": "Network Interface Controllers to tune."
+            },
+            "--output-script": {
+                "type": "string",
+                "description": "If set tuners will generate tuning file that can later be used to tune the system."
+            },
+            "--reboot-allowed": {
+                "type": "-",
+                "description": "If set will allow tuners to tune boot parameters and request system reboot."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time to wait for the tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 10s)."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda tune help": {
+        "description": "Display detailed information about the tuner",
+        "usage": "Usage:\r\n  rpk redpanda tune help <tuner> [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for help."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda tune list": {
+        "description": "List available redpanda tuners and check if they are enabled and \r\nsupported by your system\r\n\r\nTo enable a tuner it must be set in the redpanda.yaml configuration file\r\nunder rpk section, e.g:\r\n\r\n  rpk:\r\n      tune_cpu: true\r\n      tune_swappiness: true\r\n\r\nYou may use 'rpk redpanda config set' to enable or disable a tuner.",
+        "usage": "Usage:\r\n  rpk redpanda tune list [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-r, --dirs": {
+                "type": "strings",
+                "description": "List of *data* directories or places to store data, i.e.: '/var/vectorized/redpanda/', usually your XFS filesystem on an NVMe SSD device."
+            },
+            "-d, --disks": {
+                "type": "strings",
+                "description": "Lists of devices to tune f.e. 'sda1'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-m, --mode": {
+                "type": "string",
+                "description": "Operation Mode: one of: [sq, sq_split, mq]."
+            },
+            "-n, --nic": {
+                "type": "strings",
+                "description": "Network Interface Controllers to tune."
+            },
+            "--reboot-allowed": {
+                "type": "-",
+                "description": "If set will allow tuners to tune boot parameters and request system reboot."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic": {
+        "description": "Create, delete, produce to and consume from Redpanda topics",
+        "usage": "Usage:\r\n  rpk topic [command]\r\n\r",
+        "flags": {
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for topic."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic add-partitions": {
+        "description": "Add partitions to existing topics.",
+        "usage": "Usage:\r\n  rpk topic add-partitions [TOPICS...] --num [#] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for add-partitions."
+            },
+            "-n, --num": {
+                "type": "int",
+                "description": "Number of partitions to add to each topic."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic alter-config": {
+        "description": "Set, delete, add, and remove key/value configs for a topic.\r\n\r\nThis command allows you to incrementally alter the configuration for multiple\r\ntopics at a time.\r\n\r\nIncremental altering supports four operations:\r\n\r\n  1) Setting a key=value pair\r\n  2) Deleting a key's value\r\n  3) Appending a new value to a list-of-values key\r\n  4) Subtracting (removing) an existing value from a list-of-values key\r\n\r\nThe --dry option will validate whether the requested configuration change is\r\nvalid, but does not apply it.",
+        "usage": "Usage:\r\n  rpk topic alter-config [TOPICS...] --set key=value --delete key2,key3 [flags]\r\n\r",
+        "flags": {
+            "--append": {
+                "type": "stringArray",
+                "description": "key=value; Value to append to a list-of-values key (repeatable)."
+            },
+            "-d, --delete": {
+                "type": "stringArray",
+                "description": "Key to delete (repeatable)."
+            },
+            "--dry": {
+                "type": "-",
+                "description": "Dry run: validate the alter request, but do not apply."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for alter-config."
+            },
+            "-s, --set": {
+                "type": "stringArray",
+                "description": "key=value; Pair to set (repeatable)."
+            },
+            "--subtract": {
+                "type": "stringArray",
+                "description": "key=value; Value to remove from list-of-values key (repeatable)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic consume": {
+        "description": "Consume records from topics.\r\n\r\nConsuming records reads from any amount of input topics, formats each record\r\naccording to --format, and prints them to STDOUT. The output formatter\r\nunderstands a wide variety of formats.\r\n\r\nThe default output format \"--format json\" is a special format that outputs each\r\nrecord as JSON. There may be more single-word-no-escapes formats added later.\r\nOutside of these special formats, formatting follows the rules described below.\r\n\r\nFormatting output is based on percent escapes and modifiers. Slashes can be\r\nused for common escapes:\r\n\r\n    \\t \\n \\r \\\\ \\xNN\r\n\r\nprints tabs, newlines, carriage returns, slashes, or hex encoded characters.p\r\n\r\nPercent encoding prints record fields, fetch partition fields, or extra values:\r\n\r\n    %t    topic\r\n    %T    topic length\r\n    %k    key\r\n    %K    key length\r\n    %v    topic\r\n    %V    value length\r\n    %h    begin the header specification\r\n    %H    number of headers\r\n    %p    partition\r\n    %o    offset\r\n    %e    leader epoch\r\n    %d    timestamp (formatting described below)\r\n    %a    record attributes (formatting described below)\r\n    %x    producer id\r\n    %y    producer epoch\r\n\r\n    %[    partition log start offset\r\n    %|    partition last stable offset\r\n    %]    partition high watermark\r\n\r\n    %%    percent sign\r\n    %{    left brace\r\n    %}    right brace\r\n\r\n    %i    the number of records formatted\r\n\r\nMODIFIERS\r\n\r\nText and numbers can be formatted in many different ways, and the default\r\nformat can be changed within brace modifiers. %v prints a value, while %v{hex}\r\nprints the value hex encoded. %T prints the length of a topic in ascii, while\r\n%T{big8} prints the length of the topic as an eight byte big endian.\r\n\r\nAll modifiers go within braces following a percent-escape.\r\n\r\nNUMBERS\r\n\r\nFormatting number values can have the following modifiers:\r\n\r\n     ascii       print the number as ascii (default)\r\n\r\n     hex64       sixteen hex characters\r\n     hex32       eight hex characters\r\n     hex16       four hex characters\r\n     hex8        two hex characters\r\n     hex4        one hex character\r\n\r\n     big64       eight byte big endian number\r\n     big32       four byte big endian number\r\n     big16       two byte big endian number\r\n     big8        alias for byte\r\n\r\n     little64    eight byte little endian number\r\n     little32    four byte little endian number\r\n     little16    two byte little endian number\r\n     little8     alias for byte\r\n\r\n     byte        one byte number\r\n     bool        \"true\" if the number is non-zero, \"false\" if the number is zero\r\n\r\nAll numbers are truncated as necessary per the modifier. Printing %V{byte} for\r\na length 256 value will print a single null, whereas printing %V{big8} would\r\nprint the bytes 1 and 0.\r\n\r\nWhen writing number sizes, the size corresponds to the size of the raw values,\r\nnot the size of encoded values. \"%T% t{hex}\" for the topic \"foo\" will print\r\n\"3 666f6f\", not \"6 666f6f\".\r\n\r\nTIMESTAMPS\r\n\r\nBy default, the timestamp field is printed as a millisecond number value. In\r\naddition to the number modifiers above, timestamps can be printed with either\r\nGo formatting or strftime formatting:\r\n\r\n    %d{go[2006-01-02T15:04:05Z07:00]}\r\n    %d{strftime[%F]}\r\n\r\nAn arbitrary amount of brackets (or braces, or # symbols) can wrap your date\r\nformatting:\r\n\r\n    %d{strftime### [%F] ###}\r\n\r\nThe above will print \" [YYYY-MM-DD] \", while the surrounding three # on each\r\nside are used to wrap the formatting. Further details on Go time formatting can\r\nbe found at https://pkg.go.dev/time, while further details on strftime\r\nformatting can be read by checking \"man strftime\".\r\n\r\nATTRIBUTES\r\n\r\nEach record (or batch of records) has a set of possible attributes. Internally,\r\nthese are packed into bit flags. Printing an attribute requires first selecting\r\nwhich attribute you want to print, and then optionally specifying how you want\r\nit to be printed:\r\n\r\n     %a{compression}\r\n     %a{compression;number}\r\n     %a{compression;big64}\r\n     %a{compression;hex8}\r\n\r\nCompression is by default printed as text (\"none\", \"gzip\", ...). Compression\r\ncan be printed as a number with \";number\", where number is any number\r\nformatting option described above. No compression is 0, gzip is 1, etc.\r\n\r\n     %a{timestamp-type}\r\n     %a{timestamp-type;big64}\r\n\r\nThe record's timestamp type is printed as -1 for very old records (before\r\ntimestamps existed), 0 for client generated timestamps, and 1 for broker\r\ngenerated timestamps. Number formatting can be controlled with \";number\".\r\n\r\n     %a{transactional-bit}\r\n     %a{transactional-bit;bool}\r\n\r\nPrints 1 if the record a part of a transaction or 0 if it is not.\r\nNumber formatting can be controlled with \";number\".\r\n\r\n     %a{control-bit}\r\n     %a{control-bit;bool}\r\n\r\nPrints 1 if the record is a commit marker or 0 if it is not.\r\nNumber formatting can be controlled with \";number\".\r\n\r\nTEXT\r\n\r\nText fields without modifiers default to writing the raw bytes. Alternatively,\r\nthere are the following modifiers:\r\n\r\n    %t{hex}\r\n    %k{base64}\r\n    %v{base64raw}\r\n    %v{unpack[<bBhH>iIqQc.$]}\r\n\r\nThe hex modifier hex encodes the text, the base64 modifier base64 encodes the\r\ntext with standard encoding, and the base64raw modifier encodes the text with\r\nraw standard encoding. The unpack modifier has a further internal\r\nspecification, similar to timestamps above:\r\n\r\n    x    pad character (does not parse input)\r\n    <    switch what follows to little endian\r\n    >    switch what follows to big endian\r\n\r\n    b    signed byte\r\n    B    unsigned byte\r\n    h    int16  (\"half word\")\r\n    H    uint16 (\"half word\")\r\n    i    int32\r\n    I    uint32\r\n    q    int64  (\"quad word\")\r\n    Q    uint64 (\"quad word\")\r\n\r\n    c    any character\r\n    .    alias for c\r\n    s    consume the rest of the input as a string\r\n    $    match the end of the line (append error string if anything remains)\r\n\r\nUnpacking text can allow translating binary input into readable output. If a\r\nvalue is a big-endian uint32, %v will print the raw four bytes, while\r\n%v{unpack[>I]} will print the number in as ascii. If unpacking exhausts the\r\ninput before something is unpacked fully, an error message is appended to the\r\noutput.\r\n\r\nHEADERS\r\n\r\nHeaders are formatted with percent encoding inside of the modifier:\r\n\r\n    %h{ %k=%v{hex} }\r\n\r\nwill print all headers with a space before the key and after the value, an\r\nequals sign between the key and value, and with the value hex encoded. Header\r\nformatting actually just parses the internal format as a record format, so all\r\nof the above rules about %K, %V, text, and numbers apply.\r\n\r\nEXAMPLES\r\n\r\nA key and value, separated by a space and ending in newline:\r\n    -f '%k %v\\n'\r\nA key length as four big endian bytes, and the key as hex:\r\n    -f '%K{big32}%k{hex}'\r\nA little endian uint32 and a string unpacked from a value:\r\n    -f '%v{unpack[is$]}'\r\n\r\nOFFSETS\r\n\r\nThe --offset flag allows for specifying where to begin consuming, and\r\noptionally, where to stop consuming. The literal words \"start\" and \"end\"\r\nspecify consuming from the start and the end.\r\n\r\n    start     consume from the beginning\r\n    end       consume from the end\r\n    :end      consume until the current end\r\n    +oo       consume oo after the current start offset\r\n    -oo       consume oo before the current end offset\r\n    oo        consume after an exact offset\r\n    oo:       alias for oo\r\n    :oo       consume until an exact offset\r\n    o1:o2     consume from exact offset o1 until exact offset o2\r\n    @t        consume starting from a given timestamp\r\n    @t:       alias for @t\r\n    @:t       consume until a given timestamp\r\n    @t1:t2    consume from timestamp t1 until timestamp t2\r\n\r\nThere are a few options for timestamps, with each option being evaluated\r\nuntil one succeeds:\r\n\r\n    13 digits             parsed as a unix millisecond\r\n    9 digits              parsed as a unix second\r\n    YYYY-MM-DD            parsed as a day, UTC\r\n    YYYY-MM-DDTHH:MM:SSZ  parsed as RFC3339, UTC; fractional seconds optional (.MMM)\r\n    -dur                  duration ago; from now (as t1) or from t1 (as t2)\r\n    dur                   for t2 in @t1:t2, relative duration from t1\r\n    end                   for t2 in @t1:t2, the current end of the partition\r\n\r\nDurations are parsed simply:\r\n\r\n    3ms    three milliseconds\r\n    10s    ten seconds\r\n    9m     nine minutes\r\n    1h     one hour\r\n    1m3ms  one minute and three milliseconds\r\n\r\nFor example,\r\n\r\n    -o @2022-02-14:1h   consume 1h of time on Valentine's Day 2022\r\n    -o @-48h:-24h       consume from 2 days ago to 1 day ago\r\n    -o @-1m:end         consume from 1m ago until now\r\n    -o @:-1hr           consume from the start until an hour ago",
+        "usage": "Usage:\r\n  rpk topic consume TOPICS... [flags]\r\n\r",
+        "flags": {
+            "-b, --balancer": {
+                "type": "string",
+                "description": "Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky) (default \"cooperative-sticky\")."
+            },
+            "--fetch-max-bytes": {
+                "type": "int32",
+                "description": "Maximum amount of bytes per fetch request per broker (default 1048576)."
+            },
+            "--fetch-max-wait": {
+                "type": "duration",
+                "description": "Maximum amount of time to wait when fetching from a broker before the broker replies (default 5s)."
+            },
+            "-f, --format": {
+                "type": "string",
+                "description": "Output format (see --help for details) (default \"json\")."
+            },
+            "-g, --group": {
+                "type": "string",
+                "description": "Group to use for consuming (incompatible with -p)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for consume."
+            },
+            "--meta-only": {
+                "type": "-",
+                "description": "Print all record info except the record value (for -f json)."
+            },
+            "-n, --num": {
+                "type": "int",
+                "description": "Quit after consuming this number of records (0 is unbounded)."
+            },
+            "-o, --offset": {
+                "type": "string",
+                "description": "Offset to consume from / to (start, end, 47, +2, -3) (default \"start\")."
+            },
+            "-p, --partitions": {
+                "type": "int32",
+                "description": "int32Slice     Comma delimited list of specific partitions to consume (default [])."
+            },
+            "--pretty-print": {
+                "type": "-",
+                "description": "Pretty print each record over multiple lines (for -f json) (default true)."
+            },
+            "--print-control-records": {
+                "type": "-",
+                "description": "Opt in to printing control records."
+            },
+            "--read-committed": {
+                "type": "-",
+                "description": "Opt in to reading only committed offsets."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; consume any topic that matches any expression."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic create": {
+        "description": "Create topics.\r\n\r\nAll topics created with this command will have the same number of partitions,\r\nreplication factor, and key/value configs.\r\n\r\nFor example,\r\n\r\n\tcreate -c cleanup.policy=compact -r 3 -p 20 foo bar\r\n\r\nwill create two topics, foo and bar, each with 20 partitions, 3 replicas, and\r\nthe cleanup.policy=compact config option set.",
+        "usage": "Usage:\r\n  rpk topic create [TOPICS...] [flags]\r\n\r",
+        "flags": {
+            "-d, --dry": {
+                "type": "-",
+                "description": "Dry run: validate the topic creation request; do not create topics."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "-p, --partitions": {
+                "type": "int32",
+                "description": "Number of partitions to create per topic; -1 defaults to the cluster's default_topic_partitions (default -1)."
+            },
+            "-r, --replicas": {
+                "type": "int16",
+                "description": "Replication factor (must be odd); -1 defaults to the cluster's default_topic_replications (default -1)."
+            },
+            "-c, --topic-config": {
+                "type": "stringArray",
+                "description": "key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic delete": {
+        "description": "Delete topics.\r\n\r\nThis command deletes all requested topics, printing the success or fail status\r\nper topic.\r\n\r\nThe --regex flag (-r) opts into parsing the input topics as regular expressions\r\nand deleting any non-internal topic that matches any of expressions. The input\r\nexpressions are wrapped with ^ and $ so that the expression must match the\r\nwhole topic name (which also prevents accidental delete-everything mistakes).\r\n\r\nThe topic list command accepts the same input regex format as this delete\r\ncommand. If you want to check what your regular expressions will delete before\r\nactually deleting them, you can check the output of 'rpk topic list -r'.\r\n\r\nFor example,\r\n\r\n    delete foo bar            # deletes topics foo and bar\r\n    delete -r '^f.*' '.*r$'   # deletes any topic starting with f and any topics ending in r\r\n    delete -r '.*'            # deletes all topics\r\n    delete -r .               # deletes any one-character topics",
+        "usage": "Usage:\r\n  rpk topic delete [TOPICS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; delete any topic that matches any input topic expression."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic describe": {
+        "description": "Describe a topic.\r\n\r\nThis command prints detailed information about a topic. There are three\r\npotential sections: a summary of the topic, the topic configs, and a detailed\r\npartitions section. By default, the summary and configs sections are printed.",
+        "usage": "Usage:\r\n  rpk topic describe [TOPIC] [flags]\r\n\r\nAliases:\r\n  describe, info\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "-a, --print-all": {
+                "type": "-",
+                "description": "Print all sections."
+            },
+            "-c, --print-configs": {
+                "type": "-",
+                "description": "Print the config section."
+            },
+            "-p, --print-partitions": {
+                "type": "-",
+                "description": "Print the detailed partitions section."
+            },
+            "-s, --print-summary": {
+                "type": "-",
+                "description": "Print the summary section."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic list": {
+        "description": "List topics, optionally listing specific topics.\r\n\r\nThis command lists all topics that you have access to by default. If specifying\r\ntopics or regular expressions, this command can be used to know exactly what\r\ntopics you would delete if using the same input to the delete command.\r\n\r\nAlternatively, you can request specific topics to list, which can be used to\r\ncheck authentication errors (do you not have access to a topic you were\r\nexpecting to see?), or to list all topics that match regular expressions.\r\n\r\nThe --regex flag (-r) opts into parsing the input topics as regular expressions\r\nand listing any non-internal topic that matches any of expressions. The input\r\nexpressions are wrapped with ^ and $ so that the expression must match the\r\nwhole topic name. Regular expressions cannot be used to match internal topics,\r\nas such, specifying both -i and -r will exit with failure.\r\n\r\nLastly, --detailed flag (-d) opts in to printing extra per-partition\r\ninformation.",
+        "usage": "Usage:\r\n  rpk topic list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-d, --detailed": {
+                "type": "-",
+                "description": "Print per-partition information for topics."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-i, --internal": {
+                "type": "-",
+                "description": "Print internal topics."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; list any topic that matches any input topic expression."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic produce": {
+        "description": "Produce records to a topic.\r\n\r\nProducing records reads from STDIN, parses input according to --format, and\r\nproduce records to Redpanda. The input formatter understands a wide variety of\r\nformats.\r\n\r\nParsing input operates on either sizes or on delimiters, both of which can be\r\nspecified in the same formatting options. If using sizes to specify something,\r\nthe size must come before what it is specifying. Delimiters match on an exact\r\ntext basis. This command will quit with an error if any input fails to match\r\nyour specified format.\r\n\r\nSlashes can be used for common escapes:\r\n\r\n    \\t \\n \\r \\\\ \\xNN\r\n\r\nmatches tabs, newlines, carriage returns, slashes, and hex encoded characters.\r\n\r\nPercent encoding reads into specific values of a record:\r\n\r\n    %t    topic\r\n    %T    topic length\r\n    %k    key\r\n    %K    key length\r\n    %v    value\r\n    %V    value length\r\n    %h    begin the header specification\r\n    %H    number of headers\r\n    %p    partition (if using the --partition flag)\r\n\r\nThree escapes exist to parse characters that are used to modify the previous\r\nescapes:\r\n\r\n    %%    percent sign\r\n    %{    left brace\r\n    %}    right brace\r\n\r\nMODIFIERS\r\n\r\nText and numbers can be read in multiple formats, and the default format can be\r\nchanged within brace modifiers. %v reads a value, while %v{hex} reads a value\r\nand then hex decodes it before producing. %T reads the length of a topic from\r\nthe input, while %T{3} reads exactly three bytes for a topic from the input.\r\n\r\nAll modifiers go within braces following a percent-escape.\r\n\r\nNUMBERS\r\n\r\nReading number values can have the following modifiers:\r\n\r\n     ascii       parse numeric digits until a non-numeric (default)\r\n\r\n     hex64       sixteen hex characters\r\n     hex32       eight hex characters\r\n     hex16       four hex characters\r\n     hex8        two hex characters\r\n     hex4        one hex character\r\n\r\n     big64       eight byte big endian number\r\n     big32       four byte big endian number\r\n     big16       two byte big endian number\r\n     big8        alias for byte\r\n\r\n     little64    eight byte little endian number\r\n     little32    four byte little endian number\r\n     little16    two byte little endian number\r\n     little8     alias for byte\r\n\r\n     byte        one byte number\r\n     <digits>    directly specify the length as this many digits\r\n     bool        read \"true\" as 1, \"false\" as 0\r\n\r\nWhen reading number sizes, the size corresponds to the size of the encoded\r\nvalues, not the decoded values. \"%T{6}%t{hex}\" will read six hex bytes and\r\ndecode into three.\r\n\r\nTEXT\r\n\r\nReading text values can have the following modifiers:\r\n\r\n    hex       read text then hex decode it\r\n    base64    read text then std-encoding base64 decode it\r\n    re        read text matching a regular expression\r\n\r\nHEADERS\r\n\r\nHeaders are parsed with an internal key / value specifier format. For example,\r\nthe following will read three headers that begin and end with a space and are\r\nseparated by an equal:\r\n\r\n    %H{3}%h{ %k=%v }\r\n\r\nEXAMPLES\r\n\r\nIn the below examples, we can parse many records at once. The produce command\r\nreads input and tokenizes based on your specified format. Every time the format\r\nis completely matched, a record is produced and parsing begins anew.\r\n\r\nA key and value, separated by a space and ending in newline:\r\n    -f '%k %v\\n'\r\nA four byte topic, four byte key, and four byte value:\r\n    -f '%T{4}%K{4}%V{4}%t%k%v'\r\nA value to a specific partition, if using a non-negative --partition flag:\r\n    -f '%p %v\\n'\r\nA big-endian uint16 key size, the text \" foo \", and then that key:\r\n    -f '%K{big16} foo %k'\r\nA value that can be two or three characters followed by a newline:\r\n    -f '%v{re#...?#}\\n'\r\n\r\nMISC\r\n\r\nProducing requires a topic to produce to. The topic can be specified either\r\ndirectly on as an argument, or in the input text through %t. A parsed topic\r\ntakes precedence over the default passed in topic. If no topic is specified\r\ndirectly and no topic is parsed, this command will quit with an error.\r\n\r\nThe input format can parse partitions to produce directly to with %p. Doing so\r\nrequires specifying a non-negative --partition flag. Any parsed partition\r\ntakes precedence over the --partition flag; specifying the flag is the main\r\nrequirement for being able to directly control which partition to produce to.\r\n\r\nYou can also specify an output format to write when a record is produced\r\nsuccessfully. The output format follows the same formatting rules as the topic\r\nconsume command. See that command's help text for a detailed description.",
+        "usage": "Usage:\r\n  rpk topic produce [TOPIC] [flags]\r\n\r",
+        "flags": {
+            "--acks": {
+                "type": "int",
+                "description": "Number of acks required for producing (-1=all, 0=none, 1=leader) (default -1)."
+            },
+            "--allow-auto-topic-creation": {
+                "type": "-",
+                "description": "Auto-create non-existent topics; requires auto_create_topics_enabled on the broker."
+            },
+            "-z, --compression": {
+                "type": "string",
+                "description": "Compression to use for producing batches (none, gzip, snapy, lz4, zstd) (default \"snappy\")."
+            },
+            "--delivery-timeout": {
+                "type": "duration",
+                "description": "Per-record delivery timeout, if non-zero, min 1s."
+            },
+            "-f, --format": {
+                "type": "string",
+                "description": "Input record format (default \"%v\\n\")."
+            },
+            "-H, --header": {
+                "type": "stringArray",
+                "description": "Headers in format key:value to add to each record (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for produce."
+            },
+            "-k, --key": {
+                "type": "string",
+                "description": "A fixed key to use for each record (parsed input keys take precedence)."
+            },
+            "-o, --output-format": {
+                "type": "string",
+                "description": "what to write to stdout when a record is successfully produced (default \"Produced to partition %p at offset %o with timestamp %d.\\n\")."
+            },
+            "-p, --partition": {
+                "type": "int32",
+                "description": "Partition to directly produce to, if non-negative (also allows %p parsing to set partitions) (default -1)."
+            },
+            "-Z, --tombstone": {
+                "type": "-",
+                "description": "Produce empty values as tombstones."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk version": {
+        "description": "Check the current version",
+        "usage": "Usage:\r\n  rpk version [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for version."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk wasm": {
+        "description": "Deploy and remove inline WASM engine scripts",
+        "usage": "Usage:\r\n  rpk wasm [command]\r\n\r",
+        "flags": {
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for wasm."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk wasm deploy": {
+        "description": "Deploy inline WASM function",
+        "usage": "Usage:\r\n  rpk wasm deploy [PATH] [flags]\r\n\r",
+        "flags": {
+            "--description": {
+                "type": "string",
+                "description": "Optional description about what the wasm function does."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for deploy."
+            },
+            "--name": {
+                "type": "string",
+                "description": "Unique deploy identifier attached to the instance of this script."
+            },
+            "--type": {
+                "type": "string",
+                "description": "WASM engine type (async, data-policy) (default \"async\")."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk wasm generate": {
+        "description": "Create a npm template project for inline WASM engine",
+        "usage": "Usage:\r\n  rpk wasm generate [PROJECT DIRECTORY] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for generate."
+            },
+            "--skip-version": {
+                "type": "-",
+                "description": "Omit wasm-api version check from npm, use default instead."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk wasm remove": {
+        "description": "Remove inline WASM function",
+        "usage": "Usage:\r\n  rpk wasm remove [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for remove."
+            },
+            "--type": {
+                "type": "string",
+                "description": "WASM engine type (async, data-policy) (default \"async\")."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk_version": "v22.3.25 (rev db0f35b)\r"
+}

--- a/tools/gen/22.3/rpk-acl-create.adoc
+++ b/tools/gen/22.3/rpk-acl-create.adoc
@@ -1,0 +1,84 @@
+= rpk acl create
+:description: rpk acl create
+
+Create ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. Following the
+multiplying effect of combining flags, the create command works on a
+straightforward basis: every ACL combination is a created ACL.
+
+As mentioned in the 'rpk acl' help text, if no host is specified, an allowed
+principal is allowed access from all hosts. The wildcard principal '*' allows
+all principals. At least one principal, one host, one resource, and one
+operation is required to create a single ACL.
+
+Allow all permissions to user bar on topic "foo" and group "g":
+    --allow-principal bar --operation all --topic foo --group g
+Allow read permissions to all users on topics biz and baz:
+    --allow-principal '*' --operation read --topic biz,baz
+Allow write permissions to user buzz to transactional id "txn":
+    --allow-principal User:buzz --operation write --transactional-id txn
+
+== Usage
+
+[,bash]
+----
+rpk acl create [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Hosts from which access will be granted (repeatable).
+
+|`--allow-principal` |strings |Principals for which these permissions will be granted (repeatable).
+
+|`--cluster` |- |Whether to grant ACLs to the cluster.
+
+|`--deny-host` |strings |Hosts from from access will be denied (repeatable).
+
+|`--deny-principal` |strings |Principal for which these permissions will be denied (repeatable).
+
+|`--group` |strings |Group to grant ACLs for (repeatable).
+
+|`-h, --help` |- |Help for create.
+
+|`--operation` |strings |Operation to grant (repeatable).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (literal or prefixed) (default "literal").
+
+|`--topic` |strings |Topic to grant ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to grant ACLs for (repeatable).
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-acl-delete.adoc
+++ b/tools/gen/22.3/rpk-acl-delete.adoc
@@ -1,0 +1,94 @@
+= rpk acl delete
+:description: rpk acl delete
+
+Delete ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. Delete flags work in a
+similar multiplying effect as creating ACLs, but delete is more advanced:
+deletion works on a filter basis. Any unspecified flag defaults to matching
+everything (all operations, or all allowed principals, etc). To ensure that you
+do not accidentally delete more than you intend, this command prints everything
+that matches your input filters and prompts for a confirmation before the
+delete request is issued. Anything matching more than 10 ACLs doubly confirms.
+
+As mentioned, not specifying flags matches everything. If no resources are
+specified, all resources are matched. If no operations are specified, all
+operations are matched. You can also opt in to matching everything with "any":
+--operation any matches any operation.
+
+The --resource-pattern-type, defaulting to "any", configures how to filter
+resource names:
+  * "any" returns exact name matches of either prefixed or literal pattern type
+  * "match" returns wildcard matches, prefix patterns that match your input, and literal matches
+  * "prefix" returns prefix patterns that match your input (prefix "fo" matches "foo")
+  * "literal" returns exact name matches
+
+== Usage
+
+[,bash]
+----
+rpk acl delete [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Allowed host ACLs to remove (repeatable).
+
+|`--allow-principal` |strings |Allowed principal ACLs to remove (repeatable).
+
+|`--cluster` |- |Whether to remove ACLs to the cluster.
+
+|`--deny-host` |strings |Denied host ACLs to remove (repeatable).
+
+|`--deny-principal` |strings |Denied principal ACLs to remove (repeatable).
+
+|`-d, --dry` |- |Dry run: validate what would be deleted.
+
+|`--group` |strings |Group to remove ACLs for (repeatable).
+
+|`-h, --help` |- |Help for delete.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`--operation` |strings |Operation to remove (repeatable).
+
+|`-f, --print-filters` |- |Print the filters that were requested (failed filters are always printed).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (any, match, literal, or prefixed) (default "any").
+
+|`--topic` |strings |Topic to remove ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to remove ACLs for (repeatable).
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-acl-list.adoc
+++ b/tools/gen/22.3/rpk-acl-list.adoc
@@ -1,0 +1,94 @@
+= rpk acl list
+:description: rpk acl list
+
+List ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. List flags work in a
+similar multiplying effect as creating ACLs, but list is more advanced:
+listing works on a filter basis. Any unspecified flag defaults to matching
+everything (all operations, or all allowed principals, etc).
+
+As mentioned, not specifying flags matches everything. If no resources are
+specified, all resources are matched. If no operations are specified, all
+operations are matched. You can also opt in to matching everything with "any":
+--operation any matches any operation.
+
+The --resource-pattern-type, defaulting to "any", configures how to filter
+resource names:
+  * "any" returns exact name matches of either prefixed or literal pattern type
+  * "match" returns wildcard matches, prefix patterns that match your input, and literal matches
+  * "prefix" returns prefix patterns that match your input (prefix "fo" matches "foo")
+  * "literal" returns exact name matches
+
+== Usage
+
+[,bash]
+----
+rpk acl list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls, describe
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Allowed host ACLs to match (repeatable).
+
+|`--allow-principal` |strings |Allowed principal ACLs to match (repeatable).
+
+|`--cluster` |- |Whether to match ACLs to the cluster.
+
+|`--deny-host` |strings |Denied host ACLs to match (repeatable).
+
+|`--deny-principal` |strings |Denied principal ACLs to match (repeatable).
+
+|`--group` |strings |Group to match ACLs for (repeatable).
+
+|`-h, --help` |- |Help for list.
+
+|`--operation` |strings |Operation to match (repeatable).
+
+|`-f, --print-filters` |- |Print the filters that were requested (failed filters are always printed).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (any, match, literal, or prefixed) (default "any").
+
+|`--topic` |strings |Topic to match ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to match ACLs for (repeatable).
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-acl-user-create.adoc
+++ b/tools/gen/22.3/rpk-acl-user-create.adoc
@@ -1,0 +1,65 @@
+= rpk acl user create
+:description: rpk acl user create
+
+Create a SASL user.
+
+This command creates a single SASL user with the given password, optionally
+with a custom "mechanism". SASL consists of three parts: a username, a
+password, and a mechanism. The mechanism determines which authentication flow
+the client will use for this user/pass.
+
+Redpanda currently supports two mechanisms: SCRAM-SHA-256, the default, and
+SCRAM-SHA-512, which is the same flow but uses sha512 rather than sha256.
+
+Using SASL requires setting "enable_sasl: true" in the redpanda section of your
+`redpanda.yaml`. Before a created SASL account can be used, you must also create
+ACLs to grant the account access to certain resources in your cluster. See the
+acl help text for more info.
+
+== Usage
+
+[,bash]
+----
+rpk acl user create [USER] -p [PASS] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for create.
+
+|`--mechanism` |string |SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive); not to be confused with the global flag --sasl-mechanism which is used for authenticating the rpk client (default "scram-sha-256").
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |strings |The comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-acl-user-delete.adoc
+++ b/tools/gen/22.3/rpk-acl-user-delete.adoc
@@ -1,0 +1,53 @@
+= rpk acl user delete
+:description: rpk acl user delete
+
+Delete a SASL user.
+
+This command deletes the specified SASL account from Redpanda. This does not
+delete any ACLs that may exist for this user.
+
+== Usage
+
+[,bash]
+----
+rpk acl user delete [USER] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |strings |The comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-acl-user-list.adoc
+++ b/tools/gen/22.3/rpk-acl-user-list.adoc
@@ -1,0 +1,57 @@
+= rpk acl user list
+:description: rpk acl user list
+
+List SASL users
+
+== Usage
+
+[,bash]
+----
+rpk acl user list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |strings |The comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-acl-user.adoc
+++ b/tools/gen/22.3/rpk-acl-user.adoc
@@ -1,0 +1,56 @@
+= rpk acl user
+:description: rpk acl user
+
+Manage SASL users.
+
+If SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs
+control what your user has access to. See 'rpk acl --help' for more information
+about ACLs, and 'rpk acl user create --help' for more information about
+creating SASL users. Using SASL requires setting "enable_sasl: true" in the
+redpanda section of your `redpanda.yaml`.
+
+== Usage
+
+[,bash]
+----
+rpk acl user [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--api-urls` |strings |The comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-h, --help` |- |Help for user.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-acl.adoc
+++ b/tools/gen/22.3/rpk-acl.adoc
@@ -1,0 +1,159 @@
+= rpk acl
+:description: rpk acl
+
+Manage ACLs and SASL users.
+
+This command space creates, lists, and deletes ACLs, as well as creates SASL
+users. The help text below is specific to ACLs. To learn about SASL users,
+check the help text under the "user" command.
+
+When using SASL, ACLs allow or deny you access to certain requests. The
+"create", "delete", and "list" commands help you manage your ACLs.
+
+An ACL is made up of five components:
+
+  * a principal (the user)
+  * a host the principal is allowed or denied requests from
+  * what resource to access (topic name, group ID, ...)
+  * the operation (read, write, ...)
+  * the permission: whether to allow or deny the above
+
+ACL commands work on a multiplicative basis. If creating, specifying two
+principals and two permissions creates four ACLs: both permissions for the
+first principal, as well as both permissions for the second principal. Adding
+two resources further doubles the ACLs created.
+
+It is recommended to be as specific as possible when granting ACLs. Granting
+more ACLs than necessary per principal may inadvertently allow clients to do
+things they should not, such as deleting topics or joining the wrong consumer
+group.
+
+PRINCIPALS
+
+All ACLs require a principal. A principal is composed of two parts: the type
+and the name. Within Redpanda, only one type is supported, "User". The reason
+for the prefix is that a potential future authorizer may add support for
+authorizing by Group or anything else.
+
+When you create a user, you need to add ACLs for it before it can be used. You
+can create / delete / list ACLs for that user with either "User:bar" or "bar"
+in the --allow-principal and --deny-principal flags. This command will add the
+"User:" prefix for you if it is missing. The wildcard '*' matches any user.
+Creating an ACL with user '*' grants or denies the permission for all users.
+
+HOSTS
+
+Hosts can be seen as an extension of the principal, and effectively gate where
+the principal can connect from. When creating ACLs, unless otherwise specified,
+the default host is the wildcard '*' which allows or denies the principal from
+all hosts (where allow & deny are based on whether --allow-principal or
+--deny-principal is used). If specifying hosts, you must pair the --allow-host
+flag with the --allow-principal flag, and the --deny-host flag with the
+--deny-principal flag.
+
+RESOURCES
+
+A resource is what an ACL allows or denies access to. There are four resources
+within Redpanda: topics, groups, the cluster itself, and transactional IDs.
+Names for each of these resources can be specified with their respective flags.
+
+Resources combine with the operation that is allowed or denied on that
+resource. The next section describes which operations are required for which
+requests, and further fleshes out the concept of a resource.
+
+By default, resources are specified on an exact name match (a "literal" match).
+The --resource-pattern-type flag can be used to specify that a resource name is
+"prefixed", meaning to allow anything with the given prefix. A literal name of
+"foo" will match only the topic "foo", while the prefixed name of "foo-" will
+match both "foo-bar" and "foo-baz". The special wildcard resource name '*'
+matches any name of the given resource type (--topic '*' matches all topics).
+
+OPERATIONS
+
+Pairing with resources, operations are the actions that are allowed or denied.
+Redpanda has the following operations:
+
+    ALL                 Allows all operations below.
+    READ                Allows reading a given resource.
+    WRITE               Allows writing to a given resource.
+    CREATE              Allows creating a given resource.
+    DELETE              Allows deleting a given resource.
+    ALTER               Allows altering non-configurations.
+    DESCRIBE            Allows querying non-configurations.
+    DESCRIBE_CONFIGS    Allows describing configurations.
+    ALTER_CONFIGS       Allows altering configurations.
+
+Check --help-operations to see which operations are required for which
+requests. In flag form to set up a general producing/consuming client, you can
+invoke 'rpk acl create' three times with the following (including your
+--allow-principal):
+
+    --operation write,read,describe --topic [topics]
+    --operation describe,read --group [group.id]
+    --operation describe,write --transactional-id [transactional.id]
+
+PERMISSIONS
+
+A client can be allowed access or denied access. By default, all permissions
+are denied. You only need to specifically deny a permission if you allow a wide
+set of permissions and then want to deny a specific permission in that set.
+You could allow all operations, and then specifically deny writing to topics.
+
+MANAGEMENT
+
+Creating ACLs works on a specific ACL basis, but listing and deleting ACLs
+works on filters. Filters allow matching many ACLs to be printed listed and
+deleted at once. Because this can be risky for deleting, the delete command
+prompts for confirmation by default. More details and examples for creating,
+listing, and deleting can be seen in each of the commands.
+
+Using SASL requires setting "enable_sasl: true" in the redpanda section of your
+`redpanda.yaml`. User management is a separate, simpler concept that is
+described in the user command.
+
+== Usage
+
+[,bash]
+----
+rpk acl [flags]
+  rpk acl [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for acl.
+
+|`--help-operations` |- |Print more help about ACL operations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cloud-byoc-install.adoc
+++ b/tools/gen/22.3/rpk-cloud-byoc-install.adoc
@@ -1,0 +1,32 @@
+= rpk cloud byoc install
+:description: rpk cloud byoc install
+
+Install the BYOC plugin
+
+This command downloads the BYOC managed plugin if necessary. The plugin is
+installed by default if you try to run a non-install command, but this command
+exists if you want to download the plugin ahead of time.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc install [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--client-id` |string |The client ID of the organization in Redpanda Cloud.
+
+|`--client-secret` |string |The client secret of the organization in Redpanda Cloud.
+
+|`-h, --help` |- |Help for install.
+
+|`--redpanda-id` |string |The redpanda ID of the cluster you are creating.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cloud-byoc-uninstall.adoc
+++ b/tools/gen/22.3/rpk-cloud-byoc-uninstall.adoc
@@ -1,0 +1,27 @@
+= rpk cloud byoc uninstall
+:description: rpk cloud byoc uninstall
+
+Uninstall the BYOC plugin
+
+This command deletes your locally downloaded BYOC managed plugin if it exists.
+Often, you only need to download the plugin to create your cluster once, and
+then you never need the plugin again. You can uninstall to save a small bit of
+disk space.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc uninstall [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for uninstall.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cloud-byoc.adoc
+++ b/tools/gen/22.3/rpk-cloud-byoc.adoc
@@ -1,0 +1,36 @@
+= rpk cloud byoc
+:description: rpk cloud byoc
+
+Manage a Redpanda cloud BYOC agent
+
+For BYOC, Redpanda installs an agent service in your owned cluster. The agent
+then proceeds to provision further infrastructure and eventually, a full
+Redpanda cluster.
+
+The BYOC command runs Terraform to create and start the agent. You first need
+a redpanda-id (or cluster ID); this is used to get the details of how your
+agent should be provisioned. You can create a BYOC cluster in our cloud UI
+and then come back to this command to complete the process.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc [flags]
+  rpk cloud byoc [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--client-id` |string |The client ID of the organization in Redpanda Cloud.
+
+|`--client-secret` |string |The client secret of the organization in Redpanda Cloud.
+
+|`-h, --help` |- |Help for byoc.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cloud-login.adoc
+++ b/tools/gen/22.3/rpk-cloud-login.adoc
@@ -1,0 +1,48 @@
+= rpk cloud login
+:description: rpk cloud login
+
+Log in to the Redpanda cloud
+
+This command checks for an existing token and, if present, ensures it is still
+valid. If no token is found or the token is no longer valid, this command will
+login and save your token.
+
+You may use any of the following methods to pass the cloud credentials to rpk:
+
+Logging in requires cloud credentials, which can be created in the Clients
+tab of the Users section in the Redpanda Cloud online interface. Client
+credentials can be provided in three ways, in order of preference:
+
+* In $HOME/.config/rpk/__cloud.yaml, in 'client_id' and 'client_secret' fields
+* Through RPK_CLOUD_CLIENT_ID and RPK_CLOUD_CLIENT_SECRET environment variables
+* Through the --client-id and --client-secret flags
+
+If none of these are provided, login will prompt you for the client ID and
+client secret and will save them to the __cloud.yaml file. If you specify
+environment variables or flags, they will not be synced to the __cloud.yaml
+file unless the --save flag is passed. The cloud authorization token is always 
+synced.
+
+== Usage
+
+[,bash]
+----
+rpk cloud login [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--client-id` |string |The client ID of the organization in Redpanda Cloud.
+
+|`--client-secret` |string |The client secret of the organization in Redpanda Cloud.
+
+|`-h, --help` |- |Help for login.
+
+|`--save` |- |Save environment or flag specified client ID and client secret to the configuration file.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cloud-logout.adoc
+++ b/tools/gen/22.3/rpk-cloud-logout.adoc
@@ -1,0 +1,28 @@
+= rpk cloud logout
+:description: rpk cloud logout
+
+Log out from Redpanda cloud
+
+This command deletes your cloud auth token. If you want to log out entirely and
+switch to a different organization, you can use the --clear-credentials flag to
+additionally clear your client ID and client secret.
+
+== Usage
+
+[,bash]
+----
+rpk cloud logout [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-c, --clear-credentials` |- |Clear the client ID and client secret in addition to the auth token.
+
+|`-h, --help` |- |Help for logout.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cloud.adoc
+++ b/tools/gen/22.3/rpk-cloud.adoc
@@ -1,0 +1,22 @@
+= rpk cloud
+:description: rpk cloud
+
+Interact with Redpanda cloud
+
+== Usage
+
+[,bash]
+----
+rpk cloud [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for cloud.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-config-edit.adoc
+++ b/tools/gen/22.3/rpk-cluster-config-edit.adoc
@@ -1,0 +1,65 @@
+= rpk cluster config edit
+:description: rpk cluster config edit
+
+Edit cluster-wide configuration properties.
+
+This command opens a text editor to modify the cluster's configuration.
+
+Cluster properties are redpanda settings which apply to all nodes in
+the cluster.  These are separate to node properties, which are set with
+'rpk redpanda config'.
+
+Modified values are written back when the file is saved and the editor
+is closed.  Properties which are deleted are reset to their default
+values.
+
+By default, low level tunables are excluded: use the '--all' flag
+to edit all properties including these tunables.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config edit [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for edit.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-config-export.adoc
+++ b/tools/gen/22.3/rpk-cluster-config-export.adoc
@@ -1,0 +1,61 @@
+= rpk cluster config export
+:description: rpk cluster config export
+
+Export cluster configuration.
+
+Writes out a YAML representation of the cluster configuration to a file,
+suitable for editing and later applying with the corresponding 'import'
+command.
+
+By default, low level tunables are excluded: use the '--all' flag
+to include all properties including these low level tunables.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config export [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --filename` |string |path to file to export to, e.g. './config.yml'.
+
+|`-h, --help` |- |Help for export.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-config-force-reset.adoc
+++ b/tools/gen/22.3/rpk-cluster-config-force-reset.adoc
@@ -1,0 +1,67 @@
+= rpk cluster config force-reset
+:description: rpk cluster config force-reset
+
+Forcibly clear a cluster configuration property on this node.
+
+This command is not for general changes to cluster configuration: use this only
+when redpanda will not start due to a configuration issue.
+
+If your cluster is working properly and you would like to reset a property
+to its default, you may use the 'set' command with an empty string, or
+use the 'edit' command and delete the property's line.
+
+This command erases a named property from an internal cache of the cluster
+configuration on the local node, so that on next startup redpanda will treat
+the setting as if it was set to the default.
+
+WARNING: this should only be used when redpanda is not running.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config force-reset [PROPERTY...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--cache-file` |string |location of configuration cache file (defaults to redpanda data directory).
+
+|`-h, --help` |- |Help for force-reset.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-config-get.adoc
+++ b/tools/gen/22.3/rpk-cluster-config-get.adoc
@@ -1,0 +1,55 @@
+= rpk cluster config get
+:description: rpk cluster config get
+
+Get a cluster configuration property.
+
+This command is provided for use in scripts.  For interactive editing, or bulk
+output, use the 'edit' and 'export' commands respectively.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config get <key> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for get.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-config-import.adoc
+++ b/tools/gen/22.3/rpk-cluster-config-import.adoc
@@ -1,0 +1,60 @@
+= rpk cluster config import
+:description: rpk cluster config import
+
+Import cluster configuration from a file.
+
+Import configuration from a YAML file, usually generated with
+corresponding 'export' command.  This downloads the current cluster
+configuration, calculates the difference with the YAML file, and
+updates any properties that were changed.  If a property is removed
+from the YAML file, it is reset to its default value.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config import [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --filename` |string |full path to file to import, e.g. '/tmp/config.yml'.
+
+|`-h, --help` |- |Help for import.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-config-lint.adoc
+++ b/tools/gen/22.3/rpk-cluster-config-lint.adoc
@@ -1,0 +1,56 @@
+= rpk cluster config lint
+:description: rpk cluster config lint
+
+Remove any deprecated content from `redpanda.yaml`.
+
+Deprecated content includes properties which were set via `redpanda.yaml`
+in earlier versions of redpanda, but are now managed via Redpanda's
+central configuration store (and via 'rpk cluster config edit').
+
+== Usage
+
+[,bash]
+----
+rpk cluster config lint [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for lint.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-config-set.adoc
+++ b/tools/gen/22.3/rpk-cluster-config-set.adoc
@@ -1,0 +1,57 @@
+= rpk cluster config set
+:description: rpk cluster config set
+
+Set a single cluster configuration property.
+
+This command is provided for use in scripts.  For interactive editing, or bulk
+changes, use the 'edit' and 'import' commands respectively.
+
+If an empty string is given as the value, the property is reset to its default.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config set <key> <value> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-config-status.adoc
+++ b/tools/gen/22.3/rpk-cluster-config-status.adoc
@@ -1,0 +1,61 @@
+= rpk cluster config status
+:description: rpk cluster config status
+
+Get configuration status of redpanda nodes.
+
+For each node, indicate whether a restart is required for settings to
+take effect, and any settings that the node has identified as invalid
+or unknown properties.
+
+Additionally show the version of cluster configuration that each node
+has applied: under normal circumstances these should all be equal,
+a lower number shows that a node is out of sync, perhaps because it
+is offline.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-config.adoc
+++ b/tools/gen/22.3/rpk-cluster-config.adoc
@@ -1,0 +1,70 @@
+= rpk cluster config
+:description: rpk cluster config
+
+Interact with cluster configuration properties.
+
+Cluster properties are redpanda settings which apply to all nodes in
+the cluster.  These are separate to node properties, which are set with
+'rpk redpanda config'.
+
+Use the 'edit' subcommand to interactively modify the cluster configuration, or
+'export' and 'import' to write configuration to a file that can be edited and
+read back later.
+
+These commands take an optional '--all' flag to include all properties including
+low level tunables such as internal buffer sizes, that do not usually need
+to be changed during normal operations.  These properties generally require
+some expertize to set safely, so if in doubt, avoid using '--all'.
+
+Modified properties are propagated immediately to all nodes.  The 'status'
+subcommand can be used to verify that all nodes are up to date, and identify
+any settings which were rejected by a node, for example if a node is running a
+different redpanda version that does not recognize certain properties.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`-h, --help` |- |Help for config.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-health.adoc
+++ b/tools/gen/22.3/rpk-cluster-health.adoc
@@ -1,0 +1,62 @@
+= rpk cluster health
+:description: rpk cluster health
+
+Queries health overview.
+
+Health overview is created based on the health reports collected periodically
+from all nodes in the cluster. A cluster is considered healthy when the
+following conditions are met:
+
+* all cluster nodes are responding
+* all partitions have leaders
+* the cluster controller is present
+
+== Usage
+
+[,bash]
+----
+rpk cluster health [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`-e, --exit-when-healthy` |- |When used with watch, exits after cluster is back in healthy state.
+
+|`-h, --help` |- |Help for health.
+
+|`-w, --watch` |- |Blocks and writes out all cluster health changes.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-license-info.adoc
+++ b/tools/gen/22.3/rpk-cluster-license-info.adoc
@@ -1,0 +1,57 @@
+= rpk cluster license info
+:description: rpk cluster license info
+
+Retrieve license information:
+
+    Organization:    Organization the license was generated for.
+    Type:            Type of license: free, enterprise, etc.
+    Expires:         Expiration date of the license
+    Version:         License schema version.
+
+== Usage
+
+[,bash]
+----
+rpk cluster license info [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (text, json) (default "text").
+
+|`-h, --help` |- |Help for info.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-license-set.adoc
+++ b/tools/gen/22.3/rpk-cluster-license-set.adoc
@@ -1,0 +1,63 @@
+= rpk cluster license set
+:description: rpk cluster license set
+
+Upload license to the cluster
+
+You can either provide a path to a file containing the license:
+
+    rpk cluster license set --path /home/organization/redpanda.license
+
+Or inline the license string:
+
+    rpk cluster license set <license string>
+
+If neither are present, rpk will look for the license in the
+default location '/etc/redpanda/redpanda.license'.
+
+== Usage
+
+[,bash]
+----
+rpk cluster license set [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--path` |string |Path to the license file.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-license.adoc
+++ b/tools/gen/22.3/rpk-cluster-license.adoc
@@ -1,0 +1,50 @@
+= rpk cluster license
+:description: rpk cluster license
+
+Manage cluster license.
+
+== Usage
+
+[,bash]
+----
+rpk cluster license [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`-h, --help` |- |Help for license.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-logdirs-describe.adoc
+++ b/tools/gen/22.3/rpk-cluster-logdirs-describe.adoc
@@ -1,0 +1,62 @@
+= rpk cluster logdirs describe
+:description: rpk cluster logdirs describe
+
+Describe log directories on Redpanda brokers.
+
+This command prints information about log directories on brokers, particularly,
+the base directory that topics and partitions are located in, and the size of
+data that has been written to the partitions. The size you see may not exactly
+match the size on disk as reported by du: Redpanda allocates files in chunks.
+The chunks will show up in du, while the actual bytes so far written to the
+file will show up in this command.
+
+The directory returned is the root directory for partitions. Within Redpanda,
+the partition data lives underneath the the returned root directory in
+
+    kafka/{topic}/{partition}_{revision}/
+
+where revision is a Redpanda internal concept.
+
+== Usage
+
+[,bash]
+----
+rpk cluster logdirs describe [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--aggregate-into` |string |If non-empty, what column to aggregate into starting from the partition column (broker, dir, topic).
+
+|`-b, --broker` |int32 |If non-negative, the specific broker to describe (default -1).
+
+|`-h, --help` |- |Help for describe.
+
+|`--sort-by-size` |- |If true, sort by size.
+
+|`--topics` |strings |Specific topics to describe.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-logdirs.adoc
+++ b/tools/gen/22.3/rpk-cluster-logdirs.adoc
@@ -1,0 +1,40 @@
+= rpk cluster logdirs
+:description: rpk cluster logdirs
+
+Describe log directories on Redpanda brokers
+
+== Usage
+
+[,bash]
+----
+rpk cluster logdirs [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for logdirs.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-maintenance-disable.adoc
+++ b/tools/gen/22.3/rpk-cluster-maintenance-disable.adoc
@@ -1,0 +1,50 @@
+= rpk cluster maintenance disable
+:description: rpk cluster maintenance disable
+
+Disable maintenance mode for a node.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance disable <broker-id> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for disable.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-maintenance-enable.adoc
+++ b/tools/gen/22.3/rpk-cluster-maintenance-enable.adoc
@@ -1,0 +1,55 @@
+= rpk cluster maintenance enable
+:description: rpk cluster maintenance enable
+
+Enable maintenance mode for a node.
+
+This command enables maintenance mode for the node with the specified ID. If a
+node exists that is already in maintenance mode then an error will be returned.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance enable <node-id> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for enable.
+
+|`-w, --wait` |- |Wait until node is drained.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-maintenance-status.adoc
+++ b/tools/gen/22.3/rpk-cluster-maintenance-status.adoc
@@ -1,0 +1,76 @@
+= rpk cluster maintenance status
+:description: rpk cluster maintenance status
+
+Report maintenance status.
+
+This command reports maintenance status for each node in the cluster. The output
+is presented as a table with each row representing a node in the cluster.  The
+output can be used to monitor the progress of node draining.
+
+   NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
+   1        false     false     false   0           0         0             0
+
+Field descriptions:
+
+        NODE-ID: the node ID
+       DRAINING: true if the node is actively draining leadership
+       FINISHED: leadership draining has completed
+         ERRORS: errors have been encountered while draining
+     PARTITIONS: number of partitions whose leadership has moved
+       ELIGIBLE: number of partitions with leadership eligible to move
+   TRANSFERRING: current active number of leadership transfers
+         FAILED: number of failed leadership transfers
+
+Notes:
+
+   - When errors are present further information will be available in the logs
+     for the corresponding node.
+
+   - Only partitions with more than one replica are eligible for leadership
+     transfer.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-maintenance.adoc
+++ b/tools/gen/22.3/rpk-cluster-maintenance.adoc
@@ -1,0 +1,68 @@
+= rpk cluster maintenance
+:description: rpk cluster maintenance
+
+Interact with cluster maintenance mode.
+
+Maintenance mode is a state that a node may be placed into in which the node
+may be shutdown or restarted with minimal disruption to client workloads. The
+primary use of maintenance mode is to perform a rolling upgrade in which each
+node is placed into maintenance mode prior to upgrading the node.
+
+Use the 'enable' and 'disable' subcommands to place a node into maintenance mode
+or remove it, respectively. Only one node at a time may be in maintenance mode.
+
+When a node is placed into maintenance mode the following occurs:
+
+Leadership draining. All raft leadership is transferred to another eligible
+node, and the node in maintenance mode rejects new leadership requests. By
+transferring leadership off of the node in maintenance mode all client traffic
+and requests are directed to other nodes minimizing disruption to client
+workloads when the node is shutdown.
+
+Currently leadership is not transferred for partitions with one replica.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|.
+
+|`-h, --help` |- |Help for maintenance.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-metadata.adoc
+++ b/tools/gen/22.3/rpk-cluster-metadata.adoc
@@ -1,0 +1,71 @@
+= rpk cluster metadata
+:description: rpk cluster metadata
+
+Request broker metadata.
+
+The Kafka protocol's metadata contains information about brokers, topics, and
+the cluster as a whole.
+
+This command only runs if specific sections of metadata are requested. There
+are currently three sections: the cluster, the list of brokers, and the topics.
+If no section is specified, this defaults to printing all sections.
+
+If the topic section is requested, all topics are requested by default unless
+some are manually specified as arguments. Expanded per-partition information
+can be printed with the -d flag, and internal topics can be printed with the -i
+flag.
+
+In the broker section, the controller node is suffixed with *.
+
+== Usage
+
+[,bash]
+----
+rpk cluster metadata [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+metadata, status, info
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for metadata.
+
+|`-b, --print-brokers` |- |Print brokers section.
+
+|`-c, --print-cluster` |- |Print cluster section.
+
+|`-d, --print-detailed-topics` |- |Print per-partition information for topics (implies -t).
+
+|`-i, --print-internal-topics` |- |Print internal topics (if all topics requested, implies -t).
+
+|`-t, --print-topics` |- |Print topics section (implied if any topics are specified).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-partitions-balancer-status.adoc
+++ b/tools/gen/22.3/rpk-cluster-partitions-balancer-status.adoc
@@ -1,0 +1,100 @@
+= rpk cluster partitions balancer-status
+:description: rpk cluster partitions balancer-status
+
+Queries cluster for partition balancer status:
+
+If continuous partition balancing is enabled, redpanda will continuously
+reassign partitions from both unavailable nodes and from nodes using more disk
+space than the configured limit.
+
+This command can be used to monitor the partition balancer status.
+
+FIELDS
+
+    Status:                        Either off, ready, starting, in progress, or
+                                   stalled.
+    Seconds Since Last Tick:       The last time the partition balancer ran.
+    Current Reassignments Count:   Current number of partition reassignments in
+                                   progress.
+    Unavailable Nodes:             The nodes that have been unavailable after a
+                                   time set by the
+                                   "partition_autobalancing_node_availability_timeout_sec"
+                                   cluster property.
+    Over Disk Limit Nodes:         The nodes that surpassed the threshold of
+                                   used disk percentage specified in the
+                                   "partition_autobalancing_max_disk_usage_percent"
+                                   cluster property.
+
+BALANCER STATUS
+
+    off:          The balancer is disabled.
+    ready:        The balancer is active but there is nothing to do.
+    starting:     The balancer is starting but has not run yet.
+    in_progress:  The balancer is active and is in the process of scheduling
+                  partition movements.
+    stalled:      Violations have been detected and the balancer cannot correct
+                  them.
+
+STALLED BALANCER
+
+A stalled balancer can occur for a few reasons and requires a bit of manual
+investigation. A few areas to investigate:
+
+* Are there are enough healthy nodes to which to move partitions? For example,
+  in a three node cluster, no movements are possible for partitions with three
+  replicas. You will see a stall every time there is a violation.
+
+* Does the cluster have sufficient space? If all nodes in the cluster are
+  utilizing more than 80% of their disk space, rebalancing cannot proceed.
+
+* Do all partitions have quorum? If the majority of a partition's replicas are
+  down, the partition cannot be moved.
+
+* Are any nodes in maintenance mode? Partitions are not moved if any node is in
+  maintenance mode.
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions balancer-status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for balancer-status.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-partitions-movement-cancel.adoc
+++ b/tools/gen/22.3/rpk-cluster-partitions-movement-cancel.adoc
@@ -1,0 +1,66 @@
+= rpk cluster partitions movement-cancel
+:description: rpk cluster partitions movement-cancel
+
+Cancel ongoing partition movements.
+
+By default, this command cancels all the partition movements in the cluster. 
+To ensure that you do not accidentally cancel all partition movements, this 
+command prompts users for confirmation before issuing the cancellation request. 
+You can use "--no-confirm" to disable the confirmation prompt:
+
+    rpk cluster partitions movement-cancel --no-confirm
+
+If "--node" is set, this command will only stop the partition movements 
+occurring in the specified node:
+
+    rpk cluster partitions movement-cancel --node 1
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions movement-cancel [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for movement-cancel.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`--node` |int |ID of a specific node on which to cancel ongoing partition movements (default -1).
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster-partitions.adoc
+++ b/tools/gen/22.3/rpk-cluster-partitions.adoc
@@ -1,0 +1,50 @@
+= rpk cluster partitions
+:description: rpk cluster partitions
+
+Manage cluster partitions
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`-h, --help` |- |Help for partitions.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-cluster.adoc
+++ b/tools/gen/22.3/rpk-cluster.adoc
@@ -1,0 +1,40 @@
+= rpk cluster
+:description: rpk cluster
+
+Interact with a Redpanda cluster
+
+== Usage
+
+[,bash]
+----
+rpk cluster [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for cluster.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-container-purge.adoc
+++ b/tools/gen/22.3/rpk-container-purge.adoc
@@ -1,0 +1,22 @@
+= rpk container purge
+:description: rpk container purge
+
+Stop and remove an existing local container cluster's data
+
+== Usage
+
+[,bash]
+----
+rpk container purge [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for purge.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-container-start.adoc
+++ b/tools/gen/22.3/rpk-container-start.adoc
@@ -1,0 +1,26 @@
+= rpk container start
+:description: rpk container start
+
+Start a local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for start.
+
+|`-n, --nodes` |- |uint     The number of nodes to start (default 1).
+
+|`--retries` |- |uint   The amount of times to check for the cluster before considering it unstable and exiting. (default 10).
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-container-stop.adoc
+++ b/tools/gen/22.3/rpk-container-stop.adoc
@@ -1,0 +1,22 @@
+= rpk container stop
+:description: rpk container stop
+
+Stop an existing local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for stop.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-container.adoc
+++ b/tools/gen/22.3/rpk-container.adoc
@@ -1,0 +1,22 @@
+= rpk container
+:description: rpk container
+
+Manage a local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for container.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-debug-bundle.adoc
+++ b/tools/gen/22.3/rpk-debug-bundle.adoc
@@ -1,0 +1,107 @@
+= rpk debug bundle
+:description: rpk debug bundle
+
+'rpk debug bundle' collects environment data that can help debug and diagnose
+issues with a redpanda cluster, a broker, or the machine it's running on. It
+then bundles the collected data into a zip file.
+
+The following are the data sources that are bundled in the compressed file:
+
+ - Kafka metadata: Broker configs, topic configs, start/committed/end offsets,
+   groups, group commits.
+
+ - Data directory structure: A file describing the data directory's contents.
+
+ - redpanda configuration: The redpanda configuration file (`redpanda.yaml`;
+   SASL credentials are stripped).
+
+ - /proc/cpuinfo: CPU information like make, core count, cache, frequency.
+
+ - /proc/interrupts: IRQ distribution across CPU cores.
+
+ - Resource usage data: CPU usage percentage, free memory available for the
+   redpanda process.
+
+ - Clock drift: The ntp clock delta (using pool.ntp.org as a reference) & round
+   trip time.
+
+ - Kernel logs: The kernel logs ring buffer (syslog).
+
+ - Broker metrics: The local broker's Prometheus metrics, fetched through its
+   admin API.
+
+ - DNS: The DNS info as reported by 'dig', using the hosts in
+   /etc/resolv.conf.
+
+ - Disk usage: The disk usage for the data directory, as output by 'du'.
+
+ - redpanda logs: The redpanda logs written to journald. If --logs-since or
+   --logs-until are passed, then only the logs within the resulting time frame
+   will be included.
+
+ - Socket info: The active sockets data output by 'ss'.
+
+ - Running process info: As reported by 'top'.
+
+ - Virtual memory stats: As reported by 'vmstat'.
+
+ - Network config: As reported by 'ip addr'.
+
+ - lspci: List the PCI buses and the devices connected to them.
+
+ - dmidecode: The DMI table contents. Only included if this command is run
+   as root.
+
+== Usage
+
+[,bash]
+----
+rpk debug bundle [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--admin-url` |string |The address to the broker's admin API. Defaults to the one in the config file.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for bundle.
+
+|`--logs-since` |string |Include log entries on or newer than the specified date. (journalctl date format, e.g. YYYY-MM-DD).
+
+|`--logs-size-limit` |string |Read the logs until the given size is reached. Multipliers are also supported, e.g. 3MB, 1GiB (default "100MiB").
+
+|`--logs-until` |string |Include log entries on or older than the specified date. (journalctl date format, e.g. YYYY-MM-DD).
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--timeout` |duration |How long to wait for child commands to execute (e.g. '30s', '1.5m') (default 10s).
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-debug.adoc
+++ b/tools/gen/22.3/rpk-debug.adoc
@@ -1,0 +1,22 @@
+= rpk debug
+:description: rpk debug
+
+Debug the local Redpanda process
+
+== Usage
+
+[,bash]
+----
+rpk debug [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for debug.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-generate-grafana-dashboard.adoc
+++ b/tools/gen/22.3/rpk-generate-grafana-dashboard.adoc
@@ -1,0 +1,28 @@
+= rpk generate grafana-dashboard
+:description: rpk generate grafana-dashboard
+
+Generate a Grafana dashboard for redpanda metrics
+
+== Usage
+
+[,bash]
+----
+rpk generate grafana-dashboard [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--datasource` |string |The name of the Prometheus datasource as configured in your grafana instance.
+
+|`-h, --help` |- |Help for grafana-dashboard.
+
+|`--job-name` |string |The prometheus job name by which to identify the redpanda nodes (default "redpanda").
+
+|`--metrics-endpoint` |string |The redpanda metrics endpoint where to get the metrics metadata. i.e. redpanda_host:9644/metrics (default "http://localhost:9644/metrics").
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-generate-prometheus-config.adoc
+++ b/tools/gen/22.3/rpk-generate-prometheus-config.adoc
@@ -1,0 +1,52 @@
+= rpk generate prometheus-config
+:description: rpk generate prometheus-config
+
+Generate the Prometheus configuration to scrape redpanda nodes. This command's
+output should be added to the 'scrape_configs' array in your Prometheus
+instance's YAML config file.
+
+If --seed-addr is passed, it will be used to discover the rest of the cluster
+hosts via Redpanda's Kafka API. If --node-addrs is passed, they will be used
+directly. Otherwise, 'rpk generate prometheus-conf' will read the redpanda
+config file and use the node IP configured there. --config may be passed to
+specify an arbitrary config file.
+
+If the node you want to scrape uses TLS, you can provide the TLS flags:
+--tls-key, --tls-cert, and --tls-truststore and rpk will generate the required
+tls_config section in the scrape configuration.
+
+== Usage
+
+[,bash]
+----
+rpk generate prometheus-config [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |The path to the redpanda config file.
+
+|`-h, --help` |- |Help for prometheus-config.
+
+|`--internal-metrics` |- |Include scrape config for internal metrics (/metrics).
+
+|`--job-name` |string |The prometheus job name by which to identify the redpanda nodes (default "redpanda").
+
+|`--node-addrs` |strings |A comma-delimited list of the addresses (|host|:|port|) of all the redpanda nodes in a cluster. The port must be the one configured for the nodes' admin API (9644 by default).
+
+|`--seed-addr` |string |The URL of a redpanda node with which to discover the rest.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-generate-shell-completion.adoc
+++ b/tools/gen/22.3/rpk-generate-shell-completion.adoc
@@ -1,0 +1,64 @@
+= rpk generate shell-completion
+:description: rpk generate shell-completion
+
+Shell completion can help autocomplete rpk commands when you press tab.
+
+# Bash
+
+Bash autocompletion relies on the bash-completion package. You can test if you
+have this by running "type _init_completion", if you do not, you can install
+the package through your package manager.
+
+If you have bash-completion installed, and the command still fails, you likely
+need to add the following line to your ~/.bashrc:
+
+    source /usr/share/bash-completion/bash_completion
+
+To ensure autocompletion of rpk exists in all shell sessions, add the following
+to your ~/.bashrc:
+
+    command -v rpk >/dev/null && . <(rpk generate shell-completion bash)
+
+Alternatively, to globally enable rpk completion, you can run the following:
+
+    rpk generate shell-completion bash > /etc/bash_completion.d/rpk
+
+# Zsh
+
+To enable autocompletion in any zsh session for any user, run this once:
+
+    rpk generate shell-completion zsh > "${fpath[1]}/_rpk"
+
+You can also place that command in your ~/.zshrc to ensure that when you update
+rpk, you update autocompletion. If you initially require sudo to edit that
+file, you can chmod it to be world writeable, after which you will always be
+able to update it from ~/.zshrc.
+
+If shell completion is not already enabled in your zsh environment, also
+add the following to your ~/.zshrc:
+
+    autoload -U compinit; compinit
+
+# Fish
+
+To enable autocompletion in any fish session, run:
+
+    rpk generate shell-completion fish > ~/.config/fish/completions/rpk.fish
+
+== Usage
+
+[,bash]
+----
+rpk generate shell-completion [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for shell-completion.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-generate.adoc
+++ b/tools/gen/22.3/rpk-generate.adoc
@@ -1,0 +1,22 @@
+= rpk generate
+:description: rpk generate
+
+Generate a configuration template for related services
+
+== Usage
+
+[,bash]
+----
+rpk generate [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for generate.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-group-delete.adoc
+++ b/tools/gen/22.3/rpk-group-delete.adoc
@@ -1,0 +1,57 @@
+= rpk group delete
+:description: rpk group delete
+
+Delete groups from brokers.
+
+Older versions of the Kafka protocol included a retention_millis field in
+offset commit requests. Group commits persisted for this retention and then
+eventually expired. Once all commits for a group expired, the group would be
+considered deleted.
+
+The retention field was removed because it proved problematic for infrequently
+committing consumers: the offsets could be expired for a group that was still
+active. If clients use new enough versions of OffsetCommit (versions that have
+removed the retention field), brokers expire offsets only when the group is
+empty for offset.retention.minutes. Redpanda does not currently support that
+configuration (see #2904), meaning offsets for empty groups expire only when
+they are explicitly deleted.
+
+You may want to delete groups to clean up offsets sooner than when they
+automatically are cleaned up, such as when you create temporary groups for
+quick investigation or testing. This command helps you do that.
+
+== Usage
+
+[,bash]
+----
+rpk group delete [GROUPS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-group-describe.adoc
+++ b/tools/gen/22.3/rpk-group-describe.adoc
@@ -1,0 +1,45 @@
+= rpk group describe
+:description: rpk group describe
+
+Describe group offset status & lag.
+
+This command describes group members, calculates their lag, and prints detailed
+information about the members.
+
+== Usage
+
+[,bash]
+----
+rpk group describe [GROUPS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for describe.
+
+|`-s, --print-summary` |- |Print only the group summary section.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-group-list.adoc
+++ b/tools/gen/22.3/rpk-group-list.adoc
@@ -1,0 +1,52 @@
+= rpk group list
+:description: rpk group list
+
+List all groups.
+
+This command lists all groups currently known to Redpanda, including empty
+groups that have not yet expired. The BROKER column is which broker node is the
+coordinator for the group. This command can be used to track down unknown
+groups, or to list groups that need to be cleaned up.
+
+== Usage
+
+[,bash]
+----
+rpk group list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-group-seek.adoc
+++ b/tools/gen/22.3/rpk-group-seek.adoc
@@ -1,0 +1,94 @@
+= rpk group seek
+:description: rpk group seek
+
+Modify a group's current offsets.
+
+This command allows you to modify a group's offsets. Sometimes, you may need to
+rewind a group if you had a mistaken deploy, or fast-forward a group if it is
+falling behind on messages that can be skipped.
+
+The --to option allows you to seek to the start of partitions, end of
+partitions, or after a specific timestamp. The default is to seek any topic
+previously committed. Using --topics allows to you set commits for only the
+specified topics; all other commits will remain untouched. Topics with no
+commits will not be committed unless allowed with --allow-new-topics.
+
+The --to-group option allows you to seek to commits that are in another group.
+This is a merging operation: if g1 is consuming topics A and B, and g2 is
+consuming only topic B, "rpk group seek g1 --to-group g2" will update g1's
+commits for topic B only. The --topics flag can be used to further narrow which
+topics are updated. Unlike --to, all non-filtered topics are committed, even
+topics not yet being consumed, meaning --allow-new-topics is not needed.
+
+The --to-file option allows to seek to offsets specified in a text file with
+the following format:
+    [TOPIC] [PARTITION] [OFFSET]
+    [TOPIC] [PARTITION] [OFFSET]
+    ...
+Each line contains the topic, the partition, and the offset to seek to. As with
+the prior options, --topics allows filtering which topics are updated. Similar
+to --to-group, all non-filtered topics are committed, even topics not yet being
+consumed, meaning --allow-new-topics is not needed.
+
+The --to, --to-group, and --to-file options are mutually exclusive. If you are
+not authorized to describe or read some topics used in a group, you will not be
+able to modify offsets for those topics.
+
+EXAMPLES
+
+Seek group G to June 1st, 2021:
+    rpk group seek g --to 1622505600
+    or, rpk group seek g --to 1622505600000
+    or, rpk group seek g --to 1622505600000000000
+Seek group X to the commits of group Y topic foo:
+    rpk group seek X --to-group Y --topics foo
+Seek group G's topics foo, bar, and biz to the end:
+    rpk group seek G --to end --topics foo,bar,biz
+Seek group G to the beginning of a topic it was not previously consuming:
+    rpk group seek G --to start --topics foo --allow-new-topics
+
+== Usage
+
+[,bash]
+----
+rpk group seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ... [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-new-topics` |- |Allow seeking to new topics not currently consumed (implied with --to-group or --to-file).
+
+|`-h, --help` |- |Help for seek.
+
+|`--to` |string |Where to seek (start, end, unix second | millisecond | nanosecond).
+
+|`--to-file` |string |Seek to offsets as specified in the file.
+
+|`--to-group` |string |Seek to the commits of another group.
+
+|`--topics` |strings |Only seek these topics, if any are specified.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-group.adoc
+++ b/tools/gen/22.3/rpk-group.adoc
@@ -1,0 +1,85 @@
+= rpk group
+:description: rpk group
+
+Describe, list, and delete consumer groups and manage their offsets.
+
+Consumer groups allow you to horizontally scale consuming from topics. A
+non-group consumer consumes all records from all partitions you assign it. In
+contrast, consumer groups allow many consumers to coordinate and divide work.
+If you have two members in a group consuming topics A and B, each with three
+partitions, then both members consume three partitions. If you add another
+member to the group, then each of the three members will consume two
+partitions. This allows you to horizontally scale consuming of topics.
+
+The unit of scaling is a single partition. If you add more consumers to a group
+than there are are total partitions to consume, then some consumers will be
+idle. More commonly, you have many more partitions than consumer group members
+and each member consumes a chunk of available partitions. One scenario where
+you may want more members than partitions is if you want active standby's to
+take over load immediately if any consuming member dies.
+
+How group members divide work is entirely client driven (the "partition
+assignment strategy" or "balancer" depending on the client). Brokers know
+nothing about how consumers are assigning partitions. A broker's role in group
+consuming is to choose which member is the leader of a group, forward that
+member's assignment to every other member, and ensure all members are alive
+through heartbeats.
+
+Consumers periodically commit their progress when consuming partitions. Through
+these commits, you can monitor just how far behind a consumer is from the
+latest messages in a partition. This is called "lag". Large lag implies that
+the client is having problems, which could be from the server being too slow,
+or the client being oversubscribed in the number of partitions it is consuming,
+or the server being in a bad state that requires restarting or removing from
+the server pool, and so on.
+
+You can manually manage offsets for a group, which allows you to rewind or
+forward commits. If you notice that a recent deploy of your consumers had a
+bug, you may want to stop all members, rewind the commits to before the latest
+deploy, and restart the members with a patch.
+
+This command allows you to list all groups, describe a group (to view the
+members and their lag), and manage offsets.
+
+== Usage
+
+[,bash]
+----
+rpk group [command]
+----
+
+== Aliases
+
+[,bash]
+----
+group, g
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for group.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-help.adoc
+++ b/tools/gen/22.3/rpk-help.adoc
@@ -1,0 +1,23 @@
+= rpk help
+:description: rpk help
+
+Help provides help for any command in the application.
+Simply type rpk help [path to command] for full details.
+
+== Usage
+
+[,bash]
+----
+rpk help [command] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |help for help.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-iotune.adoc
+++ b/tools/gen/22.3/rpk-iotune.adoc
@@ -1,0 +1,34 @@
+= rpk iotune
+:description: rpk iotune
+
+Measure filesystem performance and create IO configuration file
+
+== Usage
+
+[,bash]
+----
+rpk iotune [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--directories` |strings |List of directories to evaluate.
+
+|`--duration` |duration |Duration of tests.The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 10m0s).
+
+|`-h, --help` |- |Help for iotune.
+
+|`--no-confirm` |- |Disable confirmation prompt if the iotune file already exists.
+
+|`--out` |string |The file path where the IO config will be written (default "/etc/redpanda/io-config.yaml").
+
+|`--timeout` |duration |The maximum time after -- to wait for iotune to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 1h0m0s).
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-plugin-install.adoc
+++ b/tools/gen/22.3/rpk-plugin-install.adoc
@@ -1,0 +1,39 @@
+= rpk plugin install
+:description: rpk plugin install
+
+Install an rpk plugin.
+
+An rpk plugin must be saved in $HOME/.local/bin or in a directory that is in 
+your $PATH. By default, this command installs plugins to $HOME/.local/bin. This 
+can be overridden by specifying the --dir flag.
+
+If --dir is not present, rpk will create $HOME/.local/bin if it does not exist.
+
+== Usage
+
+[,bash]
+----
+rpk plugin install [PLUGIN] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+install, download
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--dir` |string |Destination directory to save the installed plugin (defaults to $HOME/.local/bin) (default "/var/lib/redpanda/.local/bin").
+
+|`-h, --help` |- |Help for install.
+
+|`-u, --update` |- |Update a locally installed plugin if it differs from the current remote version.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-plugin-list.adoc
+++ b/tools/gen/22.3/rpk-plugin-list.adoc
@@ -1,0 +1,33 @@
+= rpk plugin list
+:description: rpk plugin list
+
+List all available plugins.
+
+By default, this command fetches the remote manifest and prints plugins
+available for download. Any plugin that is already downloaded is prefixed with
+an asterisk. If a locally installed plugin has a different sha256sum as the one
+specified in the manifest, or if the sha256sum could not be calculated for the
+local plugin, an additional message is printed.
+
+You can specify --local to print all locally installed plugins, as well as
+whether you have "shadowed" plugins (the same plugin specified multiple times).
+
+== Usage
+
+[,bash]
+----
+rpk plugin list [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`-l, --local` |- |List locally installed plugins and shadowed plugins.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-plugin-uninstall.adoc
+++ b/tools/gen/22.3/rpk-plugin-uninstall.adoc
@@ -1,0 +1,36 @@
+= rpk plugin uninstall
+:description: rpk plugin uninstall
+
+Uninstall / remove an existing local plugin.
+
+This command lists locally installed plugins and removes the first plugin that
+matches the requested removal. If --include-shadowed is specified, this command
+also removes all shadowed plugins of the same name. To remove a command under a
+nested namespace ("rpk foo bar"), you can use "foo_bar".
+
+== Usage
+
+[,bash]
+----
+rpk plugin uninstall [NAME] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+uninstall, rm
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for uninstall.
+
+|`--include-shadowed` |- |Also remove shadowed plugins that have the same name.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-plugin.adoc
+++ b/tools/gen/22.3/rpk-plugin.adoc
@@ -1,0 +1,63 @@
+= rpk plugin
+:description: rpk plugin
+
+List, download, update, and remove rpk plugins.
+	
+Plugins augment rpk with new commands.
+
+For a plugin to be used, it must be in $HOME/.local/bin or somewhere 
+discoverable by rpk in your $PATH. All plugins follow a defined naming scheme:
+
+  .rpk-|name|
+  .rpk.ac-|name|
+
+All plugins are prefixed with either .rpk- or .rpk.ac-. When rpk starts up, it
+searches all directories in your $PATH for any executable binary that begins
+with either of those prefixes. For any binary it finds, rpk adds a command for
+that name to the rpk command space itself.
+
+No plugin name can shadow an existing rpk command, and only one plugin can
+exist under a given name at once. Plugins are added to the rpk command space on
+a first-seen basis. If you have two plugins rpk-foo, and the second is
+discovered later on in the $PATH directories, then only the first will be used.
+The second will be ignored.
+
+Plugins that have an .rpk.ac- prefix indicate that they support the
+--help-autocomplete flag. If rpk sees this, rpk will exec the plugin with that
+flag when rpk starts up, and the plugin will return all commands it supports as
+well as short and long help test for each command. Rpk uses this return to
+build a shadow command space within rpk itself so that it looks as if the
+plugin exists within rpk. This is particularly useful if you enable
+autocompletion.
+
+The expected return for plugins from --help-autocomplete is an array of the
+following:
+
+  type pluginHelp struct {
+          Path    string   `json:"path,omitempty"`
+          Short   string   `json:"short,omitempty"`
+          Long    string   `json:"long,omitempty"`
+          Example string   `json:"example,omitempty"`
+          Args    []string `json:"args,omitempty"`
+  }
+
+where "path" is an underscore delimited argument path to a command. For
+example, "foo_bar_baz" corresponds to the command "rpk foo bar baz".
+
+== Usage
+
+[,bash]
+----
+rpk plugin [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for plugin.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-brokers-decommission-status.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-brokers-decommission-status.adoc
@@ -1,0 +1,36 @@
+= rpk redpanda admin brokers decommission-status
+:description: rpk redpanda admin brokers decommission-status
+
+Show the progress of a node decommissioning
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers decommission-status [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --detailed` |- |Print how much data moved and remaining in bytes.
+
+|`-h, --help` |- |Help for decommission-status.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-brokers-decommission.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-brokers-decommission.adoc
@@ -1,0 +1,45 @@
+= rpk redpanda admin brokers decommission
+:description: rpk redpanda admin brokers decommission
+
+Decommission the given broker.
+
+Decommissioning a broker removes it from the cluster.
+
+A decommission request is sent to every broker in the cluster, only the cluster
+leader handles the request.
+
+For safety on v22.x clusters, this command will not run if the requested 
+broker is in maintenance mode. As of v23.x, Redpanda supports 
+decommissioning a node that is currently in maintenance mode. If you are on 
+a v22.x cluster and need to bypass the maintenance mode check (perhaps your 
+cluster is unreachable), use the hidden --force flag.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers decommission [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for decommission.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-brokers-list.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-brokers-list.adoc
@@ -1,0 +1,41 @@
+= rpk redpanda admin brokers list
+:description: rpk redpanda admin brokers list
+
+List the brokers in your cluster
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-brokers-recommission.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-brokers-recommission.adoc
@@ -1,0 +1,42 @@
+= rpk redpanda admin brokers recommission
+:description: rpk redpanda admin brokers recommission
+
+Recommission the given broker if is is still decommissioning.
+
+Recommissioning can stop an active decommission.
+
+Once a broker is decommissioned, it cannot be recommissioned through this
+command.
+
+A recommission request is sent to every broker in the cluster, only
+the cluster leader handles the request.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers recommission [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for recommission.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-brokers.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-brokers.adoc
@@ -1,0 +1,34 @@
+= rpk redpanda admin brokers
+:description: rpk redpanda admin brokers
+
+View and configure Redpanda brokers through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for brokers.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-config-log-level-set.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-config-log-level-set.adoc
@@ -1,0 +1,57 @@
+= rpk redpanda admin config log-level set
+:description: rpk redpanda admin config log-level set
+
+Set broker logger's log level.
+
+This command temporarily changes a broker logger's log level. Each Redpanda
+broker has many loggers, and each can be individually changed. Any change
+to a logger persists for a limited amount of time, so as to ensure you do
+not accidentally enable debug logging permanently.
+
+It is optional to specify a logger; if you do not, this command will prompt
+from the set of available loggers.
+
+The special logger "all" enables all loggers. Alternatively, you can specify
+many loggers at once. To see all possible loggers, run the following command:
+
+  redpanda --help-loggers
+
+This command accepts loggers that it does not know of to ensure you can
+independently update your redpanda installations from rpk. The success or
+failure of enabling each logger is individually printed.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config log-level set [LOGGERS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-e, --expiry-seconds` |int |seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown) (default 300).
+
+|`-h, --help` |- |Help for set.
+
+|`--host` |string |either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to.
+
+|`-l, --level` |string |log level to set (error, warn, info, debug, trace) (default "debug").
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-config-log-level.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-config-log-level.adoc
@@ -1,0 +1,34 @@
+= rpk redpanda admin config log-level
+:description: rpk redpanda admin config log-level
+
+Manage a broker's log level
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config log-level [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for log-level.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-config-print.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-config-print.adoc
@@ -1,0 +1,43 @@
+= rpk redpanda admin config print
+:description: rpk redpanda admin config print
+
+Display the current Redpanda configuration
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config print [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+print, dump, list, ls, display
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for print.
+
+|`--host` |string |either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-config.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-config.adoc
@@ -1,0 +1,34 @@
+= rpk redpanda admin config
+:description: rpk redpanda admin config
+
+View or modify Redpanda configuration through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for config.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-partitions-list.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-partitions-list.adoc
@@ -1,0 +1,43 @@
+= rpk redpanda admin partitions list
+:description: rpk redpanda admin partitions list
+
+List the partitions in a broker in the cluster
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin partitions list [BROKER ID] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`-l, --leader-only` |- |print the partitions on broker which are leaders.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin-partitions.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin-partitions.adoc
@@ -1,0 +1,34 @@
+= rpk redpanda admin partitions
+:description: rpk redpanda admin partitions
+
+View and configure Redpanda partitions through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin partitions [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for partitions.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-admin.adoc
+++ b/tools/gen/22.3/rpk-redpanda-admin.adoc
@@ -1,0 +1,34 @@
+= rpk redpanda admin
+:description: rpk redpanda admin
+
+Talk to the Redpanda admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for admin.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-check.adoc
+++ b/tools/gen/22.3/rpk-redpanda-check.adoc
@@ -1,0 +1,26 @@
+= rpk redpanda check
+:description: rpk redpanda check
+
+Check if system meets redpanda requirements
+
+== Usage
+
+[,bash]
+----
+rpk redpanda check [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for check.
+
+|`--timeout` |duration |The maximum amount of time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 2s).
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-config-bootstrap.adoc
+++ b/tools/gen/22.3/rpk-redpanda-config-bootstrap.adoc
@@ -1,0 +1,41 @@
+= rpk redpanda config bootstrap
+:description: rpk redpanda config bootstrap
+
+Initialize the configuration to bootstrap a cluster.
+
+This command generates a `redpanda.yaml` configuration file to bootstrap a
+cluster. If you are modifying the configuration file further, it is recommended
+to first bootstrap and then modify. If the file already exists, this command
+will set fields as requested by flags, and this may undo some of your earlier
+edits.
+
+The --ips flag specifies seed servers (ips, ip:ports, or hostnames) that this
+broker will use to form a cluster.
+
+By default, redpanda expects your machine to have one private IP address, and
+redpanda will listen on it. If your machine has multiple private IP addresses,
+you must use the --self flag to specify which ip redpanda should listen on.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config bootstrap [--self <ip>] [--ips <ip1,ip2,...>] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default location.
+
+|`-h, --help` |- |Help for bootstrap.
+
+|`--ips` |strings |Comma-separated list of the seed node addresses or hostnames; at least three are recommended.
+
+|`--self` |string |Optional IP address for redpanda to listen on; if empty, defaults to a private address.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-config-init.adoc
+++ b/tools/gen/22.3/rpk-redpanda-config-init.adoc
@@ -1,0 +1,24 @@
+= rpk redpanda config init
+:description: rpk redpanda config init
+
+Init the node after install, by setting the node's UUID
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config init [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default location.
+
+|`-h, --help` |- |Help for init.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-config-set.adoc
+++ b/tools/gen/22.3/rpk-redpanda-config-set.adoc
@@ -1,0 +1,53 @@
+= rpk redpanda config set
+:description: rpk redpanda config set
+
+Set configuration values, such as the redpanda node ID or the list of seed servers
+
+This command modifies the `redpanda.yaml` you have locally on disk. The first
+argument is the key within the yaml representing a property / field that you
+would like to set. Nested fields can be accessed through a dot:
+
+  rpk redpanda config set redpanda.developer_mode true
+
+The default format is to parse the value as yaml. Individual specific fields
+can be set, or full structs:
+
+  rpk redpanda config set rpk.tune_disk_irq true
+  rpk redpanda config set redpanda.rpc_server '{address: 3.250.158.1, port: 9092}'
+
+You can set an entire array by wrapping all items with braces, or by using one
+struct:
+
+  rpk redpanda config set redpanda.advertised_kafka_api '[{address: 0.0.0.0, port: 9092}]'
+  rpk redpanda config set redpanda.advertised_kafka_api '{address: 0.0.0.0, port: 9092}' # same
+
+Indexing can be used to set specific items in an array. You can index one past
+the end of an array to extend it:
+
+  rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 0.0.0.0, port: 9092}'
+
+The json format can be used to set values as json:
+
+  rpk redpanda config set redpanda.rpc_server '{"address":"0.0.0.0","port":33145}' --format json
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config set <key> <value> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default location.
+
+|`--format` |string |Format of the value (yaml/json) (default "yaml").
+
+|`-h, --help` |- |Help for set.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-config.adoc
+++ b/tools/gen/22.3/rpk-redpanda-config.adoc
@@ -1,0 +1,22 @@
+= rpk redpanda config
+:description: rpk redpanda config
+
+Edit configuration
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for config.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-mode.adoc
+++ b/tools/gen/22.3/rpk-redpanda-mode.adoc
@@ -1,0 +1,24 @@
+= rpk redpanda mode
+:description: rpk redpanda mode
+
+Enable a default configuration mode
+
+== Usage
+
+[,bash]
+----
+rpk redpanda mode <mode> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for mode.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-start.adoc
+++ b/tools/gen/22.3/rpk-redpanda-start.adoc
@@ -1,0 +1,52 @@
+= rpk redpanda start
+:description: rpk redpanda start
+
+Start redpanda
+
+== Usage
+
+[,bash]
+----
+rpk redpanda start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--advertise-kafka-addr` |strings |A comma-separated list of Kafka addresses to advertise (|name|://|host|:|port|).
+
+|`--advertise-pandaproxy-addr` |strings |A comma-separated list of Pandaproxy addresses to advertise (|name|://|host|:|port|).
+
+|`--advertise-rpc-addr` |string |The advertised RPC address (|host|:|port|).
+
+|`--check` |- |When set to false will disable system checking before starting redpanda (default true).
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for start.
+
+|`--install-dir` |string |Directory where redpanda has been installed.
+
+|`--kafka-addr` |strings |A comma-separated list of Kafka listener addresses to bind to (|name|://|host|:|port|).
+
+|`--mode` |string |Mode sets well-known configuration properties for development or test environments; use --mode help for more info.
+
+|`--pandaproxy-addr` |strings |A comma-separated list of Pandaproxy listener addresses to bind to (|name|://|host|:|port|).
+
+|`--rpc-addr` |string |The RPC address to bind to (|host|:|port|).
+
+|`--schema-registry-addr` |strings |A comma-separated list of Schema Registry listener addresses to bind to (|name|://|host|:|port|).
+
+|`-s, --seeds` |strings |A comma-separated list of seed node addresses (|host|[:|port|]) to connect to.
+
+|`--timeout` |duration |The maximum time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 10s).
+
+|`--tune` |- |When present will enable tuning before starting redpanda.
+
+|`--well-known-io` |string |The cloud vendor and VM type, in the format |vendor|:|vm type|:|storage type|.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-stop.adoc
+++ b/tools/gen/22.3/rpk-redpanda-stop.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda stop
+:description: rpk redpanda stop
+
+Stop a local redpanda process. 'rpk stop'
+first sends SIGINT, and waits for the specified timeout. Then, if redpanda
+hasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still
+running.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for stop.
+
+|`--timeout` |duration |The maximum amount of time to wait for redpanda to stop,after each signal is sent. The value passed is asequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 5s).
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-tune-help.adoc
+++ b/tools/gen/22.3/rpk-redpanda-tune-help.adoc
@@ -1,0 +1,22 @@
+= rpk redpanda tune help
+:description: rpk redpanda tune help
+
+Display detailed information about the tuner
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune help <tuner> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for help.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-tune-list.adoc
+++ b/tools/gen/22.3/rpk-redpanda-tune-list.adoc
@@ -1,0 +1,44 @@
+= rpk redpanda tune list
+:description: rpk redpanda tune list
+
+List available redpanda tuners and check if they are enabled and 
+supported by your system
+
+To enable a tuner it must be set in the `redpanda.yaml` configuration file
+under rpk section, e.g:
+
+  rpk:
+      tune_cpu: true
+      tune_swappiness: true
+
+You may use 'rpk redpanda config set' to enable or disable a tuner.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune list [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-r, --dirs` |strings |List of *data* directories or places to store data, i.e.: '/var/vectorized/redpanda/', usually your XFS filesystem on an NVMe SSD device.
+
+|`-d, --disks` |strings |Lists of devices to tune f.e. 'sda1'.
+
+|`-h, --help` |- |Help for list.
+
+|`-m, --mode` |string |Operation Mode: one of: [sq, sq_split, mq].
+
+|`-n, --nic` |strings |Network Interface Controllers to tune.
+
+|`--reboot-allowed` |- |If set will allow tuners to tune boot parameters and request system reboot.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda-tune.adoc
+++ b/tools/gen/22.3/rpk-redpanda-tune.adoc
@@ -1,0 +1,60 @@
+= rpk redpanda tune
+:description: rpk redpanda tune
+
+Sets the OS parameters to tune system performance.
+
+Available tuners:
+
+  - all.
+  - swappiness
+  - transparent_hugepages
+  - coredump
+  - disk_irq
+  - disk_nomerges
+  - fstrim
+  - net
+  - aio_events
+  - disk_scheduler
+  - disk_write_cache
+  - cpu
+  - clocksource
+  - ballast_file
+
+To learn more about a tuner, run 'rpk redpanda tune help |tuner name|'.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune <list of elements to tune> [flags]
+  rpk redpanda tune [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--cpu-set` |string |Set of CPUs for tuner to use in cpuset(7) format if not specified tuner will use all available CPUs (default "all").
+
+|`-r, --dirs` |strings |List of *data* directories or places to store data, i.e.: '/var/vectorized/redpanda/', usually your XFS filesystem on an NVMe SSD device.
+
+|`-d, --disks` |strings |Lists of devices to tune f.e. 'sda1'.
+
+|`-h, --help` |- |Help for tune.
+
+|`-m, --mode` |string |Operation Mode: one of: [sq, sq_split, mq].
+
+|`-n, --nic` |strings |Network Interface Controllers to tune.
+
+|`--output-script` |string |If set tuners will generate tuning file that can later be used to tune the system.
+
+|`--reboot-allowed` |- |If set will allow tuners to tune boot parameters and request system reboot.
+
+|`--timeout` |duration |The maximum time to wait for the tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 10s).
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-redpanda.adoc
+++ b/tools/gen/22.3/rpk-redpanda.adoc
@@ -1,0 +1,22 @@
+= rpk redpanda
+:description: rpk redpanda
+
+Interact with a local Redpanda process
+
+== Usage
+
+[,bash]
+----
+rpk redpanda [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for redpanda.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-topic-add-partitions.adoc
+++ b/tools/gen/22.3/rpk-topic-add-partitions.adoc
@@ -1,0 +1,42 @@
+= rpk topic add-partitions
+:description: rpk topic add-partitions
+
+Add partitions to existing topics.
+
+== Usage
+
+[,bash]
+----
+rpk topic add-partitions [TOPICS...] --num [#] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for add-partitions.
+
+|`-n, --num` |int |Number of partitions to add to each topic.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-topic-alter-config.adoc
+++ b/tools/gen/22.3/rpk-topic-alter-config.adoc
@@ -1,0 +1,63 @@
+= rpk topic alter-config
+:description: rpk topic alter-config
+
+Set, delete, add, and remove key/value configs for a topic.
+
+This command allows you to incrementally alter the configuration for multiple
+topics at a time.
+
+Incremental altering supports four operations:
+
+  1) Setting a key=value pair
+  2) Deleting a key's value
+  3) Appending a new value to a list-of-values key
+  4) Subtracting (removing) an existing value from a list-of-values key
+
+The --dry option will validate whether the requested configuration change is
+valid, but does not apply it.
+
+== Usage
+
+[,bash]
+----
+rpk topic alter-config [TOPICS...] --set key=value --delete key2,key3 [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--append` |stringArray |key=value; Value to append to a list-of-values key (repeatable).
+
+|`-d, --delete` |stringArray |Key to delete (repeatable).
+
+|`--dry` |- |Dry run: validate the alter request, but do not apply.
+
+|`-h, --help` |- |Help for alter-config.
+
+|`-s, --set` |stringArray |key=value; Pair to set (repeatable).
+
+|`--subtract` |stringArray |key=value; Value to remove from list-of-values key (repeatable).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-topic-consume.adoc
+++ b/tools/gen/22.3/rpk-topic-consume.adoc
@@ -1,0 +1,310 @@
+= rpk topic consume
+:description: rpk topic consume
+
+Consume records from topics.
+
+Consuming records reads from any amount of input topics, formats each record
+according to --format, and prints them to STDOUT. The output formatter
+understands a wide variety of formats.
+
+The default output format "--format json" is a special format that outputs each
+record as JSON. There may be more single-word-no-escapes formats added later.
+Outside of these special formats, formatting follows the rules described below.
+
+Formatting output is based on percent escapes and modifiers. Slashes can be
+used for common escapes:
+
+    \t \n \r \\ \xNN
+
+prints tabs, newlines, carriage returns, slashes, or hex encoded characters.p
+
+Percent encoding prints record fields, fetch partition fields, or extra values:
+
+    %t    topic
+    %T    topic length
+    %k    key
+    %K    key length
+    %v    topic
+    %V    value length
+    %h    begin the header specification
+    %H    number of headers
+    %p    partition
+    %o    offset
+    %e    leader epoch
+    %d    timestamp (formatting described below)
+    %a    record attributes (formatting described below)
+    %x    producer id
+    %y    producer epoch
+
+    %[    partition log start offset
+    %|    partition last stable offset
+    %]    partition high watermark
+
+    %%    percent sign
+    %{    left brace
+    %}    right brace
+
+    %i    the number of records formatted
+
+MODIFIERS
+
+Text and numbers can be formatted in many different ways, and the default
+format can be changed within brace modifiers. %v prints a value, while %v{hex}
+prints the value hex encoded. %T prints the length of a topic in ascii, while
+%T{big8} prints the length of the topic as an eight byte big endian.
+
+All modifiers go within braces following a percent-escape.
+
+NUMBERS
+
+Formatting number values can have the following modifiers:
+
+     ascii       print the number as ascii (default)
+
+     hex64       sixteen hex characters
+     hex32       eight hex characters
+     hex16       four hex characters
+     hex8        two hex characters
+     hex4        one hex character
+
+     big64       eight byte big endian number
+     big32       four byte big endian number
+     big16       two byte big endian number
+     big8        alias for byte
+
+     little64    eight byte little endian number
+     little32    four byte little endian number
+     little16    two byte little endian number
+     little8     alias for byte
+
+     byte        one byte number
+     bool        "true" if the number is non-zero, "false" if the number is zero
+
+All numbers are truncated as necessary per the modifier. Printing %V{byte} for
+a length 256 value will print a single null, whereas printing %V{big8} would
+print the bytes 1 and 0.
+
+When writing number sizes, the size corresponds to the size of the raw values,
+not the size of encoded values. "%T% t{hex}" for the topic "foo" will print
+"3 666f6f", not "6 666f6f".
+
+TIMESTAMPS
+
+By default, the timestamp field is printed as a millisecond number value. In
+addition to the number modifiers above, timestamps can be printed with either
+Go formatting or strftime formatting:
+
+    %d{go[2006-01-02T15:04:05Z07:00]}
+    %d{strftime[%F]}
+
+An arbitrary amount of brackets (or braces, or # symbols) can wrap your date
+formatting:
+
+    %d{strftime### [%F] ###}
+
+The above will print " [YYYY-MM-DD] ", while the surrounding three # on each
+side are used to wrap the formatting. Further details on Go time formatting can
+be found at https://pkg.go.dev/time, while further details on strftime
+formatting can be read by checking "man strftime".
+
+ATTRIBUTES
+
+Each record (or batch of records) has a set of possible attributes. Internally,
+these are packed into bit flags. Printing an attribute requires first selecting
+which attribute you want to print, and then optionally specifying how you want
+it to be printed:
+
+     %a{compression}
+     %a{compression;number}
+     %a{compression;big64}
+     %a{compression;hex8}
+
+Compression is by default printed as text ("none", "gzip", ...). Compression
+can be printed as a number with ";number", where number is any number
+formatting option described above. No compression is 0, gzip is 1, etc.
+
+     %a{timestamp-type}
+     %a{timestamp-type;big64}
+
+The record's timestamp type is printed as -1 for very old records (before
+timestamps existed), 0 for client generated timestamps, and 1 for broker
+generated timestamps. Number formatting can be controlled with ";number".
+
+     %a{transactional-bit}
+     %a{transactional-bit;bool}
+
+Prints 1 if the record a part of a transaction or 0 if it is not.
+Number formatting can be controlled with ";number".
+
+     %a{control-bit}
+     %a{control-bit;bool}
+
+Prints 1 if the record is a commit marker or 0 if it is not.
+Number formatting can be controlled with ";number".
+
+TEXT
+
+Text fields without modifiers default to writing the raw bytes. Alternatively,
+there are the following modifiers:
+
+    %t{hex}
+    %k{base64}
+    %v{base64raw}
+    %v{unpack[<bBhH>iIqQc.$]}
+
+The hex modifier hex encodes the text, the base64 modifier base64 encodes the
+text with standard encoding, and the base64raw modifier encodes the text with
+raw standard encoding. The unpack modifier has a further internal
+specification, similar to timestamps above:
+
+    x    pad character (does not parse input)
+    <    switch what follows to little endian
+    >    switch what follows to big endian
+
+    b    signed byte
+    B    unsigned byte
+    h    int16  ("half word")
+    H    uint16 ("half word")
+    i    int32
+    I    uint32
+    q    int64  ("quad word")
+    Q    uint64 ("quad word")
+
+    c    any character
+    .    alias for c
+    s    consume the rest of the input as a string
+    $    match the end of the line (append error string if anything remains)
+
+Unpacking text can allow translating binary input into readable output. If a
+value is a big-endian uint32, %v will print the raw four bytes, while
+%v{unpack[>I]} will print the number in as ascii. If unpacking exhausts the
+input before something is unpacked fully, an error message is appended to the
+output.
+
+HEADERS
+
+Headers are formatted with percent encoding inside of the modifier:
+
+    %h{ %k=%v{hex} }
+
+will print all headers with a space before the key and after the value, an
+equals sign between the key and value, and with the value hex encoded. Header
+formatting actually just parses the internal format as a record format, so all
+of the above rules about %K, %V, text, and numbers apply.
+
+EXAMPLES
+
+A key and value, separated by a space and ending in newline:
+    -f '%k %v\n'
+A key length as four big endian bytes, and the key as hex:
+    -f '%K{big32}%k{hex}'
+A little endian uint32 and a string unpacked from a value:
+    -f '%v{unpack[is$]}'
+
+OFFSETS
+
+The --offset flag allows for specifying where to begin consuming, and
+optionally, where to stop consuming. The literal words "start" and "end"
+specify consuming from the start and the end.
+
+    start     consume from the beginning
+    end       consume from the end
+    :end      consume until the current end
+    +oo       consume oo after the current start offset
+    -oo       consume oo before the current end offset
+    oo        consume after an exact offset
+    oo:       alias for oo
+    :oo       consume until an exact offset
+    o1:o2     consume from exact offset o1 until exact offset o2
+    @t        consume starting from a given timestamp
+    @t:       alias for @t
+    @:t       consume until a given timestamp
+    @t1:t2    consume from timestamp t1 until timestamp t2
+
+There are a few options for timestamps, with each option being evaluated
+until one succeeds:
+
+    13 digits             parsed as a unix millisecond
+    9 digits              parsed as a unix second
+    YYYY-MM-DD            parsed as a day, UTC
+    YYYY-MM-DDTHH:MM:SSZ  parsed as RFC3339, UTC; fractional seconds optional (.MMM)
+    -dur                  duration ago; from now (as t1) or from t1 (as t2)
+    dur                   for t2 in @t1:t2, relative duration from t1
+    end                   for t2 in @t1:t2, the current end of the partition
+
+Durations are parsed simply:
+
+    3ms    three milliseconds
+    10s    ten seconds
+    9m     nine minutes
+    1h     one hour
+    1m3ms  one minute and three milliseconds
+
+For example,
+
+    -o @2022-02-14:1h   consume 1h of time on Valentine's Day 2022
+    -o @-48h:-24h       consume from 2 days ago to 1 day ago
+    -o @-1m:end         consume from 1m ago until now
+    -o @:-1hr           consume from the start until an hour ago
+
+== Usage
+
+[,bash]
+----
+rpk topic consume TOPICS... [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-b, --balancer` |string |Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky) (default "cooperative-sticky").
+
+|`--fetch-max-bytes` |int32 |Maximum amount of bytes per fetch request per broker (default 1048576).
+
+|`--fetch-max-wait` |duration |Maximum amount of time to wait when fetching from a broker before the broker replies (default 5s).
+
+|`-f, --format` |string |Output format (see --help for details) (default "json").
+
+|`-g, --group` |string |Group to use for consuming (incompatible with -p).
+
+|`-h, --help` |- |Help for consume.
+
+|`--meta-only` |- |Print all record info except the record value (for -f json).
+
+|`-n, --num` |int |Quit after consuming this number of records (0 is unbounded).
+
+|`-o, --offset` |string |Offset to consume from / to (start, end, 47, +2, -3) (default "start").
+
+|`-p, --partitions` |int32 |int32Slice     Comma delimited list of specific partitions to consume (default []).
+
+|`--pretty-print` |- |Pretty print each record over multiple lines (for -f json) (default true).
+
+|`--print-control-records` |- |Opt in to printing control records.
+
+|`--read-committed` |- |Opt in to reading only committed offsets.
+
+|`-r, --regex` |- |Parse topics as regex; consume any topic that matches any expression.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-topic-create.adoc
+++ b/tools/gen/22.3/rpk-topic-create.adoc
@@ -1,0 +1,58 @@
+= rpk topic create
+:description: rpk topic create
+
+Create topics.
+
+All topics created with this command will have the same number of partitions,
+replication factor, and key/value configs.
+
+For example,
+
+	create -c cleanup.policy=compact -r 3 -p 20 foo bar
+
+will create two topics, foo and bar, each with 20 partitions, 3 replicas, and
+the cleanup.policy=compact config option set.
+
+== Usage
+
+[,bash]
+----
+rpk topic create [TOPICS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --dry` |- |Dry run: validate the topic creation request; do not create topics.
+
+|`-h, --help` |- |Help for create.
+
+|`-p, --partitions` |int32 |Number of partitions to create per topic; -1 defaults to the cluster's default_topic_partitions (default -1).
+
+|`-r, --replicas` |int16 |Replication factor (must be odd); -1 defaults to the cluster's default_topic_replications (default -1).
+
+|`-c, --topic-config` |stringArray |key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-topic-delete.adoc
+++ b/tools/gen/22.3/rpk-topic-delete.adoc
@@ -1,0 +1,61 @@
+= rpk topic delete
+:description: rpk topic delete
+
+Delete topics.
+
+This command deletes all requested topics, printing the success or fail status
+per topic.
+
+The --regex flag (-r) opts into parsing the input topics as regular expressions
+and deleting any non-internal topic that matches any of expressions. The input
+expressions are wrapped with ^ and $ so that the expression must match the
+whole topic name (which also prevents accidental delete-everything mistakes).
+
+The topic list command accepts the same input regex format as this delete
+command. If you want to check what your regular expressions will delete before
+actually deleting them, you can check the output of 'rpk topic list -r'.
+
+For example,
+
+    delete foo bar            # deletes topics foo and bar
+    delete -r '^f.*' '.*r$'   # deletes any topic starting with f and any topics ending in r
+    delete -r '.*'            # deletes all topics
+    delete -r .               # deletes any one-character topics
+
+== Usage
+
+[,bash]
+----
+rpk topic delete [TOPICS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`-r, --regex` |- |Parse topics as regex; delete any topic that matches any input topic expression.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-topic-describe.adoc
+++ b/tools/gen/22.3/rpk-topic-describe.adoc
@@ -1,0 +1,59 @@
+= rpk topic describe
+:description: rpk topic describe
+
+Describe a topic.
+
+This command prints detailed information about a topic. There are three
+potential sections: a summary of the topic, the topic configs, and a detailed
+partitions section. By default, the summary and configs sections are printed.
+
+== Usage
+
+[,bash]
+----
+rpk topic describe [TOPIC] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+describe, info
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for describe.
+
+|`-a, --print-all` |- |Print all sections.
+
+|`-c, --print-configs` |- |Print the config section.
+
+|`-p, --print-partitions` |- |Print the detailed partitions section.
+
+|`-s, --print-summary` |- |Print the summary section.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-topic-list.adoc
+++ b/tools/gen/22.3/rpk-topic-list.adoc
@@ -1,0 +1,70 @@
+= rpk topic list
+:description: rpk topic list
+
+List topics, optionally listing specific topics.
+
+This command lists all topics that you have access to by default. If specifying
+topics or regular expressions, this command can be used to know exactly what
+topics you would delete if using the same input to the delete command.
+
+Alternatively, you can request specific topics to list, which can be used to
+check authentication errors (do you not have access to a topic you were
+expecting to see?), or to list all topics that match regular expressions.
+
+The --regex flag (-r) opts into parsing the input topics as regular expressions
+and listing any non-internal topic that matches any of expressions. The input
+expressions are wrapped with ^ and $ so that the expression must match the
+whole topic name. Regular expressions cannot be used to match internal topics,
+as such, specifying both -i and -r will exit with failure.
+
+Lastly, --detailed flag (-d) opts in to printing extra per-partition
+information.
+
+== Usage
+
+[,bash]
+----
+rpk topic list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --detailed` |- |Print per-partition information for topics.
+
+|`-h, --help` |- |Help for list.
+
+|`-i, --internal` |- |Print internal topics.
+
+|`-r, --regex` |- |Parse topics as regex; list any topic that matches any input topic expression.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-topic-produce.adoc
+++ b/tools/gen/22.3/rpk-topic-produce.adoc
@@ -1,0 +1,183 @@
+= rpk topic produce
+:description: rpk topic produce
+
+Produce records to a topic.
+
+Producing records reads from STDIN, parses input according to --format, and
+produce records to Redpanda. The input formatter understands a wide variety of
+formats.
+
+Parsing input operates on either sizes or on delimiters, both of which can be
+specified in the same formatting options. If using sizes to specify something,
+the size must come before what it is specifying. Delimiters match on an exact
+text basis. This command will quit with an error if any input fails to match
+your specified format.
+
+Slashes can be used for common escapes:
+
+    \t \n \r \\ \xNN
+
+matches tabs, newlines, carriage returns, slashes, and hex encoded characters.
+
+Percent encoding reads into specific values of a record:
+
+    %t    topic
+    %T    topic length
+    %k    key
+    %K    key length
+    %v    value
+    %V    value length
+    %h    begin the header specification
+    %H    number of headers
+    %p    partition (if using the --partition flag)
+
+Three escapes exist to parse characters that are used to modify the previous
+escapes:
+
+    %%    percent sign
+    %{    left brace
+    %}    right brace
+
+MODIFIERS
+
+Text and numbers can be read in multiple formats, and the default format can be
+changed within brace modifiers. %v reads a value, while %v{hex} reads a value
+and then hex decodes it before producing. %T reads the length of a topic from
+the input, while %T{3} reads exactly three bytes for a topic from the input.
+
+All modifiers go within braces following a percent-escape.
+
+NUMBERS
+
+Reading number values can have the following modifiers:
+
+     ascii       parse numeric digits until a non-numeric (default)
+
+     hex64       sixteen hex characters
+     hex32       eight hex characters
+     hex16       four hex characters
+     hex8        two hex characters
+     hex4        one hex character
+
+     big64       eight byte big endian number
+     big32       four byte big endian number
+     big16       two byte big endian number
+     big8        alias for byte
+
+     little64    eight byte little endian number
+     little32    four byte little endian number
+     little16    two byte little endian number
+     little8     alias for byte
+
+     byte        one byte number
+     <digits>    directly specify the length as this many digits
+     bool        read "true" as 1, "false" as 0
+
+When reading number sizes, the size corresponds to the size of the encoded
+values, not the decoded values. "%T{6}%t{hex}" will read six hex bytes and
+decode into three.
+
+TEXT
+
+Reading text values can have the following modifiers:
+
+    hex       read text then hex decode it
+    base64    read text then std-encoding base64 decode it
+    re        read text matching a regular expression
+
+HEADERS
+
+Headers are parsed with an internal key / value specifier format. For example,
+the following will read three headers that begin and end with a space and are
+separated by an equal:
+
+    %H{3}%h{ %k=%v }
+
+EXAMPLES
+
+In the below examples, we can parse many records at once. The produce command
+reads input and tokenizes based on your specified format. Every time the format
+is completely matched, a record is produced and parsing begins anew.
+
+A key and value, separated by a space and ending in newline:
+    -f '%k %v\n'
+A four byte topic, four byte key, and four byte value:
+    -f '%T{4}%K{4}%V{4}%t%k%v'
+A value to a specific partition, if using a non-negative --partition flag:
+    -f '%p %v\n'
+A big-endian uint16 key size, the text " foo ", and then that key:
+    -f '%K{big16} foo %k'
+A value that can be two or three characters followed by a newline:
+    -f '%v{re#...?#}\n'
+
+MISC
+
+Producing requires a topic to produce to. The topic can be specified either
+directly on as an argument, or in the input text through %t. A parsed topic
+takes precedence over the default passed in topic. If no topic is specified
+directly and no topic is parsed, this command will quit with an error.
+
+The input format can parse partitions to produce directly to with %p. Doing so
+requires specifying a non-negative --partition flag. Any parsed partition
+takes precedence over the --partition flag; specifying the flag is the main
+requirement for being able to directly control which partition to produce to.
+
+You can also specify an output format to write when a record is produced
+successfully. The output format follows the same formatting rules as the topic
+consume command. See that command's help text for a detailed description.
+
+== Usage
+
+[,bash]
+----
+rpk topic produce [TOPIC] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--acks` |int |Number of acks required for producing (-1=all, 0=none, 1=leader) (default -1).
+
+|`--allow-auto-topic-creation` |- |Auto-create non-existent topics; requires auto_create_topics_enabled on the broker.
+
+|`-z, --compression` |string |Compression to use for producing batches (none, gzip, snapy, lz4, zstd) (default "snappy").
+
+|`--delivery-timeout` |duration |Per-record delivery timeout, if non-zero, min 1s.
+
+|`-f, --format` |string |Input record format (default "%v\n").
+
+|`-H, --header` |stringArray |Headers in format key:value to add to each record (repeatable).
+
+|`-h, --help` |- |Help for produce.
+
+|`-k, --key` |string |A fixed key to use for each record (parsed input keys take precedence).
+
+|`-o, --output-format` |string |what to write to stdout when a record is successfully produced (default "Produced to partition %p at offset %o with timestamp %d.\n").
+
+|`-p, --partition` |int32 |Partition to directly produce to, if non-negative (also allows %p parsing to set partitions) (default -1).
+
+|`-Z, --tombstone` |- |Produce empty values as tombstones.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-topic.adoc
+++ b/tools/gen/22.3/rpk-topic.adoc
@@ -1,0 +1,40 @@
+= rpk topic
+:description: rpk topic
+
+Create, delete, produce to and consume from Redpanda topics
+
+== Usage
+
+[,bash]
+----
+rpk topic [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for topic.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-version.adoc
+++ b/tools/gen/22.3/rpk-version.adoc
@@ -1,0 +1,22 @@
+= rpk version
+:description: rpk version
+
+Check the current version
+
+== Usage
+
+[,bash]
+----
+rpk version [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for version.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-wasm-deploy.adoc
+++ b/tools/gen/22.3/rpk-wasm-deploy.adoc
@@ -1,0 +1,46 @@
+= rpk wasm deploy
+:description: rpk wasm deploy
+
+Deploy inline WASM function
+
+== Usage
+
+[,bash]
+----
+rpk wasm deploy [PATH] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--description` |string |Optional description about what the wasm function does.
+
+|`-h, --help` |- |Help for deploy.
+
+|`--name` |string |Unique deploy identifier attached to the instance of this script.
+
+|`--type` |string |WASM engine type (async, data-policy) (default "async").
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-wasm-generate.adoc
+++ b/tools/gen/22.3/rpk-wasm-generate.adoc
@@ -1,0 +1,42 @@
+= rpk wasm generate
+:description: rpk wasm generate
+
+Create a npm template project for inline WASM engine
+
+== Usage
+
+[,bash]
+----
+rpk wasm generate [PROJECT DIRECTORY] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for generate.
+
+|`--skip-version` |- |Omit wasm-api version check from npm, use default instead.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-wasm-remove.adoc
+++ b/tools/gen/22.3/rpk-wasm-remove.adoc
@@ -1,0 +1,42 @@
+= rpk wasm remove
+:description: rpk wasm remove
+
+Remove inline WASM function
+
+== Usage
+
+[,bash]
+----
+rpk wasm remove [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for remove.
+
+|`--type` |string |WASM engine type (async, data-policy) (default "async").
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/22.3/rpk-wasm.adoc
+++ b/tools/gen/22.3/rpk-wasm.adoc
@@ -1,0 +1,40 @@
+= rpk wasm
+:description: rpk wasm
+
+Deploy and remove inline WASM engine scripts
+
+== Usage
+
+[,bash]
+----
+rpk wasm [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for wasm.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/json/rpk-commands.json
+++ b/tools/gen/23.1/json/rpk-commands.json
@@ -1,0 +1,5693 @@
+{
+    "rpk acl": {
+        "description": "Manage ACLs and SASL users.\r\n\r\nThis command space creates, lists, and deletes ACLs, as well as creates SASL\r\nusers. The help text below is specific to ACLs. To learn about SASL users,\r\ncheck the help text under the \"user\" command.\r\n\r\nWhen using SASL, ACLs allow or deny you access to certain requests. The\r\n\"create\", \"delete\", and \"list\" commands help you manage your ACLs.\r\n\r\nAn ACL is made up of five components:\r\n\r\n  * a principal (the user)\r\n  * a host the principal is allowed or denied requests from\r\n  * what resource to access (topic name, group ID, ...)\r\n  * the operation (read, write, ...)\r\n  * the permission: whether to allow or deny the above\r\n\r\nACL commands work on a multiplicative basis. If creating, specifying two\r\nprincipals and two permissions creates four ACLs: both permissions for the\r\nfirst principal, as well as both permissions for the second principal. Adding\r\ntwo resources further doubles the ACLs created.\r\n\r\nIt is recommended to be as specific as possible when granting ACLs. Granting\r\nmore ACLs than necessary per principal may inadvertently allow clients to do\r\nthings they should not, such as deleting topics or joining the wrong consumer\r\ngroup.\r\n\r\nPRINCIPALS\r\n\r\nAll ACLs require a principal. A principal is composed of two parts: the type\r\nand the name. Within Redpanda, only one type is supported, \"User\". The reason\r\nfor the prefix is that a potential future authorizer may add support for\r\nauthorizing by Group or anything else.\r\n\r\nWhen you create a user, you need to add ACLs for it before it can be used. You\r\ncan create / delete / list ACLs for that user with either \"User:bar\" or \"bar\"\r\nin the --allow-principal and --deny-principal flags. This command will add the\r\n\"User:\" prefix for you if it is missing. The wildcard '*' matches any user.\r\nCreating an ACL with user '*' grants or denies the permission for all users.\r\n\r\nHOSTS\r\n\r\nHosts can be seen as an extension of the principal, and effectively gate where\r\nthe principal can connect from. When creating ACLs, unless otherwise specified,\r\nthe default host is the wildcard '*' which allows or denies the principal from\r\nall hosts (where allow & deny are based on whether --allow-principal or\r\n--deny-principal is used). If specifying hosts, you must pair the --allow-host\r\nflag with the --allow-principal flag, and the --deny-host flag with the\r\n--deny-principal flag.\r\n\r\nRESOURCES\r\n\r\nA resource is what an ACL allows or denies access to. There are four resources\r\nwithin Redpanda: topics, groups, the cluster itself, and transactional IDs.\r\nNames for each of these resources can be specified with their respective flags.\r\n\r\nResources combine with the operation that is allowed or denied on that\r\nresource. The next section describes which operations are required for which\r\nrequests, and further fleshes out the concept of a resource.\r\n\r\nBy default, resources are specified on an exact name match (a \"literal\" match).\r\nThe --resource-pattern-type flag can be used to specify that a resource name is\r\n\"prefixed\", meaning to allow anything with the given prefix. A literal name of\r\n\"foo\" will match only the topic \"foo\", while the prefixed name of \"foo-\" will\r\nmatch both \"foo-bar\" and \"foo-baz\". The special wildcard resource name '*'\r\nmatches any name of the given resource type (--topic '*' matches all topics).\r\n\r\nOPERATIONS\r\n\r\nPairing with resources, operations are the actions that are allowed or denied.\r\nRedpanda has the following operations:\r\n\r\n    ALL                 Allows all operations below.\r\n    READ                Allows reading a given resource.\r\n    WRITE               Allows writing to a given resource.\r\n    CREATE              Allows creating a given resource.\r\n    DELETE              Allows deleting a given resource.\r\n    ALTER               Allows altering non-configurations.\r\n    DESCRIBE            Allows querying non-configurations.\r\n    DESCRIBE_CONFIGS    Allows describing configurations.\r\n    ALTER_CONFIGS       Allows altering configurations.\r\n\r\nCheck --help-operations to see which operations are required for which\r\nrequests. In flag form to set up a general producing/consuming client, you can\r\ninvoke 'rpk acl create' three times with the following (including your\r\n--allow-principal):\r\n\r\n    --operation write,read,describe --topic [topics]\r\n    --operation describe,read --group [group.id]\r\n    --operation describe,write --transactional-id [transactional.id]\r\n\r\nPERMISSIONS\r\n\r\nA client can be allowed access or denied access. By default, all permissions\r\nare denied. You only need to specifically deny a permission if you allow a wide\r\nset of permissions and then want to deny a specific permission in that set.\r\nYou could allow all operations, and then specifically deny writing to topics.\r\n\r\nMANAGEMENT\r\n\r\nCreating ACLs works on a specific ACL basis, but listing and deleting ACLs\r\nworks on filters. Filters allow matching many ACLs to be printed listed and\r\ndeleted at once. Because this can be risky for deleting, the delete command\r\nprompts for confirmation by default. More details and examples for creating,\r\nlisting, and deleting can be seen in each of the commands.\r\n\r\nUsing SASL requires setting \"enable_sasl: true\" in the redpanda section of your\r\nredpanda.yaml. User management is a separate, simpler concept that is\r\ndescribed in the user command.",
+        "usage": "Usage:\r\n  rpk acl [flags]\r\n  rpk acl [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for acl."
+            },
+            "--help-operations": {
+                "type": "-",
+                "description": "Print more help about ACL operations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl create": {
+        "description": "Create ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. Following the\r\nmultiplying effect of combining flags, the create command works on a\r\nstraightforward basis: every ACL combination is a created ACL.\r\n\r\nAs mentioned in the 'rpk acl' help text, if no host is specified, an allowed\r\nprincipal is allowed access from all hosts. The wildcard principal '*' allows\r\nall principals. At least one principal, one host, one resource, and one\r\noperation is required to create a single ACL.\r\n\r\nAllow all permissions to user bar on topic \"foo\" and group \"g\":\r\n    --allow-principal bar --operation all --topic foo --group g\r\nAllow read permissions to all users on topics biz and baz:\r\n    --allow-principal '*' --operation read --topic biz,baz\r\nAllow write permissions to user buzz to transactional id \"txn\":\r\n    --allow-principal User:buzz --operation write --transactional-id txn",
+        "usage": "Usage:\r\n  rpk acl create [flags]\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Hosts from which access will be granted (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Principals for which these permissions will be granted (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to grant ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Hosts from from access will be denied (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Principal for which these permissions will be denied (repeatable)."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to grant ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to grant (repeatable)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (literal or prefixed) (default \"literal\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to grant ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to grant ACLs for (repeatable)."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl delete": {
+        "description": "Delete ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. Delete flags work in a\r\nsimilar multiplying effect as creating ACLs, but delete is more advanced:\r\ndeletion works on a filter basis. Any unspecified flag defaults to matching\r\neverything (all operations, or all allowed principals, etc). To ensure that you\r\ndo not accidentally delete more than you intend, this command prints everything\r\nthat matches your input filters and prompts for a confirmation before the\r\ndelete request is issued. Anything matching more than 10 ACLs doubly confirms.\r\n\r\nAs mentioned, not specifying flags matches everything. If no resources are\r\nspecified, all resources are matched. If no operations are specified, all\r\noperations are matched. You can also opt in to matching everything with \"any\":\r\n--operation any matches any operation.\r\n\r\nThe --resource-pattern-type, defaulting to \"any\", configures how to filter\r\nresource names:\r\n  * \"any\" returns exact name matches of either prefixed or literal pattern type\r\n  * \"match\" returns wildcard matches, prefix patterns that match your input, and literal matches\r\n  * \"prefix\" returns prefix patterns that match your input (prefix \"fo\" matches \"foo\")\r\n  * \"literal\" returns exact name matches",
+        "usage": "Usage:\r\n  rpk acl delete [flags]\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Allowed host ACLs to remove (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Allowed principal ACLs to remove (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to remove ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Denied host ACLs to remove (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Denied principal ACLs to remove (repeatable)."
+            },
+            "-d, --dry": {
+                "type": "-",
+                "description": "Dry run: validate what would be deleted."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to remove ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to remove (repeatable)."
+            },
+            "-f, --print-filters": {
+                "type": "-",
+                "description": "Print the filters that were requested (failed filters are always printed)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (any, match, literal, or prefixed) (default \"any\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to remove ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to remove ACLs for (repeatable)."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl list": {
+        "description": "List ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. List flags work in a\r\nsimilar multiplying effect as creating ACLs, but list is more advanced:\r\nlisting works on a filter basis. Any unspecified flag defaults to matching\r\neverything (all operations, or all allowed principals, etc).\r\n\r\nAs mentioned, not specifying flags matches everything. If no resources are\r\nspecified, all resources are matched. If no operations are specified, all\r\noperations are matched. You can also opt in to matching everything with \"any\":\r\n--operation any matches any operation.\r\n\r\nThe --resource-pattern-type, defaulting to \"any\", configures how to filter\r\nresource names:\r\n  * \"any\" returns exact name matches of either prefixed or literal pattern type\r\n  * \"match\" returns wildcard matches, prefix patterns that match your input, and literal matches\r\n  * \"prefix\" returns prefix patterns that match your input (prefix \"fo\" matches \"foo\")\r\n  * \"literal\" returns exact name matches",
+        "usage": "Usage:\r\n  rpk acl list [flags]\r\n\r\nAliases:\r\n  list, ls, describe\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Allowed host ACLs to match (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Allowed principal ACLs to match (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to match ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Denied host ACLs to match (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Denied principal ACLs to match (repeatable)."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to match ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to match (repeatable)."
+            },
+            "-f, --print-filters": {
+                "type": "-",
+                "description": "Print the filters that were requested (failed filters are always printed)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (any, match, literal, or prefixed) (default \"any\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to match ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to match ACLs for (repeatable)."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl user": {
+        "description": "Manage SASL users.\r\n\r\nIf SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs\r\ncontrol what your user has access to. See 'rpk acl --help' for more information\r\nabout ACLs, and 'rpk acl user create --help' for more information about\r\ncreating SASL users. Using SASL requires setting \"enable_sasl: true\" in the\r\nredpanda section of your redpanda.yaml.",
+        "usage": "Usage:\r\n  rpk acl user [command]\r\n\r",
+        "flags": {
+            "--api-urls": {
+                "type": "strings",
+                "description": "The comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for user."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl user create": {
+        "description": "Create a SASL user.\r\n\r\nThis command creates a single SASL user with the given password, optionally\r\nwith a custom \"mechanism\". SASL consists of three parts: a username, a\r\npassword, and a mechanism. The mechanism determines which authentication flow\r\nthe client will use for this user/pass.\r\n\r\nRedpanda currently supports two mechanisms: SCRAM-SHA-256, the default, and\r\nSCRAM-SHA-512, which is the same flow but uses sha512 rather than sha256.\r\n\r\nUsing SASL requires setting \"enable_sasl: true\" in the redpanda section of your\r\nredpanda.yaml. Before a created SASL account can be used, you must also create\r\nACLs to grant the account access to certain resources in your cluster. See the\r\nacl help text for more info.",
+        "usage": "Usage:\r\n  rpk acl user create [USER] -p [PASS] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "--mechanism": {
+                "type": "string",
+                "description": "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive); not to be confused with the global flag --sasl-mechanism which is used for authenticating the rpk client (default \"scram-sha-256\")."
+            },
+            "--password": {
+                "type": "string",
+                "description": "New user's password (NOTE: if using --password for the admin API, use --new-password)."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "strings",
+                "description": "The comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl user delete": {
+        "description": "Delete a SASL user.\r\n\r\nThis command deletes the specified SASL account from Redpanda. This does not\r\ndelete any ACLs that may exist for this user.",
+        "usage": "Usage:\r\n  rpk acl user delete [USER] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "strings",
+                "description": "The comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk acl user list": {
+        "description": "List SASL users",
+        "usage": "Usage:\r\n  rpk acl user list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "strings",
+                "description": "The comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud": {
+        "description": "Interact with Redpanda cloud",
+        "usage": "Usage:\r\n  rpk cloud [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for cloud."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud byoc": {
+        "description": "Manage a Redpanda cloud BYOC agent\r\n\r\nFor BYOC, Redpanda installs an agent service in your owned cluster. The agent\r\nthen proceeds to provision further infrastructure and eventually, a full\r\nRedpanda cluster.\r\n\r\nThe BYOC command runs Terraform to create and start the agent. You first need\r\na redpanda-id (or cluster ID); this is used to get the details of how your\r\nagent should be provisioned. You can create a BYOC cluster in our cloud UI\r\nand then come back to this command to complete the process.",
+        "usage": "Usage:\r\n  rpk cloud byoc [flags]\r\n  rpk cloud byoc [command]\r\n\r",
+        "flags": {
+            "--client-id": {
+                "type": "string",
+                "description": "The client ID of the organization in Redpanda Cloud."
+            },
+            "--client-secret": {
+                "type": "string",
+                "description": "The client secret of the organization in Redpanda Cloud."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for byoc."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud byoc install": {
+        "description": "Install the BYOC plugin\r\n\r\nThis command downloads the BYOC managed plugin if necessary. The plugin is\r\ninstalled by default if you try to run a non-install command, but this command\r\nexists if you want to download the plugin ahead of time.",
+        "usage": "Usage:\r\n  rpk cloud byoc install [flags]\r\n\r",
+        "flags": {
+            "--client-id": {
+                "type": "string",
+                "description": "The client ID of the organization in Redpanda Cloud."
+            },
+            "--client-secret": {
+                "type": "string",
+                "description": "The client secret of the organization in Redpanda Cloud."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for install."
+            },
+            "--redpanda-id": {
+                "type": "string",
+                "description": "The redpanda ID of the cluster you are creating."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud byoc uninstall": {
+        "description": "Uninstall the BYOC plugin\r\n\r\nThis command deletes your locally downloaded BYOC managed plugin if it exists.\r\nOften, you only need to download the plugin to create your cluster once, and\r\nthen you never need the plugin again. You can uninstall to save a small bit of\r\ndisk space.",
+        "usage": "Usage:\r\n  rpk cloud byoc uninstall [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for uninstall."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud login": {
+        "description": "Log in to the Redpanda cloud\r\n\r\nThis command checks for an existing token and, if present, ensures it is still\r\nvalid. If no token is found or the token is no longer valid, this command will\r\nlogin and save your token.\r\n\r\nYou may use any of the following methods to pass the cloud credentials to rpk:\r\n\r\nLogging in requires cloud credentials, which can be created in the Clients\r\ntab of the Users section in the Redpanda Cloud online interface. Client\r\ncredentials can be provided in three ways, in order of preference:\r\n\r\n* In $HOME/.config/rpk/__cloud.yaml, in 'client_id' and 'client_secret' fields\r\n* Through RPK_CLOUD_CLIENT_ID and RPK_CLOUD_CLIENT_SECRET environment variables\r\n* Through the --client-id and --client-secret flags\r\n\r\nIf none of these are provided, login will prompt you for the client ID and\r\nclient secret and will save them to the __cloud.yaml file. If you specify\r\nenvironment variables or flags, they will not be synced to the __cloud.yaml\r\nfile unless the --save flag is passed. The cloud authorization token is always \r\nsynced.",
+        "usage": "Usage:\r\n  rpk cloud login [flags]\r\n\r",
+        "flags": {
+            "--client-id": {
+                "type": "string",
+                "description": "The client ID of the organization in Redpanda Cloud."
+            },
+            "--client-secret": {
+                "type": "string",
+                "description": "The client secret of the organization in Redpanda Cloud."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for login."
+            },
+            "--save": {
+                "type": "-",
+                "description": "Save environment or flag specified client ID and client secret to the configuration file."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cloud logout": {
+        "description": "Log out from Redpanda cloud\r\n\r\nThis command deletes your cloud auth token. If you want to log out entirely and\r\nswitch to a different organization, you can use the --clear-credentials flag to\r\nadditionally clear your client ID and client secret.",
+        "usage": "Usage:\r\n  rpk cloud logout [flags]\r\n\r",
+        "flags": {
+            "-c, --clear-credentials": {
+                "type": "-",
+                "description": "Clear the client ID and client secret in addition to the auth token."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for logout."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster": {
+        "description": "Interact with a Redpanda cluster",
+        "usage": "Usage:\r\n  rpk cluster [command]\r\n\r",
+        "flags": {
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for cluster."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config": {
+        "description": "Interact with cluster configuration properties.\r\n\r\nCluster properties are redpanda settings which apply to all nodes in\r\nthe cluster.  These are separate to node properties, which are set with\r\n'rpk redpanda config'.\r\n\r\nUse the 'edit' subcommand to interactively modify the cluster configuration, or\r\n'export' and 'import' to write configuration to a file that can be edited and\r\nread back later.\r\n\r\nThese commands take an optional '--all' flag to include all properties including\r\nlow level tunables such as internal buffer sizes, that do not usually need\r\nto be changed during normal operations.  These properties generally require\r\nsome expertize to set safely, so if in doubt, avoid using '--all'.\r\n\r\nModified properties are propagated immediately to all nodes.  The 'status'\r\nsubcommand can be used to verify that all nodes are up to date, and identify\r\nany settings which were rejected by a node, for example if a node is running a\r\ndifferent redpanda version that does not recognize certain properties.",
+        "usage": "Usage:\r\n  rpk cluster config [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config edit": {
+        "description": "Edit cluster-wide configuration properties.\r\n\r\nThis command opens a text editor to modify the cluster's configuration.\r\n\r\nCluster properties are redpanda settings which apply to all nodes in\r\nthe cluster.  These are separate to node properties, which are set with\r\n'rpk redpanda config'.\r\n\r\nModified values are written back when the file is saved and the editor\r\nis closed.  Properties which are deleted are reset to their default\r\nvalues.\r\n\r\nBy default, low level tunables are excluded: use the '--all' flag\r\nto edit all properties including these tunables.",
+        "usage": "Usage:\r\n  rpk cluster config edit [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for edit."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config export": {
+        "description": "Export cluster configuration.\r\n\r\nWrites out a YAML representation of the cluster configuration to a file,\r\nsuitable for editing and later applying with the corresponding 'import'\r\ncommand.\r\n\r\nBy default, low level tunables are excluded: use the '--all' flag\r\nto include all properties including these low level tunables.",
+        "usage": "Usage:\r\n  rpk cluster config export [flags]\r\n\r",
+        "flags": {
+            "-f, --filename": {
+                "type": "string",
+                "description": "path to file to export to, e.g. './config.yml'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for export."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config force-reset": {
+        "description": "Forcibly clear a cluster configuration property on this node.\r\n\r\nThis command is not for general changes to cluster configuration: use this only\r\nwhen redpanda will not start due to a configuration issue.\r\n\r\nIf your cluster is working properly and you would like to reset a property\r\nto its default, you may use the 'set' command with an empty string, or\r\nuse the 'edit' command and delete the property's line.\r\n\r\nThis command erases a named property from an internal cache of the cluster\r\nconfiguration on the local node, so that on next startup redpanda will treat\r\nthe setting as if it was set to the default.\r\n\r\nWARNING: this should only be used when redpanda is not running.",
+        "usage": "Usage:\r\n  rpk cluster config force-reset [PROPERTY...] [flags]\r\n\r",
+        "flags": {
+            "--cache-file": {
+                "type": "string",
+                "description": "location of configuration cache file (defaults to redpanda data directory)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for force-reset."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config get": {
+        "description": "Get a cluster configuration property.\r\n\r\nThis command is provided for use in scripts.  For interactive editing, or bulk\r\noutput, use the 'edit' and 'export' commands respectively.",
+        "usage": "Usage:\r\n  rpk cluster config get <key> [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for get."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config import": {
+        "description": "Import cluster configuration from a file.\r\n\r\nImport configuration from a YAML file, usually generated with\r\ncorresponding 'export' command.  This downloads the current cluster\r\nconfiguration, calculates the difference with the YAML file, and\r\nupdates any properties that were changed.  If a property is removed\r\nfrom the YAML file, it is reset to its default value.",
+        "usage": "Usage:\r\n  rpk cluster config import [flags]\r\n\r",
+        "flags": {
+            "-f, --filename": {
+                "type": "string",
+                "description": "full path to file to import, e.g. '/tmp/config.yml'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for import."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config lint": {
+        "description": "Remove any deprecated content from redpanda.yaml.\r\n\r\nDeprecated content includes properties which were set via redpanda.yaml\r\nin earlier versions of redpanda, but are now managed via Redpanda's\r\ncentral configuration store (and via 'rpk cluster config edit').",
+        "usage": "Usage:\r\n  rpk cluster config lint [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for lint."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config set": {
+        "description": "Set a single cluster configuration property.\r\n\r\nThis command is provided for use in scripts.  For interactive editing, or bulk\r\nchanges, use the 'edit' and 'import' commands respectively.\r\n\r\nIf an empty string is given as the value, the property is reset to its default.",
+        "usage": "Usage:\r\n  rpk cluster config set <key> <value> [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster config status": {
+        "description": "Get configuration status of redpanda nodes.\r\n\r\nFor each node, indicate whether a restart is required for settings to\r\ntake effect, and any settings that the node has identified as invalid\r\nor unknown properties.\r\n\r\nAdditionally show the version of cluster configuration that each node\r\nhas applied: under normal circumstances these should all be equal,\r\na lower number shows that a node is out of sync, perhaps because it\r\nis offline.",
+        "usage": "Usage:\r\n  rpk cluster config status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster health": {
+        "description": "Queries health overview.\r\n\r\nHealth overview is created based on the health reports collected periodically\r\nfrom all nodes in the cluster. A cluster is considered healthy when the\r\nfollowing conditions are met:\r\n\r\n* all cluster nodes are responding\r\n* all partitions have leaders\r\n* the cluster controller is present",
+        "usage": "Usage:\r\n  rpk cluster health [flags]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "-e, --exit-when-healthy": {
+                "type": "-",
+                "description": "When used with watch, exits after cluster is back in healthy state."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for health."
+            },
+            "-w, --watch": {
+                "type": "-",
+                "description": "Blocks and writes out all cluster health changes."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster license": {
+        "description": "Manage cluster license",
+        "usage": "Usage:\r\n  rpk cluster license [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for license."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster license info": {
+        "description": "Retrieve license information:\r\n\r\n    Organization:    Organization the license was generated for.\r\n    Type:            Type of license: free, enterprise, etc.\r\n    Expires:         Expiration date of the license\r\n    Version:         License schema version.",
+        "usage": "Usage:\r\n  rpk cluster license info [flags]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (text, json) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for info."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster license set": {
+        "description": "Upload license to the cluster\r\n\r\nYou can either provide a path to a file containing the license:\r\n\r\n    rpk cluster license set --path /home/organization/redpanda.license\r\n\r\nOr inline the license string:\r\n\r\n    rpk cluster license set <license string>\r\n\r\nIf neither are present, rpk will look for the license in the\r\ndefault location '/etc/redpanda/redpanda.license'.",
+        "usage": "Usage:\r\n  rpk cluster license set [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--path": {
+                "type": "string",
+                "description": "Path to the license file."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster logdirs": {
+        "description": "Describe log directories on Redpanda brokers",
+        "usage": "Usage:\r\n  rpk cluster logdirs [command]\r\n\r",
+        "flags": {
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for logdirs."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster logdirs describe": {
+        "description": "Describe log directories on Redpanda brokers.\r\n\r\nThis command prints information about log directories on brokers, particularly,\r\nthe base directory that topics and partitions are located in, and the size of\r\ndata that has been written to the partitions. The size you see may not exactly\r\nmatch the size on disk as reported by du: Redpanda allocates files in chunks.\r\nThe chunks will show up in du, while the actual bytes so far written to the\r\nfile will show up in this command.\r\n\r\nThe directory returned is the root directory for partitions. Within Redpanda,\r\nthe partition data lives underneath the the returned root directory in\r\n\r\n    kafka/{topic}/{partition}_{revision}/\r\n\r\nwhere revision is a Redpanda internal concept.",
+        "usage": "Usage:\r\n  rpk cluster logdirs describe [flags]\r\n\r",
+        "flags": {
+            "--aggregate-into": {
+                "type": "string",
+                "description": "If non-empty, what column to aggregate into starting from the partition column (broker, dir, topic)."
+            },
+            "-b, --broker": {
+                "type": "int32",
+                "description": "If non-negative, the specific broker to describe (default -1)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "--sort-by-size": {
+                "type": "-",
+                "description": "If true, sort by size."
+            },
+            "--topics": {
+                "type": "strings",
+                "description": "Specific topics to describe."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster maintenance": {
+        "description": "Interact with cluster maintenance mode.\r\n\r\nMaintenance mode is a state that a node may be placed into in which the node\r\nmay be shutdown or restarted with minimal disruption to client workloads. The\r\nprimary use of maintenance mode is to perform a rolling upgrade in which each\r\nnode is placed into maintenance mode prior to upgrading the node.\r\n\r\nUse the 'enable' and 'disable' subcommands to place a node into maintenance mode\r\nor remove it, respectively. Only one node at a time may be in maintenance mode.\r\n\r\nWhen a node is placed into maintenance mode the following occurs:\r\n\r\nLeadership draining. All raft leadership is transferred to another eligible\r\nnode, and the node in maintenance mode rejects new leadership requests. By\r\ntransferring leadership off of the node in maintenance mode all client traffic\r\nand requests are directed to other nodes minimizing disruption to client\r\nworkloads when the node is shutdown.\r\n\r\nCurrently leadership is not transferred for partitions with one replica.",
+        "usage": "Usage:\r\n  rpk cluster maintenance [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for maintenance."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster maintenance disable": {
+        "description": "Disable maintenance mode for a node.",
+        "usage": "Usage:\r\n  rpk cluster maintenance disable <broker-id> [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for disable."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster maintenance enable": {
+        "description": "Enable maintenance mode for a node.\r\n\r\nThis command enables maintenance mode for the node with the specified ID. If a\r\nnode exists that is already in maintenance mode then an error will be returned.",
+        "usage": "Usage:\r\n  rpk cluster maintenance enable <node-id> [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for enable."
+            },
+            "-w, --wait": {
+                "type": "-",
+                "description": "Wait until node is drained."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster maintenance status": {
+        "description": "Report maintenance status.\r\n\r\nThis command reports maintenance status for each node in the cluster. The output\r\nis presented as a table with each row representing a node in the cluster.  The\r\noutput can be used to monitor the progress of node draining.\r\n\r\n   NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED\r\n   1        false     false     false   0           0         0             0\r\n\r\nField descriptions:\r\n\r\n        NODE-ID: the node ID\r\n       DRAINING: true if the node is actively draining leadership\r\n       FINISHED: leadership draining has completed\r\n         ERRORS: errors have been encountered while draining\r\n     PARTITIONS: number of partitions whose leadership has moved\r\n       ELIGIBLE: number of partitions with leadership eligible to move\r\n   TRANSFERRING: current active number of leadership transfers\r\n         FAILED: number of failed leadership transfers\r\n\r\nNotes:\r\n\r\n   - When errors are present further information will be available in the logs\r\n     for the corresponding node.\r\n\r\n   - Only partitions with more than one replica are eligible for leadership\r\n     transfer.",
+        "usage": "Usage:\r\n  rpk cluster maintenance status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster metadata": {
+        "description": "Request broker metadata.\r\n\r\nThe Kafka protocol's metadata contains information about brokers, topics, and\r\nthe cluster as a whole.\r\n\r\nThis command only runs if specific sections of metadata are requested. There\r\nare currently three sections: the cluster, the list of brokers, and the topics.\r\nIf no section is specified, this defaults to printing all sections.\r\n\r\nIf the topic section is requested, all topics are requested by default unless\r\nsome are manually specified as arguments. Expanded per-partition information\r\ncan be printed with the -d flag, and internal topics can be printed with the -i\r\nflag.\r\n\r\nIn the broker section, the controller node is suffixed with *.",
+        "usage": "Usage:\r\n  rpk cluster metadata [flags]\r\n\r\nAliases:\r\n  metadata, status, info\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for metadata."
+            },
+            "-b, --print-brokers": {
+                "type": "-",
+                "description": "Print brokers section."
+            },
+            "-c, --print-cluster": {
+                "type": "-",
+                "description": "Print cluster section."
+            },
+            "-d, --print-detailed-topics": {
+                "type": "-",
+                "description": "Print per-partition information for topics (implies -t)."
+            },
+            "-i, --print-internal-topics": {
+                "type": "-",
+                "description": "Print internal topics (if all topics requested, implies -t)."
+            },
+            "-t, --print-topics": {
+                "type": "-",
+                "description": "Print topics section (implied if any topics are specified)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster partitions": {
+        "description": "Manage cluster partitions",
+        "usage": "Usage:\r\n  rpk cluster partitions [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for partitions."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster partitions balancer-status": {
+        "description": "Queries cluster for partition balancer status:\r\n\r\nIf continuous partition balancing is enabled, redpanda will continuously\r\nreassign partitions from both unavailable nodes and from nodes using more disk\r\nspace than the configured limit.\r\n\r\nThis command can be used to monitor the partition balancer status.\r\n\r\nFIELDS\r\n\r\n    Status:                        Either off, ready, starting, in progress, or\r\n                                   stalled.\r\n    Seconds Since Last Tick:       The last time the partition balancer ran.\r\n    Current Reassignments Count:   Current number of partition reassignments in\r\n                                   progress.\r\n    Unavailable Nodes:             The nodes that have been unavailable after a\r\n                                   time set by the\r\n                                   \"partition_autobalancing_node_availability_timeout_sec\"\r\n                                   cluster property.\r\n    Over Disk Limit Nodes:         The nodes that surpassed the threshold of\r\n                                   used disk percentage specified in the\r\n                                   \"partition_autobalancing_max_disk_usage_percent\"\r\n                                   cluster property.\r\n\r\nBALANCER STATUS\r\n\r\n    off:          The balancer is disabled.\r\n    ready:        The balancer is active but there is nothing to do.\r\n    starting:     The balancer is starting but has not run yet.\r\n    in_progress:  The balancer is active and is in the process of scheduling\r\n                  partition movements.\r\n    stalled:      Violations have been detected and the balancer cannot correct\r\n                  them.\r\n\r\nSTALLED BALANCER\r\n\r\nA stalled balancer can occur for a few reasons and requires a bit of manual\r\ninvestigation. A few areas to investigate:\r\n\r\n* Are there are enough healthy nodes to which to move partitions? For example,\r\n  in a three node cluster, no movements are possible for partitions with three\r\n  replicas. You will see a stall every time there is a violation.\r\n\r\n* Does the cluster have sufficient space? If all nodes in the cluster are\r\n  utilizing more than 80% of their disk space, rebalancing cannot proceed.\r\n\r\n* Do all partitions have quorum? If the majority of a partition's replicas are\r\n  down, the partition cannot be moved.\r\n\r\n* Are any nodes in maintenance mode? Partitions are not moved if any node is in\r\n  maintenance mode.",
+        "usage": "Usage:\r\n  rpk cluster partitions balancer-status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for balancer-status."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster partitions movement-cancel": {
+        "description": "Cancel ongoing partition movements.\r\n\r\nBy default, this command cancels all the partition movements in the cluster. \r\nTo ensure that you do not accidentally cancel all partition movements, this \r\ncommand prompts users for confirmation before issuing the cancellation request. \r\nYou can use \"--no-confirm\" to disable the confirmation prompt:\r\n\r\n    rpk cluster partitions movement-cancel --no-confirm\r\n\r\nIf \"--node\" is set, this command will only stop the partition movements \r\noccurring in the specified node:\r\n\r\n    rpk cluster partitions movement-cancel --node 1",
+        "usage": "Usage:\r\n  rpk cluster partitions movement-cancel [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for movement-cancel."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "--node": {
+                "type": "int",
+                "description": "ID of a specific node on which to cancel ongoing partition movements (default -1)."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster self-test": {
+        "description": "Start, stop and query runs of Redpanda self-test through the Admin API listener",
+        "usage": "Usage:\r\n  rpk cluster self-test [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of Admin API addresses (<IP>:<port>)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for self-test."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster self-test start": {
+        "description": "Starts one or more benchmark tests on one or more nodes\r\nof the cluster. Available tests to run:\r\n\r\n* Disk tests:\r\n  * Throughput test: 512 KB messages, sequential read/write\r\n    * Uses a larger request message sizes and deeper I/O queue depth to write/read more bytes in a shorter amount of time, at the cost of IOPS/latency.\r\n  * Latency test: 4 KB messages, sequential read/write\r\n    * Uses smaller request message sizes and lower levels of parallelism to achieve higher IOPS and lower latency.\r\n\r\n* Network tests:\r\n  * Throughput test: 8192-bit messages\r\n    * Unique pairs of Redpanda nodes each act as a client and a server.\r\n    * The test pushes as much data over the wire, within the test parameters.\r\n\r\nThis command immediately returns on success, and the tests run asynchronously. The\r\nuser polls for results with the 'self-test status'\r\ncommand.",
+        "usage": "Usage:\r\n  rpk cluster self-test start [flags]\r\n\r",
+        "flags": {
+            "--disk-duration-ms": {
+                "type": "duration",
+                "description": "uint       The  in milliseconds of individual disk test runs (default 30000)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--network-duration-ms": {
+                "type": "duration",
+                "description": "uint    The  in milliseconds of individual network test runs (default 30000)."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Acknowledge warning prompt skipping read from stdin."
+            },
+            "--only-disk-test": {
+                "type": "-",
+                "description": "Runs only the disk benchmarks."
+            },
+            "--only-network-test": {
+                "type": "-",
+                "description": "Runs only network benchmarks."
+            },
+            "--participant-node-ids": {
+                "type": "-",
+                "description": "ints   IDs of nodes that the tests will run on. If not set, tests will run for all node IDs."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of Admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster self-test status": {
+        "description": "Returns the status of the currently running or last completed self-test run.\r\n\r\nUse this command after invoking 'self-test start' to determine the status of\r\nthe jobs launched. Possible results are:\r\n\r\n* One or more jobs still running\r\n  * Returns the IDs of Redpanda nodes still running self-tests.\r\n\r\n* No jobs running:\r\n  * Returns cached results for all nodes of the last completed test.",
+        "usage": "Usage:\r\n  rpk cluster self-test status [flags]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (text, json) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of Admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster self-test stop": {
+        "description": "Stops all self-test tests.\r\n\r\nThis command stops all currently running self-tests. The command is synchronous and returns\r\nsuccess when all jobs have been stopped or reports errors if broker timeouts have expired.",
+        "usage": "Usage:\r\n  rpk cluster self-test stop [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of Admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster storage": {
+        "description": "Manage the cluster storage",
+        "usage": "Usage:\r\n  rpk cluster storage [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for storage."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster storage recovery": {
+        "description": "Interact with the topic recovery process.\r\n\t\t\r\nThis command is used to restore topics from the archival bucket, which can be \r\nuseful for disaster recovery or if a topic was accidentally deleted.\r\n\r\nTo begin the recovery process, use the \"recovery start\" command. Note that this \r\nprocess can take a while to complete, so the command will exit after starting \r\nit. If you want the command to wait for the process to finish, use the \"--wait\"\r\nor \"-w\" flag.\r\n\r\nYou can check the status of the recovery process with the \"recovery status\" \r\ncommand after it has been started.",
+        "usage": "Usage:\r\n  rpk cluster storage recovery [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for recovery."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster storage recovery start": {
+        "description": "Start the topic recovery process.\r\n\t\t\r\nThis command starts the process of restoring topics from the archival bucket.\r\nIf the wait flag (--wait/-w) is set, the command will poll the status of the\r\nrecovery process until it's finished.",
+        "usage": "Usage:\r\n  rpk cluster storage recovery start [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--polling-interval": {
+                "type": "duration",
+                "description": "The status check interval (e.g. '30s', '1.5m'); ignored if --wait is not used (default 5s)."
+            },
+            "--topic-name-pattern": {
+                "type": "string",
+                "description": "A regex pattern that restores any matching topics (default \".*\")."
+            },
+            "-w, --wait": {
+                "type": "-",
+                "description": "Wait until auto-restore is complete."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk cluster storage recovery status": {
+        "description": "Fetch the status of the topic recovery process.\r\n\t\t\r\nThis command fetches the status of the process of restoring topics from the \r\narchival bucket.",
+        "usage": "Usage:\r\n  rpk cluster storage recovery status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk container": {
+        "description": "Manage a local container cluster",
+        "usage": "Usage:\r\n  rpk container [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for container."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk container purge": {
+        "description": "Stop and remove an existing local container cluster's data",
+        "usage": "Usage:\r\n  rpk container purge [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for purge."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk container start": {
+        "description": "Start a local container cluster",
+        "usage": "Usage:\r\n  rpk container start [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "-n, --nodes": {
+                "type": "-",
+                "description": "uint     The number of nodes to start (default 1)."
+            },
+            "--retries": {
+                "type": "-",
+                "description": "uint   The amount of times to check for the cluster before considering it unstable and exiting. (default 10)."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk container status": {
+        "description": "Get status",
+        "usage": "Usage:\r\n  rpk container status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk container stop": {
+        "description": "Stop an existing local container cluster",
+        "usage": "Usage:\r\n  rpk container stop [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk debug": {
+        "description": "Debug the local Redpanda process",
+        "usage": "Usage:\r\n  rpk debug [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for debug."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk debug bundle": {
+        "description": "'rpk debug bundle' collects environment data that can help debug and diagnose\r\nissues with a redpanda cluster, a broker, or the machine it's running on. It\r\nthen bundles the collected data into a ZIP file, called a diagnostics bundle.\r\n\r\nThe files and directories in the diagnostics bundle differ depending on the \r\nenvironment in which Redpanda is running:\r\n\r\nCOMMON FILES\r\n\r\n - Kafka metadata: Broker configs, topic configs, start/committed/end offsets,\r\n   groups, group commits.\r\n\r\n - Controller logs: The controller logs directory up to a limit set by\r\n   --controller-logs-size-limit flag\r\n\r\n - Data directory structure: A file describing the data directory's contents.\r\n\r\n - redpanda configuration: The redpanda configuration file (redpanda.yaml;\r\n   SASL credentials are stripped).\r\n\r\n - /proc/cpuinfo: CPU information like make, core count, cache, frequency.\r\n\r\n - /proc/interrupts: IRQ distribution across CPU cores.\r\n\r\n - Resource usage data: CPU usage percentage, free memory available for the\r\n   redpanda process.\r\n\r\n - Clock drift: The ntp clock delta (using pool.ntp.org as a reference) & round\r\n   trip time.\r\n\r\n - Admin API calls: Cluster and broker configurations, cluster health data, and \r\n   license key information.\r\n\r\n - Broker metrics: The broker's Prometheus metrics, fetched through its\r\n   admin API (/metrics and /public_metrics).\r\n\r\nBARE-METAL\r\n\r\n - Kernel logs: The kernel logs ring buffer (syslog).\r\n\r\n - DNS: The DNS info as reported by 'dig', using the hosts in\r\n   /etc/resolv.conf.\r\n\r\n - Disk usage: The disk usage for the data directory, as output by 'du'.\r\n\r\n - redpanda logs: The node's redpanda logs written to journald. If --logs-since \r\n   or --logs-until are passed, then only the logs within the resulting time frame\r\n   will be included.\r\n\r\n - Socket info: The active sockets data output by 'ss'.\r\n\r\n - Running process info: As reported by 'top'.\r\n\r\n - Virtual memory stats: As reported by 'vmstat'.\r\n\r\n - Network config: As reported by 'ip addr'.\r\n\r\n - lspci: List the PCI buses and the devices connected to them.\r\n\r\n - dmidecode: The DMI table contents. Only included if this command is run\r\n   as root.\r\n\r\nKUBERNETES\r\n\r\n - Kubernetes Resources: Kubernetes manifests for all resources in the given \r\n   Kubernetes namespace (via --namespace).\r\n\r\n - redpanda logs: Logs of each Pod in the the given Kubernetes namespace. If \r\n   --logs-since is passed, only the logs within the given timeframe are \r\n   included.\r\n\r\n\r\nIf you have an upload URL from the Redpanda support team, provide it in the \r\n--upload-url flag to upload your diagnostics bundle to Redpanda.",
+        "usage": "Usage:\r\n  rpk debug bundle [flags]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--api-urls": {
+                "type": "string",
+                "description": "Comma-separated list of admin API addresses (<IP>:<port>)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--controller-logs-size-limit": {
+                "type": "string",
+                "description": "Sets the limit of the controller log size that can be stored in the bundle. Multipliers are also supported, e.g. 3MB, 1GiB (default \"20MB\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for bundle."
+            },
+            "--logs-since": {
+                "type": "string",
+                "description": "Include log entries on or newer than the specified date. (journalctl date format, e.g. YYYY-MM-DD)."
+            },
+            "--logs-size-limit": {
+                "type": "string",
+                "description": "Read the logs until the given size is reached. Multipliers are also supported, e.g. 3MB, 1GiB (default \"100MiB\")."
+            },
+            "--logs-until": {
+                "type": "string",
+                "description": "Include log entries on or older than the specified date. (journalctl date format, e.g. YYYY-MM-DD)."
+            },
+            "--metrics-interval": {
+                "type": "duration",
+                "description": "Interval between metrics snapshots (e.g. '30s', '1.5m') (default 10s)."
+            },
+            "-n, --namespace": {
+                "type": "string",
+                "description": "The namespace to use to collect the resources from (k8s only) (default \"redpanda\")."
+            },
+            "-o, --output": {
+                "type": "string",
+                "description": "The file path where the debug file will be written (default ./<timestamp>-bundle.zip)."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "How long to wait for child commands to execute (e.g. '30s', '1.5m') (default 12s)."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--upload-url": {
+                "type": "string",
+                "description": "If provided, rpk will upload the bundle to the given URL in addition to creating a copy on disk."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk generate": {
+        "description": "Generate a configuration template for related services",
+        "usage": "Usage:\r\n  rpk generate [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for generate."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk generate grafana-dashboard": {
+        "description": "Generate a Grafana dashboard for redpanda metrics",
+        "usage": "Usage:\r\n  rpk generate grafana-dashboard [flags]\r\n\r",
+        "flags": {
+            "--datasource": {
+                "type": "string",
+                "description": "The name of the Prometheus datasource as configured in your grafana instance."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for grafana-dashboard."
+            },
+            "--job-name": {
+                "type": "string",
+                "description": "The prometheus job name by which to identify the redpanda nodes (default \"redpanda\")."
+            },
+            "--metrics-endpoint": {
+                "type": "string",
+                "description": "The redpanda metrics endpoint where to get the metrics metadata. i.e. redpanda_host:9644/metrics (default \"http://localhost:9644/metrics\")."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk generate prometheus-config": {
+        "description": "Generate the Prometheus configuration to scrape redpanda nodes. This command's\r\noutput should be added to the 'scrape_configs' array in your Prometheus\r\ninstance's YAML config file.\r\n\r\nIf --seed-addr is passed, it will be used to discover the rest of the cluster\r\nhosts via Redpanda's Kafka API. If --node-addrs is passed, they will be used\r\ndirectly. Otherwise, 'rpk generate prometheus-conf' will read the redpanda\r\nconfig file and use the node IP configured there. --config may be passed to\r\nspecify an arbitrary config file.\r\n\r\nIf the node you want to scrape uses TLS, you can provide the TLS flags:\r\n--tls-key, --tls-cert, and --tls-truststore and rpk will generate the required\r\ntls_config section in the scrape configuration.",
+        "usage": "Usage:\r\n  rpk generate prometheus-config [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "The path to the redpanda config file."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for prometheus-config."
+            },
+            "--internal-metrics": {
+                "type": "-",
+                "description": "Include scrape config for internal metrics (/metrics)."
+            },
+            "--job-name": {
+                "type": "string",
+                "description": "The prometheus job name by which to identify the redpanda nodes (default \"redpanda\")."
+            },
+            "--node-addrs": {
+                "type": "strings",
+                "description": "A comma-delimited list of the addresses (<host>:<port>) of all the redpanda nodes in a cluster. The port must be the one configured for the nodes' admin API (9644 by default)."
+            },
+            "--seed-addr": {
+                "type": "string",
+                "description": "The URL of a redpanda node with which to discover the rest."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk generate shell-completion": {
+        "description": "Shell completion can help autocomplete rpk commands when you press tab.\r\n\r\n# Bash\r\n\r\nBash autocompletion relies on the bash-completion package. You can test if you\r\nhave this by running \"type _init_completion\", if you do not, you can install\r\nthe package through your package manager.\r\n\r\nIf you have bash-completion installed, and the command still fails, you likely\r\nneed to add the following line to your ~/.bashrc:\r\n\r\n    source /usr/share/bash-completion/bash_completion\r\n\r\nTo ensure autocompletion of rpk exists in all shell sessions, add the following\r\nto your ~/.bashrc:\r\n\r\n    command -v rpk >/dev/null && . <(rpk generate shell-completion bash)\r\n\r\nAlternatively, to globally enable rpk completion, you can run the following:\r\n\r\n    rpk generate shell-completion bash > /etc/bash_completion.d/rpk\r\n\r\n# Zsh\r\n\r\nTo enable autocompletion in any zsh session for any user, run this once:\r\n\r\n    rpk generate shell-completion zsh > \"${fpath[1]}/_rpk\"\r\n\r\nYou can also place that command in your ~/.zshrc to ensure that when you update\r\nrpk, you update autocompletion. If you initially require sudo to edit that\r\nfile, you can chmod it to be world writeable, after which you will always be\r\nable to update it from ~/.zshrc.\r\n\r\nIf shell completion is not already enabled in your zsh environment, also\r\nadd the following to your ~/.zshrc:\r\n\r\n    autoload -U compinit; compinit\r\n\r\n# Fish\r\n\r\nTo enable autocompletion in any fish session, run:\r\n\r\n    rpk generate shell-completion fish > ~/.config/fish/completions/rpk.fish",
+        "usage": "Usage:\r\n  rpk generate shell-completion [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for shell-completion."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group": {
+        "description": "Describe, list, and delete consumer groups and manage their offsets.\r\n\r\nConsumer groups allow you to horizontally scale consuming from topics. A\r\nnon-group consumer consumes all records from all partitions you assign it. In\r\ncontrast, consumer groups allow many consumers to coordinate and divide work.\r\nIf you have two members in a group consuming topics A and B, each with three\r\npartitions, then both members consume three partitions. If you add another\r\nmember to the group, then each of the three members will consume two\r\npartitions. This allows you to horizontally scale consuming of topics.\r\n\r\nThe unit of scaling is a single partition. If you add more consumers to a group\r\nthan there are are total partitions to consume, then some consumers will be\r\nidle. More commonly, you have many more partitions than consumer group members\r\nand each member consumes a chunk of available partitions. One scenario where\r\nyou may want more members than partitions is if you want active standby's to\r\ntake over load immediately if any consuming member dies.\r\n\r\nHow group members divide work is entirely client driven (the \"partition\r\nassignment strategy\" or \"balancer\" depending on the client). Brokers know\r\nnothing about how consumers are assigning partitions. A broker's role in group\r\nconsuming is to choose which member is the leader of a group, forward that\r\nmember's assignment to every other member, and ensure all members are alive\r\nthrough heartbeats.\r\n\r\nConsumers periodically commit their progress when consuming partitions. Through\r\nthese commits, you can monitor just how far behind a consumer is from the\r\nlatest messages in a partition. This is called \"lag\". Large lag implies that\r\nthe client is having problems, which could be from the server being too slow,\r\nor the client being oversubscribed in the number of partitions it is consuming,\r\nor the server being in a bad state that requires restarting or removing from\r\nthe server pool, and so on.\r\n\r\nYou can manually manage offsets for a group, which allows you to rewind or\r\nforward commits. If you notice that a recent deploy of your consumers had a\r\nbug, you may want to stop all members, rewind the commits to before the latest\r\ndeploy, and restart the members with a patch.\r\n\r\nThis command allows you to list all groups, describe a group (to view the\r\nmembers and their lag), and manage offsets.",
+        "usage": "Usage:\r\n  rpk group [command]\r\n\r\nAliases:\r\n  group, g\r\n\r",
+        "flags": {
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for group."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group delete": {
+        "description": "Delete groups from brokers.\r\n\r\nOlder versions of the Kafka protocol included a retention_millis field in\r\noffset commit requests. Group commits persisted for this retention and then\r\neventually expired. Once all commits for a group expired, the group would be\r\nconsidered deleted.\r\n\r\nThe retention field was removed because it proved problematic for infrequently\r\ncommitting consumers: the offsets could be expired for a group that was still\r\nactive. If clients use new enough versions of OffsetCommit (versions that have\r\nremoved the retention field), brokers expire offsets only when the group is\r\nempty for offset.retention.minutes. Redpanda does not currently support that\r\nconfiguration (see #2904), meaning offsets for empty groups expire only when\r\nthey are explicitly deleted.\r\n\r\nYou may want to delete groups to clean up offsets sooner than when they\r\nautomatically are cleaned up, such as when you create temporary groups for\r\nquick investigation or testing. This command helps you do that.",
+        "usage": "Usage:\r\n  rpk group delete [GROUPS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group describe": {
+        "description": "Describe group offset status & lag.\r\n\r\nThis command describes group members, calculates their lag, and prints detailed\r\ninformation about the members.",
+        "usage": "Usage:\r\n  rpk group describe [GROUPS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "-s, --print-summary": {
+                "type": "-",
+                "description": "Print only the group summary section."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group list": {
+        "description": "List all groups.\r\n\r\nThis command lists all groups currently known to Redpanda, including empty\r\ngroups that have not yet expired. The BROKER column is which broker node is the\r\ncoordinator for the group. This command can be used to track down unknown\r\ngroups, or to list groups that need to be cleaned up.",
+        "usage": "Usage:\r\n  rpk group list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group offset-delete": {
+        "description": "Forcefully delete offsets for a kafka group.\r\n\r\nThe broker will only allow the request to succeed if the group is in a dead\r\nstate (no subscriptions) or there are no subscriptions for offsets for\r\ntopic/partitions requested to be deleted.\r\n\r\nUse either the --from-file or the --topic option. They are mututally exclusive.\r\nTo indicate which topics or topic partitions you'd like to remove offsets from use\r\nthe --topic (-t) flag, followed by a comma separated list of partition ids. Supplying\r\nno list will delete all offsets for all partitions for a given topic.\r\n\r\nYou may also provide a text file to indicate topic/partition tuples. Use the\r\n--from-file flag for this option. The file must contain lines of topic/partitions\r\nseparated by a tab or space. Example:\r\n\r\ntopic_a 0\r\ntopic_a 1\r\ntopic_b 0",
+        "usage": "Usage:\r\n  rpk group offset-delete [GROUP] --from-file FILE --topic foo:0,1,2 [flags]\r\n\r",
+        "flags": {
+            "-f, --from-file": {
+                "type": "string",
+                "description": "File of topic/partition tuples for which to delete offsets for."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for offset-delete."
+            },
+            "-t, --topic": {
+                "type": "stringArray",
+                "description": "topic:partition_id (repeatable; e.g. -t foo:0,1,2 )."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk group seek": {
+        "description": "Modify a group's current offsets.\r\n\r\nThis command allows you to modify a group's offsets. Sometimes, you may need to\r\nrewind a group if you had a mistaken deploy, or fast-forward a group if it is\r\nfalling behind on messages that can be skipped.\r\n\r\nThe --to option allows you to seek to the start of partitions, end of\r\npartitions, or after a specific timestamp. The default is to seek any topic\r\npreviously committed. Using --topics allows to you set commits for only the\r\nspecified topics; all other commits will remain untouched. Topics with no\r\ncommits will not be committed unless allowed with --allow-new-topics.\r\n\r\nThe --to-group option allows you to seek to commits that are in another group.\r\nThis is a merging operation: if g1 is consuming topics A and B, and g2 is\r\nconsuming only topic B, \"rpk group seek g1 --to-group g2\" will update g1's\r\ncommits for topic B only. The --topics flag can be used to further narrow which\r\ntopics are updated. Unlike --to, all non-filtered topics are committed, even\r\ntopics not yet being consumed, meaning --allow-new-topics is not needed.\r\n\r\nThe --to-file option allows to seek to offsets specified in a text file with\r\nthe following format:\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    ...\r\nEach line contains the topic, the partition, and the offset to seek to. As with\r\nthe prior options, --topics allows filtering which topics are updated. Similar\r\nto --to-group, all non-filtered topics are committed, even topics not yet being\r\nconsumed, meaning --allow-new-topics is not needed.\r\n\r\nThe --to, --to-group, and --to-file options are mutually exclusive. If you are\r\nnot authorized to describe or read some topics used in a group, you will not be\r\nable to modify offsets for those topics.\r\n\r\nEXAMPLES\r\n\r\nSeek group G to June 1st, 2021:\r\n    rpk group seek g --to 1622505600\r\n    or, rpk group seek g --to 1622505600000\r\n    or, rpk group seek g --to 1622505600000000000\r\nSeek group X to the commits of group Y topic foo:\r\n    rpk group seek X --to-group Y --topics foo\r\nSeek group G's topics foo, bar, and biz to the end:\r\n    rpk group seek G --to end --topics foo,bar,biz\r\nSeek group G to the beginning of a topic it was not previously consuming:\r\n    rpk group seek G --to start --topics foo --allow-new-topics",
+        "usage": "Usage:\r\n  rpk group seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ... [flags]\r\n\r",
+        "flags": {
+            "--allow-new-topics": {
+                "type": "-",
+                "description": "Allow seeking to new topics not currently consumed (implied with --to-group or --to-file)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for seek."
+            },
+            "--to": {
+                "type": "string",
+                "description": "Where to seek (start, end, unix second | millisecond | nanosecond)."
+            },
+            "--to-file": {
+                "type": "string",
+                "description": "Seek to offsets as specified in the file."
+            },
+            "--to-group": {
+                "type": "string",
+                "description": "Seek to the commits of another group."
+            },
+            "--topics": {
+                "type": "strings",
+                "description": "Only seek these topics, if any are specified."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk help": {
+        "description": "Help provides help for any command in the application.\r\nSimply type rpk help [path to command] for full details.",
+        "usage": "Usage:\r\n  rpk help [command] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "help for help."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk iotune": {
+        "description": "Measure filesystem performance and create IO configuration file",
+        "usage": "Usage:\r\n  rpk iotune [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--directories": {
+                "type": "strings",
+                "description": "List of directories to evaluate."
+            },
+            "--duration": {
+                "type": "duration",
+                "description": "Duration of tests.The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 10m0s)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for iotune."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt if the iotune file already exists."
+            },
+            "--out": {
+                "type": "string",
+                "description": "The file path where the IO config will be written (default \"/etc/redpanda/io-config.yaml\")."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time after -- to wait for iotune to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 1h0m0s)."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk plugin": {
+        "description": "List, download, update, and remove rpk plugins.\r\n\t\r\nPlugins augment rpk with new commands.\r\n\r\nFor a plugin to be used, it must be in $HOME/.local/bin or somewhere \r\ndiscoverable by rpk in your $PATH. All plugins follow a defined naming scheme:\r\n\r\n  .rpk-<name>\r\n  .rpk.ac-<name>\r\n\r\nAll plugins are prefixed with either .rpk- or .rpk.ac-. When rpk starts up, it\r\nsearches all directories in your $PATH for any executable binary that begins\r\nwith either of those prefixes. For any binary it finds, rpk adds a command for\r\nthat name to the rpk command space itself.\r\n\r\nNo plugin name can shadow an existing rpk command, and only one plugin can\r\nexist under a given name at once. Plugins are added to the rpk command space on\r\na first-seen basis. If you have two plugins rpk-foo, and the second is\r\ndiscovered later on in the $PATH directories, then only the first will be used.\r\nThe second will be ignored.\r\n\r\nPlugins that have an .rpk.ac- prefix indicate that they support the\r\n--help-autocomplete flag. If rpk sees this, rpk will exec the plugin with that\r\nflag when rpk starts up, and the plugin will return all commands it supports as\r\nwell as short and long help test for each command. Rpk uses this return to\r\nbuild a shadow command space within rpk itself so that it looks as if the\r\nplugin exists within rpk. This is particularly useful if you enable\r\nautocompletion.\r\n\r\nThe expected return for plugins from --help-autocomplete is an array of the\r\nfollowing:\r\n\r\n  type pluginHelp struct {\r\n          Path    string   `json:\"path,omitempty\"`\r\n          Short   string   `json:\"short,omitempty\"`\r\n          Long    string   `json:\"long,omitempty\"`\r\n          Example string   `json:\"example,omitempty\"`\r\n          Args    []string `json:\"args,omitempty\"`\r\n  }\r\n\r\nwhere \"path\" is an underscore delimited argument path to a command. For\r\nexample, \"foo_bar_baz\" corresponds to the command \"rpk foo bar baz\".",
+        "usage": "Usage:\r\n  rpk plugin [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for plugin."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk plugin install": {
+        "description": "Install an rpk plugin.\r\n\r\nAn rpk plugin must be saved in $HOME/.local/bin or in a directory that is in \r\nyour $PATH. By default, this command installs plugins to $HOME/.local/bin. This \r\ncan be overridden by specifying the --dir flag.\r\n\r\nIf --dir is not present, rpk will create $HOME/.local/bin if it does not exist.",
+        "usage": "Usage:\r\n  rpk plugin install [PLUGIN] [flags]\r\n\r\nAliases:\r\n  install, download\r\n\r",
+        "flags": {
+            "--dir": {
+                "type": "string",
+                "description": "Destination directory to save the installed plugin (defaults to $HOME/.local/bin) (default \"/var/lib/redpanda/.local/bin\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for install."
+            },
+            "-u, --update": {
+                "type": "-",
+                "description": "Update a locally installed plugin if it differs from the current remote version."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk plugin list": {
+        "description": "List all available plugins.\r\n\r\nBy default, this command fetches the remote manifest and prints plugins\r\navailable for download. Any plugin that is already downloaded is prefixed with\r\nan asterisk. If a locally installed plugin has a different sha256sum as the one\r\nspecified in the manifest, or if the sha256sum could not be calculated for the\r\nlocal plugin, an additional message is printed.\r\n\r\nYou can specify --local to print all locally installed plugins, as well as\r\nwhether you have \"shadowed\" plugins (the same plugin specified multiple times).",
+        "usage": "Usage:\r\n  rpk plugin list [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-l, --local": {
+                "type": "-",
+                "description": "List locally installed plugins and shadowed plugins."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk plugin uninstall": {
+        "description": "Uninstall / remove an existing local plugin.\r\n\r\nThis command lists locally installed plugins and removes the first plugin that\r\nmatches the requested removal. If --include-shadowed is specified, this command\r\nalso removes all shadowed plugins of the same name. To remove a command under a\r\nnested namespace (\"rpk foo bar\"), you can use \"foo_bar\".",
+        "usage": "Usage:\r\n  rpk plugin uninstall [NAME] [flags]\r\n\r\nAliases:\r\n  uninstall, rm\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for uninstall."
+            },
+            "--include-shadowed": {
+                "type": "-",
+                "description": "Also remove shadowed plugins that have the same name."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda": {
+        "description": "Interact with a local Redpanda process",
+        "usage": "Usage:\r\n  rpk redpanda [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for redpanda."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin": {
+        "description": "Talk to the Redpanda admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin [command]\r\n\r",
+        "flags": {
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for admin."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin brokers": {
+        "description": "View and configure Redpanda brokers through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for brokers."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin brokers decommission": {
+        "description": "Decommission the given broker.\r\n\r\nDecommissioning a broker removes it from the cluster.\r\n\r\nA decommission request is sent to every broker in the cluster, only the cluster\r\nleader handles the request.\r\n\r\nFor safety on v22.x clusters, this command will not run if the requested \r\nbroker is in maintenance mode. As of v23.x, Redpanda supports \r\ndecommissioning a node that is currently in maintenance mode. If you are on \r\na v22.x cluster and need to bypass the maintenance mode check (perhaps your \r\ncluster is unreachable), use the hidden --force flag.",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers decommission [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for decommission."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin brokers decommission-status": {
+        "description": "Show the progress of a node decommissioning",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers decommission-status [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-d, --detailed": {
+                "type": "-",
+                "description": "Print how much data moved and remaining in bytes."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for decommission-status."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin brokers list": {
+        "description": "List the brokers in your cluster",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin brokers recommission": {
+        "description": "Recommission the given broker if is is still decommissioning.\r\n\r\nRecommissioning can stop an active decommission.\r\n\r\nOnce a broker is decommissioned, it cannot be recommissioned through this\r\ncommand.\r\n\r\nA recommission request is sent to every broker in the cluster, only\r\nthe cluster leader handles the request.",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers recommission [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for recommission."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin config": {
+        "description": "View or modify Redpanda configuration through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin config [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin config log-level": {
+        "description": "Manage a broker's log level",
+        "usage": "Usage:\r\n  rpk redpanda admin config log-level [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for log-level."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin config log-level set": {
+        "description": "Set broker logger's log level.\r\n\r\nThis command temporarily changes a broker logger's log level. Each Redpanda\r\nbroker has many loggers, and each can be individually changed. Any change\r\nto a logger persists for a limited amount of time, so as to ensure you do\r\nnot accidentally enable debug logging permanently.\r\n\r\nIt is optional to specify a logger; if you do not, this command will prompt\r\nfrom the set of available loggers.\r\n\r\nThe special logger \"all\" enables all loggers. Alternatively, you can specify\r\nmany loggers at once. To see all possible loggers, run the following command:\r\n\r\n  redpanda --help-loggers\r\n\r\nThis command accepts loggers that it does not know of to ensure you can\r\nindependently update your redpanda installations from rpk. The success or\r\nfailure of enabling each logger is individually printed.",
+        "usage": "Usage:\r\n  rpk redpanda admin config log-level set [LOGGERS...] [flags]\r\n\r",
+        "flags": {
+            "-e, --expiry-seconds": {
+                "type": "int",
+                "description": "seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown) (default 300)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--host": {
+                "type": "string",
+                "description": "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to."
+            },
+            "-l, --level": {
+                "type": "string",
+                "description": "log level to set (error, warn, info, debug, trace) (default \"debug\")."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin config print": {
+        "description": "Display the current Redpanda configuration",
+        "usage": "Usage:\r\n  rpk redpanda admin config print [flags]\r\n\r\nAliases:\r\n  print, dump, list, ls, display\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for print."
+            },
+            "--host": {
+                "type": "string",
+                "description": "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin partitions": {
+        "description": "View and configure Redpanda partitions through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin partitions [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for partitions."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda admin partitions list": {
+        "description": "List the partitions in a broker in the cluster",
+        "usage": "Usage:\r\n  rpk redpanda admin partitions list [BROKER ID] [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-l, --leader-only": {
+                "type": "-",
+                "description": "print the partitions on broker which are leaders."
+            },
+            "--admin-api-tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Admin API (not necessary if specifying custom certs)."
+            },
+            "--admin-api-tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the Admin API."
+            },
+            "--admin-api-tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the Admin API."
+            },
+            "--config": {
+                "type": "string",
+                "description": "rpk config file, if not set the file will be searched for in the default locations."
+            },
+            "--hosts": {
+                "type": "strings",
+                "description": "A comma-separated list of Admin API addresses (<IP>:<port>). You must specify one for each node."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda check": {
+        "description": "Check if system meets redpanda requirements",
+        "usage": "Usage:\r\n  rpk redpanda check [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for check."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum amount of time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 2s)."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda config": {
+        "description": "Edit configuration",
+        "usage": "Usage:\r\n  rpk redpanda config [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda config bootstrap": {
+        "description": "Initialize the configuration to bootstrap a cluster.\r\n\r\nThis command generates a redpanda.yaml configuration file to bootstrap a\r\ncluster. If you are modifying the configuration file further, it is recommended\r\nto first bootstrap and then modify. If the file already exists, this command\r\nwill set fields as requested by flags, and this may undo some of your earlier\r\nedits.\r\n\r\nThe --ips flag specifies seed servers (ips, ip:ports, or hostnames) that this\r\nbroker will use to form a cluster.\r\n\r\nBy default, redpanda expects your machine to have one private IP address, and\r\nredpanda will listen on it. If your machine has multiple private IP addresses,\r\nyou must use the --self flag to specify which ip redpanda should listen on.",
+        "usage": "Usage:\r\n  rpk redpanda config bootstrap [--self <ip>] [--ips <ip1,ip2,...>] [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default location."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for bootstrap."
+            },
+            "--ips": {
+                "type": "strings",
+                "description": "Comma-separated list of the seed node addresses or hostnames; at least three are recommended."
+            },
+            "--self": {
+                "type": "string",
+                "description": "Optional IP address for redpanda to listen on; if empty, defaults to a private address."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda config init": {
+        "description": "Init the node after install, by setting the node's UUID",
+        "usage": "Usage:\r\n  rpk redpanda config init [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default location."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for init."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda config set": {
+        "description": "Set configuration values, such as the redpanda node ID or the list of seed servers\r\n\r\nThis command modifies the redpanda.yaml you have locally on disk. The first\r\nargument is the key within the yaml representing a property / field that you\r\nwould like to set. Nested fields can be accessed through a dot:\r\n\r\n  rpk redpanda config set redpanda.developer_mode true\r\n\r\nThe default format is to parse the value as yaml. Individual specific fields\r\ncan be set, or full structs:\r\n\r\n  rpk redpanda config set rpk.tune_disk_irq true\r\n  rpk redpanda config set redpanda.rpc_server '{address: 3.250.158.1, port: 9092}'\r\n\r\nYou can set an entire array by wrapping all items with braces, or by using one\r\nstruct:\r\n\r\n  rpk redpanda config set redpanda.advertised_kafka_api '[{address: 0.0.0.0, port: 9092}]'\r\n  rpk redpanda config set redpanda.advertised_kafka_api '{address: 0.0.0.0, port: 9092}' # same\r\n\r\nIndexing can be used to set specific items in an array. You can index one past\r\nthe end of an array to extend it:\r\n\r\n  rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 0.0.0.0, port: 9092}'\r\n\r\nThe json format can be used to set values as json:\r\n\r\n  rpk redpanda config set redpanda.rpc_server '{\"address\":\"0.0.0.0\",\"port\":33145}' --format json",
+        "usage": "Usage:\r\n  rpk redpanda config set <key> <value> [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default location."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Format of the value (yaml/json) (default \"yaml\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda mode": {
+        "description": "Enable a default configuration mode",
+        "usage": "Usage:\r\n  rpk redpanda mode <mode> [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for mode."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda start": {
+        "description": "Start redpanda",
+        "usage": "Usage:\r\n  rpk redpanda start [flags]\r\n\r",
+        "flags": {
+            "--advertise-kafka-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Kafka addresses to advertise (<name>://<host>:<port>)."
+            },
+            "--advertise-pandaproxy-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Pandaproxy addresses to advertise (<name>://<host>:<port>)."
+            },
+            "--advertise-rpc-addr": {
+                "type": "string",
+                "description": "The advertised RPC address (<host>:<port>)."
+            },
+            "--check": {
+                "type": "-",
+                "description": "When set to false will disable system checking before starting redpanda (default true)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--install-dir": {
+                "type": "string",
+                "description": "Directory where redpanda has been installed."
+            },
+            "--kafka-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Kafka listener addresses to bind to (<name>://<host>:<port>)."
+            },
+            "--mode": {
+                "type": "string",
+                "description": "Mode sets well-known configuration properties for development or test environments; use --mode help for more info."
+            },
+            "--pandaproxy-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Pandaproxy listener addresses to bind to (<name>://<host>:<port>)."
+            },
+            "--rpc-addr": {
+                "type": "string",
+                "description": "The RPC address to bind to (<host>:<port>)."
+            },
+            "--schema-registry-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Schema Registry listener addresses to bind to (<name>://<host>:<port>)."
+            },
+            "-s, --seeds": {
+                "type": "strings",
+                "description": "A comma-separated list of seed node addresses (<host>[:<port>]) to connect to."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 10s)."
+            },
+            "--tune": {
+                "type": "-",
+                "description": "When present will enable tuning before starting redpanda."
+            },
+            "--well-known-io": {
+                "type": "string",
+                "description": "The cloud vendor and VM type, in the format <vendor>:<vm type>:<storage type>."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda stop": {
+        "description": "Stop a local redpanda process. 'rpk stop'\r\nfirst sends SIGINT, and waits for the specified timeout. Then, if redpanda\r\nhasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still\r\nrunning.",
+        "usage": "Usage:\r\n  rpk redpanda stop [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum amount of time to wait for redpanda to stop,after each signal is sent. The value passed is asequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 5s)."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda tune": {
+        "description": "Sets the OS parameters to tune system performance.\r\n\r\nAvailable tuners:\r\n\r\n  - all.\r\n  - coredump\r\n  - disk_nomerges\r\n  - cpu\r\n  - swappiness\r\n  - ballast_file\r\n  - net\r\n  - aio_events\r\n  - disk_scheduler\r\n  - disk_write_cache\r\n  - fstrim\r\n  - clocksource\r\n  - transparent_hugepages\r\n  - disk_irq\r\n\r\nTo learn more about a tuner, run 'rpk redpanda tune help <tuner name>'.",
+        "usage": "Usage:\r\n  rpk redpanda tune <list of elements to tune> [flags]\r\n  rpk redpanda tune [command]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--cpu-set": {
+                "type": "string",
+                "description": "Set of CPUs for tuner to use in cpuset(7) format if not specified tuner will use all available CPUs (default \"all\")."
+            },
+            "-r, --dirs": {
+                "type": "strings",
+                "description": "List of *data* directories or places to store data, i.e.: '/var/vectorized/redpanda/', usually your XFS filesystem on an NVMe SSD device."
+            },
+            "-d, --disks": {
+                "type": "strings",
+                "description": "Lists of devices to tune f.e. 'sda1'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for tune."
+            },
+            "-m, --mode": {
+                "type": "string",
+                "description": "Operation Mode: one of: [sq, sq_split, mq]."
+            },
+            "-n, --nic": {
+                "type": "strings",
+                "description": "Network Interface Controllers to tune."
+            },
+            "--output-script": {
+                "type": "string",
+                "description": "If set tuners will generate tuning file that can later be used to tune the system."
+            },
+            "--reboot-allowed": {
+                "type": "-",
+                "description": "If set will allow tuners to tune boot parameters and request system reboot."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time to wait for the tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or '\u00b5s'), 'ms', 's', 'm', 'h' (default 10s)."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda tune help": {
+        "description": "Display detailed information about the tuner",
+        "usage": "Usage:\r\n  rpk redpanda tune help <tuner> [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for help."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk redpanda tune list": {
+        "description": "List available redpanda tuners and check if they are enabled and \r\nsupported by your system\r\n\r\nTo enable a tuner it must be set in the redpanda.yaml configuration file\r\nunder rpk section, e.g:\r\n\r\n  rpk:\r\n      tune_cpu: true\r\n      tune_swappiness: true\r\n\r\nYou may use 'rpk redpanda config set' to enable or disable a tuner.",
+        "usage": "Usage:\r\n  rpk redpanda tune list [flags]\r\n\r",
+        "flags": {
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-r, --dirs": {
+                "type": "strings",
+                "description": "List of *data* directories or places to store data, i.e.: '/var/vectorized/redpanda/', usually your XFS filesystem on an NVMe SSD device."
+            },
+            "-d, --disks": {
+                "type": "strings",
+                "description": "Lists of devices to tune f.e. 'sda1'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-m, --mode": {
+                "type": "string",
+                "description": "Operation Mode: one of: [sq, sq_split, mq]."
+            },
+            "-n, --nic": {
+                "type": "strings",
+                "description": "Network Interface Controllers to tune."
+            },
+            "--reboot-allowed": {
+                "type": "-",
+                "description": "If set will allow tuners to tune boot parameters and request system reboot."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic": {
+        "description": "Create, delete, produce to and consume from Redpanda topics",
+        "usage": "Usage:\r\n  rpk topic [command]\r\n\r",
+        "flags": {
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for topic."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic add-partitions": {
+        "description": "Add partitions to existing topics.",
+        "usage": "Usage:\r\n  rpk topic add-partitions [TOPICS...] --num [#] [flags]\r\n\r",
+        "flags": {
+            "-f, --force": {
+                "type": "-",
+                "description": "Force change the partition count in internal topics, e.g. __consumer_offsets."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for add-partitions."
+            },
+            "-n, --num": {
+                "type": "int",
+                "description": "Number of partitions to add to each topic."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic alter-config": {
+        "description": "Set, delete, add, and remove key/value configs for a topic.\r\n\r\nThis command allows you to incrementally alter the configuration for multiple\r\ntopics at a time.\r\n\r\nIncremental altering supports four operations:\r\n\r\n  1) Setting a key=value pair\r\n  2) Deleting a key's value\r\n  3) Appending a new value to a list-of-values key\r\n  4) Subtracting (removing) an existing value from a list-of-values key\r\n\r\nThe --dry option will validate whether the requested configuration change is\r\nvalid, but does not apply it.",
+        "usage": "Usage:\r\n  rpk topic alter-config [TOPICS...] --set key=value --delete key2,key3 [flags]\r\n\r",
+        "flags": {
+            "--append": {
+                "type": "stringArray",
+                "description": "key=value; Value to append to a list-of-values key (repeatable)."
+            },
+            "-d, --delete": {
+                "type": "stringArray",
+                "description": "Key to delete (repeatable)."
+            },
+            "--dry": {
+                "type": "-",
+                "description": "Dry run: validate the alter request, but do not apply."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for alter-config."
+            },
+            "-s, --set": {
+                "type": "stringArray",
+                "description": "key=value; Pair to set (repeatable)."
+            },
+            "--subtract": {
+                "type": "stringArray",
+                "description": "key=value; Value to remove from list-of-values key (repeatable)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic consume": {
+        "description": "Consume records from topics.\r\n\r\nConsuming records reads from any amount of input topics, formats each record\r\naccording to --format, and prints them to STDOUT. The output formatter\r\nunderstands a wide variety of formats.\r\n\r\nThe default output format \"--format json\" is a special format that outputs each\r\nrecord as JSON. There may be more single-word-no-escapes formats added later.\r\nOutside of these special formats, formatting follows the rules described below.\r\n\r\nFormatting output is based on percent escapes and modifiers. Slashes can be\r\nused for common escapes:\r\n\r\n    \\t \\n \\r \\\\ \\xNN\r\n\r\nprints tabs, newlines, carriage returns, slashes, or hex encoded characters.p\r\n\r\nPercent encoding prints record fields, fetch partition fields, or extra values:\r\n\r\n    %t    topic\r\n    %T    topic length\r\n    %k    key\r\n    %K    key length\r\n    %v    value\r\n    %V    value length\r\n    %h    begin the header specification\r\n    %H    number of headers\r\n    %p    partition\r\n    %o    offset\r\n    %e    leader epoch\r\n    %d    timestamp (formatting described below)\r\n    %a    record attributes (formatting described below)\r\n    %x    producer id\r\n    %y    producer epoch\r\n\r\n    %[    partition log start offset\r\n    %|    partition last stable offset\r\n    %]    partition high watermark\r\n\r\n    %%    percent sign\r\n    %{    left brace\r\n    %}    right brace\r\n\r\n    %i    the number of records formatted\r\n\r\nMODIFIERS\r\n\r\nText and numbers can be formatted in many different ways, and the default\r\nformat can be changed within brace modifiers. %v prints a value, while %v{hex}\r\nprints the value hex encoded. %T prints the length of a topic in ascii, while\r\n%T{big8} prints the length of the topic as an eight byte big endian.\r\n\r\nAll modifiers go within braces following a percent-escape.\r\n\r\nNUMBERS\r\n\r\nFormatting number values can have the following modifiers:\r\n\r\n     ascii       print the number as ascii (default)\r\n\r\n     hex64       sixteen hex characters\r\n     hex32       eight hex characters\r\n     hex16       four hex characters\r\n     hex8        two hex characters\r\n     hex4        one hex character\r\n\r\n     big64       eight byte big endian number\r\n     big32       four byte big endian number\r\n     big16       two byte big endian number\r\n     big8        alias for byte\r\n\r\n     little64    eight byte little endian number\r\n     little32    four byte little endian number\r\n     little16    two byte little endian number\r\n     little8     alias for byte\r\n\r\n     byte        one byte number\r\n     bool        \"true\" if the number is non-zero, \"false\" if the number is zero\r\n\r\nAll numbers are truncated as necessary per the modifier. Printing %V{byte} for\r\na length 256 value will print a single null, whereas printing %V{big8} would\r\nprint the bytes 1 and 0.\r\n\r\nWhen writing number sizes, the size corresponds to the size of the raw values,\r\nnot the size of encoded values. \"%T% t{hex}\" for the topic \"foo\" will print\r\n\"3 666f6f\", not \"6 666f6f\".\r\n\r\nTIMESTAMPS\r\n\r\nBy default, the timestamp field is printed as a millisecond number value. In\r\naddition to the number modifiers above, timestamps can be printed with either\r\nGo formatting or strftime formatting:\r\n\r\n    %d{go[2006-01-02T15:04:05Z07:00]}\r\n    %d{strftime[%F]}\r\n\r\nAn arbitrary amount of brackets (or braces, or # symbols) can wrap your date\r\nformatting:\r\n\r\n    %d{strftime### [%F] ###}\r\n\r\nThe above will print \" [YYYY-MM-DD] \", while the surrounding three # on each\r\nside are used to wrap the formatting. Further details on Go time formatting can\r\nbe found at https://pkg.go.dev/time, while further details on strftime\r\nformatting can be read by checking \"man strftime\".\r\n\r\nATTRIBUTES\r\n\r\nEach record (or batch of records) has a set of possible attributes. Internally,\r\nthese are packed into bit flags. Printing an attribute requires first selecting\r\nwhich attribute you want to print, and then optionally specifying how you want\r\nit to be printed:\r\n\r\n     %a{compression}\r\n     %a{compression;number}\r\n     %a{compression;big64}\r\n     %a{compression;hex8}\r\n\r\nCompression is by default printed as text (\"none\", \"gzip\", ...). Compression\r\ncan be printed as a number with \";number\", where number is any number\r\nformatting option described above. No compression is 0, gzip is 1, etc.\r\n\r\n     %a{timestamp-type}\r\n     %a{timestamp-type;big64}\r\n\r\nThe record's timestamp type is printed as -1 for very old records (before\r\ntimestamps existed), 0 for client generated timestamps, and 1 for broker\r\ngenerated timestamps. Number formatting can be controlled with \";number\".\r\n\r\n     %a{transactional-bit}\r\n     %a{transactional-bit;bool}\r\n\r\nPrints 1 if the record a part of a transaction or 0 if it is not.\r\nNumber formatting can be controlled with \";number\".\r\n\r\n     %a{control-bit}\r\n     %a{control-bit;bool}\r\n\r\nPrints 1 if the record is a commit marker or 0 if it is not.\r\nNumber formatting can be controlled with \";number\".\r\n\r\nTEXT\r\n\r\nText fields without modifiers default to writing the raw bytes. Alternatively,\r\nthere are the following modifiers:\r\n\r\n    %t{hex}\r\n    %k{base64}\r\n    %v{base64raw}\r\n    %v{unpack[<bBhH>iIqQc.$]}\r\n\r\nThe hex modifier hex encodes the text, the base64 modifier base64 encodes the\r\ntext with standard encoding, and the base64raw modifier encodes the text with\r\nraw standard encoding. The unpack modifier has a further internal\r\nspecification, similar to timestamps above:\r\n\r\n    x    pad character (does not parse input)\r\n    <    switch what follows to little endian\r\n    >    switch what follows to big endian\r\n\r\n    b    signed byte\r\n    B    unsigned byte\r\n    h    int16  (\"half word\")\r\n    H    uint16 (\"half word\")\r\n    i    int32\r\n    I    uint32\r\n    q    int64  (\"quad word\")\r\n    Q    uint64 (\"quad word\")\r\n\r\n    c    any character\r\n    .    alias for c\r\n    s    consume the rest of the input as a string\r\n    $    match the end of the line (append error string if anything remains)\r\n\r\nUnpacking text can allow translating binary input into readable output. If a\r\nvalue is a big-endian uint32, %v will print the raw four bytes, while\r\n%v{unpack[>I]} will print the number in as ascii. If unpacking exhausts the\r\ninput before something is unpacked fully, an error message is appended to the\r\noutput.\r\n\r\nHEADERS\r\n\r\nHeaders are formatted with percent encoding inside of the modifier:\r\n\r\n    %h{ %k=%v{hex} }\r\n\r\nwill print all headers with a space before the key and after the value, an\r\nequals sign between the key and value, and with the value hex encoded. Header\r\nformatting actually just parses the internal format as a record format, so all\r\nof the above rules about %K, %V, text, and numbers apply.\r\n\r\nEXAMPLES\r\n\r\nA key and value, separated by a space and ending in newline:\r\n    -f '%k %v\\n'\r\nA key length as four big endian bytes, and the key as hex:\r\n    -f '%K{big32}%k{hex}'\r\nA little endian uint32 and a string unpacked from a value:\r\n    -f '%v{unpack[is$]}'\r\n\r\nOFFSETS\r\n\r\nThe --offset flag allows for specifying where to begin consuming, and\r\noptionally, where to stop consuming. The literal words \"start\" and \"end\"\r\nspecify consuming from the start and the end.\r\n\r\n    start     consume from the beginning\r\n    end       consume from the end\r\n    :end      consume until the current end\r\n    +oo       consume oo after the current start offset\r\n    -oo       consume oo before the current end offset\r\n    oo        consume after an exact offset\r\n    oo:       alias for oo\r\n    :oo       consume until an exact offset\r\n    o1:o2     consume from exact offset o1 until exact offset o2\r\n    @t        consume starting from a given timestamp\r\n    @t:       alias for @t\r\n    @:t       consume until a given timestamp\r\n    @t1:t2    consume from timestamp t1 until timestamp t2\r\n\r\nThere are a few options for timestamps, with each option being evaluated\r\nuntil one succeeds:\r\n\r\n    13 digits             parsed as a unix millisecond\r\n    9 digits              parsed as a unix second\r\n    YYYY-MM-DD            parsed as a day, UTC\r\n    YYYY-MM-DDTHH:MM:SSZ  parsed as RFC3339, UTC; fractional seconds optional (.MMM)\r\n    -dur                  duration ago; from now (as t1) or from t1 (as t2)\r\n    dur                   for t2 in @t1:t2, relative duration from t1\r\n    end                   for t2 in @t1:t2, the current end of the partition\r\n\r\nDurations are parsed simply:\r\n\r\n    3ms    three milliseconds\r\n    10s    ten seconds\r\n    9m     nine minutes\r\n    1h     one hour\r\n    1m3ms  one minute and three milliseconds\r\n\r\nFor example,\r\n\r\n    -o @2022-02-14:1h   consume 1h of time on Valentine's Day 2022\r\n    -o @-48h:-24h       consume from 2 days ago to 1 day ago\r\n    -o @-1m:end         consume from 1m ago until now\r\n    -o @:-1hr           consume from the start until an hour ago",
+        "usage": "Usage:\r\n  rpk topic consume TOPICS... [flags]\r\n\r",
+        "flags": {
+            "-b, --balancer": {
+                "type": "string",
+                "description": "Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky) (default \"cooperative-sticky\")."
+            },
+            "--fetch-max-bytes": {
+                "type": "int32",
+                "description": "Maximum amount of bytes per fetch request per broker (default 1048576)."
+            },
+            "--fetch-max-wait": {
+                "type": "duration",
+                "description": "Maximum amount of time to wait when fetching from a broker before the broker replies (default 5s)."
+            },
+            "-f, --format": {
+                "type": "string",
+                "description": "Output format (see --help for details) (default \"json\")."
+            },
+            "-g, --group": {
+                "type": "string",
+                "description": "Group to use for consuming (incompatible with -p)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for consume."
+            },
+            "--meta-only": {
+                "type": "-",
+                "description": "Print all record info except the record value (for -f json)."
+            },
+            "-n, --num": {
+                "type": "int",
+                "description": "Quit after consuming this number of records (0 is unbounded)."
+            },
+            "-o, --offset": {
+                "type": "string",
+                "description": "Offset to consume from / to (start, end, 47, +2, -3) (default \"start\")."
+            },
+            "-p, --partitions": {
+                "type": "int32",
+                "description": "int32Slice     Comma delimited list of specific partitions to consume (default [])."
+            },
+            "--pretty-print": {
+                "type": "-",
+                "description": "Pretty print each record over multiple lines (for -f json) (default true)."
+            },
+            "--print-control-records": {
+                "type": "-",
+                "description": "Opt in to printing control records."
+            },
+            "--read-committed": {
+                "type": "-",
+                "description": "Opt in to reading only committed offsets."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; consume any topic that matches any expression."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic create": {
+        "description": "Create topics.\r\n\r\nAll topics created with this command will have the same number of partitions,\r\nreplication factor, and key/value configs.\r\n\r\nFor example,\r\n\r\n\tcreate -c cleanup.policy=compact -r 3 -p 20 foo bar\r\n\r\nwill create two topics, foo and bar, each with 20 partitions, 3 replicas, and\r\nthe cleanup.policy=compact config option set.",
+        "usage": "Usage:\r\n  rpk topic create [TOPICS...] [flags]\r\n\r",
+        "flags": {
+            "-d, --dry": {
+                "type": "-",
+                "description": "Dry run: validate the topic creation request; do not create topics."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "-p, --partitions": {
+                "type": "int32",
+                "description": "Number of partitions to create per topic; -1 defaults to the cluster's default_topic_partitions (default -1)."
+            },
+            "-r, --replicas": {
+                "type": "int16",
+                "description": "Replication factor (must be odd); -1 defaults to the cluster's default_topic_replications (default -1)."
+            },
+            "-c, --topic-config": {
+                "type": "stringArray",
+                "description": "key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact)."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic delete": {
+        "description": "Delete topics.\r\n\r\nThis command deletes all requested topics, printing the success or fail status\r\nper topic.\r\n\r\nThe --regex flag (-r) opts into parsing the input topics as regular expressions\r\nand deleting any non-internal topic that matches any of expressions. The input\r\nexpressions are wrapped with ^ and $ so that the expression must match the\r\nwhole topic name (which also prevents accidental delete-everything mistakes).\r\n\r\nThe topic list command accepts the same input regex format as this delete\r\ncommand. If you want to check what your regular expressions will delete before\r\nactually deleting them, you can check the output of 'rpk topic list -r'.\r\n\r\nFor example,\r\n\r\n    delete foo bar            # deletes topics foo and bar\r\n    delete -r '^f.*' '.*r$'   # deletes any topic starting with f and any topics ending in r\r\n    delete -r '.*'            # deletes all topics\r\n    delete -r .               # deletes any one-character topics",
+        "usage": "Usage:\r\n  rpk topic delete [TOPICS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; delete any topic that matches any input topic expression."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic describe": {
+        "description": "Describe a topic.\r\n\r\nThis command prints detailed information about a topic. There are three\r\npotential sections: a summary of the topic, the topic configs, and a detailed\r\npartitions section. By default, the summary and configs sections are printed.",
+        "usage": "Usage:\r\n  rpk topic describe [TOPIC] [flags]\r\n\r\nAliases:\r\n  describe, info\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "-a, --print-all": {
+                "type": "-",
+                "description": "Print all sections."
+            },
+            "-c, --print-configs": {
+                "type": "-",
+                "description": "Print the config section."
+            },
+            "-p, --print-partitions": {
+                "type": "-",
+                "description": "Print the detailed partitions section."
+            },
+            "-s, --print-summary": {
+                "type": "-",
+                "description": "Print the summary section."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic list": {
+        "description": "List topics, optionally listing specific topics.\r\n\r\nThis command lists all topics that you have access to by default. If specifying\r\ntopics or regular expressions, this command can be used to know exactly what\r\ntopics you would delete if using the same input to the delete command.\r\n\r\nAlternatively, you can request specific topics to list, which can be used to\r\ncheck authentication errors (do you not have access to a topic you were\r\nexpecting to see?), or to list all topics that match regular expressions.\r\n\r\nThe --regex flag (-r) opts into parsing the input topics as regular expressions\r\nand listing any non-internal topic that matches any of expressions. The input\r\nexpressions are wrapped with ^ and $ so that the expression must match the\r\nwhole topic name. Regular expressions cannot be used to match internal topics,\r\nas such, specifying both -i and -r will exit with failure.\r\n\r\nLastly, --detailed flag (-d) opts in to printing extra per-partition\r\ninformation.",
+        "usage": "Usage:\r\n  rpk topic list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-d, --detailed": {
+                "type": "-",
+                "description": "Print per-partition information for topics."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-i, --internal": {
+                "type": "-",
+                "description": "Print internal topics."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; list any topic that matches any input topic expression."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk topic produce": {
+        "description": "Produce records to a topic.\r\n\r\nProducing records reads from STDIN, parses input according to --format, and\r\nproduce records to Redpanda. The input formatter understands a wide variety of\r\nformats.\r\n\r\nParsing input operates on either sizes or on delimiters, both of which can be\r\nspecified in the same formatting options. If using sizes to specify something,\r\nthe size must come before what it is specifying. Delimiters match on an exact\r\ntext basis. This command will quit with an error if any input fails to match\r\nyour specified format.\r\n\r\nSlashes can be used for common escapes:\r\n\r\n    \\t \\n \\r \\\\ \\xNN\r\n\r\nmatches tabs, newlines, carriage returns, slashes, and hex encoded characters.\r\n\r\nPercent encoding reads into specific values of a record:\r\n\r\n    %t    topic\r\n    %T    topic length\r\n    %k    key\r\n    %K    key length\r\n    %v    value\r\n    %V    value length\r\n    %h    begin the header specification\r\n    %H    number of headers\r\n    %p    partition (if using the --partition flag)\r\n\r\nThree escapes exist to parse characters that are used to modify the previous\r\nescapes:\r\n\r\n    %%    percent sign\r\n    %{    left brace\r\n    %}    right brace\r\n\r\nMODIFIERS\r\n\r\nText and numbers can be read in multiple formats, and the default format can be\r\nchanged within brace modifiers. %v reads a value, while %v{hex} reads a value\r\nand then hex decodes it before producing. %T reads the length of a topic from\r\nthe input, while %T{3} reads exactly three bytes for a topic from the input.\r\n\r\nAll modifiers go within braces following a percent-escape.\r\n\r\nNUMBERS\r\n\r\nReading number values can have the following modifiers:\r\n\r\n     ascii       parse numeric digits until a non-numeric (default)\r\n\r\n     hex64       sixteen hex characters\r\n     hex32       eight hex characters\r\n     hex16       four hex characters\r\n     hex8        two hex characters\r\n     hex4        one hex character\r\n\r\n     big64       eight byte big endian number\r\n     big32       four byte big endian number\r\n     big16       two byte big endian number\r\n     big8        alias for byte\r\n\r\n     little64    eight byte little endian number\r\n     little32    four byte little endian number\r\n     little16    two byte little endian number\r\n     little8     alias for byte\r\n\r\n     byte        one byte number\r\n     <digits>    directly specify the length as this many digits\r\n     bool        read \"true\" as 1, \"false\" as 0\r\n\r\nWhen reading number sizes, the size corresponds to the size of the encoded\r\nvalues, not the decoded values. \"%T{6}%t{hex}\" will read six hex bytes and\r\ndecode into three.\r\n\r\nTEXT\r\n\r\nReading text values can have the following modifiers:\r\n\r\n    hex       read text then hex decode it\r\n    base64    read text then std-encoding base64 decode it\r\n    re        read text matching a regular expression\r\n\r\nHEADERS\r\n\r\nHeaders are parsed with an internal key / value specifier format. For example,\r\nthe following will read three headers that begin and end with a space and are\r\nseparated by an equal:\r\n\r\n    %H{3}%h{ %k=%v }\r\n\r\nEXAMPLES\r\n\r\nIn the below examples, we can parse many records at once. The produce command\r\nreads input and tokenizes based on your specified format. Every time the format\r\nis completely matched, a record is produced and parsing begins anew.\r\n\r\nA key and value, separated by a space and ending in newline:\r\n    -f '%k %v\\n'\r\nA four byte topic, four byte key, and four byte value:\r\n    -f '%T{4}%K{4}%V{4}%t%k%v'\r\nA value to a specific partition, if using a non-negative --partition flag:\r\n    -f '%p %v\\n'\r\nA big-endian uint16 key size, the text \" foo \", and then that key:\r\n    -f '%K{big16} foo %k'\r\nA value that can be two or three characters followed by a newline:\r\n    -f '%v{re#...?#}\\n'\r\n\r\nMISC\r\n\r\nProducing requires a topic to produce to. The topic can be specified either\r\ndirectly on as an argument, or in the input text through %t. A parsed topic\r\ntakes precedence over the default passed in topic. If no topic is specified\r\ndirectly and no topic is parsed, this command will quit with an error.\r\n\r\nThe input format can parse partitions to produce directly to with %p. Doing so\r\nrequires specifying a non-negative --partition flag. Any parsed partition\r\ntakes precedence over the --partition flag; specifying the flag is the main\r\nrequirement for being able to directly control which partition to produce to.\r\n\r\nYou can also specify an output format to write when a record is produced\r\nsuccessfully. The output format follows the same formatting rules as the topic\r\nconsume command. See that command's help text for a detailed description.",
+        "usage": "Usage:\r\n  rpk topic produce [TOPIC] [flags]\r\n\r",
+        "flags": {
+            "--acks": {
+                "type": "int",
+                "description": "Number of acks required for producing (-1=all, 0=none, 1=leader) (default -1)."
+            },
+            "--allow-auto-topic-creation": {
+                "type": "-",
+                "description": "Auto-create non-existent topics; requires auto_create_topics_enabled on the broker."
+            },
+            "-z, --compression": {
+                "type": "string",
+                "description": "Compression to use for producing batches (none, gzip, snapy, lz4, zstd) (default \"snappy\")."
+            },
+            "--delivery-timeout": {
+                "type": "duration",
+                "description": "Per-record delivery timeout, if non-zero, min 1s."
+            },
+            "-f, --format": {
+                "type": "string",
+                "description": "Input record format (default \"%v\\n\")."
+            },
+            "-H, --header": {
+                "type": "stringArray",
+                "description": "Headers in format key:value to add to each record (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for produce."
+            },
+            "-k, --key": {
+                "type": "string",
+                "description": "A fixed key to use for each record (parsed input keys take precedence)."
+            },
+            "--max-message-bytes": {
+                "type": "int32",
+                "description": "If non-negative, maximum size of a record batch before compression (default -1)."
+            },
+            "-o, --output-format": {
+                "type": "string",
+                "description": "what to write to stdout when a record is successfully produced (default \"Produced to partition %p at offset %o with timestamp %d.\\n\")."
+            },
+            "-p, --partition": {
+                "type": "int32",
+                "description": "Partition to directly produce to, if non-negative (also allows %p parsing to set partitions) (default -1)."
+            },
+            "-Z, --tombstone": {
+                "type": "-",
+                "description": "Produce empty values as tombstones."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk version": {
+        "description": "Check the current version",
+        "usage": "Usage:\r\n  rpk version [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for version."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk wasm": {
+        "description": "Deploy and remove inline WASM engine scripts",
+        "usage": "Usage:\r\n  rpk wasm [command]\r\n\r",
+        "flags": {
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for wasm."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk wasm deploy": {
+        "description": "Deploy inline WASM function",
+        "usage": "Usage:\r\n  rpk wasm deploy [PATH] [flags]\r\n\r",
+        "flags": {
+            "--description": {
+                "type": "string",
+                "description": "Optional description about what the wasm function does."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for deploy."
+            },
+            "--name": {
+                "type": "string",
+                "description": "Unique deploy identifier attached to the instance of this script."
+            },
+            "--type": {
+                "type": "string",
+                "description": "WASM engine type (async, data-policy) (default \"async\")."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk wasm generate": {
+        "description": "Create a npm template project for inline WASM engine",
+        "usage": "Usage:\r\n  rpk wasm generate [PROJECT DIRECTORY] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for generate."
+            },
+            "--skip-version": {
+                "type": "-",
+                "description": "Omit wasm-api version check from npm, use default instead."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk wasm remove": {
+        "description": "Remove inline WASM function",
+        "usage": "Usage:\r\n  rpk wasm remove [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for remove."
+            },
+            "--type": {
+                "type": "string",
+                "description": "WASM engine type (async, data-policy) (default \"async\")."
+            },
+            "--brokers": {
+                "type": "strings",
+                "description": "Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda config file, if not set the file will be searched for in the default locations."
+            },
+            "--password": {
+                "type": "string",
+                "description": "SASL password to be used for authentication."
+            },
+            "--sasl-mechanism": {
+                "type": "string",
+                "description": "The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The truststore to be used for TLS communication with the broker."
+            },
+            "--user": {
+                "type": "string",
+                "description": "SASL user to be used for authentication."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging (default: false)."
+            }
+        }
+    },
+    "rpk_version": "v23.1.20 (rev 603e67652)\r"
+}

--- a/tools/gen/23.1/rpk-acl-create.adoc
+++ b/tools/gen/23.1/rpk-acl-create.adoc
@@ -1,0 +1,84 @@
+= rpk acl create
+:description: rpk acl create
+
+Create ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. Following the
+multiplying effect of combining flags, the create command works on a
+straightforward basis: every ACL combination is a created ACL.
+
+As mentioned in the 'rpk acl' help text, if no host is specified, an allowed
+principal is allowed access from all hosts. The wildcard principal '*' allows
+all principals. At least one principal, one host, one resource, and one
+operation is required to create a single ACL.
+
+Allow all permissions to user bar on topic "foo" and group "g":
+    --allow-principal bar --operation all --topic foo --group g
+Allow read permissions to all users on topics biz and baz:
+    --allow-principal '*' --operation read --topic biz,baz
+Allow write permissions to user buzz to transactional id "txn":
+    --allow-principal User:buzz --operation write --transactional-id txn
+
+== Usage
+
+[,bash]
+----
+rpk acl create [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Hosts from which access will be granted (repeatable).
+
+|`--allow-principal` |strings |Principals for which these permissions will be granted (repeatable).
+
+|`--cluster` |- |Whether to grant ACLs to the cluster.
+
+|`--deny-host` |strings |Hosts from from access will be denied (repeatable).
+
+|`--deny-principal` |strings |Principal for which these permissions will be denied (repeatable).
+
+|`--group` |strings |Group to grant ACLs for (repeatable).
+
+|`-h, --help` |- |Help for create.
+
+|`--operation` |strings |Operation to grant (repeatable).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (literal or prefixed) (default "literal").
+
+|`--topic` |strings |Topic to grant ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to grant ACLs for (repeatable).
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-acl-delete.adoc
+++ b/tools/gen/23.1/rpk-acl-delete.adoc
@@ -1,0 +1,94 @@
+= rpk acl delete
+:description: rpk acl delete
+
+Delete ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. Delete flags work in a
+similar multiplying effect as creating ACLs, but delete is more advanced:
+deletion works on a filter basis. Any unspecified flag defaults to matching
+everything (all operations, or all allowed principals, etc). To ensure that you
+do not accidentally delete more than you intend, this command prints everything
+that matches your input filters and prompts for a confirmation before the
+delete request is issued. Anything matching more than 10 ACLs doubly confirms.
+
+As mentioned, not specifying flags matches everything. If no resources are
+specified, all resources are matched. If no operations are specified, all
+operations are matched. You can also opt in to matching everything with "any":
+--operation any matches any operation.
+
+The --resource-pattern-type, defaulting to "any", configures how to filter
+resource names:
+  * "any" returns exact name matches of either prefixed or literal pattern type
+  * "match" returns wildcard matches, prefix patterns that match your input, and literal matches
+  * "prefix" returns prefix patterns that match your input (prefix "fo" matches "foo")
+  * "literal" returns exact name matches
+
+== Usage
+
+[,bash]
+----
+rpk acl delete [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Allowed host ACLs to remove (repeatable).
+
+|`--allow-principal` |strings |Allowed principal ACLs to remove (repeatable).
+
+|`--cluster` |- |Whether to remove ACLs to the cluster.
+
+|`--deny-host` |strings |Denied host ACLs to remove (repeatable).
+
+|`--deny-principal` |strings |Denied principal ACLs to remove (repeatable).
+
+|`-d, --dry` |- |Dry run: validate what would be deleted.
+
+|`--group` |strings |Group to remove ACLs for (repeatable).
+
+|`-h, --help` |- |Help for delete.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`--operation` |strings |Operation to remove (repeatable).
+
+|`-f, --print-filters` |- |Print the filters that were requested (failed filters are always printed).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (any, match, literal, or prefixed) (default "any").
+
+|`--topic` |strings |Topic to remove ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to remove ACLs for (repeatable).
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-acl-list.adoc
+++ b/tools/gen/23.1/rpk-acl-list.adoc
@@ -1,0 +1,94 @@
+= rpk acl list
+:description: rpk acl list
+
+List ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. List flags work in a
+similar multiplying effect as creating ACLs, but list is more advanced:
+listing works on a filter basis. Any unspecified flag defaults to matching
+everything (all operations, or all allowed principals, etc).
+
+As mentioned, not specifying flags matches everything. If no resources are
+specified, all resources are matched. If no operations are specified, all
+operations are matched. You can also opt in to matching everything with "any":
+--operation any matches any operation.
+
+The --resource-pattern-type, defaulting to "any", configures how to filter
+resource names:
+  * "any" returns exact name matches of either prefixed or literal pattern type
+  * "match" returns wildcard matches, prefix patterns that match your input, and literal matches
+  * "prefix" returns prefix patterns that match your input (prefix "fo" matches "foo")
+  * "literal" returns exact name matches
+
+== Usage
+
+[,bash]
+----
+rpk acl list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls, describe
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Allowed host ACLs to match (repeatable).
+
+|`--allow-principal` |strings |Allowed principal ACLs to match (repeatable).
+
+|`--cluster` |- |Whether to match ACLs to the cluster.
+
+|`--deny-host` |strings |Denied host ACLs to match (repeatable).
+
+|`--deny-principal` |strings |Denied principal ACLs to match (repeatable).
+
+|`--group` |strings |Group to match ACLs for (repeatable).
+
+|`-h, --help` |- |Help for list.
+
+|`--operation` |strings |Operation to match (repeatable).
+
+|`-f, --print-filters` |- |Print the filters that were requested (failed filters are always printed).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (any, match, literal, or prefixed) (default "any").
+
+|`--topic` |strings |Topic to match ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to match ACLs for (repeatable).
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-acl-user-create.adoc
+++ b/tools/gen/23.1/rpk-acl-user-create.adoc
@@ -1,0 +1,65 @@
+= rpk acl user create
+:description: rpk acl user create
+
+Create a SASL user.
+
+This command creates a single SASL user with the given password, optionally
+with a custom "mechanism". SASL consists of three parts: a username, a
+password, and a mechanism. The mechanism determines which authentication flow
+the client will use for this user/pass.
+
+Redpanda currently supports two mechanisms: SCRAM-SHA-256, the default, and
+SCRAM-SHA-512, which is the same flow but uses sha512 rather than sha256.
+
+Using SASL requires setting "enable_sasl: true" in the redpanda section of your
+`redpanda.yaml`. Before a created SASL account can be used, you must also create
+ACLs to grant the account access to certain resources in your cluster. See the
+acl help text for more info.
+
+== Usage
+
+[,bash]
+----
+rpk acl user create [USER] -p [PASS] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for create.
+
+|`--mechanism` |string |SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive); not to be confused with the global flag --sasl-mechanism which is used for authenticating the rpk client (default "scram-sha-256").
+
+|`--password` |string |New user's password (NOTE: if using --password for the admin API, use --new-password).
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |strings |The comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-acl-user-delete.adoc
+++ b/tools/gen/23.1/rpk-acl-user-delete.adoc
@@ -1,0 +1,53 @@
+= rpk acl user delete
+:description: rpk acl user delete
+
+Delete a SASL user.
+
+This command deletes the specified SASL account from Redpanda. This does not
+delete any ACLs that may exist for this user.
+
+== Usage
+
+[,bash]
+----
+rpk acl user delete [USER] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |strings |The comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-acl-user-list.adoc
+++ b/tools/gen/23.1/rpk-acl-user-list.adoc
@@ -1,0 +1,57 @@
+= rpk acl user list
+:description: rpk acl user list
+
+List SASL users
+
+== Usage
+
+[,bash]
+----
+rpk acl user list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |strings |The comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-acl-user.adoc
+++ b/tools/gen/23.1/rpk-acl-user.adoc
@@ -1,0 +1,56 @@
+= rpk acl user
+:description: rpk acl user
+
+Manage SASL users.
+
+If SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs
+control what your user has access to. See 'rpk acl --help' for more information
+about ACLs, and 'rpk acl user create --help' for more information about
+creating SASL users. Using SASL requires setting "enable_sasl: true" in the
+redpanda section of your `redpanda.yaml`.
+
+== Usage
+
+[,bash]
+----
+rpk acl user [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--api-urls` |strings |The comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`-h, --help` |- |Help for user.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-acl.adoc
+++ b/tools/gen/23.1/rpk-acl.adoc
@@ -1,0 +1,159 @@
+= rpk acl
+:description: rpk acl
+
+Manage ACLs and SASL users.
+
+This command space creates, lists, and deletes ACLs, as well as creates SASL
+users. The help text below is specific to ACLs. To learn about SASL users,
+check the help text under the "user" command.
+
+When using SASL, ACLs allow or deny you access to certain requests. The
+"create", "delete", and "list" commands help you manage your ACLs.
+
+An ACL is made up of five components:
+
+  * a principal (the user)
+  * a host the principal is allowed or denied requests from
+  * what resource to access (topic name, group ID, ...)
+  * the operation (read, write, ...)
+  * the permission: whether to allow or deny the above
+
+ACL commands work on a multiplicative basis. If creating, specifying two
+principals and two permissions creates four ACLs: both permissions for the
+first principal, as well as both permissions for the second principal. Adding
+two resources further doubles the ACLs created.
+
+It is recommended to be as specific as possible when granting ACLs. Granting
+more ACLs than necessary per principal may inadvertently allow clients to do
+things they should not, such as deleting topics or joining the wrong consumer
+group.
+
+PRINCIPALS
+
+All ACLs require a principal. A principal is composed of two parts: the type
+and the name. Within Redpanda, only one type is supported, "User". The reason
+for the prefix is that a potential future authorizer may add support for
+authorizing by Group or anything else.
+
+When you create a user, you need to add ACLs for it before it can be used. You
+can create / delete / list ACLs for that user with either "User:bar" or "bar"
+in the --allow-principal and --deny-principal flags. This command will add the
+"User:" prefix for you if it is missing. The wildcard '*' matches any user.
+Creating an ACL with user '*' grants or denies the permission for all users.
+
+HOSTS
+
+Hosts can be seen as an extension of the principal, and effectively gate where
+the principal can connect from. When creating ACLs, unless otherwise specified,
+the default host is the wildcard '*' which allows or denies the principal from
+all hosts (where allow & deny are based on whether --allow-principal or
+--deny-principal is used). If specifying hosts, you must pair the --allow-host
+flag with the --allow-principal flag, and the --deny-host flag with the
+--deny-principal flag.
+
+RESOURCES
+
+A resource is what an ACL allows or denies access to. There are four resources
+within Redpanda: topics, groups, the cluster itself, and transactional IDs.
+Names for each of these resources can be specified with their respective flags.
+
+Resources combine with the operation that is allowed or denied on that
+resource. The next section describes which operations are required for which
+requests, and further fleshes out the concept of a resource.
+
+By default, resources are specified on an exact name match (a "literal" match).
+The --resource-pattern-type flag can be used to specify that a resource name is
+"prefixed", meaning to allow anything with the given prefix. A literal name of
+"foo" will match only the topic "foo", while the prefixed name of "foo-" will
+match both "foo-bar" and "foo-baz". The special wildcard resource name '*'
+matches any name of the given resource type (--topic '*' matches all topics).
+
+OPERATIONS
+
+Pairing with resources, operations are the actions that are allowed or denied.
+Redpanda has the following operations:
+
+    ALL                 Allows all operations below.
+    READ                Allows reading a given resource.
+    WRITE               Allows writing to a given resource.
+    CREATE              Allows creating a given resource.
+    DELETE              Allows deleting a given resource.
+    ALTER               Allows altering non-configurations.
+    DESCRIBE            Allows querying non-configurations.
+    DESCRIBE_CONFIGS    Allows describing configurations.
+    ALTER_CONFIGS       Allows altering configurations.
+
+Check --help-operations to see which operations are required for which
+requests. In flag form to set up a general producing/consuming client, you can
+invoke 'rpk acl create' three times with the following (including your
+--allow-principal):
+
+    --operation write,read,describe --topic [topics]
+    --operation describe,read --group [group.id]
+    --operation describe,write --transactional-id [transactional.id]
+
+PERMISSIONS
+
+A client can be allowed access or denied access. By default, all permissions
+are denied. You only need to specifically deny a permission if you allow a wide
+set of permissions and then want to deny a specific permission in that set.
+You could allow all operations, and then specifically deny writing to topics.
+
+MANAGEMENT
+
+Creating ACLs works on a specific ACL basis, but listing and deleting ACLs
+works on filters. Filters allow matching many ACLs to be printed listed and
+deleted at once. Because this can be risky for deleting, the delete command
+prompts for confirmation by default. More details and examples for creating,
+listing, and deleting can be seen in each of the commands.
+
+Using SASL requires setting "enable_sasl: true" in the redpanda section of your
+`redpanda.yaml`. User management is a separate, simpler concept that is
+described in the user command.
+
+== Usage
+
+[,bash]
+----
+rpk acl [flags]
+  rpk acl [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for acl.
+
+|`--help-operations` |- |Print more help about ACL operations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cloud-byoc-install.adoc
+++ b/tools/gen/23.1/rpk-cloud-byoc-install.adoc
@@ -1,0 +1,32 @@
+= rpk cloud byoc install
+:description: rpk cloud byoc install
+
+Install the BYOC plugin
+
+This command downloads the BYOC managed plugin if necessary. The plugin is
+installed by default if you try to run a non-install command, but this command
+exists if you want to download the plugin ahead of time.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc install [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--client-id` |string |The client ID of the organization in Redpanda Cloud.
+
+|`--client-secret` |string |The client secret of the organization in Redpanda Cloud.
+
+|`-h, --help` |- |Help for install.
+
+|`--redpanda-id` |string |The redpanda ID of the cluster you are creating.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cloud-byoc-uninstall.adoc
+++ b/tools/gen/23.1/rpk-cloud-byoc-uninstall.adoc
@@ -1,0 +1,27 @@
+= rpk cloud byoc uninstall
+:description: rpk cloud byoc uninstall
+
+Uninstall the BYOC plugin
+
+This command deletes your locally downloaded BYOC managed plugin if it exists.
+Often, you only need to download the plugin to create your cluster once, and
+then you never need the plugin again. You can uninstall to save a small bit of
+disk space.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc uninstall [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for uninstall.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cloud-byoc.adoc
+++ b/tools/gen/23.1/rpk-cloud-byoc.adoc
@@ -1,0 +1,36 @@
+= rpk cloud byoc
+:description: rpk cloud byoc
+
+Manage a Redpanda cloud BYOC agent
+
+For BYOC, Redpanda installs an agent service in your owned cluster. The agent
+then proceeds to provision further infrastructure and eventually, a full
+Redpanda cluster.
+
+The BYOC command runs Terraform to create and start the agent. You first need
+a redpanda-id (or cluster ID); this is used to get the details of how your
+agent should be provisioned. You can create a BYOC cluster in our cloud UI
+and then come back to this command to complete the process.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc [flags]
+  rpk cloud byoc [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--client-id` |string |The client ID of the organization in Redpanda Cloud.
+
+|`--client-secret` |string |The client secret of the organization in Redpanda Cloud.
+
+|`-h, --help` |- |Help for byoc.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cloud-login.adoc
+++ b/tools/gen/23.1/rpk-cloud-login.adoc
@@ -1,0 +1,48 @@
+= rpk cloud login
+:description: rpk cloud login
+
+Log in to the Redpanda cloud
+
+This command checks for an existing token and, if present, ensures it is still
+valid. If no token is found or the token is no longer valid, this command will
+login and save your token.
+
+You may use any of the following methods to pass the cloud credentials to rpk:
+
+Logging in requires cloud credentials, which can be created in the Clients
+tab of the Users section in the Redpanda Cloud online interface. Client
+credentials can be provided in three ways, in order of preference:
+
+* In $HOME/.config/rpk/__cloud.yaml, in 'client_id' and 'client_secret' fields
+* Through RPK_CLOUD_CLIENT_ID and RPK_CLOUD_CLIENT_SECRET environment variables
+* Through the --client-id and --client-secret flags
+
+If none of these are provided, login will prompt you for the client ID and
+client secret and will save them to the __cloud.yaml file. If you specify
+environment variables or flags, they will not be synced to the __cloud.yaml
+file unless the --save flag is passed. The cloud authorization token is always 
+synced.
+
+== Usage
+
+[,bash]
+----
+rpk cloud login [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--client-id` |string |The client ID of the organization in Redpanda Cloud.
+
+|`--client-secret` |string |The client secret of the organization in Redpanda Cloud.
+
+|`-h, --help` |- |Help for login.
+
+|`--save` |- |Save environment or flag specified client ID and client secret to the configuration file.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cloud-logout.adoc
+++ b/tools/gen/23.1/rpk-cloud-logout.adoc
@@ -1,0 +1,28 @@
+= rpk cloud logout
+:description: rpk cloud logout
+
+Log out from Redpanda cloud
+
+This command deletes your cloud auth token. If you want to log out entirely and
+switch to a different organization, you can use the --clear-credentials flag to
+additionally clear your client ID and client secret.
+
+== Usage
+
+[,bash]
+----
+rpk cloud logout [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-c, --clear-credentials` |- |Clear the client ID and client secret in addition to the auth token.
+
+|`-h, --help` |- |Help for logout.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cloud.adoc
+++ b/tools/gen/23.1/rpk-cloud.adoc
@@ -1,0 +1,22 @@
+= rpk cloud
+:description: rpk cloud
+
+Interact with Redpanda cloud
+
+== Usage
+
+[,bash]
+----
+rpk cloud [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for cloud.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-config-edit.adoc
+++ b/tools/gen/23.1/rpk-cluster-config-edit.adoc
@@ -1,0 +1,65 @@
+= rpk cluster config edit
+:description: rpk cluster config edit
+
+Edit cluster-wide configuration properties.
+
+This command opens a text editor to modify the cluster's configuration.
+
+Cluster properties are redpanda settings which apply to all nodes in
+the cluster.  These are separate to node properties, which are set with
+'rpk redpanda config'.
+
+Modified values are written back when the file is saved and the editor
+is closed.  Properties which are deleted are reset to their default
+values.
+
+By default, low level tunables are excluded: use the '--all' flag
+to edit all properties including these tunables.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config edit [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for edit.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-config-export.adoc
+++ b/tools/gen/23.1/rpk-cluster-config-export.adoc
@@ -1,0 +1,61 @@
+= rpk cluster config export
+:description: rpk cluster config export
+
+Export cluster configuration.
+
+Writes out a YAML representation of the cluster configuration to a file,
+suitable for editing and later applying with the corresponding 'import'
+command.
+
+By default, low level tunables are excluded: use the '--all' flag
+to include all properties including these low level tunables.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config export [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --filename` |string |path to file to export to, e.g. './config.yml'.
+
+|`-h, --help` |- |Help for export.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-config-force-reset.adoc
+++ b/tools/gen/23.1/rpk-cluster-config-force-reset.adoc
@@ -1,0 +1,67 @@
+= rpk cluster config force-reset
+:description: rpk cluster config force-reset
+
+Forcibly clear a cluster configuration property on this node.
+
+This command is not for general changes to cluster configuration: use this only
+when redpanda will not start due to a configuration issue.
+
+If your cluster is working properly and you would like to reset a property
+to its default, you may use the 'set' command with an empty string, or
+use the 'edit' command and delete the property's line.
+
+This command erases a named property from an internal cache of the cluster
+configuration on the local node, so that on next startup redpanda will treat
+the setting as if it was set to the default.
+
+WARNING: this should only be used when redpanda is not running.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config force-reset [PROPERTY...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--cache-file` |string |location of configuration cache file (defaults to redpanda data directory).
+
+|`-h, --help` |- |Help for force-reset.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-config-get.adoc
+++ b/tools/gen/23.1/rpk-cluster-config-get.adoc
@@ -1,0 +1,55 @@
+= rpk cluster config get
+:description: rpk cluster config get
+
+Get a cluster configuration property.
+
+This command is provided for use in scripts.  For interactive editing, or bulk
+output, use the 'edit' and 'export' commands respectively.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config get <key> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for get.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-config-import.adoc
+++ b/tools/gen/23.1/rpk-cluster-config-import.adoc
@@ -1,0 +1,60 @@
+= rpk cluster config import
+:description: rpk cluster config import
+
+Import cluster configuration from a file.
+
+Import configuration from a YAML file, usually generated with
+corresponding 'export' command.  This downloads the current cluster
+configuration, calculates the difference with the YAML file, and
+updates any properties that were changed.  If a property is removed
+from the YAML file, it is reset to its default value.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config import [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --filename` |string |full path to file to import, e.g. '/tmp/config.yml'.
+
+|`-h, --help` |- |Help for import.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-config-lint.adoc
+++ b/tools/gen/23.1/rpk-cluster-config-lint.adoc
@@ -1,0 +1,56 @@
+= rpk cluster config lint
+:description: rpk cluster config lint
+
+Remove any deprecated content from `redpanda.yaml`.
+
+Deprecated content includes properties which were set via `redpanda.yaml`
+in earlier versions of redpanda, but are now managed via Redpanda's
+central configuration store (and via 'rpk cluster config edit').
+
+== Usage
+
+[,bash]
+----
+rpk cluster config lint [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for lint.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-config-set.adoc
+++ b/tools/gen/23.1/rpk-cluster-config-set.adoc
@@ -1,0 +1,57 @@
+= rpk cluster config set
+:description: rpk cluster config set
+
+Set a single cluster configuration property.
+
+This command is provided for use in scripts.  For interactive editing, or bulk
+changes, use the 'edit' and 'import' commands respectively.
+
+If an empty string is given as the value, the property is reset to its default.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config set <key> <value> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-config-status.adoc
+++ b/tools/gen/23.1/rpk-cluster-config-status.adoc
@@ -1,0 +1,61 @@
+= rpk cluster config status
+:description: rpk cluster config status
+
+Get configuration status of redpanda nodes.
+
+For each node, indicate whether a restart is required for settings to
+take effect, and any settings that the node has identified as invalid
+or unknown properties.
+
+Additionally show the version of cluster configuration that each node
+has applied: under normal circumstances these should all be equal,
+a lower number shows that a node is out of sync, perhaps because it
+is offline.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-config.adoc
+++ b/tools/gen/23.1/rpk-cluster-config.adoc
@@ -1,0 +1,70 @@
+= rpk cluster config
+:description: rpk cluster config
+
+Interact with cluster configuration properties.
+
+Cluster properties are redpanda settings which apply to all nodes in
+the cluster.  These are separate to node properties, which are set with
+'rpk redpanda config'.
+
+Use the 'edit' subcommand to interactively modify the cluster configuration, or
+'export' and 'import' to write configuration to a file that can be edited and
+read back later.
+
+These commands take an optional '--all' flag to include all properties including
+low level tunables such as internal buffer sizes, that do not usually need
+to be changed during normal operations.  These properties generally require
+some expertize to set safely, so if in doubt, avoid using '--all'.
+
+Modified properties are propagated immediately to all nodes.  The 'status'
+subcommand can be used to verify that all nodes are up to date, and identify
+any settings which were rejected by a node, for example if a node is running a
+different redpanda version that does not recognize certain properties.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`-h, --help` |- |Help for config.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-health.adoc
+++ b/tools/gen/23.1/rpk-cluster-health.adoc
@@ -1,0 +1,62 @@
+= rpk cluster health
+:description: rpk cluster health
+
+Queries health overview.
+
+Health overview is created based on the health reports collected periodically
+from all nodes in the cluster. A cluster is considered healthy when the
+following conditions are met:
+
+* all cluster nodes are responding
+* all partitions have leaders
+* the cluster controller is present
+
+== Usage
+
+[,bash]
+----
+rpk cluster health [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`-e, --exit-when-healthy` |- |When used with watch, exits after cluster is back in healthy state.
+
+|`-h, --help` |- |Help for health.
+
+|`-w, --watch` |- |Blocks and writes out all cluster health changes.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-license-info.adoc
+++ b/tools/gen/23.1/rpk-cluster-license-info.adoc
@@ -1,0 +1,57 @@
+= rpk cluster license info
+:description: rpk cluster license info
+
+Retrieve license information:
+
+    Organization:    Organization the license was generated for.
+    Type:            Type of license: free, enterprise, etc.
+    Expires:         Expiration date of the license
+    Version:         License schema version.
+
+== Usage
+
+[,bash]
+----
+rpk cluster license info [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (text, json) (default "text").
+
+|`-h, --help` |- |Help for info.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-license-set.adoc
+++ b/tools/gen/23.1/rpk-cluster-license-set.adoc
@@ -1,0 +1,63 @@
+= rpk cluster license set
+:description: rpk cluster license set
+
+Upload license to the cluster
+
+You can either provide a path to a file containing the license:
+
+    rpk cluster license set --path /home/organization/redpanda.license
+
+Or inline the license string:
+
+    rpk cluster license set <license string>
+
+If neither are present, rpk will look for the license in the
+default location '/etc/redpanda/redpanda.license'.
+
+== Usage
+
+[,bash]
+----
+rpk cluster license set [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--path` |string |Path to the license file.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-license.adoc
+++ b/tools/gen/23.1/rpk-cluster-license.adoc
@@ -1,0 +1,50 @@
+= rpk cluster license
+:description: rpk cluster license
+
+Manage cluster license
+
+== Usage
+
+[,bash]
+----
+rpk cluster license [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`-h, --help` |- |Help for license.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-logdirs-describe.adoc
+++ b/tools/gen/23.1/rpk-cluster-logdirs-describe.adoc
@@ -1,0 +1,62 @@
+= rpk cluster logdirs describe
+:description: rpk cluster logdirs describe
+
+Describe log directories on Redpanda brokers.
+
+This command prints information about log directories on brokers, particularly,
+the base directory that topics and partitions are located in, and the size of
+data that has been written to the partitions. The size you see may not exactly
+match the size on disk as reported by du: Redpanda allocates files in chunks.
+The chunks will show up in du, while the actual bytes so far written to the
+file will show up in this command.
+
+The directory returned is the root directory for partitions. Within Redpanda,
+the partition data lives underneath the the returned root directory in
+
+    kafka/{topic}/{partition}_{revision}/
+
+where revision is a Redpanda internal concept.
+
+== Usage
+
+[,bash]
+----
+rpk cluster logdirs describe [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--aggregate-into` |string |If non-empty, what column to aggregate into starting from the partition column (broker, dir, topic).
+
+|`-b, --broker` |int32 |If non-negative, the specific broker to describe (default -1).
+
+|`-h, --help` |- |Help for describe.
+
+|`--sort-by-size` |- |If true, sort by size.
+
+|`--topics` |strings |Specific topics to describe.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-logdirs.adoc
+++ b/tools/gen/23.1/rpk-cluster-logdirs.adoc
@@ -1,0 +1,40 @@
+= rpk cluster logdirs
+:description: rpk cluster logdirs
+
+Describe log directories on Redpanda brokers
+
+== Usage
+
+[,bash]
+----
+rpk cluster logdirs [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for logdirs.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-maintenance-disable.adoc
+++ b/tools/gen/23.1/rpk-cluster-maintenance-disable.adoc
@@ -1,0 +1,50 @@
+= rpk cluster maintenance disable
+:description: rpk cluster maintenance disable
+
+Disable maintenance mode for a node.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance disable <broker-id> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for disable.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-maintenance-enable.adoc
+++ b/tools/gen/23.1/rpk-cluster-maintenance-enable.adoc
@@ -1,0 +1,55 @@
+= rpk cluster maintenance enable
+:description: rpk cluster maintenance enable
+
+Enable maintenance mode for a node.
+
+This command enables maintenance mode for the node with the specified ID. If a
+node exists that is already in maintenance mode then an error will be returned.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance enable <node-id> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for enable.
+
+|`-w, --wait` |- |Wait until node is drained.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-maintenance-status.adoc
+++ b/tools/gen/23.1/rpk-cluster-maintenance-status.adoc
@@ -1,0 +1,76 @@
+= rpk cluster maintenance status
+:description: rpk cluster maintenance status
+
+Report maintenance status.
+
+This command reports maintenance status for each node in the cluster. The output
+is presented as a table with each row representing a node in the cluster.  The
+output can be used to monitor the progress of node draining.
+
+   NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
+   1        false     false     false   0           0         0             0
+
+Field descriptions:
+
+        NODE-ID: the node ID
+       DRAINING: true if the node is actively draining leadership
+       FINISHED: leadership draining has completed
+         ERRORS: errors have been encountered while draining
+     PARTITIONS: number of partitions whose leadership has moved
+       ELIGIBLE: number of partitions with leadership eligible to move
+   TRANSFERRING: current active number of leadership transfers
+         FAILED: number of failed leadership transfers
+
+Notes:
+
+   - When errors are present further information will be available in the logs
+     for the corresponding node.
+
+   - Only partitions with more than one replica are eligible for leadership
+     transfer.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-maintenance.adoc
+++ b/tools/gen/23.1/rpk-cluster-maintenance.adoc
@@ -1,0 +1,68 @@
+= rpk cluster maintenance
+:description: rpk cluster maintenance
+
+Interact with cluster maintenance mode.
+
+Maintenance mode is a state that a node may be placed into in which the node
+may be shutdown or restarted with minimal disruption to client workloads. The
+primary use of maintenance mode is to perform a rolling upgrade in which each
+node is placed into maintenance mode prior to upgrading the node.
+
+Use the 'enable' and 'disable' subcommands to place a node into maintenance mode
+or remove it, respectively. Only one node at a time may be in maintenance mode.
+
+When a node is placed into maintenance mode the following occurs:
+
+Leadership draining. All raft leadership is transferred to another eligible
+node, and the node in maintenance mode rejects new leadership requests. By
+transferring leadership off of the node in maintenance mode all client traffic
+and requests are directed to other nodes minimizing disruption to client
+workloads when the node is shutdown.
+
+Currently leadership is not transferred for partitions with one replica.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`-h, --help` |- |Help for maintenance.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-metadata.adoc
+++ b/tools/gen/23.1/rpk-cluster-metadata.adoc
@@ -1,0 +1,71 @@
+= rpk cluster metadata
+:description: rpk cluster metadata
+
+Request broker metadata.
+
+The Kafka protocol's metadata contains information about brokers, topics, and
+the cluster as a whole.
+
+This command only runs if specific sections of metadata are requested. There
+are currently three sections: the cluster, the list of brokers, and the topics.
+If no section is specified, this defaults to printing all sections.
+
+If the topic section is requested, all topics are requested by default unless
+some are manually specified as arguments. Expanded per-partition information
+can be printed with the -d flag, and internal topics can be printed with the -i
+flag.
+
+In the broker section, the controller node is suffixed with *.
+
+== Usage
+
+[,bash]
+----
+rpk cluster metadata [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+metadata, status, info
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for metadata.
+
+|`-b, --print-brokers` |- |Print brokers section.
+
+|`-c, --print-cluster` |- |Print cluster section.
+
+|`-d, --print-detailed-topics` |- |Print per-partition information for topics (implies -t).
+
+|`-i, --print-internal-topics` |- |Print internal topics (if all topics requested, implies -t).
+
+|`-t, --print-topics` |- |Print topics section (implied if any topics are specified).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-partitions-balancer-status.adoc
+++ b/tools/gen/23.1/rpk-cluster-partitions-balancer-status.adoc
@@ -1,0 +1,100 @@
+= rpk cluster partitions balancer-status
+:description: rpk cluster partitions balancer-status
+
+Queries cluster for partition balancer status:
+
+If continuous partition balancing is enabled, redpanda will continuously
+reassign partitions from both unavailable nodes and from nodes using more disk
+space than the configured limit.
+
+This command can be used to monitor the partition balancer status.
+
+FIELDS
+
+    Status:                        Either off, ready, starting, in progress, or
+                                   stalled.
+    Seconds Since Last Tick:       The last time the partition balancer ran.
+    Current Reassignments Count:   Current number of partition reassignments in
+                                   progress.
+    Unavailable Nodes:             The nodes that have been unavailable after a
+                                   time set by the
+                                   "partition_autobalancing_node_availability_timeout_sec"
+                                   cluster property.
+    Over Disk Limit Nodes:         The nodes that surpassed the threshold of
+                                   used disk percentage specified in the
+                                   "partition_autobalancing_max_disk_usage_percent"
+                                   cluster property.
+
+BALANCER STATUS
+
+    off:          The balancer is disabled.
+    ready:        The balancer is active but there is nothing to do.
+    starting:     The balancer is starting but has not run yet.
+    in_progress:  The balancer is active and is in the process of scheduling
+                  partition movements.
+    stalled:      Violations have been detected and the balancer cannot correct
+                  them.
+
+STALLED BALANCER
+
+A stalled balancer can occur for a few reasons and requires a bit of manual
+investigation. A few areas to investigate:
+
+* Are there are enough healthy nodes to which to move partitions? For example,
+  in a three node cluster, no movements are possible for partitions with three
+  replicas. You will see a stall every time there is a violation.
+
+* Does the cluster have sufficient space? If all nodes in the cluster are
+  utilizing more than 80% of their disk space, rebalancing cannot proceed.
+
+* Do all partitions have quorum? If the majority of a partition's replicas are
+  down, the partition cannot be moved.
+
+* Are any nodes in maintenance mode? Partitions are not moved if any node is in
+  maintenance mode.
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions balancer-status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for balancer-status.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-partitions-movement-cancel.adoc
+++ b/tools/gen/23.1/rpk-cluster-partitions-movement-cancel.adoc
@@ -1,0 +1,66 @@
+= rpk cluster partitions movement-cancel
+:description: rpk cluster partitions movement-cancel
+
+Cancel ongoing partition movements.
+
+By default, this command cancels all the partition movements in the cluster. 
+To ensure that you do not accidentally cancel all partition movements, this 
+command prompts users for confirmation before issuing the cancellation request. 
+You can use "--no-confirm" to disable the confirmation prompt:
+
+    rpk cluster partitions movement-cancel --no-confirm
+
+If "--node" is set, this command will only stop the partition movements 
+occurring in the specified node:
+
+    rpk cluster partitions movement-cancel --node 1
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions movement-cancel [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for movement-cancel.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`--node` |int |ID of a specific node on which to cancel ongoing partition movements (default -1).
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-partitions.adoc
+++ b/tools/gen/23.1/rpk-cluster-partitions.adoc
@@ -1,0 +1,50 @@
+= rpk cluster partitions
+:description: rpk cluster partitions
+
+Manage cluster partitions
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`-h, --help` |- |Help for partitions.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-self-test-start.adoc
+++ b/tools/gen/23.1/rpk-cluster-self-test-start.adoc
@@ -1,0 +1,78 @@
+= rpk cluster self-test start
+:description: rpk cluster self-test start
+
+Starts one or more benchmark tests on one or more nodes
+of the cluster. Available tests to run:
+
+* Disk tests:
+  * Throughput test: 512 KB messages, sequential read/write
+    * Uses a larger request message sizes and deeper I/O queue depth to write/read more bytes in a shorter amount of time, at the cost of IOPS/latency.
+  * Latency test: 4 KB messages, sequential read/write
+    * Uses smaller request message sizes and lower levels of parallelism to achieve higher IOPS and lower latency.
+
+* Network tests:
+  * Throughput test: 8192-bit messages
+    * Unique pairs of Redpanda nodes each act as a client and a server.
+    * The test pushes as much data over the wire, within the test parameters.
+
+This command immediately returns on success, and the tests run asynchronously. The
+user polls for results with the 'self-test status'
+command.
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--disk-duration-ms` |duration |uint       The  in milliseconds of individual disk test runs (default 30000).
+
+|`-h, --help` |- |Help for start.
+
+|`--network-duration-ms` |duration |uint    The  in milliseconds of individual network test runs (default 30000).
+
+|`--no-confirm` |- |Acknowledge warning prompt skipping read from stdin.
+
+|`--only-disk-test` |- |Runs only the disk benchmarks.
+
+|`--only-network-test` |- |Runs only network benchmarks.
+
+|`--participant-node-ids` |- |ints   IDs of nodes that the tests will run on. If not set, tests will run for all node IDs.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of Admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-self-test-status.adoc
+++ b/tools/gen/23.1/rpk-cluster-self-test-status.adoc
@@ -1,0 +1,61 @@
+= rpk cluster self-test status
+:description: rpk cluster self-test status
+
+Returns the status of the currently running or last completed self-test run.
+
+Use this command after invoking 'self-test start' to determine the status of
+the jobs launched. Possible results are:
+
+* One or more jobs still running
+  * Returns the IDs of Redpanda nodes still running self-tests.
+
+* No jobs running:
+  * Returns cached results for all nodes of the last completed test.
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (text, json) (default "text").
+
+|`-h, --help` |- |Help for status.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of Admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-self-test-stop.adoc
+++ b/tools/gen/23.1/rpk-cluster-self-test-stop.adoc
@@ -1,0 +1,53 @@
+= rpk cluster self-test stop
+:description: rpk cluster self-test stop
+
+Stops all self-test tests.
+
+This command stops all currently running self-tests. The command is synchronous and returns
+success when all jobs have been stopped or reports errors if broker timeouts have expired.
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for stop.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of Admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-self-test.adoc
+++ b/tools/gen/23.1/rpk-cluster-self-test.adoc
@@ -1,0 +1,50 @@
+= rpk cluster self-test
+:description: rpk cluster self-test
+
+Start, stop and query runs of Redpanda self-test through the Admin API listener
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of Admin API addresses (|IP|:|port|).
+
+|`-h, --help` |- |Help for self-test.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-storage-recovery-start.adoc
+++ b/tools/gen/23.1/rpk-cluster-storage-recovery-start.adoc
@@ -1,0 +1,60 @@
+= rpk cluster storage recovery start
+:description: rpk cluster storage recovery start
+
+Start the topic recovery process.
+		
+This command starts the process of restoring topics from the archival bucket.
+If the wait flag (--wait/-w) is set, the command will poll the status of the
+recovery process until it's finished.
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage recovery start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for start.
+
+|`--polling-interval` |duration |The status check interval (e.g. '30s', '1.5m'); ignored if --wait is not used (default 5s).
+
+|`--topic-name-pattern` |string |A regex pattern that restores any matching topics (default ".*").
+
+|`-w, --wait` |- |Wait until auto-restore is complete.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-storage-recovery-status.adoc
+++ b/tools/gen/23.1/rpk-cluster-storage-recovery-status.adoc
@@ -1,0 +1,53 @@
+= rpk cluster storage recovery status
+:description: rpk cluster storage recovery status
+
+Fetch the status of the topic recovery process.
+		
+This command fetches the status of the process of restoring topics from the 
+archival bucket.
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage recovery status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-storage-recovery.adoc
+++ b/tools/gen/23.1/rpk-cluster-storage-recovery.adoc
@@ -1,0 +1,61 @@
+= rpk cluster storage recovery
+:description: rpk cluster storage recovery
+
+Interact with the topic recovery process.
+		
+This command is used to restore topics from the archival bucket, which can be 
+useful for disaster recovery or if a topic was accidentally deleted.
+
+To begin the recovery process, use the "recovery start" command. Note that this 
+process can take a while to complete, so the command will exit after starting 
+it. If you want the command to wait for the process to finish, use the "--wait"
+or "-w" flag.
+
+You can check the status of the recovery process with the "recovery status" 
+command after it has been started.
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage recovery [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for recovery.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster-storage.adoc
+++ b/tools/gen/23.1/rpk-cluster-storage.adoc
@@ -1,0 +1,50 @@
+= rpk cluster storage
+:description: rpk cluster storage
+
+Manage the cluster storage
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`-h, --help` |- |Help for storage.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-cluster.adoc
+++ b/tools/gen/23.1/rpk-cluster.adoc
@@ -1,0 +1,40 @@
+= rpk cluster
+:description: rpk cluster
+
+Interact with a Redpanda cluster
+
+== Usage
+
+[,bash]
+----
+rpk cluster [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for cluster.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-container-purge.adoc
+++ b/tools/gen/23.1/rpk-container-purge.adoc
@@ -1,0 +1,22 @@
+= rpk container purge
+:description: rpk container purge
+
+Stop and remove an existing local container cluster's data
+
+== Usage
+
+[,bash]
+----
+rpk container purge [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for purge.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-container-start.adoc
+++ b/tools/gen/23.1/rpk-container-start.adoc
@@ -1,0 +1,26 @@
+= rpk container start
+:description: rpk container start
+
+Start a local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for start.
+
+|`-n, --nodes` |- |uint     The number of nodes to start (default 1).
+
+|`--retries` |- |uint   The amount of times to check for the cluster before considering it unstable and exiting. (default 10).
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-container-status.adoc
+++ b/tools/gen/23.1/rpk-container-status.adoc
@@ -1,0 +1,22 @@
+= rpk container status
+:description: rpk container status
+
+Get status
+
+== Usage
+
+[,bash]
+----
+rpk container status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-container-stop.adoc
+++ b/tools/gen/23.1/rpk-container-stop.adoc
@@ -1,0 +1,22 @@
+= rpk container stop
+:description: rpk container stop
+
+Stop an existing local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for stop.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-container.adoc
+++ b/tools/gen/23.1/rpk-container.adoc
@@ -1,0 +1,22 @@
+= rpk container
+:description: rpk container
+
+Manage a local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for container.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-debug-bundle.adoc
+++ b/tools/gen/23.1/rpk-debug-bundle.adoc
@@ -1,0 +1,141 @@
+= rpk debug bundle
+:description: rpk debug bundle
+
+'rpk debug bundle' collects environment data that can help debug and diagnose
+issues with a redpanda cluster, a broker, or the machine it's running on. It
+then bundles the collected data into a ZIP file, called a diagnostics bundle.
+
+The files and directories in the diagnostics bundle differ depending on the 
+environment in which Redpanda is running:
+
+COMMON FILES
+
+ - Kafka metadata: Broker configs, topic configs, start/committed/end offsets,
+   groups, group commits.
+
+ - Controller logs: The controller logs directory up to a limit set by
+   --controller-logs-size-limit flag
+
+ - Data directory structure: A file describing the data directory's contents.
+
+ - redpanda configuration: The redpanda configuration file (`redpanda.yaml`;
+   SASL credentials are stripped).
+
+ - /proc/cpuinfo: CPU information like make, core count, cache, frequency.
+
+ - /proc/interrupts: IRQ distribution across CPU cores.
+
+ - Resource usage data: CPU usage percentage, free memory available for the
+   redpanda process.
+
+ - Clock drift: The ntp clock delta (using pool.ntp.org as a reference) & round
+   trip time.
+
+ - Admin API calls: Cluster and broker configurations, cluster health data, and 
+   license key information.
+
+ - Broker metrics: The broker's Prometheus metrics, fetched through its
+   admin API (/metrics and /public_metrics).
+
+BARE-METAL
+
+ - Kernel logs: The kernel logs ring buffer (syslog).
+
+ - DNS: The DNS info as reported by 'dig', using the hosts in
+   /etc/resolv.conf.
+
+ - Disk usage: The disk usage for the data directory, as output by 'du'.
+
+ - redpanda logs: The node's redpanda logs written to journald. If --logs-since 
+   or --logs-until are passed, then only the logs within the resulting time frame
+   will be included.
+
+ - Socket info: The active sockets data output by 'ss'.
+
+ - Running process info: As reported by 'top'.
+
+ - Virtual memory stats: As reported by 'vmstat'.
+
+ - Network config: As reported by 'ip addr'.
+
+ - lspci: List the PCI buses and the devices connected to them.
+
+ - dmidecode: The DMI table contents. Only included if this command is run
+   as root.
+
+KUBERNETES
+
+ - Kubernetes Resources: Kubernetes manifests for all resources in the given 
+   Kubernetes namespace (via --namespace).
+
+ - redpanda logs: Logs of each Pod in the the given Kubernetes namespace. If 
+   --logs-since is passed, only the logs within the given timeframe are 
+   included.
+
+
+If you have an upload URL from the Redpanda support team, provide it in the 
+--upload-url flag to upload your diagnostics bundle to Redpanda.
+
+== Usage
+
+[,bash]
+----
+rpk debug bundle [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--api-urls` |string |Comma-separated list of admin API addresses (|IP|:|port|).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--controller-logs-size-limit` |string |Sets the limit of the controller log size that can be stored in the bundle. Multipliers are also supported, e.g. 3MB, 1GiB (default "20MB").
+
+|`-h, --help` |- |Help for bundle.
+
+|`--logs-since` |string |Include log entries on or newer than the specified date. (journalctl date format, e.g. YYYY-MM-DD).
+
+|`--logs-size-limit` |string |Read the logs until the given size is reached. Multipliers are also supported, e.g. 3MB, 1GiB (default "100MiB").
+
+|`--logs-until` |string |Include log entries on or older than the specified date. (journalctl date format, e.g. YYYY-MM-DD).
+
+|`--metrics-interval` |duration |Interval between metrics snapshots (e.g. '30s', '1.5m') (default 10s).
+
+|`-n, --namespace` |string |The namespace to use to collect the resources from (k8s only) (default "redpanda").
+
+|`-o, --output` |string |The file path where the debug file will be written (default ./&lt;timestamp&gt;-bundle.zip).
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--timeout` |duration |How long to wait for child commands to execute (e.g. '30s', '1.5m') (default 12s).
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--upload-url` |string |If provided, rpk will upload the bundle to the given URL in addition to creating a copy on disk.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-debug.adoc
+++ b/tools/gen/23.1/rpk-debug.adoc
@@ -1,0 +1,22 @@
+= rpk debug
+:description: rpk debug
+
+Debug the local Redpanda process
+
+== Usage
+
+[,bash]
+----
+rpk debug [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for debug.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-generate-grafana-dashboard.adoc
+++ b/tools/gen/23.1/rpk-generate-grafana-dashboard.adoc
@@ -1,0 +1,28 @@
+= rpk generate grafana-dashboard
+:description: rpk generate grafana-dashboard
+
+Generate a Grafana dashboard for redpanda metrics
+
+== Usage
+
+[,bash]
+----
+rpk generate grafana-dashboard [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--datasource` |string |The name of the Prometheus datasource as configured in your grafana instance.
+
+|`-h, --help` |- |Help for grafana-dashboard.
+
+|`--job-name` |string |The prometheus job name by which to identify the redpanda nodes (default "redpanda").
+
+|`--metrics-endpoint` |string |The redpanda metrics endpoint where to get the metrics metadata. i.e. redpanda_host:9644/metrics (default "http://localhost:9644/metrics").
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-generate-prometheus-config.adoc
+++ b/tools/gen/23.1/rpk-generate-prometheus-config.adoc
@@ -1,0 +1,52 @@
+= rpk generate prometheus-config
+:description: rpk generate prometheus-config
+
+Generate the Prometheus configuration to scrape redpanda nodes. This command's
+output should be added to the 'scrape_configs' array in your Prometheus
+instance's YAML config file.
+
+If --seed-addr is passed, it will be used to discover the rest of the cluster
+hosts via Redpanda's Kafka API. If --node-addrs is passed, they will be used
+directly. Otherwise, 'rpk generate prometheus-conf' will read the redpanda
+config file and use the node IP configured there. --config may be passed to
+specify an arbitrary config file.
+
+If the node you want to scrape uses TLS, you can provide the TLS flags:
+--tls-key, --tls-cert, and --tls-truststore and rpk will generate the required
+tls_config section in the scrape configuration.
+
+== Usage
+
+[,bash]
+----
+rpk generate prometheus-config [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |The path to the redpanda config file.
+
+|`-h, --help` |- |Help for prometheus-config.
+
+|`--internal-metrics` |- |Include scrape config for internal metrics (/metrics).
+
+|`--job-name` |string |The prometheus job name by which to identify the redpanda nodes (default "redpanda").
+
+|`--node-addrs` |strings |A comma-delimited list of the addresses (|host|:|port|) of all the redpanda nodes in a cluster. The port must be the one configured for the nodes' admin API (9644 by default).
+
+|`--seed-addr` |string |The URL of a redpanda node with which to discover the rest.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-generate-shell-completion.adoc
+++ b/tools/gen/23.1/rpk-generate-shell-completion.adoc
@@ -1,0 +1,64 @@
+= rpk generate shell-completion
+:description: rpk generate shell-completion
+
+Shell completion can help autocomplete rpk commands when you press tab.
+
+# Bash
+
+Bash autocompletion relies on the bash-completion package. You can test if you
+have this by running "type _init_completion", if you do not, you can install
+the package through your package manager.
+
+If you have bash-completion installed, and the command still fails, you likely
+need to add the following line to your ~/.bashrc:
+
+    source /usr/share/bash-completion/bash_completion
+
+To ensure autocompletion of rpk exists in all shell sessions, add the following
+to your ~/.bashrc:
+
+    command -v rpk >/dev/null && . <(rpk generate shell-completion bash)
+
+Alternatively, to globally enable rpk completion, you can run the following:
+
+    rpk generate shell-completion bash > /etc/bash_completion.d/rpk
+
+# Zsh
+
+To enable autocompletion in any zsh session for any user, run this once:
+
+    rpk generate shell-completion zsh > "${fpath[1]}/_rpk"
+
+You can also place that command in your ~/.zshrc to ensure that when you update
+rpk, you update autocompletion. If you initially require sudo to edit that
+file, you can chmod it to be world writeable, after which you will always be
+able to update it from ~/.zshrc.
+
+If shell completion is not already enabled in your zsh environment, also
+add the following to your ~/.zshrc:
+
+    autoload -U compinit; compinit
+
+# Fish
+
+To enable autocompletion in any fish session, run:
+
+    rpk generate shell-completion fish > ~/.config/fish/completions/rpk.fish
+
+== Usage
+
+[,bash]
+----
+rpk generate shell-completion [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for shell-completion.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-generate.adoc
+++ b/tools/gen/23.1/rpk-generate.adoc
@@ -1,0 +1,22 @@
+= rpk generate
+:description: rpk generate
+
+Generate a configuration template for related services
+
+== Usage
+
+[,bash]
+----
+rpk generate [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for generate.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-group-delete.adoc
+++ b/tools/gen/23.1/rpk-group-delete.adoc
@@ -1,0 +1,57 @@
+= rpk group delete
+:description: rpk group delete
+
+Delete groups from brokers.
+
+Older versions of the Kafka protocol included a retention_millis field in
+offset commit requests. Group commits persisted for this retention and then
+eventually expired. Once all commits for a group expired, the group would be
+considered deleted.
+
+The retention field was removed because it proved problematic for infrequently
+committing consumers: the offsets could be expired for a group that was still
+active. If clients use new enough versions of OffsetCommit (versions that have
+removed the retention field), brokers expire offsets only when the group is
+empty for offset.retention.minutes. Redpanda does not currently support that
+configuration (see #2904), meaning offsets for empty groups expire only when
+they are explicitly deleted.
+
+You may want to delete groups to clean up offsets sooner than when they
+automatically are cleaned up, such as when you create temporary groups for
+quick investigation or testing. This command helps you do that.
+
+== Usage
+
+[,bash]
+----
+rpk group delete [GROUPS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-group-describe.adoc
+++ b/tools/gen/23.1/rpk-group-describe.adoc
@@ -1,0 +1,45 @@
+= rpk group describe
+:description: rpk group describe
+
+Describe group offset status & lag.
+
+This command describes group members, calculates their lag, and prints detailed
+information about the members.
+
+== Usage
+
+[,bash]
+----
+rpk group describe [GROUPS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for describe.
+
+|`-s, --print-summary` |- |Print only the group summary section.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-group-list.adoc
+++ b/tools/gen/23.1/rpk-group-list.adoc
@@ -1,0 +1,52 @@
+= rpk group list
+:description: rpk group list
+
+List all groups.
+
+This command lists all groups currently known to Redpanda, including empty
+groups that have not yet expired. The BROKER column is which broker node is the
+coordinator for the group. This command can be used to track down unknown
+groups, or to list groups that need to be cleaned up.
+
+== Usage
+
+[,bash]
+----
+rpk group list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-group-offset-delete.adoc
+++ b/tools/gen/23.1/rpk-group-offset-delete.adoc
@@ -1,0 +1,61 @@
+= rpk group offset-delete
+:description: rpk group offset-delete
+
+Forcefully delete offsets for a kafka group.
+
+The broker will only allow the request to succeed if the group is in a dead
+state (no subscriptions) or there are no subscriptions for offsets for
+topic/partitions requested to be deleted.
+
+Use either the --from-file or the --topic option. They are mututally exclusive.
+To indicate which topics or topic partitions you'd like to remove offsets from use
+the --topic (-t) flag, followed by a comma separated list of partition ids. Supplying
+no list will delete all offsets for all partitions for a given topic.
+
+You may also provide a text file to indicate topic/partition tuples. Use the
+--from-file flag for this option. The file must contain lines of topic/partitions
+separated by a tab or space. Example:
+
+topic_a 0
+topic_a 1
+topic_b 0
+
+== Usage
+
+[,bash]
+----
+rpk group offset-delete [GROUP] --from-file FILE --topic foo:0,1,2 [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --from-file` |string |File of topic/partition tuples for which to delete offsets for.
+
+|`-h, --help` |- |Help for offset-delete.
+
+|`-t, --topic` |stringArray |topic:partition_id (repeatable; e.g. -t foo:0,1,2 ).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-group-seek.adoc
+++ b/tools/gen/23.1/rpk-group-seek.adoc
@@ -1,0 +1,94 @@
+= rpk group seek
+:description: rpk group seek
+
+Modify a group's current offsets.
+
+This command allows you to modify a group's offsets. Sometimes, you may need to
+rewind a group if you had a mistaken deploy, or fast-forward a group if it is
+falling behind on messages that can be skipped.
+
+The --to option allows you to seek to the start of partitions, end of
+partitions, or after a specific timestamp. The default is to seek any topic
+previously committed. Using --topics allows to you set commits for only the
+specified topics; all other commits will remain untouched. Topics with no
+commits will not be committed unless allowed with --allow-new-topics.
+
+The --to-group option allows you to seek to commits that are in another group.
+This is a merging operation: if g1 is consuming topics A and B, and g2 is
+consuming only topic B, "rpk group seek g1 --to-group g2" will update g1's
+commits for topic B only. The --topics flag can be used to further narrow which
+topics are updated. Unlike --to, all non-filtered topics are committed, even
+topics not yet being consumed, meaning --allow-new-topics is not needed.
+
+The --to-file option allows to seek to offsets specified in a text file with
+the following format:
+    [TOPIC] [PARTITION] [OFFSET]
+    [TOPIC] [PARTITION] [OFFSET]
+    ...
+Each line contains the topic, the partition, and the offset to seek to. As with
+the prior options, --topics allows filtering which topics are updated. Similar
+to --to-group, all non-filtered topics are committed, even topics not yet being
+consumed, meaning --allow-new-topics is not needed.
+
+The --to, --to-group, and --to-file options are mutually exclusive. If you are
+not authorized to describe or read some topics used in a group, you will not be
+able to modify offsets for those topics.
+
+EXAMPLES
+
+Seek group G to June 1st, 2021:
+    rpk group seek g --to 1622505600
+    or, rpk group seek g --to 1622505600000
+    or, rpk group seek g --to 1622505600000000000
+Seek group X to the commits of group Y topic foo:
+    rpk group seek X --to-group Y --topics foo
+Seek group G's topics foo, bar, and biz to the end:
+    rpk group seek G --to end --topics foo,bar,biz
+Seek group G to the beginning of a topic it was not previously consuming:
+    rpk group seek G --to start --topics foo --allow-new-topics
+
+== Usage
+
+[,bash]
+----
+rpk group seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ... [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-new-topics` |- |Allow seeking to new topics not currently consumed (implied with --to-group or --to-file).
+
+|`-h, --help` |- |Help for seek.
+
+|`--to` |string |Where to seek (start, end, unix second | millisecond | nanosecond).
+
+|`--to-file` |string |Seek to offsets as specified in the file.
+
+|`--to-group` |string |Seek to the commits of another group.
+
+|`--topics` |strings |Only seek these topics, if any are specified.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-group.adoc
+++ b/tools/gen/23.1/rpk-group.adoc
@@ -1,0 +1,85 @@
+= rpk group
+:description: rpk group
+
+Describe, list, and delete consumer groups and manage their offsets.
+
+Consumer groups allow you to horizontally scale consuming from topics. A
+non-group consumer consumes all records from all partitions you assign it. In
+contrast, consumer groups allow many consumers to coordinate and divide work.
+If you have two members in a group consuming topics A and B, each with three
+partitions, then both members consume three partitions. If you add another
+member to the group, then each of the three members will consume two
+partitions. This allows you to horizontally scale consuming of topics.
+
+The unit of scaling is a single partition. If you add more consumers to a group
+than there are are total partitions to consume, then some consumers will be
+idle. More commonly, you have many more partitions than consumer group members
+and each member consumes a chunk of available partitions. One scenario where
+you may want more members than partitions is if you want active standby's to
+take over load immediately if any consuming member dies.
+
+How group members divide work is entirely client driven (the "partition
+assignment strategy" or "balancer" depending on the client). Brokers know
+nothing about how consumers are assigning partitions. A broker's role in group
+consuming is to choose which member is the leader of a group, forward that
+member's assignment to every other member, and ensure all members are alive
+through heartbeats.
+
+Consumers periodically commit their progress when consuming partitions. Through
+these commits, you can monitor just how far behind a consumer is from the
+latest messages in a partition. This is called "lag". Large lag implies that
+the client is having problems, which could be from the server being too slow,
+or the client being oversubscribed in the number of partitions it is consuming,
+or the server being in a bad state that requires restarting or removing from
+the server pool, and so on.
+
+You can manually manage offsets for a group, which allows you to rewind or
+forward commits. If you notice that a recent deploy of your consumers had a
+bug, you may want to stop all members, rewind the commits to before the latest
+deploy, and restart the members with a patch.
+
+This command allows you to list all groups, describe a group (to view the
+members and their lag), and manage offsets.
+
+== Usage
+
+[,bash]
+----
+rpk group [command]
+----
+
+== Aliases
+
+[,bash]
+----
+group, g
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for group.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-help.adoc
+++ b/tools/gen/23.1/rpk-help.adoc
@@ -1,0 +1,23 @@
+= rpk help
+:description: rpk help
+
+Help provides help for any command in the application.
+Simply type rpk help [path to command] for full details.
+
+== Usage
+
+[,bash]
+----
+rpk help [command] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |help for help.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-iotune.adoc
+++ b/tools/gen/23.1/rpk-iotune.adoc
@@ -1,0 +1,34 @@
+= rpk iotune
+:description: rpk iotune
+
+Measure filesystem performance and create IO configuration file
+
+== Usage
+
+[,bash]
+----
+rpk iotune [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--directories` |strings |List of directories to evaluate.
+
+|`--duration` |duration |Duration of tests.The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 10m0s).
+
+|`-h, --help` |- |Help for iotune.
+
+|`--no-confirm` |- |Disable confirmation prompt if the iotune file already exists.
+
+|`--out` |string |The file path where the IO config will be written (default "/etc/redpanda/io-config.yaml").
+
+|`--timeout` |duration |The maximum time after -- to wait for iotune to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 1h0m0s).
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-plugin-install.adoc
+++ b/tools/gen/23.1/rpk-plugin-install.adoc
@@ -1,0 +1,39 @@
+= rpk plugin install
+:description: rpk plugin install
+
+Install an rpk plugin.
+
+An rpk plugin must be saved in $HOME/.local/bin or in a directory that is in 
+your $PATH. By default, this command installs plugins to $HOME/.local/bin. This 
+can be overridden by specifying the --dir flag.
+
+If --dir is not present, rpk will create $HOME/.local/bin if it does not exist.
+
+== Usage
+
+[,bash]
+----
+rpk plugin install [PLUGIN] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+install, download
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--dir` |string |Destination directory to save the installed plugin (defaults to $HOME/.local/bin) (default "/var/lib/redpanda/.local/bin").
+
+|`-h, --help` |- |Help for install.
+
+|`-u, --update` |- |Update a locally installed plugin if it differs from the current remote version.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-plugin-list.adoc
+++ b/tools/gen/23.1/rpk-plugin-list.adoc
@@ -1,0 +1,33 @@
+= rpk plugin list
+:description: rpk plugin list
+
+List all available plugins.
+
+By default, this command fetches the remote manifest and prints plugins
+available for download. Any plugin that is already downloaded is prefixed with
+an asterisk. If a locally installed plugin has a different sha256sum as the one
+specified in the manifest, or if the sha256sum could not be calculated for the
+local plugin, an additional message is printed.
+
+You can specify --local to print all locally installed plugins, as well as
+whether you have "shadowed" plugins (the same plugin specified multiple times).
+
+== Usage
+
+[,bash]
+----
+rpk plugin list [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`-l, --local` |- |List locally installed plugins and shadowed plugins.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-plugin-uninstall.adoc
+++ b/tools/gen/23.1/rpk-plugin-uninstall.adoc
@@ -1,0 +1,36 @@
+= rpk plugin uninstall
+:description: rpk plugin uninstall
+
+Uninstall / remove an existing local plugin.
+
+This command lists locally installed plugins and removes the first plugin that
+matches the requested removal. If --include-shadowed is specified, this command
+also removes all shadowed plugins of the same name. To remove a command under a
+nested namespace ("rpk foo bar"), you can use "foo_bar".
+
+== Usage
+
+[,bash]
+----
+rpk plugin uninstall [NAME] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+uninstall, rm
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for uninstall.
+
+|`--include-shadowed` |- |Also remove shadowed plugins that have the same name.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-plugin.adoc
+++ b/tools/gen/23.1/rpk-plugin.adoc
@@ -1,0 +1,63 @@
+= rpk plugin
+:description: rpk plugin
+
+List, download, update, and remove rpk plugins.
+	
+Plugins augment rpk with new commands.
+
+For a plugin to be used, it must be in $HOME/.local/bin or somewhere 
+discoverable by rpk in your $PATH. All plugins follow a defined naming scheme:
+
+  .rpk-|name|
+  .rpk.ac-|name|
+
+All plugins are prefixed with either .rpk- or .rpk.ac-. When rpk starts up, it
+searches all directories in your $PATH for any executable binary that begins
+with either of those prefixes. For any binary it finds, rpk adds a command for
+that name to the rpk command space itself.
+
+No plugin name can shadow an existing rpk command, and only one plugin can
+exist under a given name at once. Plugins are added to the rpk command space on
+a first-seen basis. If you have two plugins rpk-foo, and the second is
+discovered later on in the $PATH directories, then only the first will be used.
+The second will be ignored.
+
+Plugins that have an .rpk.ac- prefix indicate that they support the
+--help-autocomplete flag. If rpk sees this, rpk will exec the plugin with that
+flag when rpk starts up, and the plugin will return all commands it supports as
+well as short and long help test for each command. Rpk uses this return to
+build a shadow command space within rpk itself so that it looks as if the
+plugin exists within rpk. This is particularly useful if you enable
+autocompletion.
+
+The expected return for plugins from --help-autocomplete is an array of the
+following:
+
+  type pluginHelp struct {
+          Path    string   `json:"path,omitempty"`
+          Short   string   `json:"short,omitempty"`
+          Long    string   `json:"long,omitempty"`
+          Example string   `json:"example,omitempty"`
+          Args    []string `json:"args,omitempty"`
+  }
+
+where "path" is an underscore delimited argument path to a command. For
+example, "foo_bar_baz" corresponds to the command "rpk foo bar baz".
+
+== Usage
+
+[,bash]
+----
+rpk plugin [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for plugin.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-brokers-decommission-status.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-brokers-decommission-status.adoc
@@ -1,0 +1,42 @@
+= rpk redpanda admin brokers decommission-status
+:description: rpk redpanda admin brokers decommission-status
+
+Show the progress of a node decommissioning
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers decommission-status [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --detailed` |- |Print how much data moved and remaining in bytes.
+
+|`-h, --help` |- |Help for decommission-status.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-brokers-decommission.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-brokers-decommission.adoc
@@ -1,0 +1,51 @@
+= rpk redpanda admin brokers decommission
+:description: rpk redpanda admin brokers decommission
+
+Decommission the given broker.
+
+Decommissioning a broker removes it from the cluster.
+
+A decommission request is sent to every broker in the cluster, only the cluster
+leader handles the request.
+
+For safety on v22.x clusters, this command will not run if the requested 
+broker is in maintenance mode. As of v23.x, Redpanda supports 
+decommissioning a node that is currently in maintenance mode. If you are on 
+a v22.x cluster and need to bypass the maintenance mode check (perhaps your 
+cluster is unreachable), use the hidden --force flag.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers decommission [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for decommission.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-brokers-list.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-brokers-list.adoc
@@ -1,0 +1,47 @@
+= rpk redpanda admin brokers list
+:description: rpk redpanda admin brokers list
+
+List the brokers in your cluster
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-brokers-recommission.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-brokers-recommission.adoc
@@ -1,0 +1,48 @@
+= rpk redpanda admin brokers recommission
+:description: rpk redpanda admin brokers recommission
+
+Recommission the given broker if is is still decommissioning.
+
+Recommissioning can stop an active decommission.
+
+Once a broker is decommissioned, it cannot be recommissioned through this
+command.
+
+A recommission request is sent to every broker in the cluster, only
+the cluster leader handles the request.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers recommission [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for recommission.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-brokers.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-brokers.adoc
@@ -1,0 +1,40 @@
+= rpk redpanda admin brokers
+:description: rpk redpanda admin brokers
+
+View and configure Redpanda brokers through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for brokers.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-config-log-level-set.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-config-log-level-set.adoc
@@ -1,0 +1,63 @@
+= rpk redpanda admin config log-level set
+:description: rpk redpanda admin config log-level set
+
+Set broker logger's log level.
+
+This command temporarily changes a broker logger's log level. Each Redpanda
+broker has many loggers, and each can be individually changed. Any change
+to a logger persists for a limited amount of time, so as to ensure you do
+not accidentally enable debug logging permanently.
+
+It is optional to specify a logger; if you do not, this command will prompt
+from the set of available loggers.
+
+The special logger "all" enables all loggers. Alternatively, you can specify
+many loggers at once. To see all possible loggers, run the following command:
+
+  redpanda --help-loggers
+
+This command accepts loggers that it does not know of to ensure you can
+independently update your redpanda installations from rpk. The success or
+failure of enabling each logger is individually printed.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config log-level set [LOGGERS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-e, --expiry-seconds` |int |seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown) (default 300).
+
+|`-h, --help` |- |Help for set.
+
+|`--host` |string |either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to.
+
+|`-l, --level` |string |log level to set (error, warn, info, debug, trace) (default "debug").
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-config-log-level.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-config-log-level.adoc
@@ -1,0 +1,40 @@
+= rpk redpanda admin config log-level
+:description: rpk redpanda admin config log-level
+
+Manage a broker's log level
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config log-level [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for log-level.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-config-print.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-config-print.adoc
@@ -1,0 +1,49 @@
+= rpk redpanda admin config print
+:description: rpk redpanda admin config print
+
+Display the current Redpanda configuration
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config print [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+print, dump, list, ls, display
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for print.
+
+|`--host` |string |either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-config.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-config.adoc
@@ -1,0 +1,40 @@
+= rpk redpanda admin config
+:description: rpk redpanda admin config
+
+View or modify Redpanda configuration through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for config.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-partitions-list.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-partitions-list.adoc
@@ -1,0 +1,49 @@
+= rpk redpanda admin partitions list
+:description: rpk redpanda admin partitions list
+
+List the partitions in a broker in the cluster
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin partitions list [BROKER ID] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`-l, --leader-only` |- |print the partitions on broker which are leaders.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin-partitions.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin-partitions.adoc
@@ -1,0 +1,40 @@
+= rpk redpanda admin partitions
+:description: rpk redpanda admin partitions
+
+View and configure Redpanda partitions through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin partitions [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for partitions.
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-admin.adoc
+++ b/tools/gen/23.1/rpk-redpanda-admin.adoc
@@ -1,0 +1,40 @@
+= rpk redpanda admin
+:description: rpk redpanda admin
+
+Talk to the Redpanda admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--admin-api-tls-cert` |string |The certificate to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-enabled` |- |Enable TLS for the Admin API (not necessary if specifying custom certs).
+
+|`--admin-api-tls-key` |string |The certificate key to be used for TLS authentication with the Admin API.
+
+|`--admin-api-tls-truststore` |string |The truststore to be used for TLS communication with the Admin API.
+
+|`--config` |string |rpk config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for admin.
+
+|`--hosts` |strings |A comma-separated list of Admin API addresses (|IP|:|port|). You must specify one for each node.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-check.adoc
+++ b/tools/gen/23.1/rpk-redpanda-check.adoc
@@ -1,0 +1,26 @@
+= rpk redpanda check
+:description: rpk redpanda check
+
+Check if system meets redpanda requirements
+
+== Usage
+
+[,bash]
+----
+rpk redpanda check [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for check.
+
+|`--timeout` |duration |The maximum amount of time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 2s).
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-config-bootstrap.adoc
+++ b/tools/gen/23.1/rpk-redpanda-config-bootstrap.adoc
@@ -1,0 +1,41 @@
+= rpk redpanda config bootstrap
+:description: rpk redpanda config bootstrap
+
+Initialize the configuration to bootstrap a cluster.
+
+This command generates a `redpanda.yaml` configuration file to bootstrap a
+cluster. If you are modifying the configuration file further, it is recommended
+to first bootstrap and then modify. If the file already exists, this command
+will set fields as requested by flags, and this may undo some of your earlier
+edits.
+
+The --ips flag specifies seed servers (ips, ip:ports, or hostnames) that this
+broker will use to form a cluster.
+
+By default, redpanda expects your machine to have one private IP address, and
+redpanda will listen on it. If your machine has multiple private IP addresses,
+you must use the --self flag to specify which ip redpanda should listen on.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config bootstrap [--self <ip>] [--ips <ip1,ip2,...>] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default location.
+
+|`-h, --help` |- |Help for bootstrap.
+
+|`--ips` |strings |Comma-separated list of the seed node addresses or hostnames; at least three are recommended.
+
+|`--self` |string |Optional IP address for redpanda to listen on; if empty, defaults to a private address.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-config-init.adoc
+++ b/tools/gen/23.1/rpk-redpanda-config-init.adoc
@@ -1,0 +1,24 @@
+= rpk redpanda config init
+:description: rpk redpanda config init
+
+Init the node after install, by setting the node's UUID
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config init [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default location.
+
+|`-h, --help` |- |Help for init.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-config-set.adoc
+++ b/tools/gen/23.1/rpk-redpanda-config-set.adoc
@@ -1,0 +1,53 @@
+= rpk redpanda config set
+:description: rpk redpanda config set
+
+Set configuration values, such as the redpanda node ID or the list of seed servers
+
+This command modifies the `redpanda.yaml` you have locally on disk. The first
+argument is the key within the yaml representing a property / field that you
+would like to set. Nested fields can be accessed through a dot:
+
+  rpk redpanda config set redpanda.developer_mode true
+
+The default format is to parse the value as yaml. Individual specific fields
+can be set, or full structs:
+
+  rpk redpanda config set rpk.tune_disk_irq true
+  rpk redpanda config set redpanda.rpc_server '{address: 3.250.158.1, port: 9092}'
+
+You can set an entire array by wrapping all items with braces, or by using one
+struct:
+
+  rpk redpanda config set redpanda.advertised_kafka_api '[{address: 0.0.0.0, port: 9092}]'
+  rpk redpanda config set redpanda.advertised_kafka_api '{address: 0.0.0.0, port: 9092}' # same
+
+Indexing can be used to set specific items in an array. You can index one past
+the end of an array to extend it:
+
+  rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 0.0.0.0, port: 9092}'
+
+The json format can be used to set values as json:
+
+  rpk redpanda config set redpanda.rpc_server '{"address":"0.0.0.0","port":33145}' --format json
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config set <key> <value> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default location.
+
+|`--format` |string |Format of the value (yaml/json) (default "yaml").
+
+|`-h, --help` |- |Help for set.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-config.adoc
+++ b/tools/gen/23.1/rpk-redpanda-config.adoc
@@ -1,0 +1,22 @@
+= rpk redpanda config
+:description: rpk redpanda config
+
+Edit configuration
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for config.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-mode.adoc
+++ b/tools/gen/23.1/rpk-redpanda-mode.adoc
@@ -1,0 +1,24 @@
+= rpk redpanda mode
+:description: rpk redpanda mode
+
+Enable a default configuration mode
+
+== Usage
+
+[,bash]
+----
+rpk redpanda mode <mode> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for mode.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-start.adoc
+++ b/tools/gen/23.1/rpk-redpanda-start.adoc
@@ -1,0 +1,52 @@
+= rpk redpanda start
+:description: rpk redpanda start
+
+Start redpanda
+
+== Usage
+
+[,bash]
+----
+rpk redpanda start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--advertise-kafka-addr` |strings |A comma-separated list of Kafka addresses to advertise (|name|://|host|:|port|).
+
+|`--advertise-pandaproxy-addr` |strings |A comma-separated list of Pandaproxy addresses to advertise (|name|://|host|:|port|).
+
+|`--advertise-rpc-addr` |string |The advertised RPC address (|host|:|port|).
+
+|`--check` |- |When set to false will disable system checking before starting redpanda (default true).
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for start.
+
+|`--install-dir` |string |Directory where redpanda has been installed.
+
+|`--kafka-addr` |strings |A comma-separated list of Kafka listener addresses to bind to (|name|://|host|:|port|).
+
+|`--mode` |string |Mode sets well-known configuration properties for development or test environments; use --mode help for more info.
+
+|`--pandaproxy-addr` |strings |A comma-separated list of Pandaproxy listener addresses to bind to (|name|://|host|:|port|).
+
+|`--rpc-addr` |string |The RPC address to bind to (|host|:|port|).
+
+|`--schema-registry-addr` |strings |A comma-separated list of Schema Registry listener addresses to bind to (|name|://|host|:|port|).
+
+|`-s, --seeds` |strings |A comma-separated list of seed node addresses (|host|[:|port|]) to connect to.
+
+|`--timeout` |duration |The maximum time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 10s).
+
+|`--tune` |- |When present will enable tuning before starting redpanda.
+
+|`--well-known-io` |string |The cloud vendor and VM type, in the format |vendor|:|vm type|:|storage type|.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-stop.adoc
+++ b/tools/gen/23.1/rpk-redpanda-stop.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda stop
+:description: rpk redpanda stop
+
+Stop a local redpanda process. 'rpk stop'
+first sends SIGINT, and waits for the specified timeout. Then, if redpanda
+hasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still
+running.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for stop.
+
+|`--timeout` |duration |The maximum amount of time to wait for redpanda to stop,after each signal is sent. The value passed is asequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 5s).
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-tune-help.adoc
+++ b/tools/gen/23.1/rpk-redpanda-tune-help.adoc
@@ -1,0 +1,22 @@
+= rpk redpanda tune help
+:description: rpk redpanda tune help
+
+Display detailed information about the tuner
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune help <tuner> [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for help.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-tune-list.adoc
+++ b/tools/gen/23.1/rpk-redpanda-tune-list.adoc
@@ -1,0 +1,44 @@
+= rpk redpanda tune list
+:description: rpk redpanda tune list
+
+List available redpanda tuners and check if they are enabled and 
+supported by your system
+
+To enable a tuner it must be set in the `redpanda.yaml` configuration file
+under rpk section, e.g:
+
+  rpk:
+      tune_cpu: true
+      tune_swappiness: true
+
+You may use 'rpk redpanda config set' to enable or disable a tuner.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune list [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-r, --dirs` |strings |List of *data* directories or places to store data, i.e.: '/var/vectorized/redpanda/', usually your XFS filesystem on an NVMe SSD device.
+
+|`-d, --disks` |strings |Lists of devices to tune f.e. 'sda1'.
+
+|`-h, --help` |- |Help for list.
+
+|`-m, --mode` |string |Operation Mode: one of: [sq, sq_split, mq].
+
+|`-n, --nic` |strings |Network Interface Controllers to tune.
+
+|`--reboot-allowed` |- |If set will allow tuners to tune boot parameters and request system reboot.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda-tune.adoc
+++ b/tools/gen/23.1/rpk-redpanda-tune.adoc
@@ -1,0 +1,60 @@
+= rpk redpanda tune
+:description: rpk redpanda tune
+
+Sets the OS parameters to tune system performance.
+
+Available tuners:
+
+  - all.
+  - coredump
+  - disk_nomerges
+  - cpu
+  - swappiness
+  - ballast_file
+  - net
+  - aio_events
+  - disk_scheduler
+  - disk_write_cache
+  - fstrim
+  - clocksource
+  - transparent_hugepages
+  - disk_irq
+
+To learn more about a tuner, run 'rpk redpanda tune help |tuner name|'.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune <list of elements to tune> [flags]
+  rpk redpanda tune [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--cpu-set` |string |Set of CPUs for tuner to use in cpuset(7) format if not specified tuner will use all available CPUs (default "all").
+
+|`-r, --dirs` |strings |List of *data* directories or places to store data, i.e.: '/var/vectorized/redpanda/', usually your XFS filesystem on an NVMe SSD device.
+
+|`-d, --disks` |strings |Lists of devices to tune f.e. 'sda1'.
+
+|`-h, --help` |- |Help for tune.
+
+|`-m, --mode` |string |Operation Mode: one of: [sq, sq_split, mq].
+
+|`-n, --nic` |strings |Network Interface Controllers to tune.
+
+|`--output-script` |string |If set tuners will generate tuning file that can later be used to tune the system.
+
+|`--reboot-allowed` |- |If set will allow tuners to tune boot parameters and request system reboot.
+
+|`--timeout` |duration |The maximum time to wait for the tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default 10s).
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-redpanda.adoc
+++ b/tools/gen/23.1/rpk-redpanda.adoc
@@ -1,0 +1,22 @@
+= rpk redpanda
+:description: rpk redpanda
+
+Interact with a local Redpanda process
+
+== Usage
+
+[,bash]
+----
+rpk redpanda [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for redpanda.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-topic-add-partitions.adoc
+++ b/tools/gen/23.1/rpk-topic-add-partitions.adoc
@@ -1,0 +1,44 @@
+= rpk topic add-partitions
+:description: rpk topic add-partitions
+
+Add partitions to existing topics.
+
+== Usage
+
+[,bash]
+----
+rpk topic add-partitions [TOPICS...] --num [#] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --force` |- |Force change the partition count in internal topics, e.g. __consumer_offsets.
+
+|`-h, --help` |- |Help for add-partitions.
+
+|`-n, --num` |int |Number of partitions to add to each topic.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-topic-alter-config.adoc
+++ b/tools/gen/23.1/rpk-topic-alter-config.adoc
@@ -1,0 +1,63 @@
+= rpk topic alter-config
+:description: rpk topic alter-config
+
+Set, delete, add, and remove key/value configs for a topic.
+
+This command allows you to incrementally alter the configuration for multiple
+topics at a time.
+
+Incremental altering supports four operations:
+
+  1) Setting a key=value pair
+  2) Deleting a key's value
+  3) Appending a new value to a list-of-values key
+  4) Subtracting (removing) an existing value from a list-of-values key
+
+The --dry option will validate whether the requested configuration change is
+valid, but does not apply it.
+
+== Usage
+
+[,bash]
+----
+rpk topic alter-config [TOPICS...] --set key=value --delete key2,key3 [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--append` |stringArray |key=value; Value to append to a list-of-values key (repeatable).
+
+|`-d, --delete` |stringArray |Key to delete (repeatable).
+
+|`--dry` |- |Dry run: validate the alter request, but do not apply.
+
+|`-h, --help` |- |Help for alter-config.
+
+|`-s, --set` |stringArray |key=value; Pair to set (repeatable).
+
+|`--subtract` |stringArray |key=value; Value to remove from list-of-values key (repeatable).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-topic-consume.adoc
+++ b/tools/gen/23.1/rpk-topic-consume.adoc
@@ -1,0 +1,310 @@
+= rpk topic consume
+:description: rpk topic consume
+
+Consume records from topics.
+
+Consuming records reads from any amount of input topics, formats each record
+according to --format, and prints them to STDOUT. The output formatter
+understands a wide variety of formats.
+
+The default output format "--format json" is a special format that outputs each
+record as JSON. There may be more single-word-no-escapes formats added later.
+Outside of these special formats, formatting follows the rules described below.
+
+Formatting output is based on percent escapes and modifiers. Slashes can be
+used for common escapes:
+
+    \t \n \r \\ \xNN
+
+prints tabs, newlines, carriage returns, slashes, or hex encoded characters.p
+
+Percent encoding prints record fields, fetch partition fields, or extra values:
+
+    %t    topic
+    %T    topic length
+    %k    key
+    %K    key length
+    %v    value
+    %V    value length
+    %h    begin the header specification
+    %H    number of headers
+    %p    partition
+    %o    offset
+    %e    leader epoch
+    %d    timestamp (formatting described below)
+    %a    record attributes (formatting described below)
+    %x    producer id
+    %y    producer epoch
+
+    %[    partition log start offset
+    %|    partition last stable offset
+    %]    partition high watermark
+
+    %%    percent sign
+    %{    left brace
+    %}    right brace
+
+    %i    the number of records formatted
+
+MODIFIERS
+
+Text and numbers can be formatted in many different ways, and the default
+format can be changed within brace modifiers. %v prints a value, while %v{hex}
+prints the value hex encoded. %T prints the length of a topic in ascii, while
+%T{big8} prints the length of the topic as an eight byte big endian.
+
+All modifiers go within braces following a percent-escape.
+
+NUMBERS
+
+Formatting number values can have the following modifiers:
+
+     ascii       print the number as ascii (default)
+
+     hex64       sixteen hex characters
+     hex32       eight hex characters
+     hex16       four hex characters
+     hex8        two hex characters
+     hex4        one hex character
+
+     big64       eight byte big endian number
+     big32       four byte big endian number
+     big16       two byte big endian number
+     big8        alias for byte
+
+     little64    eight byte little endian number
+     little32    four byte little endian number
+     little16    two byte little endian number
+     little8     alias for byte
+
+     byte        one byte number
+     bool        "true" if the number is non-zero, "false" if the number is zero
+
+All numbers are truncated as necessary per the modifier. Printing %V{byte} for
+a length 256 value will print a single null, whereas printing %V{big8} would
+print the bytes 1 and 0.
+
+When writing number sizes, the size corresponds to the size of the raw values,
+not the size of encoded values. "%T% t{hex}" for the topic "foo" will print
+"3 666f6f", not "6 666f6f".
+
+TIMESTAMPS
+
+By default, the timestamp field is printed as a millisecond number value. In
+addition to the number modifiers above, timestamps can be printed with either
+Go formatting or strftime formatting:
+
+    %d{go[2006-01-02T15:04:05Z07:00]}
+    %d{strftime[%F]}
+
+An arbitrary amount of brackets (or braces, or # symbols) can wrap your date
+formatting:
+
+    %d{strftime### [%F] ###}
+
+The above will print " [YYYY-MM-DD] ", while the surrounding three # on each
+side are used to wrap the formatting. Further details on Go time formatting can
+be found at https://pkg.go.dev/time, while further details on strftime
+formatting can be read by checking "man strftime".
+
+ATTRIBUTES
+
+Each record (or batch of records) has a set of possible attributes. Internally,
+these are packed into bit flags. Printing an attribute requires first selecting
+which attribute you want to print, and then optionally specifying how you want
+it to be printed:
+
+     %a{compression}
+     %a{compression;number}
+     %a{compression;big64}
+     %a{compression;hex8}
+
+Compression is by default printed as text ("none", "gzip", ...). Compression
+can be printed as a number with ";number", where number is any number
+formatting option described above. No compression is 0, gzip is 1, etc.
+
+     %a{timestamp-type}
+     %a{timestamp-type;big64}
+
+The record's timestamp type is printed as -1 for very old records (before
+timestamps existed), 0 for client generated timestamps, and 1 for broker
+generated timestamps. Number formatting can be controlled with ";number".
+
+     %a{transactional-bit}
+     %a{transactional-bit;bool}
+
+Prints 1 if the record a part of a transaction or 0 if it is not.
+Number formatting can be controlled with ";number".
+
+     %a{control-bit}
+     %a{control-bit;bool}
+
+Prints 1 if the record is a commit marker or 0 if it is not.
+Number formatting can be controlled with ";number".
+
+TEXT
+
+Text fields without modifiers default to writing the raw bytes. Alternatively,
+there are the following modifiers:
+
+    %t{hex}
+    %k{base64}
+    %v{base64raw}
+    %v{unpack[<bBhH>iIqQc.$]}
+
+The hex modifier hex encodes the text, the base64 modifier base64 encodes the
+text with standard encoding, and the base64raw modifier encodes the text with
+raw standard encoding. The unpack modifier has a further internal
+specification, similar to timestamps above:
+
+    x    pad character (does not parse input)
+    <    switch what follows to little endian
+    >    switch what follows to big endian
+
+    b    signed byte
+    B    unsigned byte
+    h    int16  ("half word")
+    H    uint16 ("half word")
+    i    int32
+    I    uint32
+    q    int64  ("quad word")
+    Q    uint64 ("quad word")
+
+    c    any character
+    .    alias for c
+    s    consume the rest of the input as a string
+    $    match the end of the line (append error string if anything remains)
+
+Unpacking text can allow translating binary input into readable output. If a
+value is a big-endian uint32, %v will print the raw four bytes, while
+%v{unpack[>I]} will print the number in as ascii. If unpacking exhausts the
+input before something is unpacked fully, an error message is appended to the
+output.
+
+HEADERS
+
+Headers are formatted with percent encoding inside of the modifier:
+
+    %h{ %k=%v{hex} }
+
+will print all headers with a space before the key and after the value, an
+equals sign between the key and value, and with the value hex encoded. Header
+formatting actually just parses the internal format as a record format, so all
+of the above rules about %K, %V, text, and numbers apply.
+
+EXAMPLES
+
+A key and value, separated by a space and ending in newline:
+    -f '%k %v\n'
+A key length as four big endian bytes, and the key as hex:
+    -f '%K{big32}%k{hex}'
+A little endian uint32 and a string unpacked from a value:
+    -f '%v{unpack[is$]}'
+
+OFFSETS
+
+The --offset flag allows for specifying where to begin consuming, and
+optionally, where to stop consuming. The literal words "start" and "end"
+specify consuming from the start and the end.
+
+    start     consume from the beginning
+    end       consume from the end
+    :end      consume until the current end
+    +oo       consume oo after the current start offset
+    -oo       consume oo before the current end offset
+    oo        consume after an exact offset
+    oo:       alias for oo
+    :oo       consume until an exact offset
+    o1:o2     consume from exact offset o1 until exact offset o2
+    @t        consume starting from a given timestamp
+    @t:       alias for @t
+    @:t       consume until a given timestamp
+    @t1:t2    consume from timestamp t1 until timestamp t2
+
+There are a few options for timestamps, with each option being evaluated
+until one succeeds:
+
+    13 digits             parsed as a unix millisecond
+    9 digits              parsed as a unix second
+    YYYY-MM-DD            parsed as a day, UTC
+    YYYY-MM-DDTHH:MM:SSZ  parsed as RFC3339, UTC; fractional seconds optional (.MMM)
+    -dur                  duration ago; from now (as t1) or from t1 (as t2)
+    dur                   for t2 in @t1:t2, relative duration from t1
+    end                   for t2 in @t1:t2, the current end of the partition
+
+Durations are parsed simply:
+
+    3ms    three milliseconds
+    10s    ten seconds
+    9m     nine minutes
+    1h     one hour
+    1m3ms  one minute and three milliseconds
+
+For example,
+
+    -o @2022-02-14:1h   consume 1h of time on Valentine's Day 2022
+    -o @-48h:-24h       consume from 2 days ago to 1 day ago
+    -o @-1m:end         consume from 1m ago until now
+    -o @:-1hr           consume from the start until an hour ago
+
+== Usage
+
+[,bash]
+----
+rpk topic consume TOPICS... [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-b, --balancer` |string |Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky) (default "cooperative-sticky").
+
+|`--fetch-max-bytes` |int32 |Maximum amount of bytes per fetch request per broker (default 1048576).
+
+|`--fetch-max-wait` |duration |Maximum amount of time to wait when fetching from a broker before the broker replies (default 5s).
+
+|`-f, --format` |string |Output format (see --help for details) (default "json").
+
+|`-g, --group` |string |Group to use for consuming (incompatible with -p).
+
+|`-h, --help` |- |Help for consume.
+
+|`--meta-only` |- |Print all record info except the record value (for -f json).
+
+|`-n, --num` |int |Quit after consuming this number of records (0 is unbounded).
+
+|`-o, --offset` |string |Offset to consume from / to (start, end, 47, +2, -3) (default "start").
+
+|`-p, --partitions` |int32 |int32Slice     Comma delimited list of specific partitions to consume (default []).
+
+|`--pretty-print` |- |Pretty print each record over multiple lines (for -f json) (default true).
+
+|`--print-control-records` |- |Opt in to printing control records.
+
+|`--read-committed` |- |Opt in to reading only committed offsets.
+
+|`-r, --regex` |- |Parse topics as regex; consume any topic that matches any expression.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-topic-create.adoc
+++ b/tools/gen/23.1/rpk-topic-create.adoc
@@ -1,0 +1,58 @@
+= rpk topic create
+:description: rpk topic create
+
+Create topics.
+
+All topics created with this command will have the same number of partitions,
+replication factor, and key/value configs.
+
+For example,
+
+	create -c cleanup.policy=compact -r 3 -p 20 foo bar
+
+will create two topics, foo and bar, each with 20 partitions, 3 replicas, and
+the cleanup.policy=compact config option set.
+
+== Usage
+
+[,bash]
+----
+rpk topic create [TOPICS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --dry` |- |Dry run: validate the topic creation request; do not create topics.
+
+|`-h, --help` |- |Help for create.
+
+|`-p, --partitions` |int32 |Number of partitions to create per topic; -1 defaults to the cluster's default_topic_partitions (default -1).
+
+|`-r, --replicas` |int16 |Replication factor (must be odd); -1 defaults to the cluster's default_topic_replications (default -1).
+
+|`-c, --topic-config` |stringArray |key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact).
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-topic-delete.adoc
+++ b/tools/gen/23.1/rpk-topic-delete.adoc
@@ -1,0 +1,61 @@
+= rpk topic delete
+:description: rpk topic delete
+
+Delete topics.
+
+This command deletes all requested topics, printing the success or fail status
+per topic.
+
+The --regex flag (-r) opts into parsing the input topics as regular expressions
+and deleting any non-internal topic that matches any of expressions. The input
+expressions are wrapped with ^ and $ so that the expression must match the
+whole topic name (which also prevents accidental delete-everything mistakes).
+
+The topic list command accepts the same input regex format as this delete
+command. If you want to check what your regular expressions will delete before
+actually deleting them, you can check the output of 'rpk topic list -r'.
+
+For example,
+
+    delete foo bar            # deletes topics foo and bar
+    delete -r '^f.*' '.*r$'   # deletes any topic starting with f and any topics ending in r
+    delete -r '.*'            # deletes all topics
+    delete -r .               # deletes any one-character topics
+
+== Usage
+
+[,bash]
+----
+rpk topic delete [TOPICS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`-r, --regex` |- |Parse topics as regex; delete any topic that matches any input topic expression.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-topic-describe.adoc
+++ b/tools/gen/23.1/rpk-topic-describe.adoc
@@ -1,0 +1,59 @@
+= rpk topic describe
+:description: rpk topic describe
+
+Describe a topic.
+
+This command prints detailed information about a topic. There are three
+potential sections: a summary of the topic, the topic configs, and a detailed
+partitions section. By default, the summary and configs sections are printed.
+
+== Usage
+
+[,bash]
+----
+rpk topic describe [TOPIC] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+describe, info
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for describe.
+
+|`-a, --print-all` |- |Print all sections.
+
+|`-c, --print-configs` |- |Print the config section.
+
+|`-p, --print-partitions` |- |Print the detailed partitions section.
+
+|`-s, --print-summary` |- |Print the summary section.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-topic-list.adoc
+++ b/tools/gen/23.1/rpk-topic-list.adoc
@@ -1,0 +1,70 @@
+= rpk topic list
+:description: rpk topic list
+
+List topics, optionally listing specific topics.
+
+This command lists all topics that you have access to by default. If specifying
+topics or regular expressions, this command can be used to know exactly what
+topics you would delete if using the same input to the delete command.
+
+Alternatively, you can request specific topics to list, which can be used to
+check authentication errors (do you not have access to a topic you were
+expecting to see?), or to list all topics that match regular expressions.
+
+The --regex flag (-r) opts into parsing the input topics as regular expressions
+and listing any non-internal topic that matches any of expressions. The input
+expressions are wrapped with ^ and $ so that the expression must match the
+whole topic name. Regular expressions cannot be used to match internal topics,
+as such, specifying both -i and -r will exit with failure.
+
+Lastly, --detailed flag (-d) opts in to printing extra per-partition
+information.
+
+== Usage
+
+[,bash]
+----
+rpk topic list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --detailed` |- |Print per-partition information for topics.
+
+|`-h, --help` |- |Help for list.
+
+|`-i, --internal` |- |Print internal topics.
+
+|`-r, --regex` |- |Parse topics as regex; list any topic that matches any input topic expression.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-topic-produce.adoc
+++ b/tools/gen/23.1/rpk-topic-produce.adoc
@@ -1,0 +1,185 @@
+= rpk topic produce
+:description: rpk topic produce
+
+Produce records to a topic.
+
+Producing records reads from STDIN, parses input according to --format, and
+produce records to Redpanda. The input formatter understands a wide variety of
+formats.
+
+Parsing input operates on either sizes or on delimiters, both of which can be
+specified in the same formatting options. If using sizes to specify something,
+the size must come before what it is specifying. Delimiters match on an exact
+text basis. This command will quit with an error if any input fails to match
+your specified format.
+
+Slashes can be used for common escapes:
+
+    \t \n \r \\ \xNN
+
+matches tabs, newlines, carriage returns, slashes, and hex encoded characters.
+
+Percent encoding reads into specific values of a record:
+
+    %t    topic
+    %T    topic length
+    %k    key
+    %K    key length
+    %v    value
+    %V    value length
+    %h    begin the header specification
+    %H    number of headers
+    %p    partition (if using the --partition flag)
+
+Three escapes exist to parse characters that are used to modify the previous
+escapes:
+
+    %%    percent sign
+    %{    left brace
+    %}    right brace
+
+MODIFIERS
+
+Text and numbers can be read in multiple formats, and the default format can be
+changed within brace modifiers. %v reads a value, while %v{hex} reads a value
+and then hex decodes it before producing. %T reads the length of a topic from
+the input, while %T{3} reads exactly three bytes for a topic from the input.
+
+All modifiers go within braces following a percent-escape.
+
+NUMBERS
+
+Reading number values can have the following modifiers:
+
+     ascii       parse numeric digits until a non-numeric (default)
+
+     hex64       sixteen hex characters
+     hex32       eight hex characters
+     hex16       four hex characters
+     hex8        two hex characters
+     hex4        one hex character
+
+     big64       eight byte big endian number
+     big32       four byte big endian number
+     big16       two byte big endian number
+     big8        alias for byte
+
+     little64    eight byte little endian number
+     little32    four byte little endian number
+     little16    two byte little endian number
+     little8     alias for byte
+
+     byte        one byte number
+     <digits>    directly specify the length as this many digits
+     bool        read "true" as 1, "false" as 0
+
+When reading number sizes, the size corresponds to the size of the encoded
+values, not the decoded values. "%T{6}%t{hex}" will read six hex bytes and
+decode into three.
+
+TEXT
+
+Reading text values can have the following modifiers:
+
+    hex       read text then hex decode it
+    base64    read text then std-encoding base64 decode it
+    re        read text matching a regular expression
+
+HEADERS
+
+Headers are parsed with an internal key / value specifier format. For example,
+the following will read three headers that begin and end with a space and are
+separated by an equal:
+
+    %H{3}%h{ %k=%v }
+
+EXAMPLES
+
+In the below examples, we can parse many records at once. The produce command
+reads input and tokenizes based on your specified format. Every time the format
+is completely matched, a record is produced and parsing begins anew.
+
+A key and value, separated by a space and ending in newline:
+    -f '%k %v\n'
+A four byte topic, four byte key, and four byte value:
+    -f '%T{4}%K{4}%V{4}%t%k%v'
+A value to a specific partition, if using a non-negative --partition flag:
+    -f '%p %v\n'
+A big-endian uint16 key size, the text " foo ", and then that key:
+    -f '%K{big16} foo %k'
+A value that can be two or three characters followed by a newline:
+    -f '%v{re#...?#}\n'
+
+MISC
+
+Producing requires a topic to produce to. The topic can be specified either
+directly on as an argument, or in the input text through %t. A parsed topic
+takes precedence over the default passed in topic. If no topic is specified
+directly and no topic is parsed, this command will quit with an error.
+
+The input format can parse partitions to produce directly to with %p. Doing so
+requires specifying a non-negative --partition flag. Any parsed partition
+takes precedence over the --partition flag; specifying the flag is the main
+requirement for being able to directly control which partition to produce to.
+
+You can also specify an output format to write when a record is produced
+successfully. The output format follows the same formatting rules as the topic
+consume command. See that command's help text for a detailed description.
+
+== Usage
+
+[,bash]
+----
+rpk topic produce [TOPIC] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--acks` |int |Number of acks required for producing (-1=all, 0=none, 1=leader) (default -1).
+
+|`--allow-auto-topic-creation` |- |Auto-create non-existent topics; requires auto_create_topics_enabled on the broker.
+
+|`-z, --compression` |string |Compression to use for producing batches (none, gzip, snapy, lz4, zstd) (default "snappy").
+
+|`--delivery-timeout` |duration |Per-record delivery timeout, if non-zero, min 1s.
+
+|`-f, --format` |string |Input record format (default "%v\n").
+
+|`-H, --header` |stringArray |Headers in format key:value to add to each record (repeatable).
+
+|`-h, --help` |- |Help for produce.
+
+|`-k, --key` |string |A fixed key to use for each record (parsed input keys take precedence).
+
+|`--max-message-bytes` |int32 |If non-negative, maximum size of a record batch before compression (default -1).
+
+|`-o, --output-format` |string |what to write to stdout when a record is successfully produced (default "Produced to partition %p at offset %o with timestamp %d.\n").
+
+|`-p, --partition` |int32 |Partition to directly produce to, if non-negative (also allows %p parsing to set partitions) (default -1).
+
+|`-Z, --tombstone` |- |Produce empty values as tombstones.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-topic.adoc
+++ b/tools/gen/23.1/rpk-topic.adoc
@@ -1,0 +1,40 @@
+= rpk topic
+:description: rpk topic
+
+Create, delete, produce to and consume from Redpanda topics
+
+== Usage
+
+[,bash]
+----
+rpk topic [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for topic.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-version.adoc
+++ b/tools/gen/23.1/rpk-version.adoc
@@ -1,0 +1,22 @@
+= rpk version
+:description: rpk version
+
+Check the current version
+
+== Usage
+
+[,bash]
+----
+rpk version [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for version.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-wasm-deploy.adoc
+++ b/tools/gen/23.1/rpk-wasm-deploy.adoc
@@ -1,0 +1,46 @@
+= rpk wasm deploy
+:description: rpk wasm deploy
+
+Deploy inline WASM function
+
+== Usage
+
+[,bash]
+----
+rpk wasm deploy [PATH] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--description` |string |Optional description about what the wasm function does.
+
+|`-h, --help` |- |Help for deploy.
+
+|`--name` |string |Unique deploy identifier attached to the instance of this script.
+
+|`--type` |string |WASM engine type (async, data-policy) (default "async").
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-wasm-generate.adoc
+++ b/tools/gen/23.1/rpk-wasm-generate.adoc
@@ -1,0 +1,42 @@
+= rpk wasm generate
+:description: rpk wasm generate
+
+Create a npm template project for inline WASM engine
+
+== Usage
+
+[,bash]
+----
+rpk wasm generate [PROJECT DIRECTORY] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for generate.
+
+|`--skip-version` |- |Omit wasm-api version check from npm, use default instead.
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-wasm-remove.adoc
+++ b/tools/gen/23.1/rpk-wasm-remove.adoc
@@ -1,0 +1,42 @@
+= rpk wasm remove
+:description: rpk wasm remove
+
+Remove inline WASM function
+
+== Usage
+
+[,bash]
+----
+rpk wasm remove [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for remove.
+
+|`--type` |string |WASM engine type (async, data-policy) (default "async").
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.1/rpk-wasm.adoc
+++ b/tools/gen/23.1/rpk-wasm.adoc
@@ -1,0 +1,40 @@
+= rpk wasm
+:description: rpk wasm
+
+Deploy and remove inline WASM engine scripts
+
+== Usage
+
+[,bash]
+----
+rpk wasm [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--brokers` |strings |Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092'). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
+
+|`--config` |string |Redpanda config file, if not set the file will be searched for in the default locations.
+
+|`-h, --help` |- |Help for wasm.
+
+|`--password` |string |SASL password to be used for authentication.
+
+|`--sasl-mechanism` |string |The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The truststore to be used for TLS communication with the broker.
+
+|`--user` |string |SASL user to be used for authentication.
+
+|`-v, --verbose` |- |Enable verbose logging (default: false).
+|===

--- a/tools/gen/23.2/json/rpk-commands.json
+++ b/tools/gen/23.2/json/rpk-commands.json
@@ -1,0 +1,4331 @@
+{
+    "rpk acl": {
+        "description": "Manage ACLs and SASL users.\r\n\r\nThis command space creates, lists, and deletes ACLs, as well as creates SASL\r\nusers. The help text below is specific to ACLs. To learn about SASL users,\r\ncheck the help text under the \"user\" command.\r\n\r\nWhen using SASL, ACLs allow or deny you access to certain requests. The\r\n\"create\", \"delete\", and \"list\" commands help you manage your ACLs.\r\n\r\nAn ACL is made up of five components:\r\n\r\n  * a principal (the user)\r\n  * a host the principal is allowed or denied requests from\r\n  * what resource to access (topic name, group ID, ...)\r\n  * the operation (read, write, ...)\r\n  * the permission: whether to allow or deny the above\r\n\r\nACL commands work on a multiplicative basis. If creating, specifying two\r\nprincipals and two permissions creates four ACLs: both permissions for the\r\nfirst principal, as well as both permissions for the second principal. Adding\r\ntwo resources further doubles the ACLs created.\r\n\r\nIt is recommended to be as specific as possible when granting ACLs. Granting\r\nmore ACLs than necessary per principal may inadvertently allow clients to do\r\nthings they should not, such as deleting topics or joining the wrong consumer\r\ngroup.\r\n\r\nPRINCIPALS\r\n\r\nAll ACLs require a principal. A principal is composed of two parts: the type\r\nand the name. Within Redpanda, only one type is supported, \"User\". The reason\r\nfor the prefix is that a potential future authorizer may add support for\r\nauthorizing by Group or anything else.\r\n\r\nWhen you create a user, you need to add ACLs for it before it can be used. You\r\ncan create / delete / list ACLs for that user with either \"User:bar\" or \"bar\"\r\nin the --allow-principal and --deny-principal flags. This command will add the\r\n\"User:\" prefix for you if it is missing. The wildcard '*' matches any user.\r\nCreating an ACL with user '*' grants or denies the permission for all users.\r\n\r\nHOSTS\r\n\r\nHosts can be seen as an extension of the principal, and effectively gate where\r\nthe principal can connect from. When creating ACLs, unless otherwise specified,\r\nthe default host is the wildcard '*' which allows or denies the principal from\r\nall hosts (where allow & deny are based on whether --allow-principal or\r\n--deny-principal is used). If specifying hosts, you must pair the --allow-host\r\nflag with the --allow-principal flag, and the --deny-host flag with the\r\n--deny-principal flag.\r\n\r\nRESOURCES\r\n\r\nA resource is what an ACL allows or denies access to. There are four resources\r\nwithin Redpanda: topics, groups, the cluster itself, and transactional IDs.\r\nNames for each of these resources can be specified with their respective flags.\r\n\r\nResources combine with the operation that is allowed or denied on that\r\nresource. The next section describes which operations are required for which\r\nrequests, and further fleshes out the concept of a resource.\r\n\r\nBy default, resources are specified on an exact name match (a \"literal\" match).\r\nThe --resource-pattern-type flag can be used to specify that a resource name is\r\n\"prefixed\", meaning to allow anything with the given prefix. A literal name of\r\n\"foo\" will match only the topic \"foo\", while the prefixed name of \"foo-\" will\r\nmatch both \"foo-bar\" and \"foo-baz\". The special wildcard resource name '*'\r\nmatches any name of the given resource type (--topic '*' matches all topics).\r\n\r\nOPERATIONS\r\n\r\nPairing with resources, operations are the actions that are allowed or denied.\r\nRedpanda has the following operations:\r\n\r\n    ALL                 Allows all operations below.\r\n    READ                Allows reading a given resource.\r\n    WRITE               Allows writing to a given resource.\r\n    CREATE              Allows creating a given resource.\r\n    DELETE              Allows deleting a given resource.\r\n    ALTER               Allows altering non-configurations.\r\n    DESCRIBE            Allows querying non-configurations.\r\n    DESCRIBE_CONFIGS    Allows describing configurations.\r\n    ALTER_CONFIGS       Allows altering configurations.\r\n\r\nCheck --help-operations to see which operations are required for which\r\nrequests. In flag form to set up a general producing/consuming client, you can\r\ninvoke 'rpk acl create' three times with the following (including your\r\n--allow-principal):\r\n\r\n    --operation write,read,describe --topic [topics]\r\n    --operation describe,read --group [group.id]\r\n    --operation describe,write --transactional-id [transactional.id]\r\n\r\nPERMISSIONS\r\n\r\nA client can be allowed access or denied access. By default, all permissions\r\nare denied. You only need to specifically deny a permission if you allow a wide\r\nset of permissions and then want to deny a specific permission in that set.\r\nYou could allow all operations, and then specifically deny writing to topics.\r\n\r\nMANAGEMENT\r\n\r\nCreating ACLs works on a specific ACL basis, but listing and deleting ACLs\r\nworks on filters. Filters allow matching many ACLs to be printed listed and\r\ndeleted at once. Because this can be risky for deleting, the delete command\r\nprompts for confirmation by default. More details and examples for creating,\r\nlisting, and deleting can be seen in each of the commands.\r\n\r\nUsing SASL requires setting \"enable_sasl: true\" in the redpanda section of your\r\nredpanda.yaml. User management is a separate, simpler concept that is\r\ndescribed in the user command.",
+        "usage": "Usage:\r\n  rpk acl [flags]\r\n  rpk acl [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for acl."
+            },
+            "--help-operations": {
+                "type": "-",
+                "description": "Print more help about ACL operations."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl create": {
+        "description": "Create ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. Following the\r\nmultiplying effect of combining flags, the create command works on a\r\nstraightforward basis: every ACL combination is a created ACL.\r\n\r\nAs mentioned in the 'rpk acl' help text, if no host is specified, an allowed\r\nprincipal is allowed access from all hosts. The wildcard principal '*' allows\r\nall principals. At least one principal, one host, one resource, and one\r\noperation is required to create a single ACL.\r\n\r\nAllow all permissions to user bar on topic \"foo\" and group \"g\":\r\n    --allow-principal bar --operation all --topic foo --group g\r\nAllow read permissions to all users on topics biz and baz:\r\n    --allow-principal '*' --operation read --topic biz,baz\r\nAllow write permissions to user buzz to transactional id \"txn\":\r\n    --allow-principal User:buzz --operation write --transactional-id txn",
+        "usage": "Usage:\r\n  rpk acl create [flags]\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Hosts from which access will be granted (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Principals for which these permissions will be granted (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to grant ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Hosts from from access will be denied (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Principal for which these permissions will be denied (repeatable)."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to grant ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to grant (repeatable)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (literal or prefixed) (default \"literal\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to grant ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to grant ACLs for (repeatable)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl delete": {
+        "description": "Delete ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. Delete flags work in a\r\nsimilar multiplying effect as creating ACLs, but delete is more advanced:\r\ndeletion works on a filter basis. Any unspecified flag defaults to matching\r\neverything (all operations, or all allowed principals, etc). To ensure that you\r\ndo not accidentally delete more than you intend, this command prints everything\r\nthat matches your input filters and prompts for a confirmation before the\r\ndelete request is issued. Anything matching more than 10 ACLs doubly confirms.\r\n\r\nAs mentioned, not specifying flags matches everything. If no resources are\r\nspecified, all resources are matched. If no operations are specified, all\r\noperations are matched. You can also opt in to matching everything with \"any\":\r\n--operation any matches any operation.\r\n\r\nThe --resource-pattern-type, defaulting to \"any\", configures how to filter\r\nresource names:\r\n  * \"any\" returns exact name matches of either prefixed or literal pattern type\r\n  * \"match\" returns wildcard matches, prefix patterns that match your input, and literal matches\r\n  * \"prefix\" returns prefix patterns that match your input (prefix \"fo\" matches \"foo\")\r\n  * \"literal\" returns exact name matches",
+        "usage": "Usage:\r\n  rpk acl delete [flags]\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Allowed host ACLs to remove (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Allowed principal ACLs to remove (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to remove ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Denied host ACLs to remove (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Denied principal ACLs to remove (repeatable)."
+            },
+            "-d, --dry": {
+                "type": "-",
+                "description": "Dry run: validate what would be deleted."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to remove ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to remove (repeatable)."
+            },
+            "-f, --print-filters": {
+                "type": "-",
+                "description": "Print the filters that were requested (failed filters are always printed)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (any, match, literal, or prefixed) (default \"any\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to remove ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to remove ACLs for (repeatable)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl list": {
+        "description": "List ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. List flags work in a\r\nsimilar multiplying effect as creating ACLs, but list is more advanced:\r\nlisting works on a filter basis. Any unspecified flag defaults to matching\r\neverything (all operations, or all allowed principals, etc).\r\n\r\nAs mentioned, not specifying flags matches everything. If no resources are\r\nspecified, all resources are matched. If no operations are specified, all\r\noperations are matched. You can also opt in to matching everything with \"any\":\r\n--operation any matches any operation.\r\n\r\nThe --resource-pattern-type, defaulting to \"any\", configures how to filter\r\nresource names:\r\n  * \"any\" returns exact name matches of either prefixed or literal pattern type\r\n  * \"match\" returns wildcard matches, prefix patterns that match your input, and literal matches\r\n  * \"prefix\" returns prefix patterns that match your input (prefix \"fo\" matches \"foo\")\r\n  * \"literal\" returns exact name matches",
+        "usage": "Usage:\r\n  rpk acl list [flags]\r\n\r\nAliases:\r\n  list, ls, describe\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Allowed host ACLs to match (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Allowed principal ACLs to match (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to match ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Denied host ACLs to match (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Denied principal ACLs to match (repeatable)."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to match ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to match (repeatable)."
+            },
+            "-f, --print-filters": {
+                "type": "-",
+                "description": "Print the filters that were requested (failed filters are always printed)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (any, match, literal, or prefixed) (default \"any\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to match ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to match ACLs for (repeatable)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl user": {
+        "description": "Manage SASL users.\r\n\r\nIf SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs\r\ncontrol what your user has access to. See 'rpk acl --help' for more information\r\nabout ACLs, and 'rpk acl user create --help' for more information about\r\ncreating SASL users. Using SASL requires setting \"enable_sasl: true\" in the\r\nredpanda section of your redpanda.yaml.",
+        "usage": "Usage:\r\n  rpk acl user [flags]\r\n  rpk acl user [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for user."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl user create": {
+        "description": "Create a SASL user.\r\n\r\nThis command creates a single SASL user with the given password, optionally\r\nwith a custom \"mechanism\". SASL consists of three parts: a username, a\r\npassword, and a mechanism. The mechanism determines which authentication flow\r\nthe client will use for this user/pass.\r\n\r\nRedpanda currently supports two mechanisms: SCRAM-SHA-256, the default, and\r\nSCRAM-SHA-512, which is the same flow but uses sha512 rather than sha256.\r\n\r\nUsing SASL requires setting \"enable_sasl: true\" in the redpanda section of your\r\nredpanda.yaml. Before a created SASL account can be used, you must also create\r\nACLs to grant the account access to certain resources in your cluster. See the\r\nacl help text for more info.",
+        "usage": "Usage:\r\n  rpk acl user create [USER] -p [PASS] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "--mechanism": {
+                "type": "string",
+                "description": "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive) (default \"scram-sha-256\")."
+            },
+            "--password": {
+                "type": "string",
+                "description": "New user's password (NOTE: if using --password for the admin API, use --new-password)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl user delete": {
+        "description": "Delete a SASL user.\r\n\r\nThis command deletes the specified SASL account from Redpanda. This does not\r\ndelete any ACLs that may exist for this user.",
+        "usage": "Usage:\r\n  rpk acl user delete [USER] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl user list": {
+        "description": "List SASL users",
+        "usage": "Usage:\r\n  rpk acl user list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl user update": {
+        "description": "Update SASL user credentials",
+        "usage": "Usage:\r\n  rpk acl user update [USER] --new-password [PW] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for update."
+            },
+            "--mechanism": {
+                "type": "string",
+                "description": "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive) (default \"SCRAM-SHA-256\")."
+            },
+            "--new-password": {
+                "type": "string",
+                "description": "New user's password."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud": {
+        "description": "Interact with Redpanda cloud",
+        "usage": "Usage:\r\n  rpk cloud [flags]\r\n  rpk cloud [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for cloud."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth": {
+        "description": "Manage rpk cloud authentications.\r\n\r\nAn rpk cloud authentication allows you to talk to Redpanda Cloud. Most likely,\r\nyou will only ever need to use a single SSO based login and you will not need\r\nthis command space. Multiple authentications can be useful if you have multiple\r\nRedpanda Cloud accounts for different organizations and want to swap between\r\nthem, or if you use SSO as well as client credentials. It is recommended to\r\nonly use a single SSO based login.",
+        "usage": "Usage:\r\n  rpk cloud auth [flags]\r\n  rpk cloud auth [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for auth."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth create": {
+        "description": "Create an rpk cloud auth.\r\n\r\nThis command creates a new rpk cloud auth. The default SSO login does not need\r\nany additional auth values (the token is populated on login) so you can just\r\ncreate an empty auth. You can also use --set to set key=value pairs for client\r\ncredentials.\r\n\r\nThe --set flag supports autocompletion, suggesting the -X key format. If you\r\nbegin writing a YAML path, the flag will suggest the rest of the path.\r\n\r\nrpk always switches the current cloud auth to the newly created auth.",
+        "usage": "Usage:\r\n  rpk cloud auth create [NAME] [flags]\r\n\r",
+        "flags": {
+            "--description": {
+                "type": "string",
+                "description": "Optional description of the auth."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "-s, --set": {
+                "type": "strings",
+                "description": "A key=value pair to set in the cloud auth."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth delete": {
+        "description": "Delete an rpk cloud auth.\r\n\r\nDeleting a cloud auth removes it from the rpk.yaml file. If the deleted\r\nauth was the current auth, rpk will use a default SSO auth the next time\r\nyou try to login and, if the login is successful, will safe that auth.",
+        "usage": "Usage:\r\n  rpk cloud auth delete [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth edit": {
+        "description": "Edit an rpk auth.\r\n\r\nThis command opens your default editor to edit the specified cloud auth, or the\r\ncurrent cloud auth if no cloud auth is specified.",
+        "usage": "Usage:\r\n  rpk cloud auth edit [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for edit."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth list": {
+        "description": "List rpk cloud auths",
+        "usage": "Usage:\r\n  rpk cloud auth list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth rename-to": {
+        "description": "Rename the current rpk auth",
+        "usage": "Usage:\r\n  rpk cloud auth rename-to [NAME] [flags]\r\n\r\nAliases:\r\n  rename-to, rename\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for rename-to."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth use": {
+        "description": "Select the rpk cloud auth to use",
+        "usage": "Usage:\r\n  rpk cloud auth use [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for use."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud byoc": {
+        "description": "Manage a Redpanda cloud BYOC agent\r\n\r\nFor BYOC, Redpanda installs an agent service in your owned cluster. The agent\r\nthen proceeds to provision further infrastructure and eventually, a full\r\nRedpanda cluster.\r\n\r\nThe BYOC command runs Terraform to create and start the agent. You first need\r\na redpanda-id (or cluster ID); this is used to get the details of how your\r\nagent should be provisioned. You can create a BYOC cluster in our cloud UI\r\nand then come back to this command to complete the process.",
+        "usage": "Usage:\r\n  rpk cloud byoc [flags]\r\n  rpk cloud byoc [command]\r\n\r",
+        "flags": {
+            "--client-id": {
+                "type": "string",
+                "description": "The client ID of the organization in Redpanda Cloud."
+            },
+            "--client-secret": {
+                "type": "string",
+                "description": "The client secret of the organization in Redpanda Cloud."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for byoc."
+            },
+            "--redpanda-id": {
+                "type": "string",
+                "description": "The redpanda ID of the cluster you are creating."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud byoc install": {
+        "description": "Install the BYOC plugin\r\n\r\nThis command downloads the BYOC managed plugin if necessary. The plugin is\r\ninstalled by default if you try to run a non-install command, but this command\r\nexists if you want to download the plugin ahead of time.",
+        "usage": "Usage:\r\n  rpk cloud byoc install [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for install."
+            },
+            "--redpanda-id": {
+                "type": "string",
+                "description": "The redpanda ID of the cluster you are creating."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud byoc uninstall": {
+        "description": "Uninstall the BYOC plugin\r\n\r\nThis command deletes your locally downloaded BYOC managed plugin if it exists.\r\nOften, you only need to download the plugin to create your cluster once, and\r\nthen you never need the plugin again. You can uninstall to save a small bit of\r\ndisk space.",
+        "usage": "Usage:\r\n  rpk cloud byoc uninstall [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for uninstall."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud login": {
+        "description": "Log in to the Redpanda cloud\r\n\r\nThis command checks for an existing Redpanda Cloud API token and, if present, \r\nensures it is still valid. If no token is found or the token is no longer valid, \r\nthis command will login and save your token along with the client ID used to \r\nrequest the token.\r\n\r\nYou may use either SSO or client credentials to log in.\r\n\r\nSSO\r\n\r\nThis will automatically launch your default web browser and prompt you to \r\nauthenticate via our Redpanda Cloud page. Once you have successfully \r\nauthenticated, you will be ready to use rpk cloud commands.\r\n\r\nYou may opt out of auto-opening the browser by passing the '--no-browser' flag.\r\n\r\nCLIENT CREDENTIALS\r\n\r\nCloud client credentials can be used to login to Redpanda, they can be created \r\nin the Clients tab of the Users section in the Redpanda Cloud online interface. \r\nclient credentials can be provided in three ways, in order of preference:\r\n\r\n* In your rpk cloud auth, 'client_id' and 'client_secret' fields\r\n* Through RPK_CLOUD_CLIENT_ID and RPK_CLOUD_CLIENT_SECRET environment variables\r\n* Through the --client-id and --client-secret flags\r\n\r\nIf none of these are provided, rpk will use the SSO method to login. \r\nIf you specify environment variables or flags, they will not be synced to the\r\nrpk.yaml file unless the --save flag is passed. The cloud authorization \r\ntoken and client ID is always synced.\r\n\r\nPROFILE SELECTION\r\n\r\nThis command by default attempts to populate a new profile that talks to a\r\ncloud cluster for you. If you have an existing cloud profile, this will select\r\nit, prompting which to use if you have many. If you have no cloud profile, this\r\ncommand will prompt you to select one that exists in your organization. If you\r\nwant to disable automatic profile creation and selection, use --no-profile.",
+        "usage": "Usage:\r\n  rpk cloud login [flags]\r\n\r",
+        "flags": {
+            "--client-id": {
+                "type": "string",
+                "description": "The client ID of the organization in Redpanda Cloud."
+            },
+            "--client-secret": {
+                "type": "string",
+                "description": "The client secret of the organization in Redpanda Cloud."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for login."
+            },
+            "--no-browser": {
+                "type": "-",
+                "description": "Opt out of auto-opening authentication URL."
+            },
+            "--no-profile": {
+                "type": "-",
+                "description": "Skip automatic profile creation and any associated prompts."
+            },
+            "--save": {
+                "type": "-",
+                "description": "Save environment or flag specified client ID and client secret to the configuration file."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud logout": {
+        "description": "Log out from Redpanda cloud\r\n\r\nThis command deletes your cloud auth token. If you want to log out entirely and\r\nswitch to a different organization, you can use the --clear-credentials flag to\r\nadditionally clear your client ID and client secret.",
+        "usage": "Usage:\r\n  rpk cloud logout [flags]\r\n\r",
+        "flags": {
+            "-c, --clear-credentials": {
+                "type": "-",
+                "description": "Clear the client ID and client secret in addition to the auth token."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for logout."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster": {
+        "description": "Interact with a Redpanda cluster",
+        "usage": "Usage:\r\n  rpk cluster [flags]\r\n  rpk cluster [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for cluster."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config": {
+        "description": "Interact with cluster configuration properties.\r\n\r\nCluster properties are redpanda settings which apply to all nodes in\r\nthe cluster.  These are separate to node properties, which are set with\r\n'rpk redpanda config'.\r\n\r\nUse the 'edit' subcommand to interactively modify the cluster configuration, or\r\n'export' and 'import' to write configuration to a file that can be edited and\r\nread back later.\r\n\r\nThese commands take an optional '--all' flag to include all properties including\r\nlow level tunables such as internal buffer sizes, that do not usually need\r\nto be changed during normal operations.  These properties generally require\r\nsome expertize to set safely, so if in doubt, avoid using '--all'.\r\n\r\nModified properties are propagated immediately to all nodes.  The 'status'\r\nsubcommand can be used to verify that all nodes are up to date, and identify\r\nany settings which were rejected by a node, for example if a node is running a\r\ndifferent redpanda version that does not recognize certain properties.",
+        "usage": "Usage:\r\n  rpk cluster config [flags]\r\n  rpk cluster config [command]\r\n\r",
+        "flags": {
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config edit": {
+        "description": "Edit cluster-wide configuration properties.\r\n\r\nThis command opens a text editor to modify the cluster's configuration.\r\n\r\nCluster properties are redpanda settings which apply to all nodes in\r\nthe cluster.  These are separate to node properties, which are set with\r\n'rpk redpanda config'.\r\n\r\nModified values are written back when the file is saved and the editor\r\nis closed.  Properties which are deleted are reset to their default\r\nvalues.\r\n\r\nBy default, low level tunables are excluded: use the '--all' flag\r\nto edit all properties including these tunables.",
+        "usage": "Usage:\r\n  rpk cluster config edit [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for edit."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config export": {
+        "description": "Export cluster configuration.\r\n\r\nWrites out a YAML representation of the cluster configuration to a file,\r\nsuitable for editing and later applying with the corresponding 'import'\r\ncommand.\r\n\r\nBy default, low level tunables are excluded: use the '--all' flag\r\nto include all properties including these low level tunables.",
+        "usage": "Usage:\r\n  rpk cluster config export [flags]\r\n\r",
+        "flags": {
+            "-f, --filename": {
+                "type": "string",
+                "description": "path to file to export to, e.g. './config.yml'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for export."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config force-reset": {
+        "description": "Forcibly clear a cluster configuration property on this node.\r\n\r\nThis command is not for general changes to cluster configuration: use this only\r\nwhen redpanda will not start due to a configuration issue.\r\n\r\nIf your cluster is working properly and you would like to reset a property\r\nto its default, you may use the 'set' command with an empty string, or\r\nuse the 'edit' command and delete the property's line.\r\n\r\nThis command erases a named property from an internal cache of the cluster\r\nconfiguration on the local node, so that on next startup redpanda will treat\r\nthe setting as if it was set to the default.\r\n\r\nWARNING: this should only be used when redpanda is not running.",
+        "usage": "Usage:\r\n  rpk cluster config force-reset [PROPERTY...] [flags]\r\n\r",
+        "flags": {
+            "--cache-file": {
+                "type": "string",
+                "description": "location of configuration cache file (defaults to redpanda data directory)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for force-reset."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config get": {
+        "description": "Get a cluster configuration property.\r\n\r\nThis command is provided for use in scripts.  For interactive editing, or bulk\r\noutput, use the 'edit' and 'export' commands respectively.",
+        "usage": "Usage:\r\n  rpk cluster config get [KEY] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for get."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config import": {
+        "description": "Import cluster configuration from a file.\r\n\r\nImport configuration from a YAML file, usually generated with\r\ncorresponding 'export' command.  This downloads the current cluster\r\nconfiguration, calculates the difference with the YAML file, and\r\nupdates any properties that were changed.  If a property is removed\r\nfrom the YAML file, it is reset to its default value.",
+        "usage": "Usage:\r\n  rpk cluster config import [flags]\r\n\r",
+        "flags": {
+            "-f, --filename": {
+                "type": "string",
+                "description": "full path to file to import, e.g. '/tmp/config.yml'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for import."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config lint": {
+        "description": "Remove any deprecated content from redpanda.yaml.\r\n\r\nDeprecated content includes properties which were set via redpanda.yaml\r\nin earlier versions of redpanda, but are now managed via Redpanda's\r\ncentral configuration store (and via 'rpk cluster config edit').",
+        "usage": "Usage:\r\n  rpk cluster config lint [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for lint."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config set": {
+        "description": "Set a single cluster configuration property.\r\n\r\nThis command is provided for use in scripts.  For interactive editing, or bulk\r\nchanges, use the 'edit' and 'import' commands respectively.\r\n\r\nIf an empty string is given as the value, the property is reset to its default.",
+        "usage": "Usage:\r\n  rpk cluster config set [KEY] [VALUE] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config status": {
+        "description": "Get configuration status of redpanda nodes.\r\n\r\nFor each node, indicate whether a restart is required for settings to\r\ntake effect, and any settings that the node has identified as invalid\r\nor unknown properties.\r\n\r\nAdditionally show the version of cluster configuration that each node\r\nhas applied: under normal circumstances these should all be equal,\r\na lower number shows that a node is out of sync, perhaps because it\r\nis offline.",
+        "usage": "Usage:\r\n  rpk cluster config status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster health": {
+        "description": "Queries health overview.\r\n\r\nHealth overview is created based on the health reports collected periodically\r\nfrom all nodes in the cluster. A cluster is considered healthy when the\r\nfollowing conditions are met:\r\n\r\n* all cluster nodes are responding\r\n* all partitions have leaders\r\n* the cluster controller is present",
+        "usage": "Usage:\r\n  rpk cluster health [flags]\r\n\r",
+        "flags": {
+            "-e, --exit-when-healthy": {
+                "type": "-",
+                "description": "When used with watch, exits after cluster is back in healthy state."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for health."
+            },
+            "-w, --watch": {
+                "type": "-",
+                "description": "Blocks and writes out all cluster health changes."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster license": {
+        "description": "Manage cluster license",
+        "usage": "Usage:\r\n  rpk cluster license [flags]\r\n  rpk cluster license [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for license."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster license info": {
+        "description": "Retrieve license information:\r\n\r\n    Organization:    Organization the license was generated for.\r\n    Type:            Type of license: free, enterprise, etc.\r\n    Expires:         Expiration date of the license\r\n    Version:         License schema version.",
+        "usage": "Usage:\r\n  rpk cluster license info [flags]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (text, json) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for info."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster license set": {
+        "description": "Upload license to the cluster\r\n\r\nYou can either provide a path to a file containing the license:\r\n\r\n    rpk cluster license set --path /home/organization/redpanda.license\r\n\r\nOr inline the license string:\r\n\r\n    rpk cluster license set <license string>\r\n\r\nIf neither are present, rpk will look for the license in the\r\ndefault location '/etc/redpanda/redpanda.license'.",
+        "usage": "Usage:\r\n  rpk cluster license set [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--path": {
+                "type": "string",
+                "description": "Path to the license file."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster logdirs": {
+        "description": "Describe log directories on Redpanda brokers",
+        "usage": "Usage:\r\n  rpk cluster logdirs [flags]\r\n  rpk cluster logdirs [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for logdirs."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster logdirs describe": {
+        "description": "Describe log directories on Redpanda brokers.\r\n\r\nThis command prints information about log directories on brokers, particularly,\r\nthe base directory that topics and partitions are located in, and the size of\r\ndata that has been written to the partitions. The size you see may not exactly\r\nmatch the size on disk as reported by du: Redpanda allocates files in chunks.\r\nThe chunks will show up in du, while the actual bytes so far written to the\r\nfile will show up in this command.\r\n\r\nThe directory returned is the root directory for partitions. Within Redpanda,\r\nthe partition data lives underneath the the returned root directory in\r\n\r\n    kafka/{topic}/{partition}_{revision}/\r\n\r\nwhere revision is a Redpanda internal concept.",
+        "usage": "Usage:\r\n  rpk cluster logdirs describe [flags]\r\n\r",
+        "flags": {
+            "--aggregate-into": {
+                "type": "string",
+                "description": "If non-empty, what column to aggregate into starting from the partition column (broker, dir, topic)."
+            },
+            "-b, --broker": {
+                "type": "int32",
+                "description": "If non-negative, the specific broker to describe (default -1)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "-H, --human-readable": {
+                "type": "-",
+                "description": "Print the logdirs size in a human-readable form."
+            },
+            "--sort-by-size": {
+                "type": "-",
+                "description": "If true, sort by size."
+            },
+            "--topics": {
+                "type": "strings",
+                "description": "Specific topics to describe."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster maintenance": {
+        "description": "Interact with cluster maintenance mode.\r\n\r\nMaintenance mode is a state that a node may be placed into in which the node\r\nmay be shutdown or restarted with minimal disruption to client workloads. The\r\nprimary use of maintenance mode is to perform a rolling upgrade in which each\r\nnode is placed into maintenance mode prior to upgrading the node.\r\n\r\nUse the 'enable' and 'disable' subcommands to place a node into maintenance mode\r\nor remove it, respectively. Only one node at a time may be in maintenance mode.\r\n\r\nWhen a node is placed into maintenance mode the following occurs:\r\n\r\nLeadership draining. All raft leadership is transferred to another eligible\r\nnode, and the node in maintenance mode rejects new leadership requests. By\r\ntransferring leadership off of the node in maintenance mode all client traffic\r\nand requests are directed to other nodes minimizing disruption to client\r\nworkloads when the node is shutdown.\r\n\r\nCurrently leadership is not transferred for partitions with one replica.",
+        "usage": "Usage:\r\n  rpk cluster maintenance [flags]\r\n  rpk cluster maintenance [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for maintenance."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster maintenance disable": {
+        "description": "Disable maintenance mode for a node.",
+        "usage": "Usage:\r\n  rpk cluster maintenance disable [BROKER-ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for disable."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster maintenance enable": {
+        "description": "Enable maintenance mode for a node.\r\n\r\nThis command enables maintenance mode for the node with the specified ID. If a\r\nnode exists that is already in maintenance mode then an error will be returned.",
+        "usage": "Usage:\r\n  rpk cluster maintenance enable [BROKER-ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for enable."
+            },
+            "-w, --wait": {
+                "type": "-",
+                "description": "Wait until node is drained."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster maintenance status": {
+        "description": "Report maintenance status.\r\n\r\nThis command reports maintenance status for each node in the cluster. The output\r\nis presented as a table with each row representing a node in the cluster.  The\r\noutput can be used to monitor the progress of node draining.\r\n\r\n   NODE-ID  ENABLED  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED\r\n   1        false     false     false   0           0         0             0\r\n\r\nField descriptions:\r\n\r\n        NODE-ID: the node ID\r\n        ENABLED: true if the node is currently in maintenance mode\r\n       FINISHED: leadership draining has completed\r\n         ERRORS: errors have been encountered while draining\r\n     PARTITIONS: number of partitions whose leadership has moved\r\n       ELIGIBLE: number of partitions with leadership eligible to move\r\n   TRANSFERRING: current active number of leadership transfers\r\n         FAILED: number of failed leadership transfers\r\n\r\nNotes:\r\n\r\n   - When errors are present further information will be available in the logs\r\n     for the corresponding node.\r\n\r\n   - Only partitions with more than one replica are eligible for leadership\r\n     transfer.",
+        "usage": "Usage:\r\n  rpk cluster maintenance status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster metadata": {
+        "description": "Request broker metadata.\r\n\r\nThe Kafka protocol's metadata contains information about brokers, topics, and\r\nthe cluster as a whole.\r\n\r\nThis command only runs if specific sections of metadata are requested. There\r\nare currently three sections: the cluster, the list of brokers, and the topics.\r\nIf no section is specified, this defaults to printing all sections.\r\n\r\nIf the topic section is requested, all topics are requested by default unless\r\nsome are manually specified as arguments. Expanded per-partition information\r\ncan be printed with the -d flag, and internal topics can be printed with the -i\r\nflag.\r\n\r\nIn the broker section, the controller node is suffixed with *.",
+        "usage": "Usage:\r\n  rpk cluster metadata [flags]\r\n\r\nAliases:\r\n  metadata, status, info\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for metadata."
+            },
+            "-b, --print-brokers": {
+                "type": "-",
+                "description": "Print brokers section."
+            },
+            "-c, --print-cluster": {
+                "type": "-",
+                "description": "Print cluster section."
+            },
+            "-d, --print-detailed-topics": {
+                "type": "-",
+                "description": "Print per-partition information for topics (implies -t)."
+            },
+            "-i, --print-internal-topics": {
+                "type": "-",
+                "description": "Print internal topics (if all topics requested, implies -t)."
+            },
+            "-t, --print-topics": {
+                "type": "-",
+                "description": "Print topics section (implied if any topics are specified)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions": {
+        "description": "Manage cluster partitions",
+        "usage": "Usage:\r\n  rpk cluster partitions [flags]\r\n  rpk cluster partitions [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for partitions."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions balancer-status": {
+        "description": "Queries cluster for partition balancer status:\r\n\r\nIf continuous partition balancing is enabled, redpanda will continuously\r\nreassign partitions from both unavailable nodes and from nodes using more disk\r\nspace than the configured limit.\r\n\r\nThis command can be used to monitor the partition balancer status.\r\n\r\nFIELDS\r\n\r\n    Status:                        Either off, ready, starting, in progress, or\r\n                                   stalled.\r\n    Seconds Since Last Tick:       The last time the partition balancer ran.\r\n    Current Reassignments Count:   Current number of partition reassignments in\r\n                                   progress.\r\n    Unavailable Nodes:             The nodes that have been unavailable after a\r\n                                   time set by the\r\n                                   \"partition_autobalancing_node_availability_timeout_sec\"\r\n                                   cluster property.\r\n    Over Disk Limit Nodes:         The nodes that surpassed the threshold of\r\n                                   used disk percentage specified in the\r\n                                   \"partition_autobalancing_max_disk_usage_percent\"\r\n                                   cluster property.\r\n\r\nBALANCER STATUS\r\n\r\n    off:          The balancer is disabled.\r\n    ready:        The balancer is active but there is nothing to do.\r\n    starting:     The balancer is starting but has not run yet.\r\n    in_progress:  The balancer is active and is in the process of scheduling\r\n                  partition movements.\r\n    stalled:      Violations have been detected and the balancer cannot correct\r\n                  them.\r\n\r\nSTALLED BALANCER\r\n\r\nA stalled balancer can occur for a few reasons and requires a bit of manual\r\ninvestigation. A few areas to investigate:\r\n\r\n* Are there are enough healthy nodes to which to move partitions? For example,\r\n  in a three node cluster, no movements are possible for partitions with three\r\n  replicas. You will see a stall every time there is a violation.\r\n\r\n* Does the cluster have sufficient space? If all nodes in the cluster are\r\n  utilizing more than 80% of their disk space, rebalancing cannot proceed.\r\n\r\n* Do all partitions have quorum? If the majority of a partition's replicas are\r\n  down, the partition cannot be moved.\r\n\r\n* Are any nodes in maintenance mode? Partitions are not moved if any node is in\r\n  maintenance mode.",
+        "usage": "Usage:\r\n  rpk cluster partitions balancer-status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for balancer-status."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions move-cancel": {
+        "description": "Cancel ongoing partition movements.\r\n\r\nBy default, this command cancels all the partition movements in the cluster. \r\nTo ensure that you do not accidentally cancel all partition movements, this \r\ncommand prompts users for confirmation before issuing the cancellation request. \r\nYou can use \"--no-confirm\" to disable the confirmation prompt:\r\n\r\n    rpk cluster partitions move-cancel --no-confirm\r\n\r\nIf \"--node\" is set, this command will only stop the partition movements \r\noccurring in the specified node:\r\n\r\n    rpk cluster partitions move-cancel --node 1",
+        "usage": "Usage:\r\n  rpk cluster partitions move-cancel [flags]\r\n\r\nAliases:\r\n  move-cancel, alter-cancel\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for move-cancel."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "--node": {
+                "type": "int",
+                "description": "ID of a specific node on which to cancel ongoing partition movements (default -1)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions move-status": {
+        "description": "Show ongoing partition movements.\r\n\r\nBy default this command lists all the ongoing partition movements in the cluster.\r\nTopics can be specified to print the move status of specific topics. By default,\r\nthis command assumes the \"kafka\" namespace, but you can use a \"namespace/\" to\r\nspecify internal namespaces.\r\n\r\n    rpk cluster partitions move-status\r\n    rpk cluster partitions move-status foo bar kafka_internal/tx\r\n\r\nThe \"--partition / -p\" flag can be used with topics to additional filter\r\nrequested partitions:\r\n\r\n    rpk cluster partitions move-status foo bar --partition 0,1,2\r\n\r\nThe output contains the following columns, where PARTITION-SIZE is in bytes.\r\nUsing -H, it prints the partition size in a human-readable format\r\n\r\n    NAMESPACE-TOPIC\r\n    PARTITION\r\n    MOVING-FROM\r\n    MOVING-TO\r\n    COMPLETION-%\r\n    PARTITION-SIZE\r\n    BYTES-MOVED\r\n    BYTES-REMAINING\r\n\r\nUsing \"--print-all / -a\" the command additionally prints \"RECONCILIATION STATUSES\"\r\nwhich reveals internal states on how the ongoing reconciliations work for debugging\r\npurposes. That is, reported errors don't necessarily mean real problems.",
+        "usage": "Usage:\r\n  rpk cluster partitions move-status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for move-status."
+            },
+            "-H, --human-readable": {
+                "type": "-",
+                "description": "Print the partition size in a human-readable form."
+            },
+            "-p, --partition": {
+                "type": "strings",
+                "description": "Partitions to print the ongoing movements (repeatable)."
+            },
+            "-a, --print-all": {
+                "type": "-",
+                "description": "Print internal states about movements for debugging."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster self-test": {
+        "description": "Start, stop and query runs of Redpanda self-test through the Admin API listener",
+        "usage": "Usage:\r\n  rpk cluster self-test [flags]\r\n  rpk cluster self-test [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for self-test."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster self-test start": {
+        "description": "Starts one or more benchmark tests on one or more nodes\r\nof the cluster. Available tests to run:\r\n\r\n* Disk tests:\r\n  * Throughput test: 512 KB messages, sequential read/write\r\n    * Uses a larger request message sizes and deeper I/O queue depth to write/read more bytes in a shorter amount of time, at the cost of IOPS/latency.\r\n  * Latency test: 4 KB messages, sequential read/write\r\n    * Uses smaller request message sizes and lower levels of parallelism to achieve higher IOPS and lower latency.\r\n\r\n* Network tests:\r\n  * Throughput test: 8192-bit messages\r\n    * Unique pairs of Redpanda nodes each act as a client and a server.\r\n    * The test pushes as much data over the wire, within the test parameters.\r\n\r\nThis command immediately returns on success, and the tests run asynchronously. The\r\nuser polls for results with the 'self-test status'\r\ncommand.",
+        "usage": "Usage:\r\n  rpk cluster self-test start [flags]\r\n\r",
+        "flags": {
+            "--disk-duration-ms": {
+                "type": "duration",
+                "description": "uint       The  in milliseconds of individual disk test runs (default 30000)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--network-duration-ms": {
+                "type": "duration",
+                "description": "uint    The  in milliseconds of individual network test runs (default 30000)."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Acknowledge warning prompt skipping read from stdin."
+            },
+            "--only-disk-test": {
+                "type": "-",
+                "description": "Runs only the disk benchmarks."
+            },
+            "--only-network-test": {
+                "type": "-",
+                "description": "Runs only network benchmarks."
+            },
+            "--participant-node-ids": {
+                "type": "-",
+                "description": "ints   IDs of nodes that the tests will run on. If not set, tests will run for all node IDs."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster self-test status": {
+        "description": "Returns the status of the currently running or last completed self-test run.\r\n\r\nUse this command after invoking 'self-test start' to determine the status of\r\nthe jobs launched. Possible results are:\r\n\r\n* One or more jobs still running\r\n  * Returns the IDs of Redpanda nodes still running self-tests.\r\n\r\n* No jobs running:\r\n  * Returns cached results for all nodes of the last completed test.",
+        "usage": "Usage:\r\n  rpk cluster self-test status [flags]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (text, json) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster self-test stop": {
+        "description": "Stops all self-test tests.\r\n\r\nThis command stops all currently running self-tests. The command is synchronous and returns\r\nsuccess when all jobs have been stopped or reports errors if broker timeouts have expired.",
+        "usage": "Usage:\r\n  rpk cluster self-test stop [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster storage": {
+        "description": "Manage the cluster storage",
+        "usage": "Usage:\r\n  rpk cluster storage [flags]\r\n  rpk cluster storage [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for storage."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster storage recovery": {
+        "description": "Interact with the topic recovery process.\r\n\t\t\r\nThis command is used to restore topics from the archival bucket, which can be \r\nuseful for disaster recovery or if a topic was accidentally deleted.\r\n\r\nTo begin the recovery process, use the \"recovery start\" command. Note that this \r\nprocess can take a while to complete, so the command will exit after starting \r\nit. If you want the command to wait for the process to finish, use the \"--wait\"\r\nor \"-w\" flag.\r\n\r\nYou can check the status of the recovery process with the \"recovery status\" \r\ncommand after it has been started.",
+        "usage": "Usage:\r\n  rpk cluster storage recovery [flags]\r\n  rpk cluster storage recovery [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for recovery."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster storage recovery start": {
+        "description": "Start the topic recovery process.\r\n\t\t\r\nThis command starts the process of restoring topics from the archival bucket.\r\nIf the wait flag (--wait/-w) is set, the command will poll the status of the\r\nrecovery process until it's finished.",
+        "usage": "Usage:\r\n  rpk cluster storage recovery start [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--polling-interval": {
+                "type": "duration",
+                "description": "The status check interval (e.g. '30s', '1.5m'); ignored if --wait is not used (default 5s)."
+            },
+            "--topic-name-pattern": {
+                "type": "string",
+                "description": "A regex pattern that restores any matching topics (default \".*\")."
+            },
+            "-w, --wait": {
+                "type": "-",
+                "description": "Wait until auto-restore is complete."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster storage recovery status": {
+        "description": "Fetch the status of the topic recovery process.\r\n\t\t\r\nThis command fetches the status of the process of restoring topics from the \r\narchival bucket.",
+        "usage": "Usage:\r\n  rpk cluster storage recovery status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk container": {
+        "description": "Manage a local container cluster",
+        "usage": "Usage:\r\n  rpk container [flags]\r\n  rpk container [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for container."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk container purge": {
+        "description": "Stop and remove an existing local container cluster's data",
+        "usage": "Usage:\r\n  rpk container purge [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for purge."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk container start": {
+        "description": "Start a local container cluster",
+        "usage": "Usage:\r\n  rpk container start [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "-n, --nodes": {
+                "type": "-",
+                "description": "uint     The number of nodes to start (default 1)."
+            },
+            "--retries": {
+                "type": "-",
+                "description": "uint   The amount of times to check for the cluster before considering it unstable and exiting. (default 10)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk container status": {
+        "description": "Get status",
+        "usage": "Usage:\r\n  rpk container status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk container stop": {
+        "description": "Stop an existing local container cluster",
+        "usage": "Usage:\r\n  rpk container stop [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk debug": {
+        "description": "Debug the local Redpanda process",
+        "usage": "Usage:\r\n  rpk debug [flags]\r\n  rpk debug [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for debug."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk debug bundle": {
+        "description": "'rpk debug bundle' collects environment data that can help debug and diagnose\r\nissues with a redpanda cluster, a broker, or the machine it's running on. It\r\nthen bundles the collected data into a ZIP file, called a diagnostics bundle.\r\n\r\nThe files and directories in the diagnostics bundle differ depending on the \r\nenvironment in which Redpanda is running:\r\n\r\nCOMMON FILES\r\n\r\n - Kafka metadata: Broker configs, topic configs, start/committed/end offsets,\r\n   groups, group commits.\r\n\r\n - Controller logs: The controller logs directory up to a limit set by\r\n   --controller-logs-size-limit flag\r\n\r\n - Data directory structure: A file describing the data directory's contents.\r\n\r\n - redpanda configuration: The redpanda configuration file (redpanda.yaml;\r\n   SASL credentials are stripped).\r\n\r\n - /proc/cpuinfo: CPU information like make, core count, cache, frequency.\r\n\r\n - /proc/interrupts: IRQ distribution across CPU cores.\r\n\r\n - Resource usage data: CPU usage percentage, free memory available for the\r\n   redpanda process.\r\n\r\n - Clock drift: The ntp clock delta (using pool.ntp.org as a reference) & round\r\n   trip time.\r\n\r\n - Admin API calls: Cluster and broker configurations, cluster health data, and \r\n   license key information.\r\n\r\n - Broker metrics: The broker's Prometheus metrics, fetched through its\r\n   admin API (/metrics and /public_metrics).\r\n\r\nBARE-METAL\r\n\r\n - Kernel logs: The kernel logs ring buffer (syslog).\r\n\r\n - DNS: The DNS info as reported by 'dig', using the hosts in\r\n   /etc/resolv.conf.\r\n\r\n - Disk usage: The disk usage for the data directory, as output by 'du'.\r\n\r\n - redpanda logs: The node's redpanda logs written to journald. If --logs-since \r\n   or --logs-until are passed, then only the logs within the resulting time frame\r\n   will be included.\r\n\r\n - Socket info: The active sockets data output by 'ss'.\r\n\r\n - Running process info: As reported by 'top'.\r\n\r\n - Virtual memory stats: As reported by 'vmstat'.\r\n\r\n - Network config: As reported by 'ip addr'.\r\n\r\n - lspci: List the PCI buses and the devices connected to them.\r\n\r\n - dmidecode: The DMI table contents. Only included if this command is run\r\n   as root.\r\n\r\nKUBERNETES\r\n\r\n - Kubernetes Resources: Kubernetes manifests for all resources in the given \r\n   Kubernetes namespace (via --namespace).\r\n\r\n - redpanda logs: Logs of each Pod in the the given Kubernetes namespace. If \r\n   --logs-since is passed, only the logs within the given timeframe are \r\n   included.\r\n\r\n\r\nIf you have an upload URL from the Redpanda support team, provide it in the \r\n--upload-url flag to upload your diagnostics bundle to Redpanda.",
+        "usage": "Usage:\r\n  rpk debug bundle [flags]\r\n\r",
+        "flags": {
+            "--controller-logs-size-limit": {
+                "type": "string",
+                "description": "The size limit of the controller logs that can be stored in the bundle (e.g. 3MB, 1GiB) (default \"20MB\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for bundle."
+            },
+            "--logs-since": {
+                "type": "string",
+                "description": "Include log entries on or newer than the specified date (journalctl date format, e.g. YYYY-MM-DD."
+            },
+            "--logs-size-limit": {
+                "type": "string",
+                "description": "Read the logs until the given size is reached (e.g. 3MB, 1GiB) (default \"100MiB\")."
+            },
+            "--logs-until": {
+                "type": "string",
+                "description": "Include log entries on or older than the specified date (journalctl date format, e.g. YYYY-MM-DD."
+            },
+            "--metrics-interval": {
+                "type": "duration",
+                "description": "Interval between metrics snapshots (e.g. 30s, 1.5m) (default 10s)."
+            },
+            "-n, --namespace": {
+                "type": "string",
+                "description": "The namespace to use to collect the resources from (k8s only) (default \"redpanda\")."
+            },
+            "-o, --output": {
+                "type": "string",
+                "description": "The file path where the debug file will be written (default ./<timestamp>-bundle.zip)."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "How long to wait for child commands to execute (e.g. 30s, 1.5m) (default 12s)."
+            },
+            "--upload-url": {
+                "type": "string",
+                "description": "If provided, where to upload the bundle in addition to creating a copy on disk."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk generate": {
+        "description": "Generate a configuration template for related services",
+        "usage": "Usage:\r\n  rpk generate [template] [flags]\r\n  rpk generate [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for generate."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk generate app": {
+        "description": "Generate a sample application to connect with Redpanda.\r\n\r\nThis command generates a starter application to produce and consume from the\r\nsettings defined in the rpk profile. Its goal is to get you producing and\r\nconsuming quickly with Redpanda in a language that is familiar to you.\r\n\r\nBy default, this will run interactively, prompting you to select a language and\r\na user with which to create your application. To use this without interactivity,\r\nspecify how you would like your application to be created using flags.\r\n\r\nThe --language option allows you to specify the language. There is no default.\r\n\r\nThe --new-sasl-credentials <user>:<password> allows you to generate a new SASL\r\nuser with admin ACLs. If you don't want to use your current profile user nor\r\ncreate a new one, you may use --no-user flag to generate the starter app without\r\nthe user.\r\n\r\nIf you are having trouble connecting to your cluster, you can use -X\r\nadmin.hosts=comma,delimited,host:ports to pass a specific admin api address.\r\n\r\nExamples:\r\n\r\nGenerate an app with interactive prompts:\r\n  rpk generate app\r\n\r\nGenerate an app in a specified language with the existing SASL user:\r\n  rpk generate app --language <lang>\r\n\r\nGenerate an app in the specified language with a new SASL user:\r\n  rpk generate app -l <lang> --new-sasl-credentials <user>:<password>\r\n\r\nGenerate an app in the 'tmp' dir, but take no action on the user:\r\n  rpk generate app -l <lang> --no-user --output /tmp",
+        "usage": "Usage:\r\n  rpk generate app [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for app."
+            },
+            "-l, --language": {
+                "type": "string",
+                "description": "The language you want the code sample to be generated with."
+            },
+            "--new-sasl-credentials": {
+                "type": "string",
+                "description": "If provided, rpk will generate and use these credentials (<user>:<password>)."
+            },
+            "--no-user": {
+                "type": "-",
+                "description": "Generates the sample app without SASL user."
+            },
+            "-o, --output": {
+                "type": "string",
+                "description": "The path where the app will be written."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk generate grafana-dashboard": {
+        "description": "Generate Grafana Dashboards for Redpanda Metrics\r\n\r\nUse this command to generate sample Grafana dashboards for Redpanda metrics. \r\nThese dashboards can be imported into a Grafana or Grafana Cloud instance.\r\n\r\nTo select a specific dashboard, use the '--dashboard' flag followed by the \r\ndashboard name. For example, to generate the operations dashboard, run:\r\n\r\n    rpk generate grafana-dashboard --dashboard operations\r\n\r\nThe selected dashboard will be downloaded from our GitHub repository:\r\n\r\n  https://github.com/redpanda-data/observability\r\n\r\nNote that the legacy dashboard is still available as an option, and will not be \r\ndownloaded from github. Instead, the dashboard will be generated based on the \r\nmetrics endpoint used.\r\n\r\nTo see a list of all available dashboards, use the '--dashboard help' flag.",
+        "usage": "Usage:\r\n  rpk generate grafana-dashboard [flags]\r\n\r",
+        "flags": {
+            "--dashboard": {
+                "type": "string",
+                "description": "The name of the dashboard you wish to download; use --dashboard help for more info (default \"operations\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for grafana-dashboard."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk generate prometheus-config": {
+        "description": "Generate the Prometheus configuration to scrape Redpanda nodes. \r\n\r\nThe output of this command should be included in the 'scrape_configs' array \r\nwithin the YAML configuration file of your Prometheus instance.\r\n\r\nThere are different options you can use when generating the configuration:\r\n\r\n - If you provide the --seed-addr flag, the command will use the address to \r\n   discover the rest of the cluster hosts using Redpanda's Kafka API.\r\n - If you provide the --node-addrs flag, the command will directly use the \r\n   provided addresses.\r\n - If neither --seed-addr nor --node-addrs are passed, the command will read the \r\n   redpanda config file and use the node IP configured there.\r\n\r\nIf the node you want to scrape uses TLS, you can provide the TLS flags \r\n(--tls-key, --tls-cert, and --tls-truststore). The command will generate the \r\nrequired tls_config section in the scrape configuration.\r\n\r\nAdditionally, you have the option to define labels for the target in the \r\nstatic-config section by using the --labels flag. You can specify the desired \r\nmetric that the label should target, either internal (/metrics) or public \r\n(/public_metrics).\r\n\r\nFor example:\r\n\r\n  --job-name test --labels \"public:group=one,internal:group=two\"\r\n\r\nThis will result in two separate configs for the test job, each with a \r\ndifferent label:\r\n\r\n  - job_name: test\r\n    static_configs:\r\n      - targets: [<targets>]\r\n        labels:\r\n          group: one\r\n    metrics_path: /public_metrics\r\n  - job_name: test\r\n    static_configs:\r\n      - targets: [<targets>]\r\n        labels:\r\n          group: two\r\n    metrics_path: /metrics\r\n\r\nYou can only provide one label per job. By default, if no metric target is \r\nspecified, the label will be shared across the jobs.",
+        "usage": "Usage:\r\n  rpk generate prometheus-config [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for prometheus-config."
+            },
+            "--internal-metrics": {
+                "type": "-",
+                "description": "Include scrape config for internal metrics (/metrics)."
+            },
+            "--job-name": {
+                "type": "string",
+                "description": "The prometheus job name by which to identify the Redpanda nodes (default \"redpanda\")."
+            },
+            "--labels": {
+                "type": "strings",
+                "description": "Comma-separated labels and their target metric (int or pub): [metric|labelName:labelValue, ...]."
+            },
+            "--node-addrs": {
+                "type": "strings",
+                "description": "Comma-separated list of admin API host:ports."
+            },
+            "--seed-addr": {
+                "type": "string",
+                "description": "The URL of a Redpanda node with which to discover the rest."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The CA certificate to be used for TLS communication with the broker."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk generate shell-completion": {
+        "description": "Shell completion can help autocomplete rpk commands when you press tab.\r\n\r\nBASH\r\n\r\nBash autocompletion relies on the bash-completion package. You can test if you\r\nhave this by running \"type _init_completion\", if you do not, you can install\r\nthe package through your package manager.\r\n\r\nIf you have bash-completion installed, and the command still fails, you likely\r\nneed to add the following line to your ~/.bashrc:\r\n\r\n    source /usr/share/bash-completion/bash_completion\r\n\r\nTo ensure autocompletion of rpk exists in all shell sessions, add the following\r\nto your ~/.bashrc:\r\n\r\n    command -v rpk >/dev/null && . <(rpk generate shell-completion bash)\r\n\r\nAlternatively, to globally enable rpk completion, you can run the following:\r\n\r\n    rpk generate shell-completion bash > /etc/bash_completion.d/rpk\r\n\r\nZSH\r\n\r\nIf shell completion is not already enabled in your environment, you will need to\r\nenable it. You can execute the following once:\r\n\r\n  $ echo \"autoload -U compinit; compinit\" >> ~/.zshrc\r\n\r\nTo enable autocompletion in any zsh session for any user, run this once:\r\n\r\n# Linux:\r\n\r\n    rpk generate shell-completion zsh > \"${fpath[1]}/_rpk\"\r\n\r\n# macOS:\r\n\r\n     rpk generate shell-completion zsh > \"$(brew --prefix)/share/zsh/site-functions/_rpk\"\r\n\r\nYou can also place that command in your ~/.zshrc to ensure that when you update\r\nrpk, you update autocompletion. If you initially require sudo to edit that\r\nfile, you can chmod it to be world writeable, after which you will always be\r\nable to update it from ~/.zshrc.\r\n\r\nFISH\r\n\r\nTo enable autocompletion in any fish session, run:\r\n\r\n    rpk generate shell-completion fish > ~/.config/fish/completions/rpk.fish",
+        "usage": "Usage:\r\n  rpk generate shell-completion [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for shell-completion."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group": {
+        "description": "Describe, list, and delete consumer groups and manage their offsets.\r\n\r\nConsumer groups allow you to horizontally scale consuming from topics. A\r\nnon-group consumer consumes all records from all partitions you assign it. In\r\ncontrast, consumer groups allow many consumers to coordinate and divide work.\r\nIf you have two members in a group consuming topics A and B, each with three\r\npartitions, then both members consume three partitions. If you add another\r\nmember to the group, then each of the three members will consume two\r\npartitions. This allows you to horizontally scale consuming of topics.\r\n\r\nThe unit of scaling is a single partition. If you add more consumers to a group\r\nthan there are are total partitions to consume, then some consumers will be\r\nidle. More commonly, you have many more partitions than consumer group members\r\nand each member consumes a chunk of available partitions. One scenario where\r\nyou may want more members than partitions is if you want active standby's to\r\ntake over load immediately if any consuming member dies.\r\n\r\nHow group members divide work is entirely client driven (the \"partition\r\nassignment strategy\" or \"balancer\" depending on the client). Brokers know\r\nnothing about how consumers are assigning partitions. A broker's role in group\r\nconsuming is to choose which member is the leader of a group, forward that\r\nmember's assignment to every other member, and ensure all members are alive\r\nthrough heartbeats.\r\n\r\nConsumers periodically commit their progress when consuming partitions. Through\r\nthese commits, you can monitor just how far behind a consumer is from the\r\nlatest messages in a partition. This is called \"lag\". Large lag implies that\r\nthe client is having problems, which could be from the server being too slow,\r\nor the client being oversubscribed in the number of partitions it is consuming,\r\nor the server being in a bad state that requires restarting or removing from\r\nthe server pool, and so on.\r\n\r\nYou can manually manage offsets for a group, which allows you to rewind or\r\nforward commits. If you notice that a recent deploy of your consumers had a\r\nbug, you may want to stop all members, rewind the commits to before the latest\r\ndeploy, and restart the members with a patch.\r\n\r\nThis command allows you to list all groups, describe a group (to view the\r\nmembers and their lag), and manage offsets.",
+        "usage": "Usage:\r\n  rpk group [flags]\r\n  rpk group [command]\r\n\r\nAliases:\r\n  group, g\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for group."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group delete": {
+        "description": "Delete groups from brokers.\r\n\r\nOlder versions of the Kafka protocol included a retention_millis field in\r\noffset commit requests. Group commits persisted for this retention and then\r\neventually expired. Once all commits for a group expired, the group would be\r\nconsidered deleted.\r\n\r\nThe retention field was removed because it proved problematic for infrequently\r\ncommitting consumers: the offsets could be expired for a group that was still\r\nactive. If clients use new enough versions of OffsetCommit (versions that have\r\nremoved the retention field), brokers expire offsets only when the group is\r\nempty for offset.retention.minutes. Redpanda does not currently support that\r\nconfiguration (see #2904), meaning offsets for empty groups expire only when\r\nthey are explicitly deleted.\r\n\r\nYou may want to delete groups to clean up offsets sooner than when they\r\nautomatically are cleaned up, such as when you create temporary groups for\r\nquick investigation or testing. This command helps you do that.",
+        "usage": "Usage:\r\n  rpk group delete [GROUPS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group describe": {
+        "description": "Describe group offset status & lag.\r\n\r\nThis command describes group members, calculates their lag, and prints detailed\r\ninformation about the members.",
+        "usage": "Usage:\r\n  rpk group describe [GROUPS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "-c, --print-commits": {
+                "type": "-",
+                "description": "Print only the group commits section."
+            },
+            "-t, --print-lag-per-topic": {
+                "type": "-",
+                "description": "Print the aggregated lag per topic."
+            },
+            "-s, --print-summary": {
+                "type": "-",
+                "description": "Print only the group summary section."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group list": {
+        "description": "List all groups.\r\n\r\nThis command lists all groups currently known to Redpanda, including empty\r\ngroups that have not yet expired. The BROKER column is which broker node is the\r\ncoordinator for the group. This command can be used to track down unknown\r\ngroups, or to list groups that need to be cleaned up.",
+        "usage": "Usage:\r\n  rpk group list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group offset-delete": {
+        "description": "Forcefully delete offsets for a kafka group.\r\n\r\nThe broker will only allow the request to succeed if the group is in a dead\r\nstate (no subscriptions) or there are no subscriptions for offsets for\r\ntopic/partitions requested to be deleted.\r\n\r\nUse either the --from-file or the --topic option. They are mutually exclusive.\r\nTo indicate which topics or topic partitions you'd like to remove offsets from use\r\nthe --topic (-t) flag, followed by a comma separated list of partition ids. Supplying\r\nno list will delete all offsets for all partitions for a given topic.\r\n\r\nYou may also provide a text file to indicate topic/partition tuples. Use the\r\n--from-file flag for this option. The file must contain lines of topic/partitions\r\nseparated by a tab or space. Example:\r\n\r\ntopic_a 0\r\ntopic_a 1\r\ntopic_b 0",
+        "usage": "Usage:\r\n  rpk group offset-delete [GROUP] --from-file FILE --topic foo:0,1,2 [flags]\r\n\r",
+        "flags": {
+            "-f, --from-file": {
+                "type": "string",
+                "description": "File of topic/partition tuples for which to delete offsets for."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for offset-delete."
+            },
+            "-t, --topic": {
+                "type": "stringArray",
+                "description": "topic:partition_id (repeatable; e.g. -t foo:0,1,2 )."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group seek": {
+        "description": "Modify a group's current offsets.\r\n\r\nThis command allows you to modify a group's offsets. Sometimes, you may need to\r\nrewind a group if you had a mistaken deploy, or fast-forward a group if it is\r\nfalling behind on messages that can be skipped.\r\n\r\nThe --to option allows you to seek to the start of partitions, end of\r\npartitions, or after a specific timestamp. The default is to seek any topic\r\npreviously committed. Using --topics allows to you set commits for only the\r\nspecified topics; all other commits will remain untouched. Topics with no\r\ncommits will not be committed unless allowed with --allow-new-topics.\r\n\r\nThe --to-group option allows you to seek to commits that are in another group.\r\nThis is a merging operation: if g1 is consuming topics A and B, and g2 is\r\nconsuming only topic B, \"rpk group seek g1 --to-group g2\" will update g1's\r\ncommits for topic B only. The --topics flag can be used to further narrow which\r\ntopics are updated. Unlike --to, all non-filtered topics are committed, even\r\ntopics not yet being consumed, meaning --allow-new-topics is not needed.\r\n\r\nThe --to-file option allows to seek to offsets specified in a text file with\r\nthe following format:\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    ...\r\nEach line contains the topic, the partition, and the offset to seek to. As with\r\nthe prior options, --topics allows filtering which topics are updated. Similar\r\nto --to-group, all non-filtered topics are committed, even topics not yet being\r\nconsumed, meaning --allow-new-topics is not needed.\r\n\r\nThe --to, --to-group, and --to-file options are mutually exclusive. If you are\r\nnot authorized to describe or read some topics used in a group, you will not be\r\nable to modify offsets for those topics.\r\n\r\nEXAMPLES\r\n\r\nSeek group G to June 1st, 2021:\r\n    rpk group seek g --to 1622505600\r\n    or, rpk group seek g --to 1622505600000\r\n    or, rpk group seek g --to 1622505600000000000\r\nSeek group X to the commits of group Y topic foo:\r\n    rpk group seek X --to-group Y --topics foo\r\nSeek group G's topics foo, bar, and biz to the end:\r\n    rpk group seek G --to end --topics foo,bar,biz\r\nSeek group G to the beginning of a topic it was not previously consuming:\r\n    rpk group seek G --to start --topics foo --allow-new-topics",
+        "usage": "Usage:\r\n  rpk group seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ... [flags]\r\n\r",
+        "flags": {
+            "--allow-new-topics": {
+                "type": "-",
+                "description": "Allow seeking to new topics not currently consumed (implied with --to-group or --to-file)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for seek."
+            },
+            "--to": {
+                "type": "string",
+                "description": "Where to seek (start, end, unix second | millisecond | nanosecond)."
+            },
+            "--to-file": {
+                "type": "string",
+                "description": "Seek to offsets as specified in the file."
+            },
+            "--to-group": {
+                "type": "string",
+                "description": "Seek to the commits of another group."
+            },
+            "--topics": {
+                "type": "strings",
+                "description": "Only seek these topics, if any are specified."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk help": {
+        "description": "Help provides help for any command in the application.\r\nSimply type rpk help [path to command] for full details.",
+        "usage": "Usage:\r\n  rpk help [command] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "help for help."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk iotune": {
+        "description": "Measure filesystem performance and create IO configuration file",
+        "usage": "Usage:\r\n  rpk iotune [flags]\r\n\r",
+        "flags": {
+            "--directories": {
+                "type": "strings",
+                "description": "List of directories to evaluate."
+            },
+            "--duration": {
+                "type": "duration",
+                "description": "Duration of tests (e.g. 300ms, 1.5s, 2h45m) (default 10m0s)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for iotune."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt if the iotune file already exists."
+            },
+            "--out": {
+                "type": "string",
+                "description": "The file path where the IO config will be written (default \"/etc/redpanda/io-config.yaml\")."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time after -- to wait for iotune to complete (e.g. 300ms, 1.5s, 2h45m) (default 1h0m0s)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk plugin": {
+        "description": "List, download, update, and remove rpk plugins.\r\n\t\r\nPlugins augment rpk with new commands.\r\n\r\nFor a plugin to be used, it must be in $HOME/.local/bin or somewhere \r\ndiscoverable by rpk in your $PATH. All plugins follow a defined naming scheme:\r\n\r\n  .rpk-<name>\r\n  .rpk.ac-<name>\r\n\r\nAll plugins are prefixed with either .rpk- or .rpk.ac-. When rpk starts up, it\r\nsearches all directories in your $PATH for any executable binary that begins\r\nwith either of those prefixes. For any binary it finds, rpk adds a command for\r\nthat name to the rpk command space itself.\r\n\r\nNo plugin name can shadow an existing rpk command, and only one plugin can\r\nexist under a given name at once. Plugins are added to the rpk command space on\r\na first-seen basis. If you have two plugins rpk-foo, and the second is\r\ndiscovered later on in the $PATH directories, then only the first will be used.\r\nThe second will be ignored.\r\n\r\nPlugins that have an .rpk.ac- prefix indicate that they support the\r\n--help-autocomplete flag. If rpk sees this, rpk will exec the plugin with that\r\nflag when rpk starts up, and the plugin will return all commands it supports as\r\nwell as short and long help test for each command. Rpk uses this return to\r\nbuild a shadow command space within rpk itself so that it looks as if the\r\nplugin exists within rpk. This is particularly useful if you enable\r\nautocompletion.\r\n\r\nThe expected return for plugins from --help-autocomplete is an array of the\r\nfollowing:\r\n\r\n  type pluginHelp struct {\r\n          Path    string   `json:\"path,omitempty\"`\r\n          Short   string   `json:\"short,omitempty\"`\r\n          Long    string   `json:\"long,omitempty\"`\r\n          Example string   `json:\"example,omitempty\"`\r\n          Args    []string `json:\"args,omitempty\"`\r\n  }\r\n\r\nwhere \"path\" is an underscore delimited argument path to a command. For\r\nexample, \"foo_bar_baz\" corresponds to the command \"rpk foo bar baz\".",
+        "usage": "Usage:\r\n  rpk plugin [flags]\r\n  rpk plugin [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for plugin."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk plugin install": {
+        "description": "Install an rpk plugin.\r\n\r\nAn rpk plugin must be saved in $HOME/.local/bin or in a directory that is in \r\nyour $PATH. By default, this command installs plugins to $HOME/.local/bin. This \r\ncan be overridden by specifying the --dir flag.\r\n\r\nIf --dir is not present, rpk will create $HOME/.local/bin if it does not exist.",
+        "usage": "Usage:\r\n  rpk plugin install [PLUGIN] [flags]\r\n\r\nAliases:\r\n  install, download\r\n\r",
+        "flags": {
+            "--dir": {
+                "type": "string",
+                "description": "Destination directory to save the installed plugin (defaults to $HOME/.local/bin) (default \"/var/lib/redpanda/.local/bin\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for install."
+            },
+            "-u, --update": {
+                "type": "-",
+                "description": "Update a locally installed plugin if it differs from the current remote version."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk plugin list": {
+        "description": "List all available plugins.\r\n\r\nBy default, this command fetches the remote manifest and prints plugins\r\navailable for download. Any plugin that is already downloaded is prefixed with\r\nan asterisk. If a locally installed plugin has a different sha256sum as the one\r\nspecified in the manifest, or if the sha256sum could not be calculated for the\r\nlocal plugin, an additional message is printed.\r\n\r\nYou can specify --local to print all locally installed plugins, as well as\r\nwhether you have \"shadowed\" plugins (the same plugin specified multiple times).",
+        "usage": "Usage:\r\n  rpk plugin list [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-l, --local": {
+                "type": "-",
+                "description": "List locally installed plugins and shadowed plugins."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk plugin uninstall": {
+        "description": "Uninstall / remove an existing local plugin.\r\n\r\nThis command lists locally installed plugins and removes the first plugin that\r\nmatches the requested removal. If --include-shadowed is specified, this command\r\nalso removes all shadowed plugins of the same name. To remove a command under a\r\nnested namespace (\"rpk foo bar\"), you can use \"foo_bar\".",
+        "usage": "Usage:\r\n  rpk plugin uninstall [NAME] [flags]\r\n\r\nAliases:\r\n  uninstall, rm\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for uninstall."
+            },
+            "--include-shadowed": {
+                "type": "-",
+                "description": "Also remove shadowed plugins that have the same name."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile": {
+        "description": "Manage rpk profiles.\r\n\r\nAn rpk profile talks to a single Redpanda cluster. You can create multiple\r\nprofiles for multiple clusters and swap between them with 'rpk profile use'.\r\nMultiple profiles may be useful if, for example, you use rpk to talk to\r\na localhost cluster, a dev cluster, and a prod cluster, and you want to keep\r\nyour configuration in one place.",
+        "usage": "Usage:\r\n  rpk profile [flags]\r\n  rpk profile [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for profile."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile clear": {
+        "description": "Clear the current profile\r\n\r\nThis small command clears the current profile, which can be useful to unset an\r\nprod cluster profile.",
+        "usage": "Usage:\r\n  rpk profile clear [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for clear."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile create": {
+        "description": "Create an rpk profile.\r\n\r\nThere are multiple ways to create a profile. A name must be provided if not\r\nusing --from-cloud.\r\n\r\n* You can use --from-redpanda to generate a new profile from an existing\r\n  redpanda.yaml file. The special values \"current\" create a profile from the\r\n  current redpanda.yaml as it is loaded within rpk.\r\n\r\n* You can use --from-profile to generate a profile from an existing profile or\r\n  from from a profile in a yaml file. First, the filename is checked, then an\r\n  existing profile name is checked. The special value \"current\" creates a new\r\n  profile from the existing profile.\r\n\r\n* You can use --from-cloud to generate a profile from an existing cloud cluster\r\n  id. Note that you must be logged in with 'rpk cloud login' first. The special\r\n  value \"prompt\" will prompt to select a cloud cluster to create a profile for.\r\n\r\n* You can use --set key=value to directly set fields. The key can either be\r\n  the name of a -X flag or the path to the field in the profile's YAML format.\r\n  For example, using --set tls.enabled=true OR --set kafka_api.tls.enabled=true\r\n  is equivalent. The former corresponds to the -X flag tls.enabled, while the\r\n  latter corresponds to the path kafka_api.tls.enabled in the profile's YAML.\r\n\r\nThe --set flag is always applied last and can be used to set additional fields\r\nin tandem with --from-redpanda or --from-cloud.\r\n\r\nThe --set flag supports autocompletion, suggesting the -X key format. If you\r\nbegin writing a YAML path, the flag will suggest the rest of the path.\r\n\r\nIt is recommended to always use the --description flag; the description is\r\nprinted in the output of 'rpk profile list'.\r\n\r\nrpk always switches to the newly created profile.",
+        "usage": "Usage:\r\n  rpk profile create [NAME] [flags]\r\n\r",
+        "flags": {
+            "-d, --description": {
+                "type": "string",
+                "description": "Optional description of the profile."
+            },
+            "--from-cloud": {
+                "type": "string",
+                "description": "[=\"prompt\"]   Create and switch to a new profile generated from a Redpanda Cloud cluster ID."
+            },
+            "--from-profile": {
+                "type": "string",
+                "description": "Create and switch to a new profile from an existing profile or from a profile in a yaml file."
+            },
+            "--from-redpanda": {
+                "type": "string",
+                "description": "Create and switch to a new profile from a redpanda.yaml file."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "-s, --set": {
+                "type": "stringArray",
+                "description": "Create and switch to a new profile, setting profile fields with key=value pairs."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile current": {
+        "description": "Print the current profile name.\r\n\r\nThis is a tiny command that simply prints the current profile name, which may\r\nbe useful in scripts, or a PS1, or to confirm what you have selected.",
+        "usage": "Usage:\r\n  rpk profile current [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for current."
+            },
+            "-n, --no-newline": {
+                "type": "-",
+                "description": "Do not print a newline after the profile name."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile delete": {
+        "description": "Delete an rpk profile.\r\n\r\nDeleting a profile removes it from the rpk.yaml file. If the deleted profile\r\nwas the selected profile, rpk will use in-memory defaults until a new profile\r\nis selected.",
+        "usage": "Usage:\r\n  rpk profile delete [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile edit": {
+        "description": "Edit an rpk profile.\r\n\r\nThis command opens your default editor to edit the specified profile, or\r\nthe current profile if no profile is specified. If the profile does not\r\nexist, this command creates it and switches to it.",
+        "usage": "Usage:\r\n  rpk profile edit [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for edit."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile edit-globals": {
+        "description": "Edit rpk globals.\r\n\r\nThis command opens your default editor to edit the rpk global configurations.",
+        "usage": "Usage:\r\n  rpk profile edit-globals [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for edit-globals."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile list": {
+        "description": "List rpk profiles",
+        "usage": "Usage:\r\n  rpk profile list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile print": {
+        "description": "Print rpk profile configuration.\r\n\r\nIf no name is specified, this command prints the current profile as it exists\r\nin the rpk.yaml file.",
+        "usage": "Usage:\r\n  rpk profile print [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for print."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile print-globals": {
+        "description": "Print rpk global configuration",
+        "usage": "Usage:\r\n  rpk profile print-globals [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for print-globals."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile prompt": {
+        "description": "Prompt a profile name formatted for a PS1 prompt.\r\n\r\nThis command prints ANSI-escaped text per your current profile's \"prompt\"\r\nfield. If the current profile does not have a prompt, this prints nothing.\r\nIf the prompt is invalid, this exits 0 with no message. To validate the\r\ncurrent prompt, use the --validate flag.\r\n\r\nThis command may introduce other % variables in the future, if you want to\r\nprint a % directly, use %% to escape it.\r\n\r\nTo use this in zsh, be sure to add setopt PROMPT_SUBST to your .zshrc.\r\nTo edit your PS1, use something like PS1='$(rpk profile prompt)' in your\r\nshell rc file.\r\n\r\nFORMAT\r\n\r\nThe \"prompt\" field supports space or comma separated modifiers and a quoted\r\nstring that is be modified. Inside the string, the variable %p or %n refers to\r\nthe profile name. As a few examples:\r\n\r\n    prompt: hi-white, bg-red, bold, \"[%p]\"\r\n    prompt: hi-red  \"PROD\"\r\n    prompt: white, \"dev-%n\r\n\r\nIf you want to have multiple formats, you can wrap each formatted section in\r\nparentheses.\r\n\r\n    prompt: (\"--\") (hi-white bg-red bold \"[%p]\")\r\n\r\nCOLORS\r\n\r\nAll ANSI colors are supported, with names matching the color name:\r\n\"black\", \"red\", \"green\", \"yellow\", \"blue\", \"magenta\", \"cyan\", \"white\".\r\n\r\nThe \"hi-\" prefix indicates a high-intensity color: \"hi-black\", \"hi-red\", etc.\r\nThe \"bg-\" prefix modifies the background color: \"bg-black\", \"bg-hi-red\", etc.\r\n\r\nMODIFIERS\r\n\r\nFour modifiers are supported, \"bold\", \"faint\", \"underline\", and \"invert\".",
+        "usage": "Usage:\r\n  rpk profile prompt [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for prompt."
+            },
+            "--validate": {
+                "type": "-",
+                "description": "Exit with an error message if the prompt is invalid."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile rename-to": {
+        "description": "Rename the current rpk profile",
+        "usage": "Usage:\r\n  rpk profile rename-to [NAME] [flags]\r\n\r\nAliases:\r\n  rename-to, rename\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for rename-to."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile set": {
+        "description": "Set fields in the current rpk profile.\r\n\r\nAs in the create command, this command takes a list of key=value pairs to write\r\nto the current profile.\r\n\r\nThe key can either be the name of a -X flag or the path to the field in the\r\nprofile's yaml format. For example, using --set tls.enabled=true OR --set\r\nkafka_api.tls.enabled=true is equivalent. The former corresponds to the -X flag\r\ntls.enabled, while the latter corresponds to the path kafka_api.tls.enabled in\r\nthe profile's yaml.\r\n\r\nThis command supports autocompletion of valid keys, suggesting the -X key\r\nformat. If you begin writing a YAML path, this command will suggest the rest of\r\nthe path.\r\n\r\nYou can also use the format 'set key value' if you intend to only set one key.",
+        "usage": "Usage:\r\n  rpk profile set [KEY=VALUE]+ [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile set-globals": {
+        "description": "Set rpk globals fields.\r\n\r\nThis command takes a list of key=value pairs to write to the global config \r\nsection of rpk.yaml. The globals section contains a set of settings that apply\r\nto all profiles and changes the way that rpk acts. For a list of global flags\r\nand what they mean, check 'rpk -X help' and look for any key that begins with\r\n\"globals\".\r\n\r\nThis command supports autocompletion of valid keys. You can also use the\r\nformat 'set key value' if you intend to only set one key.",
+        "usage": "Usage:\r\n  rpk profile set-globals [KEY=VALUE]+ [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set-globals."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile use": {
+        "description": "Select the rpk profile to use",
+        "usage": "Usage:\r\n  rpk profile use [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for use."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda": {
+        "description": "Interact with a local Redpanda process",
+        "usage": "Usage:\r\n  rpk redpanda [flags]\r\n  rpk redpanda [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for redpanda."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin": {
+        "description": "Talk to the Redpanda admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin [flags]\r\n  rpk redpanda admin [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for admin."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin brokers": {
+        "description": "View and configure Redpanda brokers through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers [flags]\r\n  rpk redpanda admin brokers [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for brokers."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin brokers decommission": {
+        "description": "Decommission the given broker.\r\n\r\nDecommissioning a broker removes it from the cluster.\r\n\r\nA decommission request is sent to every broker in the cluster, only the cluster\r\nleader handles the request.\r\n\r\nFor safety on v22.x clusters, this command will not run if the requested \r\nbroker is in maintenance mode. As of v23.x, Redpanda supports \r\ndecommissioning a node that is currently in maintenance mode. If you are on \r\na v22.x cluster and need to bypass the maintenance mode check (perhaps your \r\ncluster is unreachable), use the hidden --force flag.",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers decommission [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for decommission."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin brokers decommission-status": {
+        "description": "Show the progrss of a node decommissioning.\r\n\r\nWhen a node is being decommissioned, this command reports the decommissioning\r\nprogress as follows, where PARTITION-SIZE is in bytes. Using -H, it prints the\r\npartition size in a human-readable format.\r\n\r\n$ rpk redpanda admin brokers decommission-status 4\r\nDECOMMISSION PROGRESS\r\n=====================\r\nNAMESPACE-TOPIC              PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE\r\nkafka/test                   0          3          9             1699470920\r\nkafka/test                   4          3          0             1614258779\r\nkafka/test2                  3          3          3             2722706514\r\nkafka/test2                  4          3          4             2945518089\r\nkafka_internal/id_allocator  0          3          0             3562\r\n\r\nUsing --detailed / -d, it additionally prints granular reports.\r\n\r\n$ rpk redpanda admin brokers decommission-status 4 -d\r\nDECOMMISSION PROGRESS\r\n=====================\r\nNAMESPACE-TOPIC  PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE  BYTES-MOVED  BYTES-REMAINING\r\nkafka/test       0          3          13            1731773243      228114727    1503658516\r\nkafka/test       4          3          1             1645952961      18752660     1627200301\r\nkafka/test2      3          3          5             2752632301      140975805    2611656496\r\nkafka/test2      4          3          6             2975443783      181581219    2793862564\r\n\r\nIf a partition cannot be moved with some reason, the command reports the\r\nproblematic partition in the 'ALLOCATION FAILURES' section and decommission\r\nnever succeeds. Typical scenarios the failure occurs are; there's no node\r\nthat has enough space to allocate a partition or that can satisfy rack\r\nconstraints, etc.\r\n\r\nALLOCATION FAILURES\r\n==================\r\nkafka/foo/2\r\nkafka/test/0\r\n\r\nNote that the command reports allocation failed partitions only when\r\n'partition_autobalancing_mode' is set to 'continuous'. See the current value\r\nusing 'rpk cluster config get partition_autobalancing_mode'.",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers decommission-status [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-d, --detailed": {
+                "type": "-",
+                "description": "Print how much data moved and remaining in bytes."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for decommission-status."
+            },
+            "-H, --human-readable": {
+                "type": "-",
+                "description": "Print the partition size in a human-readable form."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin brokers list": {
+        "description": "List the brokers in your cluster",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin brokers recommission": {
+        "description": "Recommission the given broker if is is still decommissioning.\r\n\r\nRecommissioning can stop an active decommission.\r\n\r\nOnce a broker is decommissioned, it cannot be recommissioned through this\r\ncommand.\r\n\r\nA recommission request is sent to every broker in the cluster, only\r\nthe cluster leader handles the request.",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers recommission [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for recommission."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin config": {
+        "description": "View or modify Redpanda configuration through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin config [flags]\r\n  rpk redpanda admin config [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin config log-level": {
+        "description": "Manage a broker's log level",
+        "usage": "Usage:\r\n  rpk redpanda admin config log-level [flags]\r\n  rpk redpanda admin config log-level [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for log-level."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin config log-level set": {
+        "description": "Set broker logger's log level.\r\n\r\nThis command temporarily changes a broker logger's log level. Each Redpanda\r\nbroker has many loggers, and each can be individually changed. Any change\r\nto a logger persists for a limited amount of time, so as to ensure you do\r\nnot accidentally enable debug logging permanently.\r\n\r\nIt is optional to specify a logger; if you do not, this command will prompt\r\nfrom the set of available loggers.\r\n\r\nThe special logger \"all\" enables all loggers. Alternatively, you can specify\r\nmany loggers at once. To see all possible loggers, run the following command:\r\n\r\n  redpanda --help-loggers\r\n\r\nThis command accepts loggers that it does not know of to ensure you can\r\nindependently update your redpanda installations from rpk. The success or\r\nfailure of enabling each logger is individually printed.",
+        "usage": "Usage:\r\n  rpk redpanda admin config log-level set [LOGGERS...] [flags]\r\n\r",
+        "flags": {
+            "-e, --expiry-seconds": {
+                "type": "int",
+                "description": "seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown) (default 300)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--host": {
+                "type": "string",
+                "description": "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to."
+            },
+            "-l, --level": {
+                "type": "string",
+                "description": "log level to set (error, warn, info, debug, trace) (default \"debug\")."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin config print": {
+        "description": "Display the current Redpanda configuration",
+        "usage": "Usage:\r\n  rpk redpanda admin config print [flags]\r\n\r\nAliases:\r\n  print, dump, list, ls, display\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for print."
+            },
+            "--host": {
+                "type": "string",
+                "description": "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin partitions": {
+        "description": "View and configure Redpanda partitions through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin partitions [flags]\r\n  rpk redpanda admin partitions [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for partitions."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin partitions list": {
+        "description": "List the partitions in a broker in the cluster",
+        "usage": "Usage:\r\n  rpk redpanda admin partitions list [BROKER ID] [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-l, --leader-only": {
+                "type": "-",
+                "description": "print the partitions on broker which are leaders."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda check": {
+        "description": "Check if system meets redpanda requirements",
+        "usage": "Usage:\r\n  rpk redpanda check [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for check."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum amount of time to wait for the checks and tune process to complete (e.g. 300ms, 1.5s, 2h45m) (default 2s)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda config": {
+        "description": "Edit configuration",
+        "usage": "Usage:\r\n  rpk redpanda config [flags]\r\n  rpk redpanda config [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda config bootstrap": {
+        "description": "Initialize the configuration to bootstrap a cluster.\r\n\r\nThis command generates a redpanda.yaml configuration file to bootstrap a\r\ncluster. If you are modifying the configuration file further, it is recommended\r\nto first bootstrap and then modify. If the file already exists, this command\r\nwill set fields as requested by flags, and this may undo some of your earlier\r\nedits.\r\n\r\nThe --ips flag specifies seed servers (ips, ip:ports, or hostnames) that this\r\nbroker will use to form a cluster.\r\n\r\nBy default, redpanda expects your machine to have one private IP address, and\r\nredpanda will listen on it. If your machine has multiple private IP addresses,\r\nyou must use the --self flag to specify which ip redpanda should listen on.",
+        "usage": "Usage:\r\n  rpk redpanda config bootstrap [--self <ip>] [--ips <ip1,ip2,...>] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for bootstrap."
+            },
+            "--ips": {
+                "type": "strings",
+                "description": "Comma-separated list of the seed node addresses or hostnames; at least three are recommended."
+            },
+            "--self": {
+                "type": "string",
+                "description": "Optional IP address for redpanda to listen on; if empty, defaults to a private address."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda config init": {
+        "description": "This command has been deprecated.",
+        "usage": "Usage:\r\n  rpk redpanda config init [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for init."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda config set": {
+        "description": "Set configuration values, such as the redpanda node ID or the list of seed servers\r\n\r\nThis command modifies the redpanda.yaml you have locally on disk. The first\r\nargument is the key within the yaml representing a property / field that you\r\nwould like to set. Nested fields can be accessed through a dot:\r\n\r\n  rpk redpanda config set redpanda.developer_mode true\r\n\r\nAll values are parsed as yaml and, since yaml is a superset of json, you can\r\nalso format your input as json. Individual specific fields or full structs can\r\nbe set:\r\n\r\n  rpk redpanda config set rpk.tune_disk_irq true\r\n  rpk redpanda config set redpanda.rpc_server '{address: 3.250.158.1, port: 9092}'\r\n\r\nYou can set an entire array by wrapping all items with braces, or by using one\r\nstruct:\r\n\r\n  rpk redpanda config set redpanda.advertised_kafka_api '[{address: 0.0.0.0, port: 9092}]'\r\n  rpk redpanda config set redpanda.advertised_kafka_api '{address: 0.0.0.0, port: 9092}' # same\r\n\r\nIndexing can be used to set specific items in an array. You can index one past\r\nthe end of an array to extend it:\r\n\r\n  rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 0.0.0.0, port: 9092}'",
+        "usage": "Usage:\r\n  rpk redpanda config set [KEY] [VALUE] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda mode": {
+        "description": "Enable a default configuration mode",
+        "usage": "Usage:\r\n  rpk redpanda mode [MODE] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for mode."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda start": {
+        "description": "Start redpanda",
+        "usage": "Usage:\r\n  rpk redpanda start [flags]\r\n\r",
+        "flags": {
+            "--advertise-kafka-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Kafka addresses to advertise (scheme://host:port|name)."
+            },
+            "--advertise-pandaproxy-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Pandaproxy addresses to advertise (scheme://host:port|name)."
+            },
+            "--advertise-rpc-addr": {
+                "type": "string",
+                "description": "The advertised RPC address (host:port)."
+            },
+            "--check": {
+                "type": "-",
+                "description": "When set to false will disable system checking before starting redpanda (default true)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--install-dir": {
+                "type": "string",
+                "description": "Directory where redpanda has been installed."
+            },
+            "--kafka-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Kafka listener addresses to bind to (scheme://host:port|name)."
+            },
+            "--mode": {
+                "type": "string",
+                "description": "Mode sets well-known configuration properties for development or test environments; use --mode help for more info."
+            },
+            "--pandaproxy-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Pandaproxy listener addresses to bind to (scheme://host:port|name)."
+            },
+            "--rpc-addr": {
+                "type": "string",
+                "description": "The RPC address to bind to (host:port)."
+            },
+            "--schema-registry-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Schema Registry listener addresses to bind to (scheme://host:port|name)."
+            },
+            "-s, --seeds": {
+                "type": "strings",
+                "description": "A comma-separated list of seed nodes to connect to (scheme://host:port|name)."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time to wait for the checks and tune processes to complete (e.g. 300ms, 1.5s, 2h45m) (default 10s)."
+            },
+            "--tune": {
+                "type": "-",
+                "description": "When present will enable tuning before starting redpanda."
+            },
+            "--well-known-io": {
+                "type": "string",
+                "description": "The cloud vendor and VM type, in the format <vendor>:<vm type>:<storage type>."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda stop": {
+        "description": "Stop a local redpanda process. 'rpk stop'\r\nfirst sends SIGINT, and waits for the specified timeout. Then, if redpanda\r\nhasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still\r\nrunning.",
+        "usage": "Usage:\r\n  rpk redpanda stop [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum amount of time to wait for redpanda to stop after each signal is sent (e.g. 300ms, 1.5s, 2h45m) (default 5s)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda tune": {
+        "description": "Sets the OS parameters to tune system performance.\r\n\r\nAvailable tuners:\r\n\r\n  - all.\r\n  - disk_write_cache\r\n  - net\r\n  - clocksource\r\n  - transparent_hugepages\r\n  - disk_irq\r\n  - disk_scheduler\r\n  - aio_events\r\n  - swappiness\r\n  - coredump\r\n  - fstrim\r\n  - cpu\r\n  - ballast_file\r\n  - disk_nomerges\r\n\r\nTo learn more about a tuner, run 'rpk redpanda tune help <tuner name>'.",
+        "usage": "Usage:\r\n  rpk redpanda tune [list of elements to tune] [flags]\r\n  rpk redpanda tune [command]\r\n\r",
+        "flags": {
+            "--cpu-set": {
+                "type": "string",
+                "description": "Set of CPUs for tuners to use in cpuset(7) format; if not specified, tuners will use all available CPUs (default \"all\")."
+            },
+            "-r, --dirs": {
+                "type": "strings",
+                "description": "List of *data* directories or places to store data (e.g. /var/vectorized/redpanda/); usually your XFS filesystem on an NVMe SSD device."
+            },
+            "-d, --disks": {
+                "type": "strings",
+                "description": "Lists of devices to tune f.e. 'sda1'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for tune."
+            },
+            "-m, --mode": {
+                "type": "string",
+                "description": "Operation Mode: one of: [sq, sq_split, mq]."
+            },
+            "-n, --nic": {
+                "type": "strings",
+                "description": "Network Interface Controllers to tune."
+            },
+            "--output-script": {
+                "type": "string",
+                "description": "Generate a tuning file that can later be used to tune the system."
+            },
+            "--reboot-allowed": {
+                "type": "-",
+                "description": "Allow tuners to tune boot parameters and request system reboot."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time to wait for the tune processes to complete (e.g. 300ms, 1.5s, 2h45m) (default 10s)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda tune help": {
+        "description": "Display detailed information about the tuner",
+        "usage": "Usage:\r\n  rpk redpanda tune help [TUNER] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for help."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda tune list": {
+        "description": "List available redpanda tuners and check if they are enabled and \r\nsupported by your system\r\n\r\nTo enable a tuner it must be set in the redpanda.yaml configuration file\r\nunder rpk section, e.g:\r\n\r\n  rpk:\r\n      tune_cpu: true\r\n      tune_swappiness: true\r\n\r\nYou may use 'rpk redpanda config set' to enable or disable a tuner.",
+        "usage": "Usage:\r\n  rpk redpanda tune list [flags]\r\n\r",
+        "flags": {
+            "-r, --dirs": {
+                "type": "strings",
+                "description": "List of *data* directories or places to store data (e.g. /var/vectorized/redpanda/); usually your XFS filesystem on an NVMe SSD device."
+            },
+            "-d, --disks": {
+                "type": "strings",
+                "description": "Lists of devices to tune f.e. 'sda1'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-m, --mode": {
+                "type": "string",
+                "description": "Operation Mode: one of: [sq, sq_split, mq]."
+            },
+            "-n, --nic": {
+                "type": "strings",
+                "description": "Network Interface Controllers to tune."
+            },
+            "--reboot-allowed": {
+                "type": "-",
+                "description": "Allow tuners to tune boot parameters and request system reboot."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic": {
+        "description": "Create, delete, produce to and consume from Redpanda topics",
+        "usage": "Usage:\r\n  rpk topic [flags]\r\n  rpk topic [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for topic."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic add-partitions": {
+        "description": "Add partitions to existing topics.",
+        "usage": "Usage:\r\n  rpk topic add-partitions [TOPICS...] --num [#] [flags]\r\n\r",
+        "flags": {
+            "-f, --force": {
+                "type": "-",
+                "description": "Force change the partition count in internal topics, e.g. __consumer_offsets."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for add-partitions."
+            },
+            "-n, --num": {
+                "type": "int",
+                "description": "Number of partitions to add to each topic."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic alter-config": {
+        "description": "Set, delete, add, and remove key/value configs for a topic.\r\n\r\nThis command allows you to incrementally alter the configuration for multiple\r\ntopics at a time.\r\n\r\nIncremental altering supports four operations:\r\n\r\n  1) Setting a key=value pair\r\n  2) Deleting a key's value\r\n  3) Appending a new value to a list-of-values key\r\n  4) Subtracting (removing) an existing value from a list-of-values key\r\n\r\nThe --dry option will validate whether the requested configuration change is\r\nvalid, but does not apply it.",
+        "usage": "Usage:\r\n  rpk topic alter-config [TOPICS...] --set key=value --delete key2,key3 [flags]\r\n\r",
+        "flags": {
+            "--append": {
+                "type": "stringArray",
+                "description": "key=value; Value to append to a list-of-values key (repeatable)."
+            },
+            "-d, --delete": {
+                "type": "stringArray",
+                "description": "Key to delete (repeatable)."
+            },
+            "--dry": {
+                "type": "-",
+                "description": "Dry run: validate the alter request, but do not apply."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for alter-config."
+            },
+            "-s, --set": {
+                "type": "stringArray",
+                "description": "key=value; Pair to set (repeatable)."
+            },
+            "--subtract": {
+                "type": "stringArray",
+                "description": "key=value; Value to remove from list-of-values key (repeatable)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic consume": {
+        "description": "Consume records from topics.\r\n\r\nConsuming records reads from any amount of input topics, formats each record\r\naccording to --format, and prints them to STDOUT. The output formatter\r\nunderstands a wide variety of formats.\r\n\r\nThe default output format \"--format json\" is a special format that outputs each\r\nrecord as JSON. There may be more single-word-no-escapes formats added later.\r\nOutside of these special formats, formatting follows the rules described below.\r\n\r\nFormatting output is based on percent escapes and modifiers. Slashes can be\r\nused for common escapes:\r\n\r\n    \\t \\n \\r \\\\ \\xNN\r\n\r\nprints tabs, newlines, carriage returns, slashes, or hex encoded characters.p\r\n\r\nPercent encoding prints record fields, fetch partition fields, or extra values:\r\n\r\n    %t    topic\r\n    %T    topic length\r\n    %k    key\r\n    %K    key length\r\n    %v    value\r\n    %V    value length\r\n    %h    begin the header specification\r\n    %H    number of headers\r\n    %p    partition\r\n    %o    offset\r\n    %e    leader epoch\r\n    %d    timestamp (formatting described below)\r\n    %a    record attributes (formatting described below)\r\n    %x    producer id\r\n    %y    producer epoch\r\n\r\n    %[    partition log start offset\r\n    %|    partition last stable offset\r\n    %]    partition high watermark\r\n\r\n    %%    percent sign\r\n    %{    left brace\r\n    %}    right brace\r\n\r\n    %i    the number of records formatted\r\n\r\nMODIFIERS\r\n\r\nText and numbers can be formatted in many different ways, and the default\r\nformat can be changed within brace modifiers. %v prints a value, while %v{hex}\r\nprints the value hex encoded. %T prints the length of a topic in ascii, while\r\n%T{big8} prints the length of the topic as an eight byte big endian.\r\n\r\nAll modifiers go within braces following a percent-escape.\r\n\r\nNUMBERS\r\n\r\nFormatting number values can have the following modifiers:\r\n\r\n     ascii       print the number as ascii (default)\r\n\r\n     hex64       sixteen hex characters\r\n     hex32       eight hex characters\r\n     hex16       four hex characters\r\n     hex8        two hex characters\r\n     hex4        one hex character\r\n\r\n     big64       eight byte big endian number\r\n     big32       four byte big endian number\r\n     big16       two byte big endian number\r\n     big8        alias for byte\r\n\r\n     little64    eight byte little endian number\r\n     little32    four byte little endian number\r\n     little16    two byte little endian number\r\n     little8     alias for byte\r\n\r\n     byte        one byte number\r\n     bool        \"true\" if the number is non-zero, \"false\" if the number is zero\r\n\r\nAll numbers are truncated as necessary per the modifier. Printing %V{byte} for\r\na length 256 value will print a single null, whereas printing %V{big8} would\r\nprint the bytes 1 and 0.\r\n\r\nWhen writing number sizes, the size corresponds to the size of the raw values,\r\nnot the size of encoded values. \"%T% t{hex}\" for the topic \"foo\" will print\r\n\"3 666f6f\", not \"6 666f6f\".\r\n\r\nTIMESTAMPS\r\n\r\nBy default, the timestamp field is printed as a millisecond number value. In\r\naddition to the number modifiers above, timestamps can be printed with either\r\nGo formatting or strftime formatting:\r\n\r\n    %d{go[2006-01-02T15:04:05Z07:00]}\r\n    %d{strftime[%F]}\r\n\r\nAn arbitrary amount of brackets (or braces, or # symbols) can wrap your date\r\nformatting:\r\n\r\n    %d{strftime### [%F] ###}\r\n\r\nThe above will print \" [YYYY-MM-DD] \", while the surrounding three # on each\r\nside are used to wrap the formatting. Further details on Go time formatting can\r\nbe found at https://pkg.go.dev/time, while further details on strftime\r\nformatting can be read by checking \"man strftime\".\r\n\r\nATTRIBUTES\r\n\r\nEach record (or batch of records) has a set of possible attributes. Internally,\r\nthese are packed into bit flags. Printing an attribute requires first selecting\r\nwhich attribute you want to print, and then optionally specifying how you want\r\nit to be printed:\r\n\r\n     %a{compression}\r\n     %a{compression;number}\r\n     %a{compression;big64}\r\n     %a{compression;hex8}\r\n\r\nCompression is by default printed as text (\"none\", \"gzip\", ...). Compression\r\ncan be printed as a number with \";number\", where number is any number\r\nformatting option described above. No compression is 0, gzip is 1, etc.\r\n\r\n     %a{timestamp-type}\r\n     %a{timestamp-type;big64}\r\n\r\nThe record's timestamp type is printed as -1 for very old records (before\r\ntimestamps existed), 0 for client generated timestamps, and 1 for broker\r\ngenerated timestamps. Number formatting can be controlled with \";number\".\r\n\r\n     %a{transactional-bit}\r\n     %a{transactional-bit;bool}\r\n\r\nPrints 1 if the record a part of a transaction or 0 if it is not.\r\nNumber formatting can be controlled with \";number\".\r\n\r\n     %a{control-bit}\r\n     %a{control-bit;bool}\r\n\r\nPrints 1 if the record is a commit marker or 0 if it is not.\r\nNumber formatting can be controlled with \";number\".\r\n\r\nTEXT\r\n\r\nText fields without modifiers default to writing the raw bytes. Alternatively,\r\nthere are the following modifiers:\r\n\r\n    %t{hex}\r\n    %k{base64}\r\n    %v{base64raw}\r\n    %v{unpack[<bBhH>iIqQc.$]}\r\n\r\nThe hex modifier hex encodes the text, the base64 modifier base64 encodes the\r\ntext with standard encoding, and the base64raw modifier encodes the text with\r\nraw standard encoding. The unpack modifier has a further internal\r\nspecification, similar to timestamps above:\r\n\r\n    x    pad character (does not parse input)\r\n    <    switch what follows to little endian\r\n    >    switch what follows to big endian\r\n\r\n    b    signed byte\r\n    B    unsigned byte\r\n    h    int16  (\"half word\")\r\n    H    uint16 (\"half word\")\r\n    i    int32\r\n    I    uint32\r\n    q    int64  (\"quad word\")\r\n    Q    uint64 (\"quad word\")\r\n\r\n    c    any character\r\n    .    alias for c\r\n    s    consume the rest of the input as a string\r\n    $    match the end of the line (append error string if anything remains)\r\n\r\nUnpacking text can allow translating binary input into readable output. If a\r\nvalue is a big-endian uint32, %v will print the raw four bytes, while\r\n%v{unpack[>I]} will print the number in as ascii. If unpacking exhausts the\r\ninput before something is unpacked fully, an error message is appended to the\r\noutput.\r\n\r\nHEADERS\r\n\r\nHeaders are formatted with percent encoding inside of the modifier:\r\n\r\n    %h{ %k=%v{hex} }\r\n\r\nwill print all headers with a space before the key and after the value, an\r\nequals sign between the key and value, and with the value hex encoded. Header\r\nformatting actually just parses the internal format as a record format, so all\r\nof the above rules about %K, %V, text, and numbers apply.\r\n\r\nEXAMPLES\r\n\r\nA key and value, separated by a space and ending in newline:\r\n    -f '%k %v\\n'\r\nA key length as four big endian bytes, and the key as hex:\r\n    -f '%K{big32}%k{hex}'\r\nA little endian uint32 and a string unpacked from a value:\r\n    -f '%v{unpack[is$]}'\r\n\r\nOFFSETS\r\n\r\nThe --offset flag allows for specifying where to begin consuming, and\r\noptionally, where to stop consuming. The literal words \"start\" and \"end\"\r\nspecify consuming from the start and the end.\r\n\r\n    start     consume from the beginning\r\n    end       consume from the end\r\n    :end      consume until the current end\r\n    +oo       consume oo after the current start offset\r\n    -oo       consume oo before the current end offset\r\n    oo        consume after an exact offset\r\n    oo:       alias for oo\r\n    :oo       consume until an exact offset\r\n    o1:o2     consume from exact offset o1 until exact offset o2\r\n    @t        consume starting from a given timestamp\r\n    @t:       alias for @t\r\n    @:t       consume until a given timestamp\r\n    @t1:t2    consume from timestamp t1 until timestamp t2\r\n\r\nThere are a few options for timestamps, with each option being evaluated\r\nuntil one succeeds:\r\n\r\n    13 digits             parsed as a unix millisecond\r\n    9 digits              parsed as a unix second\r\n    YYYY-MM-DD            parsed as a day, UTC\r\n    YYYY-MM-DDTHH:MM:SSZ  parsed as RFC3339, UTC; fractional seconds optional (.MMM)\r\n    end                   for t2 in @t1:t2, the current end of the partition\r\n    -dur                  a negative duration from now or from a timestamp\r\n    dur                   a positive duration from now or from a timestamp\r\n\r\nDurations can be relative to the current time or relative to a timestamp.\r\nIf a duration is used for t1, that duration is relative to now.\r\nIf a duration is used for t2, if t1 is a timestamp, then t2 is relative to t1.\r\nIf a duration is used for t2, if t1 is a duration, then t2 is relative to now.\r\n\r\nDurations are parsed simply:\r\n\r\n    3ms    three milliseconds\r\n    10s    ten seconds\r\n    9m     nine minutes\r\n    1h     one hour\r\n    1m3ms  one minute and three milliseconds\r\n\r\nFor example,\r\n\r\n    -o @2022-02-14:1h   consume 1h of time on Valentine's Day 2022\r\n    -o @-48h:-24h       consume from 2 days ago to 1 day ago\r\n    -o @-1m:end         consume from 1m ago until now\r\n    -o @:-1hr           consume from the start until an hour ago",
+        "usage": "Usage:\r\n  rpk topic consume TOPICS... [flags]\r\n\r",
+        "flags": {
+            "-b, --balancer": {
+                "type": "string",
+                "description": "Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky) (default \"cooperative-sticky\")."
+            },
+            "--fetch-max-bytes": {
+                "type": "int32",
+                "description": "Maximum amount of bytes per fetch request per broker (default 1048576)."
+            },
+            "--fetch-max-wait": {
+                "type": "duration",
+                "description": "Maximum amount of time to wait when fetching from a broker before the broker replies (default 5s)."
+            },
+            "-f, --format": {
+                "type": "string",
+                "description": "Output format (see --help for details) (default \"json\")."
+            },
+            "-g, --group": {
+                "type": "string",
+                "description": "Group to use for consuming (incompatible with -p)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for consume."
+            },
+            "--meta-only": {
+                "type": "-",
+                "description": "Print all record info except the record value (for -f json)."
+            },
+            "-n, --num": {
+                "type": "int",
+                "description": "Quit after consuming this number of records (0 is unbounded)."
+            },
+            "-o, --offset": {
+                "type": "string",
+                "description": "Offset to consume from / to (start, end, 47, +2, -3) (default \"start\")."
+            },
+            "-p, --partitions": {
+                "type": "int32",
+                "description": "int32Slice     Comma delimited list of specific partitions to consume (default [])."
+            },
+            "--pretty-print": {
+                "type": "-",
+                "description": "Pretty print each record over multiple lines (for -f json) (default true)."
+            },
+            "--print-control-records": {
+                "type": "-",
+                "description": "Opt in to printing control records."
+            },
+            "--rack": {
+                "type": "string",
+                "description": "Rack to use for consuming, which opts into follower fetching."
+            },
+            "--read-committed": {
+                "type": "-",
+                "description": "Opt in to reading only committed offsets."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; consume any topic that matches any expression."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic create": {
+        "description": "Create topics.\r\n\r\nAll topics created with this command will have the same number of partitions,\r\nreplication factor, and key/value configs.\r\n\r\nFor example,\r\n\r\n\tcreate -c cleanup.policy=compact -r 3 -p 20 foo bar\r\n\r\nwill create two topics, foo and bar, each with 20 partitions, 3 replicas, and\r\nthe cleanup.policy=compact config option set.",
+        "usage": "Usage:\r\n  rpk topic create [TOPICS...] [flags]\r\n\r",
+        "flags": {
+            "-d, --dry": {
+                "type": "-",
+                "description": "Dry run: validate the topic creation request; do not create topics."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "-p, --partitions": {
+                "type": "int32",
+                "description": "Number of partitions to create per topic; -1 defaults to the cluster's default_topic_partitions (default -1)."
+            },
+            "-r, --replicas": {
+                "type": "int16",
+                "description": "Replication factor (must be odd); -1 defaults to the cluster's default_topic_replications (default -1)."
+            },
+            "-c, --topic-config": {
+                "type": "stringArray",
+                "description": "key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic delete": {
+        "description": "Delete topics.\r\n\r\nThis command deletes all requested topics, printing the success or fail status\r\nper topic.\r\n\r\nThe --regex flag (-r) opts into parsing the input topics as regular expressions\r\nand deleting any non-internal topic that matches any of expressions. The input\r\nexpressions are wrapped with ^ and $ so that the expression must match the\r\nwhole topic name (which also prevents accidental delete-everything mistakes).\r\n\r\nThe topic list command accepts the same input regex format as this delete\r\ncommand. If you want to check what your regular expressions will delete before\r\nactually deleting them, you can check the output of 'rpk topic list -r'.\r\n\r\nFor example,\r\n\r\n    delete foo bar            # deletes topics foo and bar\r\n    delete -r '^f.*' '.*r$'   # deletes any topic starting with f and any topics ending in r\r\n    delete -r '.*'            # deletes all topics\r\n    delete -r .               # deletes any one-character topics",
+        "usage": "Usage:\r\n  rpk topic delete [TOPICS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; delete any topic that matches any input topic expression."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic describe": {
+        "description": "Describe a topic.\r\n\r\nThis command prints detailed information about a topic. There are three\r\npotential sections: a summary of the topic, the topic configs, and a detailed\r\npartitions section. By default, the summary and configs sections are printed.",
+        "usage": "Usage:\r\n  rpk topic describe [TOPIC] [flags]\r\n\r\nAliases:\r\n  describe, info\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "-a, --print-all": {
+                "type": "-",
+                "description": "Print all sections."
+            },
+            "-c, --print-configs": {
+                "type": "-",
+                "description": "Print the config section."
+            },
+            "-p, --print-partitions": {
+                "type": "-",
+                "description": "Print the detailed partitions section."
+            },
+            "-s, --print-summary": {
+                "type": "-",
+                "description": "Print the summary section."
+            },
+            "--stable": {
+                "type": "-",
+                "description": "Include the stable offsets column in the partitions section; only relevant if you produce to this topic transactionally."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic describe-storage": {
+        "description": "Describe the topic storage status.\r\n\r\nThis commands prints detailed information about the cloud storage status of a\r\ngiven topic, the information is divided in 4 sections:\r\n\r\nSUMMARY\r\n\r\nThe summary section contains general information about the topic, the cloud\r\nstorage mode (one of disabled, write_only, read_only, full, and read_replica),\r\nand the delta in milliseconds since the last upload of either the partition\r\nmanifest or a segment.\r\n\r\nOFFSET\r\n\r\nThe offset section contains the start and last offsets (inclusive) per\r\npartition of data available in both the cloud and on local disk.\r\n\r\nSIZE\r\n\r\nThe size section contains the total bytes per partition in the cloud and on\r\nlocal disk, the total size of the log of each partition (excluding cloud and\r\nlocal overlap), and the number of segments in the cloud and on local disk. The\r\ncloud segment count does not include segments queued for deletion.\r\n\r\nSYNC\r\n\r\nThe sync section contains the state of cloud synchronization: milliseconds\r\nsince the last upload of the partition manifest, milliseconds since the last\r\nsegment upload, milliseconds since the last manifest sync (for read replicas),\r\nand whether the remote metadata has a pending update to include all uploaded\r\nsegments.",
+        "usage": "Usage:\r\n  rpk topic describe-storage [TOPIC] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe-storage."
+            },
+            "-H, --human-readable": {
+                "type": "-",
+                "description": "Print the times and bytes in a human-readable form."
+            },
+            "-a, --print-all": {
+                "type": "-",
+                "description": "Print all cloud storage status."
+            },
+            "-o, --print-offset": {
+                "type": "-",
+                "description": "Print the offset section."
+            },
+            "-z, --print-size": {
+                "type": "-",
+                "description": "Print the log size section."
+            },
+            "-s, --print-summary": {
+                "type": "-",
+                "description": "Print the summary section."
+            },
+            "-y, --print-sync": {
+                "type": "-",
+                "description": "Print the sync section."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic list": {
+        "description": "List topics, optionally listing specific topics.\r\n\r\nThis command lists all topics that you have access to by default. If specifying\r\ntopics or regular expressions, this command can be used to know exactly what\r\ntopics you would delete if using the same input to the delete command.\r\n\r\nAlternatively, you can request specific topics to list, which can be used to\r\ncheck authentication errors (do you not have access to a topic you were\r\nexpecting to see?), or to list all topics that match regular expressions.\r\n\r\nThe --regex flag (-r) opts into parsing the input topics as regular expressions\r\nand listing any non-internal topic that matches any of expressions. The input\r\nexpressions are wrapped with ^ and $ so that the expression must match the\r\nwhole topic name. Regular expressions cannot be used to match internal topics,\r\nas such, specifying both -i and -r will exit with failure.\r\n\r\nLastly, --detailed flag (-d) opts in to printing extra per-partition\r\ninformation.",
+        "usage": "Usage:\r\n  rpk topic list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-d, --detailed": {
+                "type": "-",
+                "description": "Print per-partition information for topics."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-i, --internal": {
+                "type": "-",
+                "description": "Print internal topics."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; list any topic that matches any input topic expression."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic produce": {
+        "description": "Produce records to a topic.\r\n\r\nProducing records reads from STDIN, parses input according to --format, and\r\nproduce records to Redpanda. The input formatter understands a wide variety of\r\nformats.\r\n\r\nParsing input operates on either sizes or on delimiters, both of which can be\r\nspecified in the same formatting options. If using sizes to specify something,\r\nthe size must come before what it is specifying. Delimiters match on an exact\r\ntext basis. This command will quit with an error if any input fails to match\r\nyour specified format.\r\n\r\nSlashes can be used for common escapes:\r\n\r\n    \\t \\n \\r \\\\ \\xNN\r\n\r\nmatches tabs, newlines, carriage returns, slashes, and hex encoded characters.\r\n\r\nPercent encoding reads into specific values of a record:\r\n\r\n    %t    topic\r\n    %T    topic length\r\n    %k    key\r\n    %K    key length\r\n    %v    value\r\n    %V    value length\r\n    %h    begin the header specification\r\n    %H    number of headers\r\n    %p    partition (if using the --partition flag)\r\n\r\nThree escapes exist to parse characters that are used to modify the previous\r\nescapes:\r\n\r\n    %%    percent sign\r\n    %{    left brace\r\n    %}    right brace\r\n\r\nMODIFIERS\r\n\r\nText and numbers can be read in multiple formats, and the default format can be\r\nchanged within brace modifiers. %v reads a value, while %v{hex} reads a value\r\nand then hex decodes it before producing. %T reads the length of a topic from\r\nthe input, while %T{3} reads exactly three bytes for a topic from the input.\r\n\r\nAll modifiers go within braces following a percent-escape.\r\n\r\nNUMBERS\r\n\r\nReading number values can have the following modifiers:\r\n\r\n     ascii       parse numeric digits until a non-numeric (default)\r\n\r\n     hex64       sixteen hex characters\r\n     hex32       eight hex characters\r\n     hex16       four hex characters\r\n     hex8        two hex characters\r\n     hex4        one hex character\r\n\r\n     big64       eight byte big endian number\r\n     big32       four byte big endian number\r\n     big16       two byte big endian number\r\n     big8        alias for byte\r\n\r\n     little64    eight byte little endian number\r\n     little32    four byte little endian number\r\n     little16    two byte little endian number\r\n     little8     alias for byte\r\n\r\n     byte        one byte number\r\n     <digits>    directly specify the length as this many digits\r\n     bool        read \"true\" as 1, \"false\" as 0\r\n\r\nWhen reading number sizes, the size corresponds to the size of the encoded\r\nvalues, not the decoded values. \"%T{6}%t{hex}\" will read six hex bytes and\r\ndecode into three.\r\n\r\nTEXT\r\n\r\nReading text values can have the following modifiers:\r\n\r\n    hex       read text then hex decode it\r\n    base64    read text then std-encoding base64 decode it\r\n    re        read text matching a regular expression\r\n\r\nHEADERS\r\n\r\nHeaders are parsed with an internal key / value specifier format. For example,\r\nthe following will read three headers that begin and end with a space and are\r\nseparated by an equal:\r\n\r\n    %H{3}%h{ %k=%v }\r\n\r\nEXAMPLES\r\n\r\nIn the below examples, we can parse many records at once. The produce command\r\nreads input and tokenizes based on your specified format. Every time the format\r\nis completely matched, a record is produced and parsing begins anew.\r\n\r\nA key and value, separated by a space and ending in newline:\r\n    -f '%k %v\\n'\r\nA four byte topic, four byte key, and four byte value:\r\n    -f '%T{4}%K{4}%V{4}%t%k%v'\r\nA value to a specific partition, if using a non-negative --partition flag:\r\n    -f '%p %v\\n'\r\nA big-endian uint16 key size, the text \" foo \", and then that key:\r\n    -f '%K{big16} foo %k'\r\nA value that can be two or three characters followed by a newline:\r\n    -f '%v{re#...?#}\\n'\r\n\r\nMISC\r\n\r\nProducing requires a topic to produce to. The topic can be specified either\r\ndirectly on as an argument, or in the input text through %t. A parsed topic\r\ntakes precedence over the default passed in topic. If no topic is specified\r\ndirectly and no topic is parsed, this command will quit with an error.\r\n\r\nThe input format can parse partitions to produce directly to with %p. Doing so\r\nrequires specifying a non-negative --partition flag. Any parsed partition\r\ntakes precedence over the --partition flag; specifying the flag is the main\r\nrequirement for being able to directly control which partition to produce to.\r\n\r\nYou can also specify an output format to write when a record is produced\r\nsuccessfully. The output format follows the same formatting rules as the topic\r\nconsume command. See that command's help text for a detailed description.",
+        "usage": "Usage:\r\n  rpk topic produce [TOPIC] [flags]\r\n\r",
+        "flags": {
+            "--acks": {
+                "type": "int",
+                "description": "Number of acks required for producing (-1=all, 0=none, 1=leader) (default -1)."
+            },
+            "--allow-auto-topic-creation": {
+                "type": "-",
+                "description": "Auto-create non-existent topics; requires auto_create_topics_enabled on the broker."
+            },
+            "-z, --compression": {
+                "type": "string",
+                "description": "Compression to use for producing batches (none, gzip, snappy, lz4, zstd) (default \"snappy\")."
+            },
+            "--delivery-timeout": {
+                "type": "duration",
+                "description": "Per-record delivery timeout, if non-zero, min 1s."
+            },
+            "-f, --format": {
+                "type": "string",
+                "description": "Input record format (default \"%v\\n\")."
+            },
+            "-H, --header": {
+                "type": "stringArray",
+                "description": "Headers in format key:value to add to each record (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for produce."
+            },
+            "-k, --key": {
+                "type": "string",
+                "description": "A fixed key to use for each record (parsed input keys take precedence)."
+            },
+            "--max-message-bytes": {
+                "type": "int32",
+                "description": "If non-negative, maximum size of a record batch before compression (default -1)."
+            },
+            "-o, --output-format": {
+                "type": "string",
+                "description": "what to write to stdout when a record is successfully produced (default \"Produced to partition %p at offset %o with timestamp %d.\\n\")."
+            },
+            "-p, --partition": {
+                "type": "int32",
+                "description": "Partition to directly produce to, if non-negative (also allows %p parsing to set partitions) (default -1)."
+            },
+            "-Z, --tombstone": {
+                "type": "-",
+                "description": "Produce empty values as tombstones."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic trim-prefix": {
+        "description": "Trim records from topics\r\n\r\nThis command allows you to trim records from topics, to trim the topics Redpanda\r\nsets the LogStartOffset for partitions to the requested offset. All segments\r\nwhose base offset is less then the requested offset are deleted, and any records\r\nwithin the segment before the requested offset can no longer be read.\r\n\r\nThe --offset/-o flag allows you to indicate which index you want to set the\r\npartition's low watermark (start offset) to. It can be a single integer value\r\ndenoting the offset or a timestamp if you prefix the offset with an '@'. You may\r\nselect which partition you want to trim the offset from with the --partition/-p\r\nflag.\r\n\r\nThe --from-file option allows to trim the offsets specified in a text file with\r\nthe following format:\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    ...\r\nor the equivalent keyed JSON/YAML file.\r\n\r\nEXAMPLES\r\n\r\nTrim records in 'foo' topic to offset 120 in partition 1\r\n    rpk topic trim-prefix foo --offset 120 --partition 1\r\n\r\nTrim records in all partitions of topic foo previous to an specific timestamp\r\n    rpk topic trim-prefix foo -o \"@1622505600\"\r\n\r\nTrim records from a JSON file\r\n    rpk topic trim-prefix --from-file /tmp/to_trim.json",
+        "usage": "Usage:\r\n  rpk topic trim-prefix [TOPIC] [flags]\r\n\r\nAliases:\r\n  trim-prefix, trim\r\n\r",
+        "flags": {
+            "-f, --from-file": {
+                "type": "string",
+                "description": "File of topic/partition/offset for which to trim offsets for."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for trim-prefix."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "-o, --offset": {
+                "type": "string",
+                "description": "Offset to set the partition's start offset to (end, 47, @<timestamp>)."
+            },
+            "-p, --partitions": {
+                "type": "int32",
+                "description": "int32Slice   Comma-separated list of partitions to trim records from (default to all) (default [])."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk version": {
+        "description": "Check the current version",
+        "usage": "Usage:\r\n  rpk version [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for version."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk_version": "v23.2.17 (rev ae9a71b913)\r"
+}

--- a/tools/gen/23.2/rpk-acl-create.adoc
+++ b/tools/gen/23.2/rpk-acl-create.adoc
@@ -1,0 +1,64 @@
+= rpk acl create
+:description: rpk acl create
+
+Create ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. Following the
+multiplying effect of combining flags, the create command works on a
+straightforward basis: every ACL combination is a created ACL.
+
+As mentioned in the 'rpk acl' help text, if no host is specified, an allowed
+principal is allowed access from all hosts. The wildcard principal '*' allows
+all principals. At least one principal, one host, one resource, and one
+operation is required to create a single ACL.
+
+Allow all permissions to user bar on topic "foo" and group "g":
+    --allow-principal bar --operation all --topic foo --group g
+Allow read permissions to all users on topics biz and baz:
+    --allow-principal '*' --operation read --topic biz,baz
+Allow write permissions to user buzz to transactional id "txn":
+    --allow-principal User:buzz --operation write --transactional-id txn
+
+== Usage
+
+[,bash]
+----
+rpk acl create [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Hosts from which access will be granted (repeatable).
+
+|`--allow-principal` |strings |Principals for which these permissions will be granted (repeatable).
+
+|`--cluster` |- |Whether to grant ACLs to the cluster.
+
+|`--deny-host` |strings |Hosts from from access will be denied (repeatable).
+
+|`--deny-principal` |strings |Principal for which these permissions will be denied (repeatable).
+
+|`--group` |strings |Group to grant ACLs for (repeatable).
+
+|`-h, --help` |- |Help for create.
+
+|`--operation` |strings |Operation to grant (repeatable).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (literal or prefixed) (default "literal").
+
+|`--topic` |strings |Topic to grant ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to grant ACLs for (repeatable).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-acl-delete.adoc
+++ b/tools/gen/23.2/rpk-acl-delete.adoc
@@ -1,0 +1,74 @@
+= rpk acl delete
+:description: rpk acl delete
+
+Delete ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. Delete flags work in a
+similar multiplying effect as creating ACLs, but delete is more advanced:
+deletion works on a filter basis. Any unspecified flag defaults to matching
+everything (all operations, or all allowed principals, etc). To ensure that you
+do not accidentally delete more than you intend, this command prints everything
+that matches your input filters and prompts for a confirmation before the
+delete request is issued. Anything matching more than 10 ACLs doubly confirms.
+
+As mentioned, not specifying flags matches everything. If no resources are
+specified, all resources are matched. If no operations are specified, all
+operations are matched. You can also opt in to matching everything with "any":
+--operation any matches any operation.
+
+The --resource-pattern-type, defaulting to "any", configures how to filter
+resource names:
+  * "any" returns exact name matches of either prefixed or literal pattern type
+  * "match" returns wildcard matches, prefix patterns that match your input, and literal matches
+  * "prefix" returns prefix patterns that match your input (prefix "fo" matches "foo")
+  * "literal" returns exact name matches
+
+== Usage
+
+[,bash]
+----
+rpk acl delete [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Allowed host ACLs to remove (repeatable).
+
+|`--allow-principal` |strings |Allowed principal ACLs to remove (repeatable).
+
+|`--cluster` |- |Whether to remove ACLs to the cluster.
+
+|`--deny-host` |strings |Denied host ACLs to remove (repeatable).
+
+|`--deny-principal` |strings |Denied principal ACLs to remove (repeatable).
+
+|`-d, --dry` |- |Dry run: validate what would be deleted.
+
+|`--group` |strings |Group to remove ACLs for (repeatable).
+
+|`-h, --help` |- |Help for delete.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`--operation` |strings |Operation to remove (repeatable).
+
+|`-f, --print-filters` |- |Print the filters that were requested (failed filters are always printed).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (any, match, literal, or prefixed) (default "any").
+
+|`--topic` |strings |Topic to remove ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to remove ACLs for (repeatable).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-acl-list.adoc
+++ b/tools/gen/23.2/rpk-acl-list.adoc
@@ -1,0 +1,74 @@
+= rpk acl list
+:description: rpk acl list
+
+List ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. List flags work in a
+similar multiplying effect as creating ACLs, but list is more advanced:
+listing works on a filter basis. Any unspecified flag defaults to matching
+everything (all operations, or all allowed principals, etc).
+
+As mentioned, not specifying flags matches everything. If no resources are
+specified, all resources are matched. If no operations are specified, all
+operations are matched. You can also opt in to matching everything with "any":
+--operation any matches any operation.
+
+The --resource-pattern-type, defaulting to "any", configures how to filter
+resource names:
+  * "any" returns exact name matches of either prefixed or literal pattern type
+  * "match" returns wildcard matches, prefix patterns that match your input, and literal matches
+  * "prefix" returns prefix patterns that match your input (prefix "fo" matches "foo")
+  * "literal" returns exact name matches
+
+== Usage
+
+[,bash]
+----
+rpk acl list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls, describe
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Allowed host ACLs to match (repeatable).
+
+|`--allow-principal` |strings |Allowed principal ACLs to match (repeatable).
+
+|`--cluster` |- |Whether to match ACLs to the cluster.
+
+|`--deny-host` |strings |Denied host ACLs to match (repeatable).
+
+|`--deny-principal` |strings |Denied principal ACLs to match (repeatable).
+
+|`--group` |strings |Group to match ACLs for (repeatable).
+
+|`-h, --help` |- |Help for list.
+
+|`--operation` |strings |Operation to match (repeatable).
+
+|`-f, --print-filters` |- |Print the filters that were requested (failed filters are always printed).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (any, match, literal, or prefixed) (default "any").
+
+|`--topic` |strings |Topic to match ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to match ACLs for (repeatable).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-acl-user-create.adoc
+++ b/tools/gen/23.2/rpk-acl-user-create.adoc
@@ -1,0 +1,45 @@
+= rpk acl user create
+:description: rpk acl user create
+
+Create a SASL user.
+
+This command creates a single SASL user with the given password, optionally
+with a custom "mechanism". SASL consists of three parts: a username, a
+password, and a mechanism. The mechanism determines which authentication flow
+the client will use for this user/pass.
+
+Redpanda currently supports two mechanisms: SCRAM-SHA-256, the default, and
+SCRAM-SHA-512, which is the same flow but uses sha512 rather than sha256.
+
+Using SASL requires setting "enable_sasl: true" in the redpanda section of your
+`redpanda.yaml`. Before a created SASL account can be used, you must also create
+ACLs to grant the account access to certain resources in your cluster. See the
+acl help text for more info.
+
+== Usage
+
+[,bash]
+----
+rpk acl user create [USER] -p [PASS] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for create.
+
+|`--mechanism` |string |SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive) (default "scram-sha-256").
+
+|`--password` |string |New user's password (NOTE: if using --password for the admin API, use --new-password).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-acl-user-delete.adoc
+++ b/tools/gen/23.2/rpk-acl-user-delete.adoc
@@ -1,0 +1,31 @@
+= rpk acl user delete
+:description: rpk acl user delete
+
+Delete a SASL user.
+
+This command deletes the specified SASL account from Redpanda. This does not
+delete any ACLs that may exist for this user.
+
+== Usage
+
+[,bash]
+----
+rpk acl user delete [USER] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-acl-user-list.adoc
+++ b/tools/gen/23.2/rpk-acl-user-list.adoc
@@ -1,0 +1,35 @@
+= rpk acl user list
+:description: rpk acl user list
+
+List SASL users
+
+== Usage
+
+[,bash]
+----
+rpk acl user list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-acl-user-update.adoc
+++ b/tools/gen/23.2/rpk-acl-user-update.adoc
@@ -1,0 +1,32 @@
+= rpk acl user update
+:description: rpk acl user update
+
+Update SASL user credentials
+
+== Usage
+
+[,bash]
+----
+rpk acl user update [USER] --new-password [PW] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for update.
+
+|`--mechanism` |string |SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive) (default "SCRAM-SHA-256").
+
+|`--new-password` |string |New user's password.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-acl-user.adoc
+++ b/tools/gen/23.2/rpk-acl-user.adoc
@@ -1,0 +1,35 @@
+= rpk acl user
+:description: rpk acl user
+
+Manage SASL users.
+
+If SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs
+control what your user has access to. See 'rpk acl --help' for more information
+about ACLs, and 'rpk acl user create --help' for more information about
+creating SASL users. Using SASL requires setting "enable_sasl: true" in the
+redpanda section of your `redpanda.yaml`.
+
+== Usage
+
+[,bash]
+----
+rpk acl user [flags]
+  rpk acl user [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for user.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-acl.adoc
+++ b/tools/gen/23.2/rpk-acl.adoc
@@ -1,0 +1,139 @@
+= rpk acl
+:description: rpk acl
+
+Manage ACLs and SASL users.
+
+This command space creates, lists, and deletes ACLs, as well as creates SASL
+users. The help text below is specific to ACLs. To learn about SASL users,
+check the help text under the "user" command.
+
+When using SASL, ACLs allow or deny you access to certain requests. The
+"create", "delete", and "list" commands help you manage your ACLs.
+
+An ACL is made up of five components:
+
+  * a principal (the user)
+  * a host the principal is allowed or denied requests from
+  * what resource to access (topic name, group ID, ...)
+  * the operation (read, write, ...)
+  * the permission: whether to allow or deny the above
+
+ACL commands work on a multiplicative basis. If creating, specifying two
+principals and two permissions creates four ACLs: both permissions for the
+first principal, as well as both permissions for the second principal. Adding
+two resources further doubles the ACLs created.
+
+It is recommended to be as specific as possible when granting ACLs. Granting
+more ACLs than necessary per principal may inadvertently allow clients to do
+things they should not, such as deleting topics or joining the wrong consumer
+group.
+
+PRINCIPALS
+
+All ACLs require a principal. A principal is composed of two parts: the type
+and the name. Within Redpanda, only one type is supported, "User". The reason
+for the prefix is that a potential future authorizer may add support for
+authorizing by Group or anything else.
+
+When you create a user, you need to add ACLs for it before it can be used. You
+can create / delete / list ACLs for that user with either "User:bar" or "bar"
+in the --allow-principal and --deny-principal flags. This command will add the
+"User:" prefix for you if it is missing. The wildcard '*' matches any user.
+Creating an ACL with user '*' grants or denies the permission for all users.
+
+HOSTS
+
+Hosts can be seen as an extension of the principal, and effectively gate where
+the principal can connect from. When creating ACLs, unless otherwise specified,
+the default host is the wildcard '*' which allows or denies the principal from
+all hosts (where allow & deny are based on whether --allow-principal or
+--deny-principal is used). If specifying hosts, you must pair the --allow-host
+flag with the --allow-principal flag, and the --deny-host flag with the
+--deny-principal flag.
+
+RESOURCES
+
+A resource is what an ACL allows or denies access to. There are four resources
+within Redpanda: topics, groups, the cluster itself, and transactional IDs.
+Names for each of these resources can be specified with their respective flags.
+
+Resources combine with the operation that is allowed or denied on that
+resource. The next section describes which operations are required for which
+requests, and further fleshes out the concept of a resource.
+
+By default, resources are specified on an exact name match (a "literal" match).
+The --resource-pattern-type flag can be used to specify that a resource name is
+"prefixed", meaning to allow anything with the given prefix. A literal name of
+"foo" will match only the topic "foo", while the prefixed name of "foo-" will
+match both "foo-bar" and "foo-baz". The special wildcard resource name '*'
+matches any name of the given resource type (--topic '*' matches all topics).
+
+OPERATIONS
+
+Pairing with resources, operations are the actions that are allowed or denied.
+Redpanda has the following operations:
+
+    ALL                 Allows all operations below.
+    READ                Allows reading a given resource.
+    WRITE               Allows writing to a given resource.
+    CREATE              Allows creating a given resource.
+    DELETE              Allows deleting a given resource.
+    ALTER               Allows altering non-configurations.
+    DESCRIBE            Allows querying non-configurations.
+    DESCRIBE_CONFIGS    Allows describing configurations.
+    ALTER_CONFIGS       Allows altering configurations.
+
+Check --help-operations to see which operations are required for which
+requests. In flag form to set up a general producing/consuming client, you can
+invoke 'rpk acl create' three times with the following (including your
+--allow-principal):
+
+    --operation write,read,describe --topic [topics]
+    --operation describe,read --group [group.id]
+    --operation describe,write --transactional-id [transactional.id]
+
+PERMISSIONS
+
+A client can be allowed access or denied access. By default, all permissions
+are denied. You only need to specifically deny a permission if you allow a wide
+set of permissions and then want to deny a specific permission in that set.
+You could allow all operations, and then specifically deny writing to topics.
+
+MANAGEMENT
+
+Creating ACLs works on a specific ACL basis, but listing and deleting ACLs
+works on filters. Filters allow matching many ACLs to be printed listed and
+deleted at once. Because this can be risky for deleting, the delete command
+prompts for confirmation by default. More details and examples for creating,
+listing, and deleting can be seen in each of the commands.
+
+Using SASL requires setting "enable_sasl: true" in the redpanda section of your
+`redpanda.yaml`. User management is a separate, simpler concept that is
+described in the user command.
+
+== Usage
+
+[,bash]
+----
+rpk acl [flags]
+  rpk acl [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for acl.
+
+|`--help-operations` |- |Print more help about ACL operations.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-auth-create.adoc
+++ b/tools/gen/23.2/rpk-cloud-auth-create.adoc
@@ -1,0 +1,42 @@
+= rpk cloud auth create
+:description: rpk cloud auth create
+
+Create an rpk cloud auth.
+
+This command creates a new rpk cloud auth. The default SSO login does not need
+any additional auth values (the token is populated on login) so you can just
+create an empty auth. You can also use --set to set key=value pairs for client
+credentials.
+
+The --set flag supports autocompletion, suggesting the -X key format. If you
+begin writing a YAML path, the flag will suggest the rest of the path.
+
+rpk always switches the current cloud auth to the newly created auth.
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth create [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--description` |string |Optional description of the auth.
+
+|`-h, --help` |- |Help for create.
+
+|`-s, --set` |strings |A key=value pair to set in the cloud auth.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-auth-delete.adoc
+++ b/tools/gen/23.2/rpk-cloud-auth-delete.adoc
@@ -1,0 +1,32 @@
+= rpk cloud auth delete
+:description: rpk cloud auth delete
+
+Delete an rpk cloud auth.
+
+Deleting a cloud auth removes it from the rpk.yaml file. If the deleted
+auth was the current auth, rpk will use a default SSO auth the next time
+you try to login and, if the login is successful, will safe that auth.
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth delete [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-auth-edit.adoc
+++ b/tools/gen/23.2/rpk-cloud-auth-edit.adoc
@@ -1,0 +1,31 @@
+= rpk cloud auth edit
+:description: rpk cloud auth edit
+
+Edit an rpk auth.
+
+This command opens your default editor to edit the specified cloud auth, or the
+current cloud auth if no cloud auth is specified.
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth edit [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for edit.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-auth-list.adoc
+++ b/tools/gen/23.2/rpk-cloud-auth-list.adoc
@@ -1,0 +1,35 @@
+= rpk cloud auth list
+:description: rpk cloud auth list
+
+List rpk cloud auths
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-auth-rename-to.adoc
+++ b/tools/gen/23.2/rpk-cloud-auth-rename-to.adoc
@@ -1,0 +1,35 @@
+= rpk cloud auth rename-to
+:description: rpk cloud auth rename-to
+
+Rename the current rpk auth
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth rename-to [NAME] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+rename-to, rename
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for rename-to.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-auth-use.adoc
+++ b/tools/gen/23.2/rpk-cloud-auth-use.adoc
@@ -1,0 +1,28 @@
+= rpk cloud auth use
+:description: rpk cloud auth use
+
+Select the rpk cloud auth to use
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth use [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for use.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-auth.adoc
+++ b/tools/gen/23.2/rpk-cloud-auth.adoc
@@ -1,0 +1,36 @@
+= rpk cloud auth
+:description: rpk cloud auth
+
+Manage rpk cloud authentications.
+
+An rpk cloud authentication allows you to talk to Redpanda Cloud. Most likely,
+you will only ever need to use a single SSO based login and you will not need
+this command space. Multiple authentications can be useful if you have multiple
+Redpanda Cloud accounts for different organizations and want to swap between
+them, or if you use SSO as well as client credentials. It is recommended to
+only use a single SSO based login.
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth [flags]
+  rpk cloud auth [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for auth.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-byoc-install.adoc
+++ b/tools/gen/23.2/rpk-cloud-byoc-install.adoc
@@ -1,0 +1,34 @@
+= rpk cloud byoc install
+:description: rpk cloud byoc install
+
+Install the BYOC plugin
+
+This command downloads the BYOC managed plugin if necessary. The plugin is
+installed by default if you try to run a non-install command, but this command
+exists if you want to download the plugin ahead of time.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc install [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for install.
+
+|`--redpanda-id` |string |The redpanda ID of the cluster you are creating.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-byoc-uninstall.adoc
+++ b/tools/gen/23.2/rpk-cloud-byoc-uninstall.adoc
@@ -1,0 +1,33 @@
+= rpk cloud byoc uninstall
+:description: rpk cloud byoc uninstall
+
+Uninstall the BYOC plugin
+
+This command deletes your locally downloaded BYOC managed plugin if it exists.
+Often, you only need to download the plugin to create your cluster once, and
+then you never need the plugin again. You can uninstall to save a small bit of
+disk space.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc uninstall [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for uninstall.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-byoc.adoc
+++ b/tools/gen/23.2/rpk-cloud-byoc.adoc
@@ -1,0 +1,44 @@
+= rpk cloud byoc
+:description: rpk cloud byoc
+
+Manage a Redpanda cloud BYOC agent
+
+For BYOC, Redpanda installs an agent service in your owned cluster. The agent
+then proceeds to provision further infrastructure and eventually, a full
+Redpanda cluster.
+
+The BYOC command runs Terraform to create and start the agent. You first need
+a redpanda-id (or cluster ID); this is used to get the details of how your
+agent should be provisioned. You can create a BYOC cluster in our cloud UI
+and then come back to this command to complete the process.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc [flags]
+  rpk cloud byoc [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--client-id` |string |The client ID of the organization in Redpanda Cloud.
+
+|`--client-secret` |string |The client secret of the organization in Redpanda Cloud.
+
+|`-h, --help` |- |Help for byoc.
+
+|`--redpanda-id` |string |The redpanda ID of the cluster you are creating.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-login.adoc
+++ b/tools/gen/23.2/rpk-cloud-login.adoc
@@ -1,0 +1,76 @@
+= rpk cloud login
+:description: rpk cloud login
+
+Log in to the Redpanda cloud
+
+This command checks for an existing Redpanda Cloud API token and, if present, 
+ensures it is still valid. If no token is found or the token is no longer valid, 
+this command will login and save your token along with the client ID used to 
+request the token.
+
+You may use either SSO or client credentials to log in.
+
+SSO
+
+This will automatically launch your default web browser and prompt you to 
+authenticate via our Redpanda Cloud page. Once you have successfully 
+authenticated, you will be ready to use rpk cloud commands.
+
+You may opt out of auto-opening the browser by passing the '--no-browser' flag.
+
+CLIENT CREDENTIALS
+
+Cloud client credentials can be used to login to Redpanda, they can be created 
+in the Clients tab of the Users section in the Redpanda Cloud online interface. 
+client credentials can be provided in three ways, in order of preference:
+
+* In your rpk cloud auth, 'client_id' and 'client_secret' fields
+* Through RPK_CLOUD_CLIENT_ID and RPK_CLOUD_CLIENT_SECRET environment variables
+* Through the --client-id and --client-secret flags
+
+If none of these are provided, rpk will use the SSO method to login. 
+If you specify environment variables or flags, they will not be synced to the
+rpk.yaml file unless the --save flag is passed. The cloud authorization 
+token and client ID is always synced.
+
+PROFILE SELECTION
+
+This command by default attempts to populate a new profile that talks to a
+cloud cluster for you. If you have an existing cloud profile, this will select
+it, prompting which to use if you have many. If you have no cloud profile, this
+command will prompt you to select one that exists in your organization. If you
+want to disable automatic profile creation and selection, use --no-profile.
+
+== Usage
+
+[,bash]
+----
+rpk cloud login [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--client-id` |string |The client ID of the organization in Redpanda Cloud.
+
+|`--client-secret` |string |The client secret of the organization in Redpanda Cloud.
+
+|`-h, --help` |- |Help for login.
+
+|`--no-browser` |- |Opt out of auto-opening authentication URL.
+
+|`--no-profile` |- |Skip automatic profile creation and any associated prompts.
+
+|`--save` |- |Save environment or flag specified client ID and client secret to the configuration file.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud-logout.adoc
+++ b/tools/gen/23.2/rpk-cloud-logout.adoc
@@ -1,0 +1,34 @@
+= rpk cloud logout
+:description: rpk cloud logout
+
+Log out from Redpanda cloud
+
+This command deletes your cloud auth token. If you want to log out entirely and
+switch to a different organization, you can use the --clear-credentials flag to
+additionally clear your client ID and client secret.
+
+== Usage
+
+[,bash]
+----
+rpk cloud logout [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-c, --clear-credentials` |- |Clear the client ID and client secret in addition to the auth token.
+
+|`-h, --help` |- |Help for logout.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cloud.adoc
+++ b/tools/gen/23.2/rpk-cloud.adoc
@@ -1,0 +1,29 @@
+= rpk cloud
+:description: rpk cloud
+
+Interact with Redpanda cloud
+
+== Usage
+
+[,bash]
+----
+rpk cloud [flags]
+  rpk cloud [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for cloud.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-config-edit.adoc
+++ b/tools/gen/23.2/rpk-cluster-config-edit.adoc
@@ -1,0 +1,43 @@
+= rpk cluster config edit
+:description: rpk cluster config edit
+
+Edit cluster-wide configuration properties.
+
+This command opens a text editor to modify the cluster's configuration.
+
+Cluster properties are redpanda settings which apply to all nodes in
+the cluster.  These are separate to node properties, which are set with
+'rpk redpanda config'.
+
+Modified values are written back when the file is saved and the editor
+is closed.  Properties which are deleted are reset to their default
+values.
+
+By default, low level tunables are excluded: use the '--all' flag
+to edit all properties including these tunables.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config edit [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for edit.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-config-export.adoc
+++ b/tools/gen/23.2/rpk-cluster-config-export.adoc
@@ -1,0 +1,39 @@
+= rpk cluster config export
+:description: rpk cluster config export
+
+Export cluster configuration.
+
+Writes out a YAML representation of the cluster configuration to a file,
+suitable for editing and later applying with the corresponding 'import'
+command.
+
+By default, low level tunables are excluded: use the '--all' flag
+to include all properties including these low level tunables.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config export [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --filename` |string |path to file to export to, e.g. './config.yml'.
+
+|`-h, --help` |- |Help for export.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-config-force-reset.adoc
+++ b/tools/gen/23.2/rpk-cluster-config-force-reset.adoc
@@ -1,0 +1,45 @@
+= rpk cluster config force-reset
+:description: rpk cluster config force-reset
+
+Forcibly clear a cluster configuration property on this node.
+
+This command is not for general changes to cluster configuration: use this only
+when redpanda will not start due to a configuration issue.
+
+If your cluster is working properly and you would like to reset a property
+to its default, you may use the 'set' command with an empty string, or
+use the 'edit' command and delete the property's line.
+
+This command erases a named property from an internal cache of the cluster
+configuration on the local node, so that on next startup redpanda will treat
+the setting as if it was set to the default.
+
+WARNING: this should only be used when redpanda is not running.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config force-reset [PROPERTY...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--cache-file` |string |location of configuration cache file (defaults to redpanda data directory).
+
+|`-h, --help` |- |Help for force-reset.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-config-get.adoc
+++ b/tools/gen/23.2/rpk-cluster-config-get.adoc
@@ -1,0 +1,33 @@
+= rpk cluster config get
+:description: rpk cluster config get
+
+Get a cluster configuration property.
+
+This command is provided for use in scripts.  For interactive editing, or bulk
+output, use the 'edit' and 'export' commands respectively.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config get [KEY] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for get.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-config-import.adoc
+++ b/tools/gen/23.2/rpk-cluster-config-import.adoc
@@ -1,0 +1,38 @@
+= rpk cluster config import
+:description: rpk cluster config import
+
+Import cluster configuration from a file.
+
+Import configuration from a YAML file, usually generated with
+corresponding 'export' command.  This downloads the current cluster
+configuration, calculates the difference with the YAML file, and
+updates any properties that were changed.  If a property is removed
+from the YAML file, it is reset to its default value.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config import [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --filename` |string |full path to file to import, e.g. '/tmp/config.yml'.
+
+|`-h, --help` |- |Help for import.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-config-lint.adoc
+++ b/tools/gen/23.2/rpk-cluster-config-lint.adoc
@@ -1,0 +1,34 @@
+= rpk cluster config lint
+:description: rpk cluster config lint
+
+Remove any deprecated content from `redpanda.yaml`.
+
+Deprecated content includes properties which were set via `redpanda.yaml`
+in earlier versions of redpanda, but are now managed via Redpanda's
+central configuration store (and via 'rpk cluster config edit').
+
+== Usage
+
+[,bash]
+----
+rpk cluster config lint [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for lint.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-config-set.adoc
+++ b/tools/gen/23.2/rpk-cluster-config-set.adoc
@@ -1,0 +1,35 @@
+= rpk cluster config set
+:description: rpk cluster config set
+
+Set a single cluster configuration property.
+
+This command is provided for use in scripts.  For interactive editing, or bulk
+changes, use the 'edit' and 'import' commands respectively.
+
+If an empty string is given as the value, the property is reset to its default.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config set [KEY] [VALUE] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-config-status.adoc
+++ b/tools/gen/23.2/rpk-cluster-config-status.adoc
@@ -1,0 +1,39 @@
+= rpk cluster config status
+:description: rpk cluster config status
+
+Get configuration status of redpanda nodes.
+
+For each node, indicate whether a restart is required for settings to
+take effect, and any settings that the node has identified as invalid
+or unknown properties.
+
+Additionally show the version of cluster configuration that each node
+has applied: under normal circumstances these should all be equal,
+a lower number shows that a node is out of sync, perhaps because it
+is offline.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-config.adoc
+++ b/tools/gen/23.2/rpk-cluster-config.adoc
@@ -1,0 +1,49 @@
+= rpk cluster config
+:description: rpk cluster config
+
+Interact with cluster configuration properties.
+
+Cluster properties are redpanda settings which apply to all nodes in
+the cluster.  These are separate to node properties, which are set with
+'rpk redpanda config'.
+
+Use the 'edit' subcommand to interactively modify the cluster configuration, or
+'export' and 'import' to write configuration to a file that can be edited and
+read back later.
+
+These commands take an optional '--all' flag to include all properties including
+low level tunables such as internal buffer sizes, that do not usually need
+to be changed during normal operations.  These properties generally require
+some expertize to set safely, so if in doubt, avoid using '--all'.
+
+Modified properties are propagated immediately to all nodes.  The 'status'
+subcommand can be used to verify that all nodes are up to date, and identify
+any settings which were rejected by a node, for example if a node is running a
+different redpanda version that does not recognize certain properties.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config [flags]
+  rpk cluster config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--all` |- |Include all properties, including tunables.
+
+|`-h, --help` |- |Help for config.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-health.adoc
+++ b/tools/gen/23.2/rpk-cluster-health.adoc
@@ -1,0 +1,40 @@
+= rpk cluster health
+:description: rpk cluster health
+
+Queries health overview.
+
+Health overview is created based on the health reports collected periodically
+from all nodes in the cluster. A cluster is considered healthy when the
+following conditions are met:
+
+* all cluster nodes are responding
+* all partitions have leaders
+* the cluster controller is present
+
+== Usage
+
+[,bash]
+----
+rpk cluster health [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-e, --exit-when-healthy` |- |When used with watch, exits after cluster is back in healthy state.
+
+|`-h, --help` |- |Help for health.
+
+|`-w, --watch` |- |Blocks and writes out all cluster health changes.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-license-info.adoc
+++ b/tools/gen/23.2/rpk-cluster-license-info.adoc
@@ -1,0 +1,35 @@
+= rpk cluster license info
+:description: rpk cluster license info
+
+Retrieve license information:
+
+    Organization:    Organization the license was generated for.
+    Type:            Type of license: free, enterprise, etc.
+    Expires:         Expiration date of the license
+    Version:         License schema version.
+
+== Usage
+
+[,bash]
+----
+rpk cluster license info [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (text, json) (default "text").
+
+|`-h, --help` |- |Help for info.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-license-set.adoc
+++ b/tools/gen/23.2/rpk-cluster-license-set.adoc
@@ -1,0 +1,41 @@
+= rpk cluster license set
+:description: rpk cluster license set
+
+Upload license to the cluster
+
+You can either provide a path to a file containing the license:
+
+    rpk cluster license set --path /home/organization/redpanda.license
+
+Or inline the license string:
+
+    rpk cluster license set <license string>
+
+If neither are present, rpk will look for the license in the
+default location '/etc/redpanda/redpanda.license'.
+
+== Usage
+
+[,bash]
+----
+rpk cluster license set [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--path` |string |Path to the license file.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-license.adoc
+++ b/tools/gen/23.2/rpk-cluster-license.adoc
@@ -1,0 +1,29 @@
+= rpk cluster license
+:description: rpk cluster license
+
+Manage cluster license
+
+== Usage
+
+[,bash]
+----
+rpk cluster license [flags]
+  rpk cluster license [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for license.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-logdirs-describe.adoc
+++ b/tools/gen/23.2/rpk-cluster-logdirs-describe.adoc
@@ -1,0 +1,52 @@
+= rpk cluster logdirs describe
+:description: rpk cluster logdirs describe
+
+Describe log directories on Redpanda brokers.
+
+This command prints information about log directories on brokers, particularly,
+the base directory that topics and partitions are located in, and the size of
+data that has been written to the partitions. The size you see may not exactly
+match the size on disk as reported by du: Redpanda allocates files in chunks.
+The chunks will show up in du, while the actual bytes so far written to the
+file will show up in this command.
+
+The directory returned is the root directory for partitions. Within Redpanda,
+the partition data lives underneath the the returned root directory in
+
+    kafka/{topic}/{partition}_{revision}/
+
+where revision is a Redpanda internal concept.
+
+== Usage
+
+[,bash]
+----
+rpk cluster logdirs describe [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--aggregate-into` |string |If non-empty, what column to aggregate into starting from the partition column (broker, dir, topic).
+
+|`-b, --broker` |int32 |If non-negative, the specific broker to describe (default -1).
+
+|`-h, --help` |- |Help for describe.
+
+|`-H, --human-readable` |- |Print the logdirs size in a human-readable form.
+
+|`--sort-by-size` |- |If true, sort by size.
+
+|`--topics` |strings |Specific topics to describe.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-logdirs.adoc
+++ b/tools/gen/23.2/rpk-cluster-logdirs.adoc
@@ -1,0 +1,29 @@
+= rpk cluster logdirs
+:description: rpk cluster logdirs
+
+Describe log directories on Redpanda brokers
+
+== Usage
+
+[,bash]
+----
+rpk cluster logdirs [flags]
+  rpk cluster logdirs [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for logdirs.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-maintenance-disable.adoc
+++ b/tools/gen/23.2/rpk-cluster-maintenance-disable.adoc
@@ -1,0 +1,28 @@
+= rpk cluster maintenance disable
+:description: rpk cluster maintenance disable
+
+Disable maintenance mode for a node.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance disable [BROKER-ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for disable.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-maintenance-enable.adoc
+++ b/tools/gen/23.2/rpk-cluster-maintenance-enable.adoc
@@ -1,0 +1,33 @@
+= rpk cluster maintenance enable
+:description: rpk cluster maintenance enable
+
+Enable maintenance mode for a node.
+
+This command enables maintenance mode for the node with the specified ID. If a
+node exists that is already in maintenance mode then an error will be returned.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance enable [BROKER-ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for enable.
+
+|`-w, --wait` |- |Wait until node is drained.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-maintenance-status.adoc
+++ b/tools/gen/23.2/rpk-cluster-maintenance-status.adoc
@@ -1,0 +1,54 @@
+= rpk cluster maintenance status
+:description: rpk cluster maintenance status
+
+Report maintenance status.
+
+This command reports maintenance status for each node in the cluster. The output
+is presented as a table with each row representing a node in the cluster.  The
+output can be used to monitor the progress of node draining.
+
+   NODE-ID  ENABLED  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
+   1        false     false     false   0           0         0             0
+
+Field descriptions:
+
+        NODE-ID: the node ID
+        ENABLED: true if the node is currently in maintenance mode
+       FINISHED: leadership draining has completed
+         ERRORS: errors have been encountered while draining
+     PARTITIONS: number of partitions whose leadership has moved
+       ELIGIBLE: number of partitions with leadership eligible to move
+   TRANSFERRING: current active number of leadership transfers
+         FAILED: number of failed leadership transfers
+
+Notes:
+
+   - When errors are present further information will be available in the logs
+     for the corresponding node.
+
+   - Only partitions with more than one replica are eligible for leadership
+     transfer.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-maintenance.adoc
+++ b/tools/gen/23.2/rpk-cluster-maintenance.adoc
@@ -1,0 +1,47 @@
+= rpk cluster maintenance
+:description: rpk cluster maintenance
+
+Interact with cluster maintenance mode.
+
+Maintenance mode is a state that a node may be placed into in which the node
+may be shutdown or restarted with minimal disruption to client workloads. The
+primary use of maintenance mode is to perform a rolling upgrade in which each
+node is placed into maintenance mode prior to upgrading the node.
+
+Use the 'enable' and 'disable' subcommands to place a node into maintenance mode
+or remove it, respectively. Only one node at a time may be in maintenance mode.
+
+When a node is placed into maintenance mode the following occurs:
+
+Leadership draining. All raft leadership is transferred to another eligible
+node, and the node in maintenance mode rejects new leadership requests. By
+transferring leadership off of the node in maintenance mode all client traffic
+and requests are directed to other nodes minimizing disruption to client
+workloads when the node is shutdown.
+
+Currently leadership is not transferred for partitions with one replica.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance [flags]
+  rpk cluster maintenance [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for maintenance.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-metadata.adoc
+++ b/tools/gen/23.2/rpk-cluster-metadata.adoc
@@ -1,0 +1,59 @@
+= rpk cluster metadata
+:description: rpk cluster metadata
+
+Request broker metadata.
+
+The Kafka protocol's metadata contains information about brokers, topics, and
+the cluster as a whole.
+
+This command only runs if specific sections of metadata are requested. There
+are currently three sections: the cluster, the list of brokers, and the topics.
+If no section is specified, this defaults to printing all sections.
+
+If the topic section is requested, all topics are requested by default unless
+some are manually specified as arguments. Expanded per-partition information
+can be printed with the -d flag, and internal topics can be printed with the -i
+flag.
+
+In the broker section, the controller node is suffixed with *.
+
+== Usage
+
+[,bash]
+----
+rpk cluster metadata [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+metadata, status, info
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for metadata.
+
+|`-b, --print-brokers` |- |Print brokers section.
+
+|`-c, --print-cluster` |- |Print cluster section.
+
+|`-d, --print-detailed-topics` |- |Print per-partition information for topics (implies -t).
+
+|`-i, --print-internal-topics` |- |Print internal topics (if all topics requested, implies -t).
+
+|`-t, --print-topics` |- |Print topics section (implied if any topics are specified).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-partitions-balancer-status.adoc
+++ b/tools/gen/23.2/rpk-cluster-partitions-balancer-status.adoc
@@ -1,0 +1,78 @@
+= rpk cluster partitions balancer-status
+:description: rpk cluster partitions balancer-status
+
+Queries cluster for partition balancer status:
+
+If continuous partition balancing is enabled, redpanda will continuously
+reassign partitions from both unavailable nodes and from nodes using more disk
+space than the configured limit.
+
+This command can be used to monitor the partition balancer status.
+
+FIELDS
+
+    Status:                        Either off, ready, starting, in progress, or
+                                   stalled.
+    Seconds Since Last Tick:       The last time the partition balancer ran.
+    Current Reassignments Count:   Current number of partition reassignments in
+                                   progress.
+    Unavailable Nodes:             The nodes that have been unavailable after a
+                                   time set by the
+                                   "partition_autobalancing_node_availability_timeout_sec"
+                                   cluster property.
+    Over Disk Limit Nodes:         The nodes that surpassed the threshold of
+                                   used disk percentage specified in the
+                                   "partition_autobalancing_max_disk_usage_percent"
+                                   cluster property.
+
+BALANCER STATUS
+
+    off:          The balancer is disabled.
+    ready:        The balancer is active but there is nothing to do.
+    starting:     The balancer is starting but has not run yet.
+    in_progress:  The balancer is active and is in the process of scheduling
+                  partition movements.
+    stalled:      Violations have been detected and the balancer cannot correct
+                  them.
+
+STALLED BALANCER
+
+A stalled balancer can occur for a few reasons and requires a bit of manual
+investigation. A few areas to investigate:
+
+* Are there are enough healthy nodes to which to move partitions? For example,
+  in a three node cluster, no movements are possible for partitions with three
+  replicas. You will see a stall every time there is a violation.
+
+* Does the cluster have sufficient space? If all nodes in the cluster are
+  utilizing more than 80% of their disk space, rebalancing cannot proceed.
+
+* Do all partitions have quorum? If the majority of a partition's replicas are
+  down, the partition cannot be moved.
+
+* Are any nodes in maintenance mode? Partitions are not moved if any node is in
+  maintenance mode.
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions balancer-status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for balancer-status.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-partitions-move-cancel.adoc
+++ b/tools/gen/23.2/rpk-cluster-partitions-move-cancel.adoc
@@ -1,0 +1,51 @@
+= rpk cluster partitions move-cancel
+:description: rpk cluster partitions move-cancel
+
+Cancel ongoing partition movements.
+
+By default, this command cancels all the partition movements in the cluster. 
+To ensure that you do not accidentally cancel all partition movements, this 
+command prompts users for confirmation before issuing the cancellation request. 
+You can use "--no-confirm" to disable the confirmation prompt:
+
+    rpk cluster partitions move-cancel --no-confirm
+
+If "--node" is set, this command will only stop the partition movements 
+occurring in the specified node:
+
+    rpk cluster partitions move-cancel --node 1
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions move-cancel [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+move-cancel, alter-cancel
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for move-cancel.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`--node` |int |ID of a specific node on which to cancel ongoing partition movements (default -1).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-partitions-move-status.adoc
+++ b/tools/gen/23.2/rpk-cluster-partitions-move-status.adoc
@@ -1,0 +1,63 @@
+= rpk cluster partitions move-status
+:description: rpk cluster partitions move-status
+
+Show ongoing partition movements.
+
+By default this command lists all the ongoing partition movements in the cluster.
+Topics can be specified to print the move status of specific topics. By default,
+this command assumes the "kafka" namespace, but you can use a "namespace/" to
+specify internal namespaces.
+
+    rpk cluster partitions move-status
+    rpk cluster partitions move-status foo bar kafka_internal/tx
+
+The "--partition / -p" flag can be used with topics to additional filter
+requested partitions:
+
+    rpk cluster partitions move-status foo bar --partition 0,1,2
+
+The output contains the following columns, where PARTITION-SIZE is in bytes.
+Using -H, it prints the partition size in a human-readable format
+
+    NAMESPACE-TOPIC
+    PARTITION
+    MOVING-FROM
+    MOVING-TO
+    COMPLETION-%
+    PARTITION-SIZE
+    BYTES-MOVED
+    BYTES-REMAINING
+
+Using "--print-all / -a" the command additionally prints "RECONCILIATION STATUSES"
+which reveals internal states on how the ongoing reconciliations work for debugging
+purposes. That is, reported errors don't necessarily mean real problems.
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions move-status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for move-status.
+
+|`-H, --human-readable` |- |Print the partition size in a human-readable form.
+
+|`-p, --partition` |strings |Partitions to print the ongoing movements (repeatable).
+
+|`-a, --print-all` |- |Print internal states about movements for debugging.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-partitions.adoc
+++ b/tools/gen/23.2/rpk-cluster-partitions.adoc
@@ -1,0 +1,29 @@
+= rpk cluster partitions
+:description: rpk cluster partitions
+
+Manage cluster partitions
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions [flags]
+  rpk cluster partitions [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for partitions.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-self-test-start.adoc
+++ b/tools/gen/23.2/rpk-cluster-self-test-start.adoc
@@ -1,0 +1,56 @@
+= rpk cluster self-test start
+:description: rpk cluster self-test start
+
+Starts one or more benchmark tests on one or more nodes
+of the cluster. Available tests to run:
+
+* Disk tests:
+  * Throughput test: 512 KB messages, sequential read/write
+    * Uses a larger request message sizes and deeper I/O queue depth to write/read more bytes in a shorter amount of time, at the cost of IOPS/latency.
+  * Latency test: 4 KB messages, sequential read/write
+    * Uses smaller request message sizes and lower levels of parallelism to achieve higher IOPS and lower latency.
+
+* Network tests:
+  * Throughput test: 8192-bit messages
+    * Unique pairs of Redpanda nodes each act as a client and a server.
+    * The test pushes as much data over the wire, within the test parameters.
+
+This command immediately returns on success, and the tests run asynchronously. The
+user polls for results with the 'self-test status'
+command.
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--disk-duration-ms` |duration |uint       The  in milliseconds of individual disk test runs (default 30000).
+
+|`-h, --help` |- |Help for start.
+
+|`--network-duration-ms` |duration |uint    The  in milliseconds of individual network test runs (default 30000).
+
+|`--no-confirm` |- |Acknowledge warning prompt skipping read from stdin.
+
+|`--only-disk-test` |- |Runs only the disk benchmarks.
+
+|`--only-network-test` |- |Runs only network benchmarks.
+
+|`--participant-node-ids` |- |ints   IDs of nodes that the tests will run on. If not set, tests will run for all node IDs.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-self-test-status.adoc
+++ b/tools/gen/23.2/rpk-cluster-self-test-status.adoc
@@ -1,0 +1,39 @@
+= rpk cluster self-test status
+:description: rpk cluster self-test status
+
+Returns the status of the currently running or last completed self-test run.
+
+Use this command after invoking 'self-test start' to determine the status of
+the jobs launched. Possible results are:
+
+* One or more jobs still running
+  * Returns the IDs of Redpanda nodes still running self-tests.
+
+* No jobs running:
+  * Returns cached results for all nodes of the last completed test.
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (text, json) (default "text").
+
+|`-h, --help` |- |Help for status.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-self-test-stop.adoc
+++ b/tools/gen/23.2/rpk-cluster-self-test-stop.adoc
@@ -1,0 +1,31 @@
+= rpk cluster self-test stop
+:description: rpk cluster self-test stop
+
+Stops all self-test tests.
+
+This command stops all currently running self-tests. The command is synchronous and returns
+success when all jobs have been stopped or reports errors if broker timeouts have expired.
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for stop.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-self-test.adoc
+++ b/tools/gen/23.2/rpk-cluster-self-test.adoc
@@ -1,0 +1,29 @@
+= rpk cluster self-test
+:description: rpk cluster self-test
+
+Start, stop and query runs of Redpanda self-test through the Admin API listener
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test [flags]
+  rpk cluster self-test [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for self-test.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-storage-recovery-start.adoc
+++ b/tools/gen/23.2/rpk-cluster-storage-recovery-start.adoc
@@ -1,0 +1,38 @@
+= rpk cluster storage recovery start
+:description: rpk cluster storage recovery start
+
+Start the topic recovery process.
+		
+This command starts the process of restoring topics from the archival bucket.
+If the wait flag (--wait/-w) is set, the command will poll the status of the
+recovery process until it's finished.
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage recovery start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for start.
+
+|`--polling-interval` |duration |The status check interval (e.g. '30s', '1.5m'); ignored if --wait is not used (default 5s).
+
+|`--topic-name-pattern` |string |A regex pattern that restores any matching topics (default ".*").
+
+|`-w, --wait` |- |Wait until auto-restore is complete.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-storage-recovery-status.adoc
+++ b/tools/gen/23.2/rpk-cluster-storage-recovery-status.adoc
@@ -1,0 +1,31 @@
+= rpk cluster storage recovery status
+:description: rpk cluster storage recovery status
+
+Fetch the status of the topic recovery process.
+		
+This command fetches the status of the process of restoring topics from the 
+archival bucket.
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage recovery status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-storage-recovery.adoc
+++ b/tools/gen/23.2/rpk-cluster-storage-recovery.adoc
@@ -1,0 +1,40 @@
+= rpk cluster storage recovery
+:description: rpk cluster storage recovery
+
+Interact with the topic recovery process.
+		
+This command is used to restore topics from the archival bucket, which can be 
+useful for disaster recovery or if a topic was accidentally deleted.
+
+To begin the recovery process, use the "recovery start" command. Note that this 
+process can take a while to complete, so the command will exit after starting 
+it. If you want the command to wait for the process to finish, use the "--wait"
+or "-w" flag.
+
+You can check the status of the recovery process with the "recovery status" 
+command after it has been started.
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage recovery [flags]
+  rpk cluster storage recovery [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for recovery.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster-storage.adoc
+++ b/tools/gen/23.2/rpk-cluster-storage.adoc
@@ -1,0 +1,29 @@
+= rpk cluster storage
+:description: rpk cluster storage
+
+Manage the cluster storage
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage [flags]
+  rpk cluster storage [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for storage.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-cluster.adoc
+++ b/tools/gen/23.2/rpk-cluster.adoc
@@ -1,0 +1,29 @@
+= rpk cluster
+:description: rpk cluster
+
+Interact with a Redpanda cluster
+
+== Usage
+
+[,bash]
+----
+rpk cluster [flags]
+  rpk cluster [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for cluster.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-container-purge.adoc
+++ b/tools/gen/23.2/rpk-container-purge.adoc
@@ -1,0 +1,28 @@
+= rpk container purge
+:description: rpk container purge
+
+Stop and remove an existing local container cluster's data
+
+== Usage
+
+[,bash]
+----
+rpk container purge [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for purge.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-container-start.adoc
+++ b/tools/gen/23.2/rpk-container-start.adoc
@@ -1,0 +1,32 @@
+= rpk container start
+:description: rpk container start
+
+Start a local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for start.
+
+|`-n, --nodes` |- |uint     The number of nodes to start (default 1).
+
+|`--retries` |- |uint   The amount of times to check for the cluster before considering it unstable and exiting. (default 10).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-container-status.adoc
+++ b/tools/gen/23.2/rpk-container-status.adoc
@@ -1,0 +1,28 @@
+= rpk container status
+:description: rpk container status
+
+Get status
+
+== Usage
+
+[,bash]
+----
+rpk container status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-container-stop.adoc
+++ b/tools/gen/23.2/rpk-container-stop.adoc
@@ -1,0 +1,28 @@
+= rpk container stop
+:description: rpk container stop
+
+Stop an existing local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for stop.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-container.adoc
+++ b/tools/gen/23.2/rpk-container.adoc
@@ -1,0 +1,29 @@
+= rpk container
+:description: rpk container
+
+Manage a local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container [flags]
+  rpk container [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for container.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-debug-bundle.adoc
+++ b/tools/gen/23.2/rpk-debug-bundle.adoc
@@ -1,0 +1,119 @@
+= rpk debug bundle
+:description: rpk debug bundle
+
+'rpk debug bundle' collects environment data that can help debug and diagnose
+issues with a redpanda cluster, a broker, or the machine it's running on. It
+then bundles the collected data into a ZIP file, called a diagnostics bundle.
+
+The files and directories in the diagnostics bundle differ depending on the 
+environment in which Redpanda is running:
+
+COMMON FILES
+
+ - Kafka metadata: Broker configs, topic configs, start/committed/end offsets,
+   groups, group commits.
+
+ - Controller logs: The controller logs directory up to a limit set by
+   --controller-logs-size-limit flag
+
+ - Data directory structure: A file describing the data directory's contents.
+
+ - redpanda configuration: The redpanda configuration file (`redpanda.yaml`;
+   SASL credentials are stripped).
+
+ - /proc/cpuinfo: CPU information like make, core count, cache, frequency.
+
+ - /proc/interrupts: IRQ distribution across CPU cores.
+
+ - Resource usage data: CPU usage percentage, free memory available for the
+   redpanda process.
+
+ - Clock drift: The ntp clock delta (using pool.ntp.org as a reference) & round
+   trip time.
+
+ - Admin API calls: Cluster and broker configurations, cluster health data, and 
+   license key information.
+
+ - Broker metrics: The broker's Prometheus metrics, fetched through its
+   admin API (/metrics and /public_metrics).
+
+BARE-METAL
+
+ - Kernel logs: The kernel logs ring buffer (syslog).
+
+ - DNS: The DNS info as reported by 'dig', using the hosts in
+   /etc/resolv.conf.
+
+ - Disk usage: The disk usage for the data directory, as output by 'du'.
+
+ - redpanda logs: The node's redpanda logs written to journald. If --logs-since 
+   or --logs-until are passed, then only the logs within the resulting time frame
+   will be included.
+
+ - Socket info: The active sockets data output by 'ss'.
+
+ - Running process info: As reported by 'top'.
+
+ - Virtual memory stats: As reported by 'vmstat'.
+
+ - Network config: As reported by 'ip addr'.
+
+ - lspci: List the PCI buses and the devices connected to them.
+
+ - dmidecode: The DMI table contents. Only included if this command is run
+   as root.
+
+KUBERNETES
+
+ - Kubernetes Resources: Kubernetes manifests for all resources in the given 
+   Kubernetes namespace (via --namespace).
+
+ - redpanda logs: Logs of each Pod in the the given Kubernetes namespace. If 
+   --logs-since is passed, only the logs within the given timeframe are 
+   included.
+
+
+If you have an upload URL from the Redpanda support team, provide it in the 
+--upload-url flag to upload your diagnostics bundle to Redpanda.
+
+== Usage
+
+[,bash]
+----
+rpk debug bundle [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--controller-logs-size-limit` |string |The size limit of the controller logs that can be stored in the bundle (e.g. 3MB, 1GiB) (default "20MB").
+
+|`-h, --help` |- |Help for bundle.
+
+|`--logs-since` |string |Include log entries on or newer than the specified date (journalctl date format, e.g. YYYY-MM-DD.
+
+|`--logs-size-limit` |string |Read the logs until the given size is reached (e.g. 3MB, 1GiB) (default "100MiB").
+
+|`--logs-until` |string |Include log entries on or older than the specified date (journalctl date format, e.g. YYYY-MM-DD.
+
+|`--metrics-interval` |duration |Interval between metrics snapshots (e.g. 30s, 1.5m) (default 10s).
+
+|`-n, --namespace` |string |The namespace to use to collect the resources from (k8s only) (default "redpanda").
+
+|`-o, --output` |string |The file path where the debug file will be written (default ./&lt;timestamp&gt;-bundle.zip).
+
+|`--timeout` |duration |How long to wait for child commands to execute (e.g. 30s, 1.5m) (default 12s).
+
+|`--upload-url` |string |If provided, where to upload the bundle in addition to creating a copy on disk.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-debug.adoc
+++ b/tools/gen/23.2/rpk-debug.adoc
@@ -1,0 +1,29 @@
+= rpk debug
+:description: rpk debug
+
+Debug the local Redpanda process
+
+== Usage
+
+[,bash]
+----
+rpk debug [flags]
+  rpk debug [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for debug.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-generate-app.adoc
+++ b/tools/gen/23.2/rpk-generate-app.adoc
@@ -1,0 +1,68 @@
+= rpk generate app
+:description: rpk generate app
+
+Generate a sample application to connect with Redpanda.
+
+This command generates a starter application to produce and consume from the
+settings defined in the rpk profile. Its goal is to get you producing and
+consuming quickly with Redpanda in a language that is familiar to you.
+
+By default, this will run interactively, prompting you to select a language and
+a user with which to create your application. To use this without interactivity,
+specify how you would like your application to be created using flags.
+
+The --language option allows you to specify the language. There is no default.
+
+The --new-sasl-credentials <user>:<password> allows you to generate a new SASL
+user with admin ACLs. If you don't want to use your current profile user nor
+create a new one, you may use --no-user flag to generate the starter app without
+the user.
+
+If you are having trouble connecting to your cluster, you can use -X
+admin.hosts=comma,delimited,host:ports to pass a specific admin api address.
+
+Examples:
+
+Generate an app with interactive prompts:
+  rpk generate app
+
+Generate an app in a specified language with the existing SASL user:
+  rpk generate app --language <lang>
+
+Generate an app in the specified language with a new SASL user:
+  rpk generate app -l <lang> --new-sasl-credentials <user>:<password>
+
+Generate an app in the 'tmp' dir, but take no action on the user:
+  rpk generate app -l <lang> --no-user --output /tmp
+
+== Usage
+
+[,bash]
+----
+rpk generate app [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for app.
+
+|`-l, --language` |string |The language you want the code sample to be generated with.
+
+|`--new-sasl-credentials` |string |If provided, rpk will generate and use these credentials (<user>:<password>).
+
+|`--no-user` |- |Generates the sample app without SASL user.
+
+|`-o, --output` |string |The path where the app will be written.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-generate-grafana-dashboard.adoc
+++ b/tools/gen/23.2/rpk-generate-grafana-dashboard.adoc
@@ -1,0 +1,48 @@
+= rpk generate grafana-dashboard
+:description: rpk generate grafana-dashboard
+
+Generate Grafana Dashboards for Redpanda Metrics
+
+Use this command to generate sample Grafana dashboards for Redpanda metrics. 
+These dashboards can be imported into a Grafana or Grafana Cloud instance.
+
+To select a specific dashboard, use the '--dashboard' flag followed by the 
+dashboard name. For example, to generate the operations dashboard, run:
+
+    rpk generate grafana-dashboard --dashboard operations
+
+The selected dashboard will be downloaded from our GitHub repository:
+
+  https://github.com/redpanda-data/observability
+
+Note that the legacy dashboard is still available as an option, and will not be 
+downloaded from github. Instead, the dashboard will be generated based on the 
+metrics endpoint used.
+
+To see a list of all available dashboards, use the '--dashboard help' flag.
+
+== Usage
+
+[,bash]
+----
+rpk generate grafana-dashboard [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--dashboard` |string |The name of the dashboard you wish to download; use --dashboard help for more info (default "operations").
+
+|`-h, --help` |- |Help for grafana-dashboard.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-generate-prometheus-config.adoc
+++ b/tools/gen/23.2/rpk-generate-prometheus-config.adoc
@@ -1,0 +1,90 @@
+= rpk generate prometheus-config
+:description: rpk generate prometheus-config
+
+Generate the Prometheus configuration to scrape Redpanda nodes. 
+
+The output of this command should be included in the 'scrape_configs' array 
+within the YAML configuration file of your Prometheus instance.
+
+There are different options you can use when generating the configuration:
+
+ - If you provide the --seed-addr flag, the command will use the address to 
+   discover the rest of the cluster hosts using Redpanda's Kafka API.
+ - If you provide the --node-addrs flag, the command will directly use the 
+   provided addresses.
+ - If neither --seed-addr nor --node-addrs are passed, the command will read the 
+   redpanda config file and use the node IP configured there.
+
+If the node you want to scrape uses TLS, you can provide the TLS flags 
+(--tls-key, --tls-cert, and --tls-truststore). The command will generate the 
+required tls_config section in the scrape configuration.
+
+Additionally, you have the option to define labels for the target in the 
+static-config section by using the --labels flag. You can specify the desired 
+metric that the label should target, either internal (/metrics) or public 
+(/public_metrics).
+
+For example:
+
+  --job-name test --labels "public:group=one,internal:group=two"
+
+This will result in two separate configs for the test job, each with a 
+different label:
+
+  - job_name: test
+    static_configs:
+      - targets: [<targets>]
+        labels:
+          group: one
+    metrics_path: /public_metrics
+  - job_name: test
+    static_configs:
+      - targets: [<targets>]
+        labels:
+          group: two
+    metrics_path: /metrics
+
+You can only provide one label per job. By default, if no metric target is 
+specified, the label will be shared across the jobs.
+
+== Usage
+
+[,bash]
+----
+rpk generate prometheus-config [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for prometheus-config.
+
+|`--internal-metrics` |- |Include scrape config for internal metrics (/metrics).
+
+|`--job-name` |string |The prometheus job name by which to identify the Redpanda nodes (default "redpanda").
+
+|`--labels` |strings |Comma-separated labels and their target metric (int or pub): [metric|labelName:labelValue, ...].
+
+|`--node-addrs` |strings |Comma-separated list of admin API host:ports.
+
+|`--seed-addr` |string |The URL of a Redpanda node with which to discover the rest.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The CA certificate to be used for TLS communication with the broker.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-generate-shell-completion.adoc
+++ b/tools/gen/23.2/rpk-generate-shell-completion.adoc
@@ -1,0 +1,76 @@
+= rpk generate shell-completion
+:description: rpk generate shell-completion
+
+Shell completion can help autocomplete rpk commands when you press tab.
+
+BASH
+
+Bash autocompletion relies on the bash-completion package. You can test if you
+have this by running "type _init_completion", if you do not, you can install
+the package through your package manager.
+
+If you have bash-completion installed, and the command still fails, you likely
+need to add the following line to your ~/.bashrc:
+
+    source /usr/share/bash-completion/bash_completion
+
+To ensure autocompletion of rpk exists in all shell sessions, add the following
+to your ~/.bashrc:
+
+    command -v rpk >/dev/null && . <(rpk generate shell-completion bash)
+
+Alternatively, to globally enable rpk completion, you can run the following:
+
+    rpk generate shell-completion bash > /etc/bash_completion.d/rpk
+
+ZSH
+
+If shell completion is not already enabled in your environment, you will need to
+enable it. You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To enable autocompletion in any zsh session for any user, run this once:
+
+# Linux:
+
+    rpk generate shell-completion zsh > "${fpath[1]}/_rpk"
+
+# macOS:
+
+     rpk generate shell-completion zsh > "$(brew --prefix)/share/zsh/site-functions/_rpk"
+
+You can also place that command in your ~/.zshrc to ensure that when you update
+rpk, you update autocompletion. If you initially require sudo to edit that
+file, you can chmod it to be world writeable, after which you will always be
+able to update it from ~/.zshrc.
+
+FISH
+
+To enable autocompletion in any fish session, run:
+
+    rpk generate shell-completion fish > ~/.config/fish/completions/rpk.fish
+
+== Usage
+
+[,bash]
+----
+rpk generate shell-completion [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for shell-completion.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-generate.adoc
+++ b/tools/gen/23.2/rpk-generate.adoc
@@ -1,0 +1,29 @@
+= rpk generate
+:description: rpk generate
+
+Generate a configuration template for related services
+
+== Usage
+
+[,bash]
+----
+rpk generate [template] [flags]
+  rpk generate [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for generate.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-group-delete.adoc
+++ b/tools/gen/23.2/rpk-group-delete.adoc
@@ -1,0 +1,45 @@
+= rpk group delete
+:description: rpk group delete
+
+Delete groups from brokers.
+
+Older versions of the Kafka protocol included a retention_millis field in
+offset commit requests. Group commits persisted for this retention and then
+eventually expired. Once all commits for a group expired, the group would be
+considered deleted.
+
+The retention field was removed because it proved problematic for infrequently
+committing consumers: the offsets could be expired for a group that was still
+active. If clients use new enough versions of OffsetCommit (versions that have
+removed the retention field), brokers expire offsets only when the group is
+empty for offset.retention.minutes. Redpanda does not currently support that
+configuration (see #2904), meaning offsets for empty groups expire only when
+they are explicitly deleted.
+
+You may want to delete groups to clean up offsets sooner than when they
+automatically are cleaned up, such as when you create temporary groups for
+quick investigation or testing. This command helps you do that.
+
+== Usage
+
+[,bash]
+----
+rpk group delete [GROUPS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-group-describe.adoc
+++ b/tools/gen/23.2/rpk-group-describe.adoc
@@ -1,0 +1,37 @@
+= rpk group describe
+:description: rpk group describe
+
+Describe group offset status & lag.
+
+This command describes group members, calculates their lag, and prints detailed
+information about the members.
+
+== Usage
+
+[,bash]
+----
+rpk group describe [GROUPS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for describe.
+
+|`-c, --print-commits` |- |Print only the group commits section.
+
+|`-t, --print-lag-per-topic` |- |Print the aggregated lag per topic.
+
+|`-s, --print-summary` |- |Print only the group summary section.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-group-list.adoc
+++ b/tools/gen/23.2/rpk-group-list.adoc
@@ -1,0 +1,40 @@
+= rpk group list
+:description: rpk group list
+
+List all groups.
+
+This command lists all groups currently known to Redpanda, including empty
+groups that have not yet expired. The BROKER column is which broker node is the
+coordinator for the group. This command can be used to track down unknown
+groups, or to list groups that need to be cleaned up.
+
+== Usage
+
+[,bash]
+----
+rpk group list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-group-offset-delete.adoc
+++ b/tools/gen/23.2/rpk-group-offset-delete.adoc
@@ -1,0 +1,49 @@
+= rpk group offset-delete
+:description: rpk group offset-delete
+
+Forcefully delete offsets for a kafka group.
+
+The broker will only allow the request to succeed if the group is in a dead
+state (no subscriptions) or there are no subscriptions for offsets for
+topic/partitions requested to be deleted.
+
+Use either the --from-file or the --topic option. They are mutually exclusive.
+To indicate which topics or topic partitions you'd like to remove offsets from use
+the --topic (-t) flag, followed by a comma separated list of partition ids. Supplying
+no list will delete all offsets for all partitions for a given topic.
+
+You may also provide a text file to indicate topic/partition tuples. Use the
+--from-file flag for this option. The file must contain lines of topic/partitions
+separated by a tab or space. Example:
+
+topic_a 0
+topic_a 1
+topic_b 0
+
+== Usage
+
+[,bash]
+----
+rpk group offset-delete [GROUP] --from-file FILE --topic foo:0,1,2 [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --from-file` |string |File of topic/partition tuples for which to delete offsets for.
+
+|`-h, --help` |- |Help for offset-delete.
+
+|`-t, --topic` |stringArray |topic:partition_id (repeatable; e.g. -t foo:0,1,2 ).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-group-seek.adoc
+++ b/tools/gen/23.2/rpk-group-seek.adoc
@@ -1,0 +1,82 @@
+= rpk group seek
+:description: rpk group seek
+
+Modify a group's current offsets.
+
+This command allows you to modify a group's offsets. Sometimes, you may need to
+rewind a group if you had a mistaken deploy, or fast-forward a group if it is
+falling behind on messages that can be skipped.
+
+The --to option allows you to seek to the start of partitions, end of
+partitions, or after a specific timestamp. The default is to seek any topic
+previously committed. Using --topics allows to you set commits for only the
+specified topics; all other commits will remain untouched. Topics with no
+commits will not be committed unless allowed with --allow-new-topics.
+
+The --to-group option allows you to seek to commits that are in another group.
+This is a merging operation: if g1 is consuming topics A and B, and g2 is
+consuming only topic B, "rpk group seek g1 --to-group g2" will update g1's
+commits for topic B only. The --topics flag can be used to further narrow which
+topics are updated. Unlike --to, all non-filtered topics are committed, even
+topics not yet being consumed, meaning --allow-new-topics is not needed.
+
+The --to-file option allows to seek to offsets specified in a text file with
+the following format:
+    [TOPIC] [PARTITION] [OFFSET]
+    [TOPIC] [PARTITION] [OFFSET]
+    ...
+Each line contains the topic, the partition, and the offset to seek to. As with
+the prior options, --topics allows filtering which topics are updated. Similar
+to --to-group, all non-filtered topics are committed, even topics not yet being
+consumed, meaning --allow-new-topics is not needed.
+
+The --to, --to-group, and --to-file options are mutually exclusive. If you are
+not authorized to describe or read some topics used in a group, you will not be
+able to modify offsets for those topics.
+
+EXAMPLES
+
+Seek group G to June 1st, 2021:
+    rpk group seek g --to 1622505600
+    or, rpk group seek g --to 1622505600000
+    or, rpk group seek g --to 1622505600000000000
+Seek group X to the commits of group Y topic foo:
+    rpk group seek X --to-group Y --topics foo
+Seek group G's topics foo, bar, and biz to the end:
+    rpk group seek G --to end --topics foo,bar,biz
+Seek group G to the beginning of a topic it was not previously consuming:
+    rpk group seek G --to start --topics foo --allow-new-topics
+
+== Usage
+
+[,bash]
+----
+rpk group seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ... [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-new-topics` |- |Allow seeking to new topics not currently consumed (implied with --to-group or --to-file).
+
+|`-h, --help` |- |Help for seek.
+
+|`--to` |string |Where to seek (start, end, unix second | millisecond | nanosecond).
+
+|`--to-file` |string |Seek to offsets as specified in the file.
+
+|`--to-group` |string |Seek to the commits of another group.
+
+|`--topics` |strings |Only seek these topics, if any are specified.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-group.adoc
+++ b/tools/gen/23.2/rpk-group.adoc
@@ -1,0 +1,74 @@
+= rpk group
+:description: rpk group
+
+Describe, list, and delete consumer groups and manage their offsets.
+
+Consumer groups allow you to horizontally scale consuming from topics. A
+non-group consumer consumes all records from all partitions you assign it. In
+contrast, consumer groups allow many consumers to coordinate and divide work.
+If you have two members in a group consuming topics A and B, each with three
+partitions, then both members consume three partitions. If you add another
+member to the group, then each of the three members will consume two
+partitions. This allows you to horizontally scale consuming of topics.
+
+The unit of scaling is a single partition. If you add more consumers to a group
+than there are are total partitions to consume, then some consumers will be
+idle. More commonly, you have many more partitions than consumer group members
+and each member consumes a chunk of available partitions. One scenario where
+you may want more members than partitions is if you want active standby's to
+take over load immediately if any consuming member dies.
+
+How group members divide work is entirely client driven (the "partition
+assignment strategy" or "balancer" depending on the client). Brokers know
+nothing about how consumers are assigning partitions. A broker's role in group
+consuming is to choose which member is the leader of a group, forward that
+member's assignment to every other member, and ensure all members are alive
+through heartbeats.
+
+Consumers periodically commit their progress when consuming partitions. Through
+these commits, you can monitor just how far behind a consumer is from the
+latest messages in a partition. This is called "lag". Large lag implies that
+the client is having problems, which could be from the server being too slow,
+or the client being oversubscribed in the number of partitions it is consuming,
+or the server being in a bad state that requires restarting or removing from
+the server pool, and so on.
+
+You can manually manage offsets for a group, which allows you to rewind or
+forward commits. If you notice that a recent deploy of your consumers had a
+bug, you may want to stop all members, rewind the commits to before the latest
+deploy, and restart the members with a patch.
+
+This command allows you to list all groups, describe a group (to view the
+members and their lag), and manage offsets.
+
+== Usage
+
+[,bash]
+----
+rpk group [flags]
+  rpk group [command]
+----
+
+== Aliases
+
+[,bash]
+----
+group, g
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for group.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-help.adoc
+++ b/tools/gen/23.2/rpk-help.adoc
@@ -1,0 +1,29 @@
+= rpk help
+:description: rpk help
+
+Help provides help for any command in the application.
+Simply type rpk help [path to command] for full details.
+
+== Usage
+
+[,bash]
+----
+rpk help [command] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |help for help.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-iotune.adoc
+++ b/tools/gen/23.2/rpk-iotune.adoc
@@ -1,0 +1,38 @@
+= rpk iotune
+:description: rpk iotune
+
+Measure filesystem performance and create IO configuration file
+
+== Usage
+
+[,bash]
+----
+rpk iotune [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--directories` |strings |List of directories to evaluate.
+
+|`--duration` |duration |Duration of tests (e.g. 300ms, 1.5s, 2h45m) (default 10m0s).
+
+|`-h, --help` |- |Help for iotune.
+
+|`--no-confirm` |- |Disable confirmation prompt if the iotune file already exists.
+
+|`--out` |string |The file path where the IO config will be written (default "/etc/redpanda/io-config.yaml").
+
+|`--timeout` |duration |The maximum time after -- to wait for iotune to complete (e.g. 300ms, 1.5s, 2h45m) (default 1h0m0s).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-plugin-install.adoc
+++ b/tools/gen/23.2/rpk-plugin-install.adoc
@@ -1,0 +1,45 @@
+= rpk plugin install
+:description: rpk plugin install
+
+Install an rpk plugin.
+
+An rpk plugin must be saved in $HOME/.local/bin or in a directory that is in 
+your $PATH. By default, this command installs plugins to $HOME/.local/bin. This 
+can be overridden by specifying the --dir flag.
+
+If --dir is not present, rpk will create $HOME/.local/bin if it does not exist.
+
+== Usage
+
+[,bash]
+----
+rpk plugin install [PLUGIN] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+install, download
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--dir` |string |Destination directory to save the installed plugin (defaults to $HOME/.local/bin) (default "/var/lib/redpanda/.local/bin").
+
+|`-h, --help` |- |Help for install.
+
+|`-u, --update` |- |Update a locally installed plugin if it differs from the current remote version.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-plugin-list.adoc
+++ b/tools/gen/23.2/rpk-plugin-list.adoc
@@ -1,0 +1,39 @@
+= rpk plugin list
+:description: rpk plugin list
+
+List all available plugins.
+
+By default, this command fetches the remote manifest and prints plugins
+available for download. Any plugin that is already downloaded is prefixed with
+an asterisk. If a locally installed plugin has a different sha256sum as the one
+specified in the manifest, or if the sha256sum could not be calculated for the
+local plugin, an additional message is printed.
+
+You can specify --local to print all locally installed plugins, as well as
+whether you have "shadowed" plugins (the same plugin specified multiple times).
+
+== Usage
+
+[,bash]
+----
+rpk plugin list [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`-l, --local` |- |List locally installed plugins and shadowed plugins.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-plugin-uninstall.adoc
+++ b/tools/gen/23.2/rpk-plugin-uninstall.adoc
@@ -1,0 +1,42 @@
+= rpk plugin uninstall
+:description: rpk plugin uninstall
+
+Uninstall / remove an existing local plugin.
+
+This command lists locally installed plugins and removes the first plugin that
+matches the requested removal. If --include-shadowed is specified, this command
+also removes all shadowed plugins of the same name. To remove a command under a
+nested namespace ("rpk foo bar"), you can use "foo_bar".
+
+== Usage
+
+[,bash]
+----
+rpk plugin uninstall [NAME] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+uninstall, rm
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for uninstall.
+
+|`--include-shadowed` |- |Also remove shadowed plugins that have the same name.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-plugin.adoc
+++ b/tools/gen/23.2/rpk-plugin.adoc
@@ -1,0 +1,70 @@
+= rpk plugin
+:description: rpk plugin
+
+List, download, update, and remove rpk plugins.
+	
+Plugins augment rpk with new commands.
+
+For a plugin to be used, it must be in $HOME/.local/bin or somewhere 
+discoverable by rpk in your $PATH. All plugins follow a defined naming scheme:
+
+  .rpk-|name|
+  .rpk.ac-|name|
+
+All plugins are prefixed with either .rpk- or .rpk.ac-. When rpk starts up, it
+searches all directories in your $PATH for any executable binary that begins
+with either of those prefixes. For any binary it finds, rpk adds a command for
+that name to the rpk command space itself.
+
+No plugin name can shadow an existing rpk command, and only one plugin can
+exist under a given name at once. Plugins are added to the rpk command space on
+a first-seen basis. If you have two plugins rpk-foo, and the second is
+discovered later on in the $PATH directories, then only the first will be used.
+The second will be ignored.
+
+Plugins that have an .rpk.ac- prefix indicate that they support the
+--help-autocomplete flag. If rpk sees this, rpk will exec the plugin with that
+flag when rpk starts up, and the plugin will return all commands it supports as
+well as short and long help test for each command. Rpk uses this return to
+build a shadow command space within rpk itself so that it looks as if the
+plugin exists within rpk. This is particularly useful if you enable
+autocompletion.
+
+The expected return for plugins from --help-autocomplete is an array of the
+following:
+
+  type pluginHelp struct {
+          Path    string   `json:"path,omitempty"`
+          Short   string   `json:"short,omitempty"`
+          Long    string   `json:"long,omitempty"`
+          Example string   `json:"example,omitempty"`
+          Args    []string `json:"args,omitempty"`
+  }
+
+where "path" is an underscore delimited argument path to a command. For
+example, "foo_bar_baz" corresponds to the command "rpk foo bar baz".
+
+== Usage
+
+[,bash]
+----
+rpk plugin [flags]
+  rpk plugin [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for plugin.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-clear.adoc
+++ b/tools/gen/23.2/rpk-profile-clear.adoc
@@ -1,0 +1,31 @@
+= rpk profile clear
+:description: rpk profile clear
+
+Clear the current profile
+
+This small command clears the current profile, which can be useful to unset an
+prod cluster profile.
+
+== Usage
+
+[,bash]
+----
+rpk profile clear [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for clear.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-create.adoc
+++ b/tools/gen/23.2/rpk-profile-create.adoc
@@ -1,0 +1,71 @@
+= rpk profile create
+:description: rpk profile create
+
+Create an rpk profile.
+
+There are multiple ways to create a profile. A name must be provided if not
+using --from-cloud.
+
+* You can use --from-redpanda to generate a new profile from an existing
+  `redpanda.yaml` file. The special values "current" create a profile from the
+  current `redpanda.yaml` as it is loaded within rpk.
+
+* You can use --from-profile to generate a profile from an existing profile or
+  from from a profile in a yaml file. First, the filename is checked, then an
+  existing profile name is checked. The special value "current" creates a new
+  profile from the existing profile.
+
+* You can use --from-cloud to generate a profile from an existing cloud cluster
+  id. Note that you must be logged in with 'rpk cloud login' first. The special
+  value "prompt" will prompt to select a cloud cluster to create a profile for.
+
+* You can use --set key=value to directly set fields. The key can either be
+  the name of a -X flag or the path to the field in the profile's YAML format.
+  For example, using --set tls.enabled=true OR --set kafka_api.tls.enabled=true
+  is equivalent. The former corresponds to the -X flag tls.enabled, while the
+  latter corresponds to the path kafka_api.tls.enabled in the profile's YAML.
+
+The --set flag is always applied last and can be used to set additional fields
+in tandem with --from-redpanda or --from-cloud.
+
+The --set flag supports autocompletion, suggesting the -X key format. If you
+begin writing a YAML path, the flag will suggest the rest of the path.
+
+It is recommended to always use the --description flag; the description is
+printed in the output of 'rpk profile list'.
+
+rpk always switches to the newly created profile.
+
+== Usage
+
+[,bash]
+----
+rpk profile create [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --description` |string |Optional description of the profile.
+
+|`--from-cloud` |string |[="prompt"]   Create and switch to a new profile generated from a Redpanda Cloud cluster ID.
+
+|`--from-profile` |string |Create and switch to a new profile from an existing profile or from a profile in a yaml file.
+
+|`--from-redpanda` |string |Create and switch to a new profile from a `redpanda.yaml` file.
+
+|`-h, --help` |- |Help for create.
+
+|`-s, --set` |stringArray |Create and switch to a new profile, setting profile fields with key=value pairs.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-current.adoc
+++ b/tools/gen/23.2/rpk-profile-current.adoc
@@ -1,0 +1,33 @@
+= rpk profile current
+:description: rpk profile current
+
+Print the current profile name.
+
+This is a tiny command that simply prints the current profile name, which may
+be useful in scripts, or a PS1, or to confirm what you have selected.
+
+== Usage
+
+[,bash]
+----
+rpk profile current [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for current.
+
+|`-n, --no-newline` |- |Do not print a newline after the profile name.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-delete.adoc
+++ b/tools/gen/23.2/rpk-profile-delete.adoc
@@ -1,0 +1,32 @@
+= rpk profile delete
+:description: rpk profile delete
+
+Delete an rpk profile.
+
+Deleting a profile removes it from the rpk.yaml file. If the deleted profile
+was the selected profile, rpk will use in-memory defaults until a new profile
+is selected.
+
+== Usage
+
+[,bash]
+----
+rpk profile delete [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-edit-globals.adoc
+++ b/tools/gen/23.2/rpk-profile-edit-globals.adoc
@@ -1,0 +1,30 @@
+= rpk profile edit-globals
+:description: rpk profile edit-globals
+
+Edit rpk globals.
+
+This command opens your default editor to edit the rpk global configurations.
+
+== Usage
+
+[,bash]
+----
+rpk profile edit-globals [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for edit-globals.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-edit.adoc
+++ b/tools/gen/23.2/rpk-profile-edit.adoc
@@ -1,0 +1,32 @@
+= rpk profile edit
+:description: rpk profile edit
+
+Edit an rpk profile.
+
+This command opens your default editor to edit the specified profile, or
+the current profile if no profile is specified. If the profile does not
+exist, this command creates it and switches to it.
+
+== Usage
+
+[,bash]
+----
+rpk profile edit [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for edit.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-list.adoc
+++ b/tools/gen/23.2/rpk-profile-list.adoc
@@ -1,0 +1,35 @@
+= rpk profile list
+:description: rpk profile list
+
+List rpk profiles
+
+== Usage
+
+[,bash]
+----
+rpk profile list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-print-globals.adoc
+++ b/tools/gen/23.2/rpk-profile-print-globals.adoc
@@ -1,0 +1,28 @@
+= rpk profile print-globals
+:description: rpk profile print-globals
+
+Print rpk global configuration
+
+== Usage
+
+[,bash]
+----
+rpk profile print-globals [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for print-globals.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-print.adoc
+++ b/tools/gen/23.2/rpk-profile-print.adoc
@@ -1,0 +1,31 @@
+= rpk profile print
+:description: rpk profile print
+
+Print rpk profile configuration.
+
+If no name is specified, this command prints the current profile as it exists
+in the rpk.yaml file.
+
+== Usage
+
+[,bash]
+----
+rpk profile print [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for print.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-prompt.adoc
+++ b/tools/gen/23.2/rpk-profile-prompt.adoc
@@ -1,0 +1,69 @@
+= rpk profile prompt
+:description: rpk profile prompt
+
+Prompt a profile name formatted for a PS1 prompt.
+
+This command prints ANSI-escaped text per your current profile's "prompt"
+field. If the current profile does not have a prompt, this prints nothing.
+If the prompt is invalid, this exits 0 with no message. To validate the
+current prompt, use the --validate flag.
+
+This command may introduce other % variables in the future, if you want to
+print a % directly, use %% to escape it.
+
+To use this in zsh, be sure to add setopt PROMPT_SUBST to your .zshrc.
+To edit your PS1, use something like PS1='$(rpk profile prompt)' in your
+shell rc file.
+
+FORMAT
+
+The "prompt" field supports space or comma separated modifiers and a quoted
+string that is be modified. Inside the string, the variable %p or %n refers to
+the profile name. As a few examples:
+
+    prompt: hi-white, bg-red, bold, "[%p]"
+    prompt: hi-red  "PROD"
+    prompt: white, "dev-%n
+
+If you want to have multiple formats, you can wrap each formatted section in
+parentheses.
+
+    prompt: ("--") (hi-white bg-red bold "[%p]")
+
+COLORS
+
+All ANSI colors are supported, with names matching the color name:
+"black", "red", "green", "yellow", "blue", "magenta", "cyan", "white".
+
+The "hi-" prefix indicates a high-intensity color: "hi-black", "hi-red", etc.
+The "bg-" prefix modifies the background color: "bg-black", "bg-hi-red", etc.
+
+MODIFIERS
+
+Four modifiers are supported, "bold", "faint", "underline", and "invert".
+
+== Usage
+
+[,bash]
+----
+rpk profile prompt [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for prompt.
+
+|`--validate` |- |Exit with an error message if the prompt is invalid.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-rename-to.adoc
+++ b/tools/gen/23.2/rpk-profile-rename-to.adoc
@@ -1,0 +1,35 @@
+= rpk profile rename-to
+:description: rpk profile rename-to
+
+Rename the current rpk profile
+
+== Usage
+
+[,bash]
+----
+rpk profile rename-to [NAME] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+rename-to, rename
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for rename-to.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-set-globals.adoc
+++ b/tools/gen/23.2/rpk-profile-set-globals.adoc
@@ -1,0 +1,37 @@
+= rpk profile set-globals
+:description: rpk profile set-globals
+
+Set rpk globals fields.
+
+This command takes a list of key=value pairs to write to the global config 
+section of rpk.yaml. The globals section contains a set of settings that apply
+to all profiles and changes the way that rpk acts. For a list of global flags
+and what they mean, check 'rpk -X help' and look for any key that begins with
+"globals".
+
+This command supports autocompletion of valid keys. You can also use the
+format 'set key value' if you intend to only set one key.
+
+== Usage
+
+[,bash]
+----
+rpk profile set-globals [KEY=VALUE]+ [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set-globals.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-set.adoc
+++ b/tools/gen/23.2/rpk-profile-set.adoc
@@ -1,0 +1,43 @@
+= rpk profile set
+:description: rpk profile set
+
+Set fields in the current rpk profile.
+
+As in the create command, this command takes a list of key=value pairs to write
+to the current profile.
+
+The key can either be the name of a -X flag or the path to the field in the
+profile's yaml format. For example, using --set tls.enabled=true OR --set
+kafka_api.tls.enabled=true is equivalent. The former corresponds to the -X flag
+tls.enabled, while the latter corresponds to the path kafka_api.tls.enabled in
+the profile's yaml.
+
+This command supports autocompletion of valid keys, suggesting the -X key
+format. If you begin writing a YAML path, this command will suggest the rest of
+the path.
+
+You can also use the format 'set key value' if you intend to only set one key.
+
+== Usage
+
+[,bash]
+----
+rpk profile set [KEY=VALUE]+ [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile-use.adoc
+++ b/tools/gen/23.2/rpk-profile-use.adoc
@@ -1,0 +1,28 @@
+= rpk profile use
+:description: rpk profile use
+
+Select the rpk profile to use
+
+== Usage
+
+[,bash]
+----
+rpk profile use [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for use.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-profile.adoc
+++ b/tools/gen/23.2/rpk-profile.adoc
@@ -1,0 +1,35 @@
+= rpk profile
+:description: rpk profile
+
+Manage rpk profiles.
+
+An rpk profile talks to a single Redpanda cluster. You can create multiple
+profiles for multiple clusters and swap between them with 'rpk profile use'.
+Multiple profiles may be useful if, for example, you use rpk to talk to
+a localhost cluster, a dev cluster, and a prod cluster, and you want to keep
+your configuration in one place.
+
+== Usage
+
+[,bash]
+----
+rpk profile [flags]
+  rpk profile [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for profile.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-brokers-decommission-status.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-brokers-decommission-status.adoc
@@ -1,0 +1,72 @@
+= rpk redpanda admin brokers decommission-status
+:description: rpk redpanda admin brokers decommission-status
+
+Show the progrss of a node decommissioning.
+
+When a node is being decommissioned, this command reports the decommissioning
+progress as follows, where PARTITION-SIZE is in bytes. Using -H, it prints the
+partition size in a human-readable format.
+
+$ rpk redpanda admin brokers decommission-status 4
+DECOMMISSION PROGRESS
+=====================
+NAMESPACE-TOPIC              PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE
+kafka/test                   0          3          9             1699470920
+kafka/test                   4          3          0             1614258779
+kafka/test2                  3          3          3             2722706514
+kafka/test2                  4          3          4             2945518089
+kafka_internal/id_allocator  0          3          0             3562
+
+Using --detailed / -d, it additionally prints granular reports.
+
+$ rpk redpanda admin brokers decommission-status 4 -d
+DECOMMISSION PROGRESS
+=====================
+NAMESPACE-TOPIC  PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE  BYTES-MOVED  BYTES-REMAINING
+kafka/test       0          3          13            1731773243      228114727    1503658516
+kafka/test       4          3          1             1645952961      18752660     1627200301
+kafka/test2      3          3          5             2752632301      140975805    2611656496
+kafka/test2      4          3          6             2975443783      181581219    2793862564
+
+If a partition cannot be moved with some reason, the command reports the
+problematic partition in the 'ALLOCATION FAILURES' section and decommission
+never succeeds. Typical scenarios the failure occurs are; there's no node
+that has enough space to allocate a partition or that can satisfy rack
+constraints, etc.
+
+ALLOCATION FAILURES
+==================
+kafka/foo/2
+kafka/test/0
+
+Note that the command reports allocation failed partitions only when
+'partition_autobalancing_mode' is set to 'continuous'. See the current value
+using 'rpk cluster config get partition_autobalancing_mode'.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers decommission-status [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --detailed` |- |Print how much data moved and remaining in bytes.
+
+|`-h, --help` |- |Help for decommission-status.
+
+|`-H, --human-readable` |- |Print the partition size in a human-readable form.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-brokers-decommission.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-brokers-decommission.adoc
@@ -1,0 +1,39 @@
+= rpk redpanda admin brokers decommission
+:description: rpk redpanda admin brokers decommission
+
+Decommission the given broker.
+
+Decommissioning a broker removes it from the cluster.
+
+A decommission request is sent to every broker in the cluster, only the cluster
+leader handles the request.
+
+For safety on v22.x clusters, this command will not run if the requested 
+broker is in maintenance mode. As of v23.x, Redpanda supports 
+decommissioning a node that is currently in maintenance mode. If you are on 
+a v22.x cluster and need to bypass the maintenance mode check (perhaps your 
+cluster is unreachable), use the hidden --force flag.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers decommission [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for decommission.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-brokers-list.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-brokers-list.adoc
@@ -1,0 +1,35 @@
+= rpk redpanda admin brokers list
+:description: rpk redpanda admin brokers list
+
+List the brokers in your cluster
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-brokers-recommission.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-brokers-recommission.adoc
@@ -1,0 +1,36 @@
+= rpk redpanda admin brokers recommission
+:description: rpk redpanda admin brokers recommission
+
+Recommission the given broker if is is still decommissioning.
+
+Recommissioning can stop an active decommission.
+
+Once a broker is decommissioned, it cannot be recommissioned through this
+command.
+
+A recommission request is sent to every broker in the cluster, only
+the cluster leader handles the request.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers recommission [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for recommission.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-brokers.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-brokers.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda admin brokers
+:description: rpk redpanda admin brokers
+
+View and configure Redpanda brokers through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers [flags]
+  rpk redpanda admin brokers [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for brokers.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-config-log-level-set.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-config-log-level-set.adoc
@@ -1,0 +1,51 @@
+= rpk redpanda admin config log-level set
+:description: rpk redpanda admin config log-level set
+
+Set broker logger's log level.
+
+This command temporarily changes a broker logger's log level. Each Redpanda
+broker has many loggers, and each can be individually changed. Any change
+to a logger persists for a limited amount of time, so as to ensure you do
+not accidentally enable debug logging permanently.
+
+It is optional to specify a logger; if you do not, this command will prompt
+from the set of available loggers.
+
+The special logger "all" enables all loggers. Alternatively, you can specify
+many loggers at once. To see all possible loggers, run the following command:
+
+  redpanda --help-loggers
+
+This command accepts loggers that it does not know of to ensure you can
+independently update your redpanda installations from rpk. The success or
+failure of enabling each logger is individually printed.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config log-level set [LOGGERS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-e, --expiry-seconds` |int |seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown) (default 300).
+
+|`-h, --help` |- |Help for set.
+
+|`--host` |string |either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to.
+
+|`-l, --level` |string |log level to set (error, warn, info, debug, trace) (default "debug").
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-config-log-level.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-config-log-level.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda admin config log-level
+:description: rpk redpanda admin config log-level
+
+Manage a broker's log level
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config log-level [flags]
+  rpk redpanda admin config log-level [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for log-level.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-config-print.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-config-print.adoc
@@ -1,0 +1,37 @@
+= rpk redpanda admin config print
+:description: rpk redpanda admin config print
+
+Display the current Redpanda configuration
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config print [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+print, dump, list, ls, display
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for print.
+
+|`--host` |string |either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-config.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-config.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda admin config
+:description: rpk redpanda admin config
+
+View or modify Redpanda configuration through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config [flags]
+  rpk redpanda admin config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for config.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-partitions-list.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-partitions-list.adoc
@@ -1,0 +1,37 @@
+= rpk redpanda admin partitions list
+:description: rpk redpanda admin partitions list
+
+List the partitions in a broker in the cluster
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin partitions list [BROKER ID] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`-l, --leader-only` |- |print the partitions on broker which are leaders.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin-partitions.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin-partitions.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda admin partitions
+:description: rpk redpanda admin partitions
+
+View and configure Redpanda partitions through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin partitions [flags]
+  rpk redpanda admin partitions [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for partitions.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-admin.adoc
+++ b/tools/gen/23.2/rpk-redpanda-admin.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda admin
+:description: rpk redpanda admin
+
+Talk to the Redpanda admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin [flags]
+  rpk redpanda admin [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for admin.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-check.adoc
+++ b/tools/gen/23.2/rpk-redpanda-check.adoc
@@ -1,0 +1,30 @@
+= rpk redpanda check
+:description: rpk redpanda check
+
+Check if system meets redpanda requirements
+
+== Usage
+
+[,bash]
+----
+rpk redpanda check [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for check.
+
+|`--timeout` |duration |The maximum amount of time to wait for the checks and tune process to complete (e.g. 300ms, 1.5s, 2h45m) (default 2s).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-config-bootstrap.adoc
+++ b/tools/gen/23.2/rpk-redpanda-config-bootstrap.adoc
@@ -1,0 +1,45 @@
+= rpk redpanda config bootstrap
+:description: rpk redpanda config bootstrap
+
+Initialize the configuration to bootstrap a cluster.
+
+This command generates a `redpanda.yaml` configuration file to bootstrap a
+cluster. If you are modifying the configuration file further, it is recommended
+to first bootstrap and then modify. If the file already exists, this command
+will set fields as requested by flags, and this may undo some of your earlier
+edits.
+
+The --ips flag specifies seed servers (ips, ip:ports, or hostnames) that this
+broker will use to form a cluster.
+
+By default, redpanda expects your machine to have one private IP address, and
+redpanda will listen on it. If your machine has multiple private IP addresses,
+you must use the --self flag to specify which ip redpanda should listen on.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config bootstrap [--self <ip>] [--ips <ip1,ip2,...>] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for bootstrap.
+
+|`--ips` |strings |Comma-separated list of the seed node addresses or hostnames; at least three are recommended.
+
+|`--self` |string |Optional IP address for redpanda to listen on; if empty, defaults to a private address.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-config-init.adoc
+++ b/tools/gen/23.2/rpk-redpanda-config-init.adoc
@@ -1,0 +1,28 @@
+= rpk redpanda config init
+:description: rpk redpanda config init
+
+This command has been deprecated.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config init [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for init.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-config-set.adoc
+++ b/tools/gen/23.2/rpk-redpanda-config-set.adoc
@@ -1,0 +1,52 @@
+= rpk redpanda config set
+:description: rpk redpanda config set
+
+Set configuration values, such as the redpanda node ID or the list of seed servers
+
+This command modifies the `redpanda.yaml` you have locally on disk. The first
+argument is the key within the yaml representing a property / field that you
+would like to set. Nested fields can be accessed through a dot:
+
+  rpk redpanda config set redpanda.developer_mode true
+
+All values are parsed as yaml and, since yaml is a superset of json, you can
+also format your input as json. Individual specific fields or full structs can
+be set:
+
+  rpk redpanda config set rpk.tune_disk_irq true
+  rpk redpanda config set redpanda.rpc_server '{address: 3.250.158.1, port: 9092}'
+
+You can set an entire array by wrapping all items with braces, or by using one
+struct:
+
+  rpk redpanda config set redpanda.advertised_kafka_api '[{address: 0.0.0.0, port: 9092}]'
+  rpk redpanda config set redpanda.advertised_kafka_api '{address: 0.0.0.0, port: 9092}' # same
+
+Indexing can be used to set specific items in an array. You can index one past
+the end of an array to extend it:
+
+  rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 0.0.0.0, port: 9092}'
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config set [KEY] [VALUE] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-config.adoc
+++ b/tools/gen/23.2/rpk-redpanda-config.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda config
+:description: rpk redpanda config
+
+Edit configuration
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config [flags]
+  rpk redpanda config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for config.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-mode.adoc
+++ b/tools/gen/23.2/rpk-redpanda-mode.adoc
@@ -1,0 +1,28 @@
+= rpk redpanda mode
+:description: rpk redpanda mode
+
+Enable a default configuration mode
+
+== Usage
+
+[,bash]
+----
+rpk redpanda mode [MODE] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for mode.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-start.adoc
+++ b/tools/gen/23.2/rpk-redpanda-start.adoc
@@ -1,0 +1,56 @@
+= rpk redpanda start
+:description: rpk redpanda start
+
+Start redpanda
+
+== Usage
+
+[,bash]
+----
+rpk redpanda start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--advertise-kafka-addr` |strings |A comma-separated list of Kafka addresses to advertise (scheme://host:port|name).
+
+|`--advertise-pandaproxy-addr` |strings |A comma-separated list of Pandaproxy addresses to advertise (scheme://host:port|name).
+
+|`--advertise-rpc-addr` |string |The advertised RPC address (host:port).
+
+|`--check` |- |When set to false will disable system checking before starting redpanda (default true).
+
+|`-h, --help` |- |Help for start.
+
+|`--install-dir` |string |Directory where redpanda has been installed.
+
+|`--kafka-addr` |strings |A comma-separated list of Kafka listener addresses to bind to (scheme://host:port|name).
+
+|`--mode` |string |Mode sets well-known configuration properties for development or test environments; use --mode help for more info.
+
+|`--pandaproxy-addr` |strings |A comma-separated list of Pandaproxy listener addresses to bind to (scheme://host:port|name).
+
+|`--rpc-addr` |string |The RPC address to bind to (host:port).
+
+|`--schema-registry-addr` |strings |A comma-separated list of Schema Registry listener addresses to bind to (scheme://host:port|name).
+
+|`-s, --seeds` |strings |A comma-separated list of seed nodes to connect to (scheme://host:port|name).
+
+|`--timeout` |duration |The maximum time to wait for the checks and tune processes to complete (e.g. 300ms, 1.5s, 2h45m) (default 10s).
+
+|`--tune` |- |When present will enable tuning before starting redpanda.
+
+|`--well-known-io` |string |The cloud vendor and VM type, in the format |vendor|:|vm type|:|storage type|.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-stop.adoc
+++ b/tools/gen/23.2/rpk-redpanda-stop.adoc
@@ -1,0 +1,33 @@
+= rpk redpanda stop
+:description: rpk redpanda stop
+
+Stop a local redpanda process. 'rpk stop'
+first sends SIGINT, and waits for the specified timeout. Then, if redpanda
+hasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still
+running.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for stop.
+
+|`--timeout` |duration |The maximum amount of time to wait for redpanda to stop after each signal is sent (e.g. 300ms, 1.5s, 2h45m) (default 5s).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-tune-help.adoc
+++ b/tools/gen/23.2/rpk-redpanda-tune-help.adoc
@@ -1,0 +1,28 @@
+= rpk redpanda tune help
+:description: rpk redpanda tune help
+
+Display detailed information about the tuner
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune help [TUNER] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for help.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-tune-list.adoc
+++ b/tools/gen/23.2/rpk-redpanda-tune-list.adoc
@@ -1,0 +1,48 @@
+= rpk redpanda tune list
+:description: rpk redpanda tune list
+
+List available redpanda tuners and check if they are enabled and 
+supported by your system
+
+To enable a tuner it must be set in the `redpanda.yaml` configuration file
+under rpk section, e.g:
+
+  rpk:
+      tune_cpu: true
+      tune_swappiness: true
+
+You may use 'rpk redpanda config set' to enable or disable a tuner.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune list [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-r, --dirs` |strings |List of *data* directories or places to store data (e.g. /var/vectorized/redpanda/); usually your XFS filesystem on an NVMe SSD device.
+
+|`-d, --disks` |strings |Lists of devices to tune f.e. 'sda1'.
+
+|`-h, --help` |- |Help for list.
+
+|`-m, --mode` |string |Operation Mode: one of: [sq, sq_split, mq].
+
+|`-n, --nic` |strings |Network Interface Controllers to tune.
+
+|`--reboot-allowed` |- |Allow tuners to tune boot parameters and request system reboot.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda-tune.adoc
+++ b/tools/gen/23.2/rpk-redpanda-tune.adoc
@@ -1,0 +1,64 @@
+= rpk redpanda tune
+:description: rpk redpanda tune
+
+Sets the OS parameters to tune system performance.
+
+Available tuners:
+
+  - all.
+  - disk_write_cache
+  - net
+  - clocksource
+  - transparent_hugepages
+  - disk_irq
+  - disk_scheduler
+  - aio_events
+  - swappiness
+  - coredump
+  - fstrim
+  - cpu
+  - ballast_file
+  - disk_nomerges
+
+To learn more about a tuner, run 'rpk redpanda tune help |tuner name|'.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune [list of elements to tune] [flags]
+  rpk redpanda tune [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--cpu-set` |string |Set of CPUs for tuners to use in cpuset(7) format; if not specified, tuners will use all available CPUs (default "all").
+
+|`-r, --dirs` |strings |List of *data* directories or places to store data (e.g. /var/vectorized/redpanda/); usually your XFS filesystem on an NVMe SSD device.
+
+|`-d, --disks` |strings |Lists of devices to tune f.e. 'sda1'.
+
+|`-h, --help` |- |Help for tune.
+
+|`-m, --mode` |string |Operation Mode: one of: [sq, sq_split, mq].
+
+|`-n, --nic` |strings |Network Interface Controllers to tune.
+
+|`--output-script` |string |Generate a tuning file that can later be used to tune the system.
+
+|`--reboot-allowed` |- |Allow tuners to tune boot parameters and request system reboot.
+
+|`--timeout` |duration |The maximum time to wait for the tune processes to complete (e.g. 300ms, 1.5s, 2h45m) (default 10s).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-redpanda.adoc
+++ b/tools/gen/23.2/rpk-redpanda.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda
+:description: rpk redpanda
+
+Interact with a local Redpanda process
+
+== Usage
+
+[,bash]
+----
+rpk redpanda [flags]
+  rpk redpanda [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for redpanda.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic-add-partitions.adoc
+++ b/tools/gen/23.2/rpk-topic-add-partitions.adoc
@@ -1,0 +1,32 @@
+= rpk topic add-partitions
+:description: rpk topic add-partitions
+
+Add partitions to existing topics.
+
+== Usage
+
+[,bash]
+----
+rpk topic add-partitions [TOPICS...] --num [#] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --force` |- |Force change the partition count in internal topics, e.g. __consumer_offsets.
+
+|`-h, --help` |- |Help for add-partitions.
+
+|`-n, --num` |int |Number of partitions to add to each topic.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic-alter-config.adoc
+++ b/tools/gen/23.2/rpk-topic-alter-config.adoc
@@ -1,0 +1,51 @@
+= rpk topic alter-config
+:description: rpk topic alter-config
+
+Set, delete, add, and remove key/value configs for a topic.
+
+This command allows you to incrementally alter the configuration for multiple
+topics at a time.
+
+Incremental altering supports four operations:
+
+  1) Setting a key=value pair
+  2) Deleting a key's value
+  3) Appending a new value to a list-of-values key
+  4) Subtracting (removing) an existing value from a list-of-values key
+
+The --dry option will validate whether the requested configuration change is
+valid, but does not apply it.
+
+== Usage
+
+[,bash]
+----
+rpk topic alter-config [TOPICS...] --set key=value --delete key2,key3 [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--append` |stringArray |key=value; Value to append to a list-of-values key (repeatable).
+
+|`-d, --delete` |stringArray |Key to delete (repeatable).
+
+|`--dry` |- |Dry run: validate the alter request, but do not apply.
+
+|`-h, --help` |- |Help for alter-config.
+
+|`-s, --set` |stringArray |key=value; Pair to set (repeatable).
+
+|`--subtract` |stringArray |key=value; Value to remove from list-of-values key (repeatable).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic-consume.adoc
+++ b/tools/gen/23.2/rpk-topic-consume.adoc
@@ -1,0 +1,305 @@
+= rpk topic consume
+:description: rpk topic consume
+
+Consume records from topics.
+
+Consuming records reads from any amount of input topics, formats each record
+according to --format, and prints them to STDOUT. The output formatter
+understands a wide variety of formats.
+
+The default output format "--format json" is a special format that outputs each
+record as JSON. There may be more single-word-no-escapes formats added later.
+Outside of these special formats, formatting follows the rules described below.
+
+Formatting output is based on percent escapes and modifiers. Slashes can be
+used for common escapes:
+
+    \t \n \r \\ \xNN
+
+prints tabs, newlines, carriage returns, slashes, or hex encoded characters.p
+
+Percent encoding prints record fields, fetch partition fields, or extra values:
+
+    %t    topic
+    %T    topic length
+    %k    key
+    %K    key length
+    %v    value
+    %V    value length
+    %h    begin the header specification
+    %H    number of headers
+    %p    partition
+    %o    offset
+    %e    leader epoch
+    %d    timestamp (formatting described below)
+    %a    record attributes (formatting described below)
+    %x    producer id
+    %y    producer epoch
+
+    %[    partition log start offset
+    %|    partition last stable offset
+    %]    partition high watermark
+
+    %%    percent sign
+    %{    left brace
+    %}    right brace
+
+    %i    the number of records formatted
+
+MODIFIERS
+
+Text and numbers can be formatted in many different ways, and the default
+format can be changed within brace modifiers. %v prints a value, while %v{hex}
+prints the value hex encoded. %T prints the length of a topic in ascii, while
+%T{big8} prints the length of the topic as an eight byte big endian.
+
+All modifiers go within braces following a percent-escape.
+
+NUMBERS
+
+Formatting number values can have the following modifiers:
+
+     ascii       print the number as ascii (default)
+
+     hex64       sixteen hex characters
+     hex32       eight hex characters
+     hex16       four hex characters
+     hex8        two hex characters
+     hex4        one hex character
+
+     big64       eight byte big endian number
+     big32       four byte big endian number
+     big16       two byte big endian number
+     big8        alias for byte
+
+     little64    eight byte little endian number
+     little32    four byte little endian number
+     little16    two byte little endian number
+     little8     alias for byte
+
+     byte        one byte number
+     bool        "true" if the number is non-zero, "false" if the number is zero
+
+All numbers are truncated as necessary per the modifier. Printing %V{byte} for
+a length 256 value will print a single null, whereas printing %V{big8} would
+print the bytes 1 and 0.
+
+When writing number sizes, the size corresponds to the size of the raw values,
+not the size of encoded values. "%T% t{hex}" for the topic "foo" will print
+"3 666f6f", not "6 666f6f".
+
+TIMESTAMPS
+
+By default, the timestamp field is printed as a millisecond number value. In
+addition to the number modifiers above, timestamps can be printed with either
+Go formatting or strftime formatting:
+
+    %d{go[2006-01-02T15:04:05Z07:00]}
+    %d{strftime[%F]}
+
+An arbitrary amount of brackets (or braces, or # symbols) can wrap your date
+formatting:
+
+    %d{strftime### [%F] ###}
+
+The above will print " [YYYY-MM-DD] ", while the surrounding three # on each
+side are used to wrap the formatting. Further details on Go time formatting can
+be found at https://pkg.go.dev/time, while further details on strftime
+formatting can be read by checking "man strftime".
+
+ATTRIBUTES
+
+Each record (or batch of records) has a set of possible attributes. Internally,
+these are packed into bit flags. Printing an attribute requires first selecting
+which attribute you want to print, and then optionally specifying how you want
+it to be printed:
+
+     %a{compression}
+     %a{compression;number}
+     %a{compression;big64}
+     %a{compression;hex8}
+
+Compression is by default printed as text ("none", "gzip", ...). Compression
+can be printed as a number with ";number", where number is any number
+formatting option described above. No compression is 0, gzip is 1, etc.
+
+     %a{timestamp-type}
+     %a{timestamp-type;big64}
+
+The record's timestamp type is printed as -1 for very old records (before
+timestamps existed), 0 for client generated timestamps, and 1 for broker
+generated timestamps. Number formatting can be controlled with ";number".
+
+     %a{transactional-bit}
+     %a{transactional-bit;bool}
+
+Prints 1 if the record a part of a transaction or 0 if it is not.
+Number formatting can be controlled with ";number".
+
+     %a{control-bit}
+     %a{control-bit;bool}
+
+Prints 1 if the record is a commit marker or 0 if it is not.
+Number formatting can be controlled with ";number".
+
+TEXT
+
+Text fields without modifiers default to writing the raw bytes. Alternatively,
+there are the following modifiers:
+
+    %t{hex}
+    %k{base64}
+    %v{base64raw}
+    %v{unpack[<bBhH>iIqQc.$]}
+
+The hex modifier hex encodes the text, the base64 modifier base64 encodes the
+text with standard encoding, and the base64raw modifier encodes the text with
+raw standard encoding. The unpack modifier has a further internal
+specification, similar to timestamps above:
+
+    x    pad character (does not parse input)
+    <    switch what follows to little endian
+    >    switch what follows to big endian
+
+    b    signed byte
+    B    unsigned byte
+    h    int16  ("half word")
+    H    uint16 ("half word")
+    i    int32
+    I    uint32
+    q    int64  ("quad word")
+    Q    uint64 ("quad word")
+
+    c    any character
+    .    alias for c
+    s    consume the rest of the input as a string
+    $    match the end of the line (append error string if anything remains)
+
+Unpacking text can allow translating binary input into readable output. If a
+value is a big-endian uint32, %v will print the raw four bytes, while
+%v{unpack[>I]} will print the number in as ascii. If unpacking exhausts the
+input before something is unpacked fully, an error message is appended to the
+output.
+
+HEADERS
+
+Headers are formatted with percent encoding inside of the modifier:
+
+    %h{ %k=%v{hex} }
+
+will print all headers with a space before the key and after the value, an
+equals sign between the key and value, and with the value hex encoded. Header
+formatting actually just parses the internal format as a record format, so all
+of the above rules about %K, %V, text, and numbers apply.
+
+EXAMPLES
+
+A key and value, separated by a space and ending in newline:
+    -f '%k %v\n'
+A key length as four big endian bytes, and the key as hex:
+    -f '%K{big32}%k{hex}'
+A little endian uint32 and a string unpacked from a value:
+    -f '%v{unpack[is$]}'
+
+OFFSETS
+
+The --offset flag allows for specifying where to begin consuming, and
+optionally, where to stop consuming. The literal words "start" and "end"
+specify consuming from the start and the end.
+
+    start     consume from the beginning
+    end       consume from the end
+    :end      consume until the current end
+    +oo       consume oo after the current start offset
+    -oo       consume oo before the current end offset
+    oo        consume after an exact offset
+    oo:       alias for oo
+    :oo       consume until an exact offset
+    o1:o2     consume from exact offset o1 until exact offset o2
+    @t        consume starting from a given timestamp
+    @t:       alias for @t
+    @:t       consume until a given timestamp
+    @t1:t2    consume from timestamp t1 until timestamp t2
+
+There are a few options for timestamps, with each option being evaluated
+until one succeeds:
+
+    13 digits             parsed as a unix millisecond
+    9 digits              parsed as a unix second
+    YYYY-MM-DD            parsed as a day, UTC
+    YYYY-MM-DDTHH:MM:SSZ  parsed as RFC3339, UTC; fractional seconds optional (.MMM)
+    end                   for t2 in @t1:t2, the current end of the partition
+    -dur                  a negative duration from now or from a timestamp
+    dur                   a positive duration from now or from a timestamp
+
+Durations can be relative to the current time or relative to a timestamp.
+If a duration is used for t1, that duration is relative to now.
+If a duration is used for t2, if t1 is a timestamp, then t2 is relative to t1.
+If a duration is used for t2, if t1 is a duration, then t2 is relative to now.
+
+Durations are parsed simply:
+
+    3ms    three milliseconds
+    10s    ten seconds
+    9m     nine minutes
+    1h     one hour
+    1m3ms  one minute and three milliseconds
+
+For example,
+
+    -o @2022-02-14:1h   consume 1h of time on Valentine's Day 2022
+    -o @-48h:-24h       consume from 2 days ago to 1 day ago
+    -o @-1m:end         consume from 1m ago until now
+    -o @:-1hr           consume from the start until an hour ago
+
+== Usage
+
+[,bash]
+----
+rpk topic consume TOPICS... [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-b, --balancer` |string |Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky) (default "cooperative-sticky").
+
+|`--fetch-max-bytes` |int32 |Maximum amount of bytes per fetch request per broker (default 1048576).
+
+|`--fetch-max-wait` |duration |Maximum amount of time to wait when fetching from a broker before the broker replies (default 5s).
+
+|`-f, --format` |string |Output format (see --help for details) (default "json").
+
+|`-g, --group` |string |Group to use for consuming (incompatible with -p).
+
+|`-h, --help` |- |Help for consume.
+
+|`--meta-only` |- |Print all record info except the record value (for -f json).
+
+|`-n, --num` |int |Quit after consuming this number of records (0 is unbounded).
+
+|`-o, --offset` |string |Offset to consume from / to (start, end, 47, +2, -3) (default "start").
+
+|`-p, --partitions` |int32 |int32Slice     Comma delimited list of specific partitions to consume (default []).
+
+|`--pretty-print` |- |Pretty print each record over multiple lines (for -f json) (default true).
+
+|`--print-control-records` |- |Opt in to printing control records.
+
+|`--rack` |string |Rack to use for consuming, which opts into follower fetching.
+
+|`--read-committed` |- |Opt in to reading only committed offsets.
+
+|`-r, --regex` |- |Parse topics as regex; consume any topic that matches any expression.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic-create.adoc
+++ b/tools/gen/23.2/rpk-topic-create.adoc
@@ -1,0 +1,46 @@
+= rpk topic create
+:description: rpk topic create
+
+Create topics.
+
+All topics created with this command will have the same number of partitions,
+replication factor, and key/value configs.
+
+For example,
+
+	create -c cleanup.policy=compact -r 3 -p 20 foo bar
+
+will create two topics, foo and bar, each with 20 partitions, 3 replicas, and
+the cleanup.policy=compact config option set.
+
+== Usage
+
+[,bash]
+----
+rpk topic create [TOPICS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --dry` |- |Dry run: validate the topic creation request; do not create topics.
+
+|`-h, --help` |- |Help for create.
+
+|`-p, --partitions` |int32 |Number of partitions to create per topic; -1 defaults to the cluster's default_topic_partitions (default -1).
+
+|`-r, --replicas` |int16 |Replication factor (must be odd); -1 defaults to the cluster's default_topic_replications (default -1).
+
+|`-c, --topic-config` |stringArray |key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic-delete.adoc
+++ b/tools/gen/23.2/rpk-topic-delete.adoc
@@ -1,0 +1,49 @@
+= rpk topic delete
+:description: rpk topic delete
+
+Delete topics.
+
+This command deletes all requested topics, printing the success or fail status
+per topic.
+
+The --regex flag (-r) opts into parsing the input topics as regular expressions
+and deleting any non-internal topic that matches any of expressions. The input
+expressions are wrapped with ^ and $ so that the expression must match the
+whole topic name (which also prevents accidental delete-everything mistakes).
+
+The topic list command accepts the same input regex format as this delete
+command. If you want to check what your regular expressions will delete before
+actually deleting them, you can check the output of 'rpk topic list -r'.
+
+For example,
+
+    delete foo bar            # deletes topics foo and bar
+    delete -r '^f.*' '.*r$'   # deletes any topic starting with f and any topics ending in r
+    delete -r '.*'            # deletes all topics
+    delete -r .               # deletes any one-character topics
+
+== Usage
+
+[,bash]
+----
+rpk topic delete [TOPICS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`-r, --regex` |- |Parse topics as regex; delete any topic that matches any input topic expression.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic-describe-storage.adoc
+++ b/tools/gen/23.2/rpk-topic-describe-storage.adoc
@@ -1,0 +1,70 @@
+= rpk topic describe-storage
+:description: rpk topic describe-storage
+
+Describe the topic storage status.
+
+This commands prints detailed information about the cloud storage status of a
+given topic, the information is divided in 4 sections:
+
+SUMMARY
+
+The summary section contains general information about the topic, the cloud
+storage mode (one of disabled, write_only, read_only, full, and read_replica),
+and the delta in milliseconds since the last upload of either the partition
+manifest or a segment.
+
+OFFSET
+
+The offset section contains the start and last offsets (inclusive) per
+partition of data available in both the cloud and on local disk.
+
+SIZE
+
+The size section contains the total bytes per partition in the cloud and on
+local disk, the total size of the log of each partition (excluding cloud and
+local overlap), and the number of segments in the cloud and on local disk. The
+cloud segment count does not include segments queued for deletion.
+
+SYNC
+
+The sync section contains the state of cloud synchronization: milliseconds
+since the last upload of the partition manifest, milliseconds since the last
+segment upload, milliseconds since the last manifest sync (for read replicas),
+and whether the remote metadata has a pending update to include all uploaded
+segments.
+
+== Usage
+
+[,bash]
+----
+rpk topic describe-storage [TOPIC] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for describe-storage.
+
+|`-H, --human-readable` |- |Print the times and bytes in a human-readable form.
+
+|`-a, --print-all` |- |Print all cloud storage status.
+
+|`-o, --print-offset` |- |Print the offset section.
+
+|`-z, --print-size` |- |Print the log size section.
+
+|`-s, --print-summary` |- |Print the summary section.
+
+|`-y, --print-sync` |- |Print the sync section.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic-describe.adoc
+++ b/tools/gen/23.2/rpk-topic-describe.adoc
@@ -1,0 +1,49 @@
+= rpk topic describe
+:description: rpk topic describe
+
+Describe a topic.
+
+This command prints detailed information about a topic. There are three
+potential sections: a summary of the topic, the topic configs, and a detailed
+partitions section. By default, the summary and configs sections are printed.
+
+== Usage
+
+[,bash]
+----
+rpk topic describe [TOPIC] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+describe, info
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for describe.
+
+|`-a, --print-all` |- |Print all sections.
+
+|`-c, --print-configs` |- |Print the config section.
+
+|`-p, --print-partitions` |- |Print the detailed partitions section.
+
+|`-s, --print-summary` |- |Print the summary section.
+
+|`--stable` |- |Include the stable offsets column in the partitions section; only relevant if you produce to this topic transactionally.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic-list.adoc
+++ b/tools/gen/23.2/rpk-topic-list.adoc
@@ -1,0 +1,58 @@
+= rpk topic list
+:description: rpk topic list
+
+List topics, optionally listing specific topics.
+
+This command lists all topics that you have access to by default. If specifying
+topics or regular expressions, this command can be used to know exactly what
+topics you would delete if using the same input to the delete command.
+
+Alternatively, you can request specific topics to list, which can be used to
+check authentication errors (do you not have access to a topic you were
+expecting to see?), or to list all topics that match regular expressions.
+
+The --regex flag (-r) opts into parsing the input topics as regular expressions
+and listing any non-internal topic that matches any of expressions. The input
+expressions are wrapped with ^ and $ so that the expression must match the
+whole topic name. Regular expressions cannot be used to match internal topics,
+as such, specifying both -i and -r will exit with failure.
+
+Lastly, --detailed flag (-d) opts in to printing extra per-partition
+information.
+
+== Usage
+
+[,bash]
+----
+rpk topic list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --detailed` |- |Print per-partition information for topics.
+
+|`-h, --help` |- |Help for list.
+
+|`-i, --internal` |- |Print internal topics.
+
+|`-r, --regex` |- |Parse topics as regex; list any topic that matches any input topic expression.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic-produce.adoc
+++ b/tools/gen/23.2/rpk-topic-produce.adoc
@@ -1,0 +1,173 @@
+= rpk topic produce
+:description: rpk topic produce
+
+Produce records to a topic.
+
+Producing records reads from STDIN, parses input according to --format, and
+produce records to Redpanda. The input formatter understands a wide variety of
+formats.
+
+Parsing input operates on either sizes or on delimiters, both of which can be
+specified in the same formatting options. If using sizes to specify something,
+the size must come before what it is specifying. Delimiters match on an exact
+text basis. This command will quit with an error if any input fails to match
+your specified format.
+
+Slashes can be used for common escapes:
+
+    \t \n \r \\ \xNN
+
+matches tabs, newlines, carriage returns, slashes, and hex encoded characters.
+
+Percent encoding reads into specific values of a record:
+
+    %t    topic
+    %T    topic length
+    %k    key
+    %K    key length
+    %v    value
+    %V    value length
+    %h    begin the header specification
+    %H    number of headers
+    %p    partition (if using the --partition flag)
+
+Three escapes exist to parse characters that are used to modify the previous
+escapes:
+
+    %%    percent sign
+    %{    left brace
+    %}    right brace
+
+MODIFIERS
+
+Text and numbers can be read in multiple formats, and the default format can be
+changed within brace modifiers. %v reads a value, while %v{hex} reads a value
+and then hex decodes it before producing. %T reads the length of a topic from
+the input, while %T{3} reads exactly three bytes for a topic from the input.
+
+All modifiers go within braces following a percent-escape.
+
+NUMBERS
+
+Reading number values can have the following modifiers:
+
+     ascii       parse numeric digits until a non-numeric (default)
+
+     hex64       sixteen hex characters
+     hex32       eight hex characters
+     hex16       four hex characters
+     hex8        two hex characters
+     hex4        one hex character
+
+     big64       eight byte big endian number
+     big32       four byte big endian number
+     big16       two byte big endian number
+     big8        alias for byte
+
+     little64    eight byte little endian number
+     little32    four byte little endian number
+     little16    two byte little endian number
+     little8     alias for byte
+
+     byte        one byte number
+     <digits>    directly specify the length as this many digits
+     bool        read "true" as 1, "false" as 0
+
+When reading number sizes, the size corresponds to the size of the encoded
+values, not the decoded values. "%T{6}%t{hex}" will read six hex bytes and
+decode into three.
+
+TEXT
+
+Reading text values can have the following modifiers:
+
+    hex       read text then hex decode it
+    base64    read text then std-encoding base64 decode it
+    re        read text matching a regular expression
+
+HEADERS
+
+Headers are parsed with an internal key / value specifier format. For example,
+the following will read three headers that begin and end with a space and are
+separated by an equal:
+
+    %H{3}%h{ %k=%v }
+
+EXAMPLES
+
+In the below examples, we can parse many records at once. The produce command
+reads input and tokenizes based on your specified format. Every time the format
+is completely matched, a record is produced and parsing begins anew.
+
+A key and value, separated by a space and ending in newline:
+    -f '%k %v\n'
+A four byte topic, four byte key, and four byte value:
+    -f '%T{4}%K{4}%V{4}%t%k%v'
+A value to a specific partition, if using a non-negative --partition flag:
+    -f '%p %v\n'
+A big-endian uint16 key size, the text " foo ", and then that key:
+    -f '%K{big16} foo %k'
+A value that can be two or three characters followed by a newline:
+    -f '%v{re#...?#}\n'
+
+MISC
+
+Producing requires a topic to produce to. The topic can be specified either
+directly on as an argument, or in the input text through %t. A parsed topic
+takes precedence over the default passed in topic. If no topic is specified
+directly and no topic is parsed, this command will quit with an error.
+
+The input format can parse partitions to produce directly to with %p. Doing so
+requires specifying a non-negative --partition flag. Any parsed partition
+takes precedence over the --partition flag; specifying the flag is the main
+requirement for being able to directly control which partition to produce to.
+
+You can also specify an output format to write when a record is produced
+successfully. The output format follows the same formatting rules as the topic
+consume command. See that command's help text for a detailed description.
+
+== Usage
+
+[,bash]
+----
+rpk topic produce [TOPIC] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--acks` |int |Number of acks required for producing (-1=all, 0=none, 1=leader) (default -1).
+
+|`--allow-auto-topic-creation` |- |Auto-create non-existent topics; requires auto_create_topics_enabled on the broker.
+
+|`-z, --compression` |string |Compression to use for producing batches (none, gzip, snappy, lz4, zstd) (default "snappy").
+
+|`--delivery-timeout` |duration |Per-record delivery timeout, if non-zero, min 1s.
+
+|`-f, --format` |string |Input record format (default "%v\n").
+
+|`-H, --header` |stringArray |Headers in format key:value to add to each record (repeatable).
+
+|`-h, --help` |- |Help for produce.
+
+|`-k, --key` |string |A fixed key to use for each record (parsed input keys take precedence).
+
+|`--max-message-bytes` |int32 |If non-negative, maximum size of a record batch before compression (default -1).
+
+|`-o, --output-format` |string |what to write to stdout when a record is successfully produced (default "Produced to partition %p at offset %o with timestamp %d.\n").
+
+|`-p, --partition` |int32 |Partition to directly produce to, if non-negative (also allows %p parsing to set partitions) (default -1).
+
+|`-Z, --tombstone` |- |Produce empty values as tombstones.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic-trim-prefix.adoc
+++ b/tools/gen/23.2/rpk-topic-trim-prefix.adoc
@@ -1,0 +1,72 @@
+= rpk topic trim-prefix
+:description: rpk topic trim-prefix
+
+Trim records from topics
+
+This command allows you to trim records from topics, to trim the topics Redpanda
+sets the LogStartOffset for partitions to the requested offset. All segments
+whose base offset is less then the requested offset are deleted, and any records
+within the segment before the requested offset can no longer be read.
+
+The --offset/-o flag allows you to indicate which index you want to set the
+partition's low watermark (start offset) to. It can be a single integer value
+denoting the offset or a timestamp if you prefix the offset with an '@'. You may
+select which partition you want to trim the offset from with the --partition/-p
+flag.
+
+The --from-file option allows to trim the offsets specified in a text file with
+the following format:
+    [TOPIC] [PARTITION] [OFFSET]
+    [TOPIC] [PARTITION] [OFFSET]
+    ...
+or the equivalent keyed JSON/YAML file.
+
+EXAMPLES
+
+Trim records in 'foo' topic to offset 120 in partition 1
+    rpk topic trim-prefix foo --offset 120 --partition 1
+
+Trim records in all partitions of topic foo previous to an specific timestamp
+    rpk topic trim-prefix foo -o "@1622505600"
+
+Trim records from a JSON file
+    rpk topic trim-prefix --from-file /tmp/to_trim.json
+
+== Usage
+
+[,bash]
+----
+rpk topic trim-prefix [TOPIC] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+trim-prefix, trim
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --from-file` |string |File of topic/partition/offset for which to trim offsets for.
+
+|`-h, --help` |- |Help for trim-prefix.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`-o, --offset` |string |Offset to set the partition's start offset to (end, 47, @<timestamp>).
+
+|`-p, --partitions` |int32 |int32Slice   Comma-separated list of partitions to trim records from (default to all) (default []).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-topic.adoc
+++ b/tools/gen/23.2/rpk-topic.adoc
@@ -1,0 +1,29 @@
+= rpk topic
+:description: rpk topic
+
+Create, delete, produce to and consume from Redpanda topics
+
+== Usage
+
+[,bash]
+----
+rpk topic [flags]
+  rpk topic [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for topic.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.2/rpk-version.adoc
+++ b/tools/gen/23.2/rpk-version.adoc
@@ -1,0 +1,28 @@
+= rpk version
+:description: rpk version
+
+Check the current version
+
+== Usage
+
+[,bash]
+----
+rpk version [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for version.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/json/rpk-commands.json
+++ b/tools/gen/23.3-beta/json/rpk-commands.json
@@ -1,0 +1,5239 @@
+{
+    "rpk acl": {
+        "description": "Manage ACLs and SASL users.\r\n\r\nThis command space creates, lists, and deletes ACLs, as well as creates SASL\r\nusers. The help text below is specific to ACLs. To learn about SASL users,\r\ncheck the help text under the \"user\" command.\r\n\r\nWhen using SASL, ACLs allow or deny you access to certain requests. The\r\n\"create\", \"delete\", and \"list\" commands help you manage your ACLs.\r\n\r\nAn ACL is made up of five components:\r\n\r\n  * a principal (the user)\r\n  * a host the principal is allowed or denied requests from\r\n  * what resource to access (topic name, group ID, ...)\r\n  * the operation (read, write, ...)\r\n  * the permission: whether to allow or deny the above\r\n\r\nACL commands work on a multiplicative basis. If creating, specifying two\r\nprincipals and two permissions creates four ACLs: both permissions for the\r\nfirst principal, as well as both permissions for the second principal. Adding\r\ntwo resources further doubles the ACLs created.\r\n\r\nIt is recommended to be as specific as possible when granting ACLs. Granting\r\nmore ACLs than necessary per principal may inadvertently allow clients to do\r\nthings they should not, such as deleting topics or joining the wrong consumer\r\ngroup.\r\n\r\nPRINCIPALS\r\n\r\nAll ACLs require a principal. A principal is composed of two parts: the type\r\nand the name. Within Redpanda, only one type is supported, \"User\". The reason\r\nfor the prefix is that a potential future authorizer may add support for\r\nauthorizing by Group or anything else.\r\n\r\nWhen you create a user, you need to add ACLs for it before it can be used. You\r\ncan create / delete / list ACLs for that user with either \"User:bar\" or \"bar\"\r\nin the --allow-principal and --deny-principal flags. This command will add the\r\n\"User:\" prefix for you if it is missing. The wildcard '*' matches any user.\r\nCreating an ACL with user '*' grants or denies the permission for all users.\r\n\r\nHOSTS\r\n\r\nHosts can be seen as an extension of the principal, and effectively gate where\r\nthe principal can connect from. When creating ACLs, unless otherwise specified,\r\nthe default host is the wildcard '*' which allows or denies the principal from\r\nall hosts (where allow & deny are based on whether --allow-principal or\r\n--deny-principal is used). If specifying hosts, you must pair the --allow-host\r\nflag with the --allow-principal flag, and the --deny-host flag with the\r\n--deny-principal flag.\r\n\r\nRESOURCES\r\n\r\nA resource is what an ACL allows or denies access to. There are four resources\r\nwithin Redpanda: topics, groups, the cluster itself, and transactional IDs.\r\nNames for each of these resources can be specified with their respective flags.\r\n\r\nResources combine with the operation that is allowed or denied on that\r\nresource. The next section describes which operations are required for which\r\nrequests, and further fleshes out the concept of a resource.\r\n\r\nBy default, resources are specified on an exact name match (a \"literal\" match).\r\nThe --resource-pattern-type flag can be used to specify that a resource name is\r\n\"prefixed\", meaning to allow anything with the given prefix. A literal name of\r\n\"foo\" will match only the topic \"foo\", while the prefixed name of \"foo-\" will\r\nmatch both \"foo-bar\" and \"foo-baz\". The special wildcard resource name '*'\r\nmatches any name of the given resource type (--topic '*' matches all topics).\r\n\r\nOPERATIONS\r\n\r\nPairing with resources, operations are the actions that are allowed or denied.\r\nRedpanda has the following operations:\r\n\r\n    ALL                 Allows all operations below.\r\n    READ                Allows reading a given resource.\r\n    WRITE               Allows writing to a given resource.\r\n    CREATE              Allows creating a given resource.\r\n    DELETE              Allows deleting a given resource.\r\n    ALTER               Allows altering non-configurations.\r\n    DESCRIBE            Allows querying non-configurations.\r\n    DESCRIBE_CONFIGS    Allows describing configurations.\r\n    ALTER_CONFIGS       Allows altering configurations.\r\n\r\nCheck --help-operations to see which operations are required for which\r\nrequests. In flag form to set up a general producing/consuming client, you can\r\ninvoke 'rpk acl create' three times with the following (including your\r\n--allow-principal):\r\n\r\n    --operation write,read,describe --topic [topics]\r\n    --operation describe,read --group [group.id]\r\n    --operation describe,write --transactional-id [transactional.id]\r\n\r\nPERMISSIONS\r\n\r\nA client can be allowed access or denied access. By default, all permissions\r\nare denied. You only need to specifically deny a permission if you allow a wide\r\nset of permissions and then want to deny a specific permission in that set.\r\nYou could allow all operations, and then specifically deny writing to topics.\r\n\r\nMANAGEMENT\r\n\r\nCreating ACLs works on a specific ACL basis, but listing and deleting ACLs\r\nworks on filters. Filters allow matching many ACLs to be printed listed and\r\ndeleted at once. Because this can be risky for deleting, the delete command\r\nprompts for confirmation by default. More details and examples for creating,\r\nlisting, and deleting can be seen in each of the commands.\r\n\r\nUsing SASL requires setting \"enable_sasl: true\" in the redpanda section of your\r\nredpanda.yaml. User management is a separate, simpler concept that is\r\ndescribed in the user command.",
+        "usage": "Usage:\r\n  rpk acl [flags]\r\n  rpk acl [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for acl."
+            },
+            "--help-operations": {
+                "type": "-",
+                "description": "Print more help about ACL operations."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl create": {
+        "description": "Create ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. Following the\r\nmultiplying effect of combining flags, the create command works on a\r\nstraightforward basis: every ACL combination is a created ACL.\r\n\r\nAs mentioned in the 'rpk acl' help text, if no host is specified, an allowed\r\nprincipal is allowed access from all hosts. The wildcard principal '*' allows\r\nall principals. At least one principal, one host, one resource, and one\r\noperation is required to create a single ACL.\r\n\r\nAllow all permissions to user bar on topic \"foo\" and group \"g\":\r\n    --allow-principal bar --operation all --topic foo --group g\r\nAllow read permissions to all users on topics biz and baz:\r\n    --allow-principal '*' --operation read --topic biz,baz\r\nAllow write permissions to user buzz to transactional id \"txn\":\r\n    --allow-principal User:buzz --operation write --transactional-id txn",
+        "usage": "Usage:\r\n  rpk acl create [flags]\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Hosts from which access will be granted (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Principals for which these permissions will be granted (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to grant ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Hosts from from access will be denied (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Principal for which these permissions will be denied (repeatable)."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to grant ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to grant (repeatable)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (literal or prefixed) (default \"literal\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to grant ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to grant ACLs for (repeatable)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl delete": {
+        "description": "Delete ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. Delete flags work in a\r\nsimilar multiplying effect as creating ACLs, but delete is more advanced:\r\ndeletion works on a filter basis. Any unspecified flag defaults to matching\r\neverything (all operations, or all allowed principals, etc). To ensure that you\r\ndo not accidentally delete more than you intend, this command prints everything\r\nthat matches your input filters and prompts for a confirmation before the\r\ndelete request is issued. Anything matching more than 10 ACLs doubly confirms.\r\n\r\nAs mentioned, not specifying flags matches everything. If no resources are\r\nspecified, all resources are matched. If no operations are specified, all\r\noperations are matched. You can also opt in to matching everything with \"any\":\r\n--operation any matches any operation.\r\n\r\nThe --resource-pattern-type, defaulting to \"any\", configures how to filter\r\nresource names:\r\n  * \"any\" returns exact name matches of either prefixed or literal pattern type\r\n  * \"match\" returns wildcard matches, prefix patterns that match your input, and literal matches\r\n  * \"prefix\" returns prefix patterns that match your input (prefix \"fo\" matches \"foo\")\r\n  * \"literal\" returns exact name matches",
+        "usage": "Usage:\r\n  rpk acl delete [flags]\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Allowed host ACLs to remove (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Allowed principal ACLs to remove (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to remove ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Denied host ACLs to remove (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Denied principal ACLs to remove (repeatable)."
+            },
+            "-d, --dry": {
+                "type": "-",
+                "description": "Dry run: validate what would be deleted."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to remove ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to remove (repeatable)."
+            },
+            "-f, --print-filters": {
+                "type": "-",
+                "description": "Print the filters that were requested (failed filters are always printed)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (any, match, literal, or prefixed) (default \"any\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to remove ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to remove ACLs for (repeatable)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl list": {
+        "description": "List ACLs.\r\n\r\nSee the 'rpk acl' help text for a full write up on ACLs. List flags work in a\r\nsimilar multiplying effect as creating ACLs, but list is more advanced:\r\nlisting works on a filter basis. Any unspecified flag defaults to matching\r\neverything (all operations, or all allowed principals, etc).\r\n\r\nAs mentioned, not specifying flags matches everything. If no resources are\r\nspecified, all resources are matched. If no operations are specified, all\r\noperations are matched. You can also opt in to matching everything with \"any\":\r\n--operation any matches any operation.\r\n\r\nThe --resource-pattern-type, defaulting to \"any\", configures how to filter\r\nresource names:\r\n  * \"any\" returns exact name matches of either prefixed or literal pattern type\r\n  * \"match\" returns wildcard matches, prefix patterns that match your input, and literal matches\r\n  * \"prefix\" returns prefix patterns that match your input (prefix \"fo\" matches \"foo\")\r\n  * \"literal\" returns exact name matches",
+        "usage": "Usage:\r\n  rpk acl list [flags]\r\n\r\nAliases:\r\n  list, ls, describe\r\n\r",
+        "flags": {
+            "--allow-host": {
+                "type": "strings",
+                "description": "Allowed host ACLs to match (repeatable)."
+            },
+            "--allow-principal": {
+                "type": "strings",
+                "description": "Allowed principal ACLs to match (repeatable)."
+            },
+            "--cluster": {
+                "type": "-",
+                "description": "Whether to match ACLs to the cluster."
+            },
+            "--deny-host": {
+                "type": "strings",
+                "description": "Denied host ACLs to match (repeatable)."
+            },
+            "--deny-principal": {
+                "type": "strings",
+                "description": "Denied principal ACLs to match (repeatable)."
+            },
+            "--group": {
+                "type": "strings",
+                "description": "Group to match ACLs for (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--operation": {
+                "type": "strings",
+                "description": "Operation to match (repeatable)."
+            },
+            "-f, --print-filters": {
+                "type": "-",
+                "description": "Print the filters that were requested (failed filters are always printed)."
+            },
+            "--resource-pattern-type": {
+                "type": "string",
+                "description": "Pattern to use when matching resource names (any, match, literal, or prefixed) (default \"any\")."
+            },
+            "--topic": {
+                "type": "strings",
+                "description": "Topic to match ACLs for (repeatable)."
+            },
+            "--transactional-id": {
+                "type": "strings",
+                "description": "Transactional IDs to match ACLs for (repeatable)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl user": {
+        "description": "Manage SASL users.\r\n\r\nIf SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs\r\ncontrol what your user has access to. See 'rpk acl --help' for more information\r\nabout ACLs, and 'rpk acl user create --help' for more information about\r\ncreating SASL users. Using SASL requires setting \"enable_sasl: true\" in the\r\nredpanda section of your redpanda.yaml.",
+        "usage": "Usage:\r\n  rpk acl user [flags]\r\n  rpk acl user [command]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for user."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl user create": {
+        "description": "Create a SASL user.\r\n\r\nThis command creates a single SASL user with the given password, optionally\r\nwith a custom \"mechanism\". SASL consists of three parts: a username, a\r\npassword, and a mechanism. The mechanism determines which authentication flow\r\nthe client will use for this user/pass.\r\n\r\nRedpanda currently supports two mechanisms: SCRAM-SHA-256, the default, and\r\nSCRAM-SHA-512, which is the same flow but uses sha512 rather than sha256.\r\n\r\nUsing SASL requires setting \"enable_sasl: true\" in the redpanda section of your\r\nredpanda.yaml. Before a created SASL account can be used, you must also create\r\nACLs to grant the account access to certain resources in your cluster. See the\r\nacl help text for more info.",
+        "usage": "Usage:\r\n  rpk acl user create [USER] -p [PASS] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "--mechanism": {
+                "type": "string",
+                "description": "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive) (default \"scram-sha-256\")."
+            },
+            "--password": {
+                "type": "string",
+                "description": "New user's password (NOTE: if using --password for the admin API, use --new-password)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl user delete": {
+        "description": "Delete a SASL user.\r\n\r\nThis command deletes the specified SASL account from Redpanda. This does not\r\ndelete any ACLs that may exist for this user.",
+        "usage": "Usage:\r\n  rpk acl user delete [USER] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl user list": {
+        "description": "List SASL users",
+        "usage": "Usage:\r\n  rpk acl user list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk acl user update": {
+        "description": "Update SASL user credentials",
+        "usage": "Usage:\r\n  rpk acl user update [USER] --new-password [PW] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for update."
+            },
+            "--mechanism": {
+                "type": "string",
+                "description": "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive) (default \"SCRAM-SHA-256\")."
+            },
+            "--new-password": {
+                "type": "string",
+                "description": "New user's password."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud": {
+        "description": "Interact with Redpanda cloud",
+        "usage": "Usage:\r\n  rpk cloud [flags]\r\n  rpk cloud [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for cloud."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth": {
+        "description": "Manage rpk cloud authentications.\r\n\r\nAn rpk cloud authentication allows you to talk to Redpanda Cloud. Most likely,\r\nyou will only ever need to use a single SSO based login and you will not need\r\nthis command space. Multiple authentications can be useful if you have multiple\r\nRedpanda Cloud accounts for different organizations and want to swap between\r\nthem, or if you use SSO as well as client credentials. It is recommended to\r\nonly use a single SSO based login.",
+        "usage": "Usage:\r\n  rpk cloud auth [flags]\r\n  rpk cloud auth [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for auth."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth create": {
+        "description": "Create an rpk cloud auth.\r\n\r\nThis command creates a new rpk cloud auth. The default SSO login does not need\r\nany additional auth values (the token is populated on login) so you can just\r\ncreate an empty auth. You can also use --set to set key=value pairs for client\r\ncredentials.\r\n\r\nThe --set flag supports autocompletion, suggesting the -X key format. If you\r\nbegin writing a YAML path, the flag will suggest the rest of the path.\r\n\r\nrpk always switches the current cloud auth to the newly created auth.",
+        "usage": "Usage:\r\n  rpk cloud auth create [NAME] [flags]\r\n\r",
+        "flags": {
+            "--description": {
+                "type": "string",
+                "description": "Optional description of the auth."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "-s, --set": {
+                "type": "strings",
+                "description": "A key=value pair to set in the cloud auth."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth delete": {
+        "description": "Delete an rpk cloud auth.\r\n\r\nDeleting a cloud auth removes it from the rpk.yaml file. If the deleted\r\nauth was the current auth, rpk will use a default SSO auth the next time\r\nyou try to login and, if the login is successful, will safe that auth.",
+        "usage": "Usage:\r\n  rpk cloud auth delete [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth edit": {
+        "description": "Edit an rpk auth.\r\n\r\nThis command opens your default editor to edit the specified cloud auth, or the\r\ncurrent cloud auth if no cloud auth is specified.",
+        "usage": "Usage:\r\n  rpk cloud auth edit [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for edit."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth list": {
+        "description": "List rpk cloud auths",
+        "usage": "Usage:\r\n  rpk cloud auth list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth rename-to": {
+        "description": "Rename the current rpk auth",
+        "usage": "Usage:\r\n  rpk cloud auth rename-to [NAME] [flags]\r\n\r\nAliases:\r\n  rename-to, rename\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for rename-to."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud auth use": {
+        "description": "Select the rpk cloud auth to use",
+        "usage": "Usage:\r\n  rpk cloud auth use [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for use."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud byoc": {
+        "description": "Manage a Redpanda cloud BYOC agent\r\n\r\nFor BYOC, Redpanda installs an agent service in your owned cluster. The agent\r\nthen proceeds to provision further infrastructure and eventually, a full\r\nRedpanda cluster.\r\n\r\nThe BYOC command runs Terraform to create and start the agent. You first need\r\na redpanda-id (or cluster ID); this is used to get the details of how your\r\nagent should be provisioned. You can create a BYOC cluster in our cloud UI\r\nand then come back to this command to complete the process.",
+        "usage": "Usage:\r\n  rpk cloud byoc [flags]\r\n  rpk cloud byoc [command]\r\n\r",
+        "flags": {
+            "--client-id": {
+                "type": "string",
+                "description": "The client ID of the organization in Redpanda Cloud."
+            },
+            "--client-secret": {
+                "type": "string",
+                "description": "The client secret of the organization in Redpanda Cloud."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for byoc."
+            },
+            "--redpanda-id": {
+                "type": "string",
+                "description": "The redpanda ID of the cluster you are creating."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud byoc install": {
+        "description": "Install the BYOC plugin\r\n\r\nThis command downloads the BYOC managed plugin if necessary. The plugin is\r\ninstalled by default if you try to run a non-install command, but this command\r\nexists if you want to download the plugin ahead of time.",
+        "usage": "Usage:\r\n  rpk cloud byoc install [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for install."
+            },
+            "--redpanda-id": {
+                "type": "string",
+                "description": "The redpanda ID of the cluster you are creating."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud byoc uninstall": {
+        "description": "Uninstall the BYOC plugin\r\n\r\nThis command deletes your locally downloaded BYOC managed plugin if it exists.\r\nOften, you only need to download the plugin to create your cluster once, and\r\nthen you never need the plugin again. You can uninstall to save a small bit of\r\ndisk space.",
+        "usage": "Usage:\r\n  rpk cloud byoc uninstall [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for uninstall."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud login": {
+        "description": "Log in to the Redpanda cloud\r\n\r\nThis command checks for an existing Redpanda Cloud API token and, if present, \r\nensures it is still valid. If no token is found or the token is no longer valid, \r\nthis command will login and save your token along with the client ID used to \r\nrequest the token.\r\n\r\nYou may use either SSO or client credentials to log in.\r\n\r\nSSO\r\n\r\nThis will automatically launch your default web browser and prompt you to \r\nauthenticate via our Redpanda Cloud page. Once you have successfully \r\nauthenticated, you will be ready to use rpk cloud commands.\r\n\r\nYou may opt out of auto-opening the browser by passing the '--no-browser' flag.\r\n\r\nCLIENT CREDENTIALS\r\n\r\nCloud client credentials can be used to login to Redpanda, they can be created \r\nin the Clients tab of the Users section in the Redpanda Cloud online interface. \r\nclient credentials can be provided in three ways, in order of preference:\r\n\r\n* In your rpk cloud auth, 'client_id' and 'client_secret' fields\r\n* Through RPK_CLOUD_CLIENT_ID and RPK_CLOUD_CLIENT_SECRET environment variables\r\n* Through the --client-id and --client-secret flags\r\n\r\nIf none of these are provided, rpk will use the SSO method to login. \r\nIf you specify environment variables or flags, they will not be synced to the\r\nrpk.yaml file unless the --save flag is passed. The cloud authorization \r\ntoken and client ID is always synced.\r\n\r\nPROFILE SELECTION\r\n\r\nThis command by default attempts to populate a new profile that talks to a\r\ncloud cluster for you. If you have an existing cloud profile, this will select\r\nit, prompting which to use if you have many. If you have no cloud profile, this\r\ncommand will prompt you to select one that exists in your organization. If you\r\nwant to disable automatic profile creation and selection, use --no-profile.",
+        "usage": "Usage:\r\n  rpk cloud login [flags]\r\n\r",
+        "flags": {
+            "--client-id": {
+                "type": "string",
+                "description": "The client ID of the organization in Redpanda Cloud."
+            },
+            "--client-secret": {
+                "type": "string",
+                "description": "The client secret of the organization in Redpanda Cloud."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for login."
+            },
+            "--no-browser": {
+                "type": "-",
+                "description": "Opt out of auto-opening authentication URL."
+            },
+            "--no-profile": {
+                "type": "-",
+                "description": "Skip automatic profile creation and any associated prompts."
+            },
+            "--save": {
+                "type": "-",
+                "description": "Save environment or flag specified client ID and client secret to the configuration file."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cloud logout": {
+        "description": "Log out from Redpanda cloud\r\n\r\nThis command deletes your cloud auth token. If you want to log out entirely and\r\nswitch to a different organization, you can use the --clear-credentials flag to\r\nadditionally clear your client ID and client secret.",
+        "usage": "Usage:\r\n  rpk cloud logout [flags]\r\n\r",
+        "flags": {
+            "-c, --clear-credentials": {
+                "type": "-",
+                "description": "Clear the client ID and client secret in addition to the auth token."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for logout."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster": {
+        "description": "Interact with a Redpanda cluster",
+        "usage": "Usage:\r\n  rpk cluster [flags]\r\n  rpk cluster [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for cluster."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config": {
+        "description": "Interact with cluster configuration properties.\r\n\r\nCluster properties are redpanda settings which apply to all nodes in\r\nthe cluster.  These are separate to node properties, which are set with\r\n'rpk redpanda config'.\r\n\r\nUse the 'edit' subcommand to interactively modify the cluster configuration, or\r\n'export' and 'import' to write configuration to a file that can be edited and\r\nread back later.\r\n\r\nThese commands take an optional '--all' flag to include all properties including\r\nlow level tunables such as internal buffer sizes, that do not usually need\r\nto be changed during normal operations.  These properties generally require\r\nsome expertize to set safely, so if in doubt, avoid using '--all'.\r\n\r\nModified properties are propagated immediately to all nodes.  The 'status'\r\nsubcommand can be used to verify that all nodes are up to date, and identify\r\nany settings which were rejected by a node, for example if a node is running a\r\ndifferent redpanda version that does not recognize certain properties.",
+        "usage": "Usage:\r\n  rpk cluster config [flags]\r\n  rpk cluster config [command]\r\n\r",
+        "flags": {
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config edit": {
+        "description": "Edit cluster-wide configuration properties.\r\n\r\nThis command opens a text editor to modify the cluster's configuration.\r\n\r\nCluster properties are redpanda settings which apply to all nodes in\r\nthe cluster.  These are separate to node properties, which are set with\r\n'rpk redpanda config'.\r\n\r\nModified values are written back when the file is saved and the editor\r\nis closed.  Properties which are deleted are reset to their default\r\nvalues.\r\n\r\nBy default, low level tunables are excluded: use the '--all' flag\r\nto edit all properties including these tunables.",
+        "usage": "Usage:\r\n  rpk cluster config edit [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for edit."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config export": {
+        "description": "Export cluster configuration.\r\n\r\nWrites out a YAML representation of the cluster configuration to a file,\r\nsuitable for editing and later applying with the corresponding 'import'\r\ncommand.\r\n\r\nBy default, low level tunables are excluded: use the '--all' flag\r\nto include all properties including these low level tunables.",
+        "usage": "Usage:\r\n  rpk cluster config export [flags]\r\n\r",
+        "flags": {
+            "-f, --filename": {
+                "type": "string",
+                "description": "path to file to export to, e.g. './config.yml'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for export."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config force-reset": {
+        "description": "Forcibly clear a cluster configuration property on this node.\r\n\r\nThis command is not for general changes to cluster configuration: use this only\r\nwhen redpanda will not start due to a configuration issue.\r\n\r\nIf your cluster is working properly and you would like to reset a property\r\nto its default, you may use the 'set' command with an empty string, or\r\nuse the 'edit' command and delete the property's line.\r\n\r\nThis command erases a named property from an internal cache of the cluster\r\nconfiguration on the local node, so that on next startup redpanda will treat\r\nthe setting as if it was set to the default.\r\n\r\nWARNING: this should only be used when redpanda is not running.",
+        "usage": "Usage:\r\n  rpk cluster config force-reset [PROPERTY...] [flags]\r\n\r",
+        "flags": {
+            "--cache-file": {
+                "type": "string",
+                "description": "location of configuration cache file (defaults to redpanda data directory)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for force-reset."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config get": {
+        "description": "Get a cluster configuration property.\r\n\r\nThis command is provided for use in scripts.  For interactive editing, or bulk\r\noutput, use the 'edit' and 'export' commands respectively.",
+        "usage": "Usage:\r\n  rpk cluster config get [KEY] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for get."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config import": {
+        "description": "Import cluster configuration from a file.\r\n\r\nImport configuration from a YAML file, usually generated with\r\ncorresponding 'export' command.  This downloads the current cluster\r\nconfiguration, calculates the difference with the YAML file, and\r\nupdates any properties that were changed.  If a property is removed\r\nfrom the YAML file, it is reset to its default value.",
+        "usage": "Usage:\r\n  rpk cluster config import [flags]\r\n\r",
+        "flags": {
+            "-f, --filename": {
+                "type": "string",
+                "description": "full path to file to import, e.g. '/tmp/config.yml'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for import."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config lint": {
+        "description": "Remove any deprecated content from redpanda.yaml.\r\n\r\nDeprecated content includes properties which were set via redpanda.yaml\r\nin earlier versions of redpanda, but are now managed via Redpanda's\r\ncentral configuration store (and via 'rpk cluster config edit').",
+        "usage": "Usage:\r\n  rpk cluster config lint [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for lint."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config set": {
+        "description": "Set a single cluster configuration property.\r\n\r\nThis command is provided for use in scripts.  For interactive editing, or bulk\r\nchanges, use the 'edit' and 'import' commands respectively.\r\n\r\nYou may also use <key>=<value> notation for setting configuration properties:\r\n\r\n  rpk cluster config set log_retention_ms=-1\r\n\r\nIf an empty string is given as the value, the property is reset to its default.",
+        "usage": "Usage:\r\n  rpk cluster config set [KEY] [VALUE] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster config status": {
+        "description": "Get configuration status of redpanda nodes.\r\n\r\nFor each node, indicate whether a restart is required for settings to\r\ntake effect, and any settings that the node has identified as invalid\r\nor unknown properties.\r\n\r\nAdditionally show the version of cluster configuration that each node\r\nhas applied: under normal circumstances these should all be equal,\r\na lower number shows that a node is out of sync, perhaps because it\r\nis offline.",
+        "usage": "Usage:\r\n  rpk cluster config status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--all": {
+                "type": "-",
+                "description": "Include all properties, including tunables."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster health": {
+        "description": "Queries health overview.\r\n\r\nHealth overview is created based on the health reports collected periodically\r\nfrom all nodes in the cluster. A cluster is considered healthy when the\r\nfollowing conditions are met:\r\n\r\n* all cluster nodes are responding\r\n* all partitions have leaders\r\n* the cluster controller is present",
+        "usage": "Usage:\r\n  rpk cluster health [flags]\r\n\r",
+        "flags": {
+            "-e, --exit-when-healthy": {
+                "type": "-",
+                "description": "When used with watch, exits after cluster is back in healthy state."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for health."
+            },
+            "-w, --watch": {
+                "type": "-",
+                "description": "Blocks and writes out all cluster health changes."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster license": {
+        "description": "Manage cluster license",
+        "usage": "Usage:\r\n  rpk cluster license [flags]\r\n  rpk cluster license [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for license."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster license info": {
+        "description": "Retrieve license information:\r\n\r\n    Organization:    Organization the license was generated for.\r\n    Type:            Type of license: free, enterprise, etc.\r\n    Expires:         Expiration date of the license\r\n    Version:         License schema version.",
+        "usage": "Usage:\r\n  rpk cluster license info [flags]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (text, json) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for info."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster license set": {
+        "description": "Upload license to the cluster\r\n\r\nYou can either provide a path to a file containing the license:\r\n\r\n    rpk cluster license set --path /home/organization/redpanda.license\r\n\r\nOr inline the license string:\r\n\r\n    rpk cluster license set <license string>\r\n\r\nIf neither are present, rpk will look for the license in the\r\ndefault location '/etc/redpanda/redpanda.license'.",
+        "usage": "Usage:\r\n  rpk cluster license set [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--path": {
+                "type": "string",
+                "description": "Path to the license file."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster logdirs": {
+        "description": "Describe log directories on Redpanda brokers",
+        "usage": "Usage:\r\n  rpk cluster logdirs [flags]\r\n  rpk cluster logdirs [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for logdirs."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster logdirs describe": {
+        "description": "Describe log directories on Redpanda brokers.\r\n\r\nThis command prints information about log directories on brokers, particularly,\r\nthe base directory that topics and partitions are located in, and the size of\r\ndata that has been written to the partitions. The size you see may not exactly\r\nmatch the size on disk as reported by du: Redpanda allocates files in chunks.\r\nThe chunks will show up in du, while the actual bytes so far written to the\r\nfile will show up in this command.\r\n\r\nThe directory returned is the root directory for partitions. Within Redpanda,\r\nthe partition data lives underneath the the returned root directory in\r\n\r\n    kafka/{topic}/{partition}_{revision}/\r\n\r\nwhere revision is a Redpanda internal concept.",
+        "usage": "Usage:\r\n  rpk cluster logdirs describe [flags]\r\n\r",
+        "flags": {
+            "--aggregate-into": {
+                "type": "string",
+                "description": "If non-empty, what column to aggregate into starting from the partition column (broker, dir, topic)."
+            },
+            "-b, --broker": {
+                "type": "int32",
+                "description": "If non-negative, the specific broker to describe (default -1)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "-H, --human-readable": {
+                "type": "-",
+                "description": "Print the logdirs size in a human-readable form."
+            },
+            "--sort-by-size": {
+                "type": "-",
+                "description": "If true, sort by size."
+            },
+            "--topics": {
+                "type": "strings",
+                "description": "Specific topics to describe."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster maintenance": {
+        "description": "Interact with cluster maintenance mode.\r\n\r\nMaintenance mode is a state that a node may be placed into in which the node\r\nmay be shutdown or restarted with minimal disruption to client workloads. The\r\nprimary use of maintenance mode is to perform a rolling upgrade in which each\r\nnode is placed into maintenance mode prior to upgrading the node.\r\n\r\nUse the 'enable' and 'disable' subcommands to place a node into maintenance mode\r\nor remove it, respectively. Only one node at a time may be in maintenance mode.\r\n\r\nWhen a node is placed into maintenance mode the following occurs:\r\n\r\nLeadership draining. All raft leadership is transferred to another eligible\r\nnode, and the node in maintenance mode rejects new leadership requests. By\r\ntransferring leadership off of the node in maintenance mode all client traffic\r\nand requests are directed to other nodes minimizing disruption to client\r\nworkloads when the node is shutdown.\r\n\r\nCurrently leadership is not transferred for partitions with one replica.",
+        "usage": "Usage:\r\n  rpk cluster maintenance [flags]\r\n  rpk cluster maintenance [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for maintenance."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster maintenance disable": {
+        "description": "Disable maintenance mode for a node.",
+        "usage": "Usage:\r\n  rpk cluster maintenance disable [BROKER-ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for disable."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster maintenance enable": {
+        "description": "Enable maintenance mode for a node.\r\n\r\nThis command enables maintenance mode for the node with the specified ID. If a\r\nnode exists that is already in maintenance mode then an error will be returned.",
+        "usage": "Usage:\r\n  rpk cluster maintenance enable [BROKER-ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for enable."
+            },
+            "-w, --wait": {
+                "type": "-",
+                "description": "Wait until node is drained."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster maintenance status": {
+        "description": "Report maintenance status.\r\n\r\nThis command reports maintenance status for each node in the cluster. The output\r\nis presented as a table with each row representing a node in the cluster.  The\r\noutput can be used to monitor the progress of node draining.\r\n\r\n   NODE-ID  ENABLED  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED\r\n   1        false     false     false   0           0         0             0\r\n\r\nField descriptions:\r\n\r\n        NODE-ID: the node ID\r\n        ENABLED: true if the node is currently in maintenance mode\r\n       FINISHED: leadership draining has completed\r\n         ERRORS: errors have been encountered while draining\r\n     PARTITIONS: number of partitions whose leadership has moved\r\n       ELIGIBLE: number of partitions with leadership eligible to move\r\n   TRANSFERRING: current active number of leadership transfers\r\n         FAILED: number of failed leadership transfers\r\n\r\nNotes:\r\n\r\n   - When errors are present further information will be available in the logs\r\n     for the corresponding node.\r\n\r\n   - Only partitions with more than one replica are eligible for leadership\r\n     transfer.",
+        "usage": "Usage:\r\n  rpk cluster maintenance status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster metadata": {
+        "description": "Request broker metadata.\r\n\r\nThe Kafka protocol's metadata contains information about brokers, topics, and\r\nthe cluster as a whole.\r\n\r\nThis command only runs if specific sections of metadata are requested. There\r\nare currently three sections: the cluster, the list of brokers, and the topics.\r\nIf no section is specified, this defaults to printing all sections.\r\n\r\nIf the topic section is requested, all topics are requested by default unless\r\nsome are manually specified as arguments. Expanded per-partition information\r\ncan be printed with the -d flag, and internal topics can be printed with the -i\r\nflag.\r\n\r\nIn the broker section, the controller node is suffixed with *.",
+        "usage": "Usage:\r\n  rpk cluster metadata [flags]\r\n\r\nAliases:\r\n  metadata, status, info\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for metadata."
+            },
+            "-b, --print-brokers": {
+                "type": "-",
+                "description": "Print brokers section."
+            },
+            "-c, --print-cluster": {
+                "type": "-",
+                "description": "Print cluster section."
+            },
+            "-d, --print-detailed-topics": {
+                "type": "-",
+                "description": "Print per-partition information for topics (implies -t)."
+            },
+            "-i, --print-internal-topics": {
+                "type": "-",
+                "description": "Print internal topics (if all topics requested, implies -t)."
+            },
+            "-t, --print-topics": {
+                "type": "-",
+                "description": "Print topics section (implied if any topics are specified)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions": {
+        "description": "Manage cluster partitions",
+        "usage": "Usage:\r\n  rpk cluster partitions [flags]\r\n  rpk cluster partitions [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for partitions."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions balancer-status": {
+        "description": "Queries cluster for partition balancer status:\r\n\r\nIf continuous partition balancing is enabled, redpanda will continuously\r\nreassign partitions from both unavailable nodes and from nodes using more disk\r\nspace than the configured limit.\r\n\r\nThis command can be used to monitor the partition balancer status.\r\n\r\nFIELDS\r\n\r\n    Status:                        Either off, ready, starting, in progress, or\r\n                                   stalled.\r\n    Seconds Since Last Tick:       The last time the partition balancer ran.\r\n    Current Reassignments Count:   Current number of partition reassignments in\r\n                                   progress.\r\n    Unavailable Nodes:             The nodes that have been unavailable after a\r\n                                   time set by the\r\n                                   \"partition_autobalancing_node_availability_timeout_sec\"\r\n                                   cluster property.\r\n    Over Disk Limit Nodes:         The nodes that surpassed the threshold of\r\n                                   used disk percentage specified in the\r\n                                   \"partition_autobalancing_max_disk_usage_percent\"\r\n                                   cluster property.\r\n\r\nBALANCER STATUS\r\n\r\n    off:          The balancer is disabled.\r\n    ready:        The balancer is active but there is nothing to do.\r\n    starting:     The balancer is starting but has not run yet.\r\n    in_progress:  The balancer is active and is in the process of scheduling\r\n                  partition movements.\r\n    stalled:      Violations have been detected and the balancer cannot correct\r\n                  them.\r\n\r\nSTALLED BALANCER\r\n\r\nA stalled balancer can occur for a few reasons and requires a bit of manual\r\ninvestigation. A few areas to investigate:\r\n\r\n* Are there are enough healthy nodes to which to move partitions? For example,\r\n  in a three node cluster, no movements are possible for partitions with three\r\n  replicas. You will see a stall every time there is a violation.\r\n\r\n* Does the cluster have sufficient space? If all nodes in the cluster are\r\n  utilizing more than 80% of their disk space, rebalancing cannot proceed.\r\n\r\n* Do all partitions have quorum? If the majority of a partition's replicas are\r\n  down, the partition cannot be moved.\r\n\r\n* Are any nodes in maintenance mode? Partitions are not moved if any node is in\r\n  maintenance mode.",
+        "usage": "Usage:\r\n  rpk cluster partitions balancer-status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for balancer-status."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions disable": {
+        "description": "Disable partitions of a topic\r\n\r\nYou may disable all partitions of a topic using the --all flag or you may select \r\na set of topic/partitions to disable with the '--partitions/-p' flag.\r\n\r\nThe partition flag accepts the format {namespace}/{topic}/[partitions...]\r\nwhere namespace and topic are optional parameters. If the namespace is not\r\nprovided, rpk will assume 'kafka'. If the topic is not provided in the flag, rpk\r\nwill use the topic provided as an argument to this command.\r\n\r\nDISABLED PARTITIONS\r\n\r\nDisabling a partition in Redpanda involves prohibiting any data consumption or\r\nproduction to and from it. All internal processes associated with the partition\r\nare stopped, and it remains unloaded during system startup. This measure aims to\r\nmaintain cluster health by preventing issues caused by specific corrupted\r\npartitions that may lead to Redpanda crashes. Although the data remains stored\r\non disk, Redpanda ceases interaction with the disabled partitions to ensure\r\nsystem stability.\r\n\r\nEXAMPLES\r\n\r\nDisable all partitions in topic 'foo'\r\n    rpk cluster partitions disable foo --all\r\n\r\nDisable partitions 1,2 and 3 of topic 'bar' in the namespace 'internal'\r\n    rpk cluster partitions disable internal/bar --partitions 1,2,3\r\n\r\nDisable partition 1, and 2 of topic 'foo', and partition 5 of topic 'bar' in the \r\n'internal' namespace' \r\n    rpk cluster partitions disable -p foo/1,2 -p internal/bar/5",
+        "usage": "Usage:\r\n  rpk cluster partitions disable [TOPIC] [flags]\r\n\r",
+        "flags": {
+            "-a, --all": {
+                "type": "-",
+                "description": "If true, disable all partitions for the specified topic."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for disable."
+            },
+            "-p, --partitions": {
+                "type": "stringArray",
+                "description": "Comma-separated list of partitions you want to disable. Use --help for additional information."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions enable": {
+        "description": "Enable partitions of a topic\r\n\r\nYou may enable all partitions of a topic using the --all flag or you may select \r\na set of topic/partitions to enable with the '--partitions/-p' flag.\r\n\r\nThe partition flag accepts the format {namespace}/{topic}/[partitions...]\r\nwhere namespace and topic are optional parameters. If the namespace is not\r\nprovided, rpk will assume 'kafka'. If the topic is not provided in the flag, rpk\r\nwill use the topic provided as an argument to this command.\r\n\r\nEXAMPLES\r\n\r\nEnable all partitions in topic 'foo'\r\n    rpk cluster partitions enable foo --all\r\n\r\nEnable partitions 1,2 and 3 of topic 'bar' in the namespace 'internal'\r\n    rpk cluster partitions enable internal/bar --partitions 1,2,3\r\n\r\nEnable partition 1, and 2 of topic 'foo', and partition 5 of topic 'bar' in the \r\n'internal' namespace'\r\n    rpk cluster partitions enable -p foo/1,2 -p internal/bar/5",
+        "usage": "Usage:\r\n  rpk cluster partitions enable [TOPIC] [flags]\r\n\r",
+        "flags": {
+            "-a, --all": {
+                "type": "-",
+                "description": "If true, enable all partitions for the specified topic."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for enable."
+            },
+            "-p, --partitions": {
+                "type": "stringArray",
+                "description": "Comma-separated list of partitions you want to enable. Check help for extended usage."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions list": {
+        "description": "List partitions in the cluster\r\n\r\nThis commands lists the cluster-level metadata of all partitions in the cluster.\r\nIt shows the current replica assignments on both brokers and CPU cores for given\r\ntopics. By default, it assumes the \"kafka\" namespace, but you can specify an\r\ninternal namespace using the \"{namespace}/\" prefix.\r\n\r\nThe REPLICA-CORE column displayed in the output table contains a list of\r\nreplicas assignments in the form of: <Node-ID>-<Core>.\r\n\r\nIf the DISABLED column contains a '-' value, then it means you are running this\r\ncommand against a cluster that does not support the underlying API.\r\n\r\nENABLED/DISABLED\r\n\r\nDisabling a partition in Redpanda involves prohibiting any data consumption or\r\nproduction to and from it. All internal processes associated with the partition\r\nare stopped, and it remains unloaded during system startup. This measure aims to\r\nmaintain cluster health by preventing issues caused by specific corrupted\r\npartitions that may lead to Redpanda crashes. Although the data remains stored\r\non disk, Redpanda ceases interaction with the disabled partitions to ensure\r\nsystem stability.\r\n\r\nYou may disable/enable partition using 'rpk cluster partitions enable/disable'.\t\r\n\r\nEXAMPLES\r\n\r\nList all partitions in the cluster.\r\n  rpk cluster partitions list --all\r\n\r\nList all partitions in the cluster, filtering for topic foo and bar.\r\n  rpk cluster partitions list foo bar\r\n\r\nList only the disabled partitions.\r\n  rpk cluster partitions list -a --disabled-only\r\n\r\nList all in json format.\r\n  rpk cluster partition list -a --format json",
+        "usage": "Usage:\r\n  rpk cluster partitions list [TOPICS...] [flags]\r\n\r\nAliases:\r\n  list, ls, describe\r\n\r",
+        "flags": {
+            "-a, --all": {
+                "type": "-",
+                "description": "If true, list all partitions in the cluster."
+            },
+            "--disabled-only": {
+                "type": "-",
+                "description": "If true, list disabled partitions only."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-p, --partition": {
+                "type": "-",
+                "description": "ints   List of comma-separated partitions IDs that you wish to filter the results with."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions move": {
+        "description": "Move partition replicas across nodes / cores.\r\n\r\nThis command changes replica assignments for given partitions. By default, it\r\nassumes the \"kafka\" namespace, but you can specify an internal namespace using\r\nthe \"{namespace}/\" prefix.\r\n\r\nTo move replicas, use the following syntax:\r\n\r\n    rpk cluster partitions move foo --partition 0:1,2,3 -p 1:2,3,4\r\n\r\nHere, the command assigns new replicas for partition 0 to brokers [1, 2, 3] and\r\nfor partition 1 to brokers [2, 3, 4] for the topic \"foo\".\r\n\r\nYou can also specify the core id with \"-{core_id}\" where the new replicas\r\nshould be placed:\r\n\r\n    rpk cluster partitions move foo -p 0:1-0,2-0,3-0\r\n\r\nHere all new replicas [1, 2, 3] will be assigned on core 0 on the nodes.\r\n\r\nThe command does not change a \"core\" assignment unless it is explicitly\r\nspecified. When a core is not specified for a new node, the command randomly\r\npicks a core and assign a replica on the core.\r\n\r\nTopic arguments are optional. For more control, you can specify the topic name\r\nin the \"--partition\" flag:\r\n\r\n    rpk cluster partitions move -p foo/0:1,2,3 -p kafka_internal/tx/0:1-0,2-0,3-0",
+        "usage": "Usage:\r\n  rpk cluster partitions move [flags]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for move."
+            },
+            "-p, --partition": {
+                "type": "stringArray",
+                "description": "Topic-partitions to move and new replica locations (repeatable)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions move-cancel": {
+        "description": "Cancel ongoing partition movements.\r\n\r\nBy default, this command cancels all the partition movements in the cluster. \r\nTo ensure that you do not accidentally cancel all partition movements, this \r\ncommand prompts users for confirmation before issuing the cancellation request. \r\nYou can use \"--no-confirm\" to disable the confirmation prompt:\r\n\r\n    rpk cluster partitions move-cancel --no-confirm\r\n\r\nIf \"--node\" is set, this command will only stop the partition movements \r\noccurring in the specified node:\r\n\r\n    rpk cluster partitions move-cancel --node 1",
+        "usage": "Usage:\r\n  rpk cluster partitions move-cancel [flags]\r\n\r\nAliases:\r\n  move-cancel, alter-cancel\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for move-cancel."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "--node": {
+                "type": "int",
+                "description": "ID of a specific node on which to cancel ongoing partition movements (default -1)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster partitions move-status": {
+        "description": "Show ongoing partition movements.\r\n\r\nBy default this command lists all ongoing partition movements in the cluster.\r\nTopics can be specified to print the move status of specific topics. By default,\r\nthis command assumes the \"kafka\" namespace, but you can use a \"namespace/\" to\r\nspecify internal namespaces.\r\n\r\n    rpk cluster partitions move-status\r\n    rpk cluster partitions move-status foo bar kafka_internal/tx\r\n\r\nThe \"--partition / -p\" flag can be used with topics to additional filter\r\nrequested partitions:\r\n\r\n    rpk cluster partitions move-status foo bar --partition 0,1,2\r\n\r\nThe output contains the following columns with PARTITION-SIZE in bytes.\r\nUsing -H, it prints the partition size in a human-readable format\r\n\r\n    NAMESPACE-TOPIC\r\n    PARTITION\r\n    MOVING-FROM\r\n    MOVING-TO\r\n    COMPLETION-%\r\n    PARTITION-SIZE\r\n    BYTES-MOVED\r\n    BYTES-REMAINING\r\n\r\nUsing \"--print-all / -a\" the command additionally prints the column\r\n\"RECONCILIATION STATUSES\", which reveals the internal status of the ongoing\r\nreconciliations. Reported errors do not necessarily mean real problems.",
+        "usage": "Usage:\r\n  rpk cluster partitions move-status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for move-status."
+            },
+            "-H, --human-readable": {
+                "type": "-",
+                "description": "Print the partition size in a human-readable form."
+            },
+            "-p, --partition": {
+                "type": "strings",
+                "description": "Partitions to filter ongoing movements status (repeatable)."
+            },
+            "-a, --print-all": {
+                "type": "-",
+                "description": "Print internal states about movements for debugging."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster self-test": {
+        "description": "Start, stop and query runs of Redpanda self-test through the Admin API listener",
+        "usage": "Usage:\r\n  rpk cluster self-test [flags]\r\n  rpk cluster self-test [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for self-test."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster self-test start": {
+        "description": "Starts one or more benchmark tests on one or more nodes\r\nof the cluster. Available tests to run:\r\n\r\n* Disk tests:\r\n  * Throughput test: 512 KB messages, sequential read/write\r\n    * Uses a larger request message sizes and deeper I/O queue depth to write/read more bytes in a shorter amount of time, at the cost of IOPS/latency.\r\n  * Latency test: 4 KB messages, sequential read/write\r\n    * Uses smaller request message sizes and lower levels of parallelism to achieve higher IOPS and lower latency.\r\n\r\n* Network tests:\r\n  * Throughput test: 8192-bit messages\r\n    * Unique pairs of Redpanda nodes each act as a client and a server.\r\n    * The test pushes as much data over the wire, within the test parameters.\r\n\r\nThis command immediately returns on success, and the tests run asynchronously. The\r\nuser polls for results with the 'self-test status'\r\ncommand.",
+        "usage": "Usage:\r\n  rpk cluster self-test start [flags]\r\n\r",
+        "flags": {
+            "--disk-duration-ms": {
+                "type": "duration",
+                "description": "uint       The  in milliseconds of individual disk test runs (default 30000)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--network-duration-ms": {
+                "type": "duration",
+                "description": "uint    The  in milliseconds of individual network test runs (default 30000)."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Acknowledge warning prompt skipping read from stdin."
+            },
+            "--only-disk-test": {
+                "type": "-",
+                "description": "Runs only the disk benchmarks."
+            },
+            "--only-network-test": {
+                "type": "-",
+                "description": "Runs only network benchmarks."
+            },
+            "--participant-node-ids": {
+                "type": "-",
+                "description": "ints   IDs of nodes that the tests will run on. If not set, tests will run for all node IDs."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster self-test status": {
+        "description": "Returns the status of the currently running or last completed self-test run.\r\n\r\nUse this command after invoking 'self-test start' to determine the status of\r\nthe jobs launched. Possible results are:\r\n\r\n* One or more jobs still running\r\n  * Returns the IDs of Redpanda nodes still running self-tests.\r\n\r\n* No jobs running:\r\n  * Returns cached results for all nodes of the last completed test.",
+        "usage": "Usage:\r\n  rpk cluster self-test status [flags]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (text, json) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster self-test stop": {
+        "description": "Stops all self-test tests.\r\n\r\nThis command stops all currently running self-tests. The command is synchronous and returns\r\nsuccess when all jobs have been stopped or reports errors if broker timeouts have expired.",
+        "usage": "Usage:\r\n  rpk cluster self-test stop [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster storage": {
+        "description": "Manage the cluster storage",
+        "usage": "Usage:\r\n  rpk cluster storage [flags]\r\n  rpk cluster storage [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for storage."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster storage restore": {
+        "description": "Interact with the topic restoration process.\r\n\t\t\r\nThis command is used to restore topics from the archival bucket, which can be \r\nuseful for disaster recovery or if a topic was accidentally deleted.\r\n\r\nTo begin the recovery process, use the \"restore start\" command. Note that this \r\nprocess can take a while to complete, so the command will exit after starting \r\nit. If you want the command to wait for the process to finish, use the \"--wait\"\r\nor \"-w\" flag.\r\n\r\nYou can check the status of the recovery process with the \"restore status\" \r\ncommand after it has been started.",
+        "usage": "Usage:\r\n  rpk cluster storage restore [flags]\r\n  rpk cluster storage restore [command]\r\n\r\nAliases:\r\n  restore, recovery\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for restore."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster storage restore start": {
+        "description": "Start the topic restoration process.\r\n\t\t\r\nThis command starts the process of restoring topics from the archival bucket.\r\nIf the wait flag (--wait/-w) is set, the command will poll the status of the\r\nrecovery process until it's finished.",
+        "usage": "Usage:\r\n  rpk cluster storage restore start [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--polling-interval": {
+                "type": "duration",
+                "description": "The status check interval (e.g. '30s', '1.5m'); ignored if --wait is not used (default 5s)."
+            },
+            "--topic-name-pattern": {
+                "type": "string",
+                "description": "A regex pattern that restores any matching topics (default \".*\")."
+            },
+            "-w, --wait": {
+                "type": "-",
+                "description": "Wait until auto-restore is complete."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk cluster storage restore status": {
+        "description": "Fetch the status of the topic restoration process.\r\n\t\t\r\nThis command fetches the status of the process of restoring topics from the \r\narchival bucket.",
+        "usage": "Usage:\r\n  rpk cluster storage restore status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk container": {
+        "description": "Manage a local container cluster",
+        "usage": "Usage:\r\n  rpk container [flags]\r\n  rpk container [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for container."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk container purge": {
+        "description": "Stop and remove an existing local container cluster's data",
+        "usage": "Usage:\r\n  rpk container purge [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for purge."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk container start": {
+        "description": "Start a local container cluster",
+        "usage": "Usage:\r\n  rpk container start [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--image": {
+                "type": "string",
+                "description": "An arbitrary container image to use (default \"redpandadata/redpanda:v0.0.0-20231206git4fb6164\")."
+            },
+            "--no-profile": {
+                "type": "-",
+                "description": "If true, rpk will not create an rpk profile after creating a cluster."
+            },
+            "-n, --nodes": {
+                "type": "-",
+                "description": "uint     The number of nodes to start (default 1)."
+            },
+            "--pull": {
+                "type": "-",
+                "description": "Force pull the container image used."
+            },
+            "--retries": {
+                "type": "-",
+                "description": "uint   The amount of times to check for the cluster before considering it unstable and exiting (default 10)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk container status": {
+        "description": "Get status",
+        "usage": "Usage:\r\n  rpk container status [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for status."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk container stop": {
+        "description": "Stop an existing local container cluster",
+        "usage": "Usage:\r\n  rpk container stop [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk debug": {
+        "description": "Debug the local Redpanda process",
+        "usage": "Usage:\r\n  rpk debug [flags]\r\n  rpk debug [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for debug."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk debug bundle": {
+        "description": "'rpk debug bundle' collects environment data that can help debug and diagnose\r\nissues with a redpanda cluster, a broker, or the machine it's running on. It\r\nthen bundles the collected data into a ZIP file, called a diagnostics bundle.\r\n\r\nThe files and directories in the diagnostics bundle differ depending on the \r\nenvironment in which Redpanda is running:\r\n\r\nCOMMON FILES\r\n\r\n - Kafka metadata: Broker configs, topic configs, start/committed/end offsets,\r\n   groups, group commits.\r\n\r\n - Controller logs: The controller logs directory up to a limit set by\r\n   --controller-logs-size-limit flag\r\n\r\n - Data directory structure: A file describing the data directory's contents.\r\n\r\n - Redpanda configuration: The redpanda configuration file (redpanda.yaml;\r\n   SASL credentials are stripped).\r\n\r\n - Runtime system information (/proc): Process information, by reading /proc \r\n  files like core count, cache, frequency, interrupts, mounted file systems, \r\n  memory usage, kernel command line.\r\n\r\n - Resource usage data: CPU usage percentage, free memory available for the\r\n   redpanda process.\r\n\r\n - Clock drift: The ntp clock delta (using pool.ntp.org as a reference) & round\r\n   trip time.\r\n\r\n - Admin API calls: Multiple requests to gather information such as: Cluster and\r\n   broker configurations, cluster health data, balancer status, cloud storage\r\n   status, and license key information.\r\n\r\n - Broker metrics: The broker's Prometheus metrics, fetched through its\r\n   admin API (/metrics and /public_metrics).\r\n\r\nBARE-METAL\r\n\r\n - Kernel: The kernel logs ring buffer (syslog) and parameters (sysctl).\r\n\r\n - DNS: The DNS info as reported by 'dig', using the hosts in\r\n   /etc/resolv.conf.\r\n\r\n - Disk usage: The disk usage for the data directory, as output by 'du'.\r\n\r\n - redpanda logs: The node's redpanda logs written to journald. If --logs-since \r\n   or --logs-until are passed, then only the logs within the resulting time frame\r\n   will be included.\r\n\r\n - Socket info: The active sockets data output by 'ss'.\r\n\r\n - Running process info: As reported by 'top'.\r\n\r\n - Virtual memory stats: As reported by 'vmstat'.\r\n\r\n - Network config: As reported by 'ip addr'.\r\n\r\n - lspci: List the PCI buses and the devices connected to them.\r\n\r\n - dmidecode: The DMI table contents. Only included if this command is run\r\n   as root.\r\n\r\nKUBERNETES\r\n\r\n - Kubernetes Resources: Kubernetes manifests for all resources in the given \r\n   Kubernetes namespace (via --namespace).\r\n\r\n - redpanda logs: Logs of each Pod in the the given Kubernetes namespace. If \r\n   --logs-since is passed, only the logs within the given timeframe are \r\n   included.\r\n\r\nEXTRA REQUESTS FOR PARTITIONS\r\n\r\nYou can provide a list of partitions to save additional admin API requests\r\nspecifically for those partitions.\r\n\r\nThe partition flag accepts the format {namespace}/[topic]/[partitions...]\r\nwhere the namespace is optional, if the namespace is not provided, rpk will \r\nassume 'kafka'. For example:\r\n\r\nTopic 'foo', partitions 1, 2 and 3:\r\n  --partitions foo/1,2,3\r\n\r\nNamespace _redpanda-internal, topic 'bar', partition 2\r\n  --partitions _redpanda-internal/bar/2\r\n\r\nIf you have an upload URL from the Redpanda support team, provide it in the \r\n--upload-url flag to upload your diagnostics bundle to Redpanda.",
+        "usage": "Usage:\r\n  rpk debug bundle [flags]\r\n\r",
+        "flags": {
+            "--controller-logs-size-limit": {
+                "type": "string",
+                "description": "The size limit of the controller logs that can be stored in the bundle (e.g. 3MB, 1GiB) (default \"20MB\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for bundle."
+            },
+            "-l, --label-selector": {
+                "type": "stringArray",
+                "description": "Comma-separated label selectors to filter your resources. e.g: <label>=<value>,<label>=<value> (k8s only) (default [app.kubernetes.io/name=redpanda])."
+            },
+            "--logs-since": {
+                "type": "string",
+                "description": "Include log entries on or newer than the specified date (journalctl date format, e.g. YYYY-MM-DD."
+            },
+            "--logs-size-limit": {
+                "type": "string",
+                "description": "Read the logs until the given size is reached (e.g. 3MB, 1GiB) (default \"100MiB\")."
+            },
+            "--logs-until": {
+                "type": "string",
+                "description": "Include log entries on or older than the specified date (journalctl date format, e.g. YYYY-MM-DD."
+            },
+            "--metrics-interval": {
+                "type": "duration",
+                "description": "Interval between metrics snapshots (e.g. 30s, 1.5m) (default 10s)."
+            },
+            "-n, --namespace": {
+                "type": "string",
+                "description": "The namespace to use to collect the resources from (k8s only) (default \"redpanda\")."
+            },
+            "-o, --output": {
+                "type": "string",
+                "description": "The file path where the debug file will be written (default ./<timestamp>-bundle.zip)."
+            },
+            "-p, --partition": {
+                "type": "stringArray",
+                "description": "Comma-separated partition IDs; when provided, rpk saves extra admin API requests for those partitions. Check help for extended usage."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "How long to wait for child commands to execute (e.g. 30s, 1.5m) (default 12s)."
+            },
+            "--upload-url": {
+                "type": "string",
+                "description": "If provided, where to upload the bundle in addition to creating a copy on disk."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk generate": {
+        "description": "Generate a configuration template for related services",
+        "usage": "Usage:\r\n  rpk generate [template] [flags]\r\n  rpk generate [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for generate."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk generate app": {
+        "description": "Generate a sample application to connect with Redpanda.\r\n\r\nThis command generates a starter application to produce and consume from the\r\nsettings defined in the rpk profile. Its goal is to get you producing and\r\nconsuming quickly with Redpanda in a language that is familiar to you.\r\n\r\nBy default, this will run interactively, prompting you to select a language and\r\na user with which to create your application. To use this without interactivity,\r\nspecify how you would like your application to be created using flags.\r\n\r\nThe --language option allows you to specify the language. There is no default.\r\n\r\nThe --new-sasl-credentials <user>:<password> allows you to generate a new SASL\r\nuser with admin ACLs. If you don't want to use your current profile user nor\r\ncreate a new one, you may use --no-user flag to generate the starter app without\r\nthe user.\r\n\r\nIf you are having trouble connecting to your cluster, you can use -X\r\nadmin.hosts=comma,delimited,host:ports to pass a specific admin api address.\r\n\r\nEXAMPLES\r\n\r\nGenerate an app with interactive prompts:\r\n  rpk generate app\r\n\r\nGenerate an app in a specified language with the existing SASL user:\r\n  rpk generate app --language <lang>\r\n\r\nGenerate an app in the specified language with a new SASL user:\r\n  rpk generate app -l <lang> --new-sasl-credentials <user>:<password>\r\n\r\nGenerate an app in the 'tmp' dir, but take no action on the user:\r\n  rpk generate app -l <lang> --no-user --output /tmp",
+        "usage": "Usage:\r\n  rpk generate app [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for app."
+            },
+            "-l, --language": {
+                "type": "string",
+                "description": "The language you want the code sample to be generated with."
+            },
+            "--new-sasl-credentials": {
+                "type": "string",
+                "description": "If provided, rpk will generate and use these credentials (<user>:<password>)."
+            },
+            "--no-user": {
+                "type": "-",
+                "description": "Generates the sample app without SASL user."
+            },
+            "-o, --output": {
+                "type": "string",
+                "description": "The path where the app will be written."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk generate grafana-dashboard": {
+        "description": "Generate Grafana Dashboards for Redpanda Metrics\r\n\r\nUse this command to generate sample Grafana dashboards for Redpanda metrics. \r\nThese dashboards can be imported into a Grafana or Grafana Cloud instance.\r\n\r\nTo select a specific dashboard, use the '--dashboard' flag followed by the \r\ndashboard name. For example, to generate the operations dashboard, run:\r\n\r\n    rpk generate grafana-dashboard --dashboard operations\r\n\r\nThe selected dashboard will be downloaded from our GitHub repository:\r\n\r\n  https://github.com/redpanda-data/observability\r\n\r\nNote that the legacy dashboard is still available as an option, and will not be \r\ndownloaded from github. Instead, the dashboard will be generated based on the \r\nmetrics endpoint used.\r\n\r\nTo see a list of all available dashboards, use the '--dashboard help' flag.",
+        "usage": "Usage:\r\n  rpk generate grafana-dashboard [flags]\r\n\r",
+        "flags": {
+            "--dashboard": {
+                "type": "string",
+                "description": "The name of the dashboard you wish to download; use --dashboard help for more info (default \"operations\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for grafana-dashboard."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk generate prometheus-config": {
+        "description": "Generate the Prometheus configuration to scrape Redpanda nodes. \r\n\r\nThe output of this command should be included in the 'scrape_configs' array \r\nwithin the YAML configuration file of your Prometheus instance.\r\n\r\nThere are different options you can use when generating the configuration:\r\n\r\n - If you provide the --seed-addr flag, the command will use the address to \r\n   discover the rest of the cluster hosts using Redpanda's Kafka API.\r\n - If you provide the --node-addrs flag, the command will directly use the \r\n   provided addresses.\r\n - If neither --seed-addr nor --node-addrs are passed, the command will read the \r\n   redpanda config file and use the node IP configured there.\r\n\r\nIf the node you want to scrape uses TLS, you can provide the TLS flags \r\n(--tls-key, --tls-cert, and --tls-truststore). The command will generate the \r\nrequired tls_config section in the scrape configuration.\r\n\r\nAdditionally, you have the option to define labels for the target in the \r\nstatic-config section by using the --labels flag. You can specify the desired \r\nmetric that the label should target, either internal (/metrics) or public \r\n(/public_metrics).\r\n\r\nFor example:\r\n\r\n  --job-name test --labels \"public:group=one,internal:group=two\"\r\n\r\nThis will result in two separate configs for the test job, each with a \r\ndifferent label:\r\n\r\n  - job_name: test\r\n    static_configs:\r\n      - targets: [<targets>]\r\n        labels:\r\n          group: one\r\n    metrics_path: /public_metrics\r\n  - job_name: test\r\n    static_configs:\r\n      - targets: [<targets>]\r\n        labels:\r\n          group: two\r\n    metrics_path: /metrics\r\n\r\nYou can only provide one label per job. By default, if no metric target is \r\nspecified, the label will be shared across the jobs.",
+        "usage": "Usage:\r\n  rpk generate prometheus-config [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for prometheus-config."
+            },
+            "--internal-metrics": {
+                "type": "-",
+                "description": "Include scrape config for internal metrics (/metrics)."
+            },
+            "--job-name": {
+                "type": "string",
+                "description": "The prometheus job name by which to identify the Redpanda nodes (default \"redpanda\")."
+            },
+            "--labels": {
+                "type": "strings",
+                "description": "Comma-separated labels and their target metric (int or pub): [metric|labelName:labelValue, ...]."
+            },
+            "--node-addrs": {
+                "type": "strings",
+                "description": "Comma-separated list of admin API host:ports."
+            },
+            "--seed-addr": {
+                "type": "string",
+                "description": "The URL of a Redpanda node with which to discover the rest."
+            },
+            "--tls-cert": {
+                "type": "string",
+                "description": "The certificate to be used for TLS authentication with the broker."
+            },
+            "--tls-enabled": {
+                "type": "-",
+                "description": "Enable TLS for the Kafka API (not necessary if specifying custom certs)."
+            },
+            "--tls-key": {
+                "type": "string",
+                "description": "The certificate key to be used for TLS authentication with the broker."
+            },
+            "--tls-truststore": {
+                "type": "string",
+                "description": "The CA certificate to be used for TLS communication with the broker."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk generate shell-completion": {
+        "description": "Shell completion can help autocomplete rpk commands when you press tab.\r\n\r\nBASH\r\n\r\nBash autocompletion relies on the bash-completion package. You can test if you\r\nhave this by running \"type _init_completion\", if you do not, you can install\r\nthe package through your package manager.\r\n\r\nIf you have bash-completion installed, and the command still fails, you likely\r\nneed to add the following line to your ~/.bashrc:\r\n\r\n    source /usr/share/bash-completion/bash_completion\r\n\r\nTo ensure autocompletion of rpk exists in all shell sessions, add the following\r\nto your ~/.bashrc:\r\n\r\n    command -v rpk >/dev/null && . <(rpk generate shell-completion bash)\r\n\r\nAlternatively, to globally enable rpk completion, you can run the following:\r\n\r\n    rpk generate shell-completion bash > /etc/bash_completion.d/rpk\r\n\r\nZSH\r\n\r\nIf shell completion is not already enabled in your environment, you will need to\r\nenable it. You can execute the following once:\r\n\r\n  $ echo \"autoload -U compinit; compinit\" >> ~/.zshrc\r\n\r\nTo enable autocompletion in any zsh session for any user, run this once:\r\n\r\n# Linux:\r\n\r\n    rpk generate shell-completion zsh > \"${fpath[1]}/_rpk\"\r\n\r\n# macOS:\r\n\r\n     rpk generate shell-completion zsh > \"$(brew --prefix)/share/zsh/site-functions/_rpk\"\r\n\r\nYou can also place that command in your ~/.zshrc to ensure that when you update\r\nrpk, you update autocompletion. If you initially require sudo to edit that\r\nfile, you can chmod it to be world writeable, after which you will always be\r\nable to update it from ~/.zshrc.\r\n\r\nFISH\r\n\r\nTo enable autocompletion in any fish session, run:\r\n\r\n    rpk generate shell-completion fish > ~/.config/fish/completions/rpk.fish",
+        "usage": "Usage:\r\n  rpk generate shell-completion [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for shell-completion."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group": {
+        "description": "Describe, list, and delete consumer groups and manage their offsets.\r\n\r\nConsumer groups allow you to horizontally scale consuming from topics. A\r\nnon-group consumer consumes all records from all partitions you assign it. In\r\ncontrast, consumer groups allow many consumers to coordinate and divide work.\r\nIf you have two members in a group consuming topics A and B, each with three\r\npartitions, then both members consume three partitions. If you add another\r\nmember to the group, then each of the three members will consume two\r\npartitions. This allows you to horizontally scale consuming of topics.\r\n\r\nThe unit of scaling is a single partition. If you add more consumers to a group\r\nthan there are are total partitions to consume, then some consumers will be\r\nidle. More commonly, you have many more partitions than consumer group members\r\nand each member consumes a chunk of available partitions. One scenario where\r\nyou may want more members than partitions is if you want active standby's to\r\ntake over load immediately if any consuming member dies.\r\n\r\nHow group members divide work is entirely client driven (the \"partition\r\nassignment strategy\" or \"balancer\" depending on the client). Brokers know\r\nnothing about how consumers are assigning partitions. A broker's role in group\r\nconsuming is to choose which member is the leader of a group, forward that\r\nmember's assignment to every other member, and ensure all members are alive\r\nthrough heartbeats.\r\n\r\nConsumers periodically commit their progress when consuming partitions. Through\r\nthese commits, you can monitor just how far behind a consumer is from the\r\nlatest messages in a partition. This is called \"lag\". Large lag implies that\r\nthe client is having problems, which could be from the server being too slow,\r\nor the client being oversubscribed in the number of partitions it is consuming,\r\nor the server being in a bad state that requires restarting or removing from\r\nthe server pool, and so on.\r\n\r\nYou can manually manage offsets for a group, which allows you to rewind or\r\nforward commits. If you notice that a recent deploy of your consumers had a\r\nbug, you may want to stop all members, rewind the commits to before the latest\r\ndeploy, and restart the members with a patch.\r\n\r\nThis command allows you to list all groups, describe a group (to view the\r\nmembers and their lag), and manage offsets.",
+        "usage": "Usage:\r\n  rpk group [flags]\r\n  rpk group [command]\r\n\r\nAliases:\r\n  group, g\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for group."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group delete": {
+        "description": "Delete groups from brokers.\r\n\r\nOlder versions of the Kafka protocol included a retention_millis field in\r\noffset commit requests. Group commits persisted for this retention and then\r\neventually expired. Once all commits for a group expired, the group would be\r\nconsidered deleted.\r\n\r\nThe retention field was removed because it proved problematic for infrequently\r\ncommitting consumers: the offsets could be expired for a group that was still\r\nactive. If clients use new enough versions of OffsetCommit (versions that have\r\nremoved the retention field), brokers expire offsets only when the group is\r\nempty for offset.retention.minutes. Redpanda does not currently support that\r\nconfiguration (see #2904), meaning offsets for empty groups expire only when\r\nthey are explicitly deleted.\r\n\r\nYou may want to delete groups to clean up offsets sooner than when they\r\nautomatically are cleaned up, such as when you create temporary groups for\r\nquick investigation or testing. This command helps you do that.",
+        "usage": "Usage:\r\n  rpk group delete [GROUPS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group describe": {
+        "description": "Describe group offset status & lag.\r\n\r\nThis command describes group members, calculates their lag, and prints detailed\r\ninformation about the members.",
+        "usage": "Usage:\r\n  rpk group describe [GROUPS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "-c, --print-commits": {
+                "type": "-",
+                "description": "Print only the group commits section."
+            },
+            "-t, --print-lag-per-topic": {
+                "type": "-",
+                "description": "Print the aggregated lag per topic."
+            },
+            "-s, --print-summary": {
+                "type": "-",
+                "description": "Print only the group summary section."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group list": {
+        "description": "List all groups.\r\n\r\nThis command lists all groups currently known to Redpanda, including empty\r\ngroups that have not yet expired. The BROKER column is which broker node is the\r\ncoordinator for the group. This command can be used to track down unknown\r\ngroups, or to list groups that need to be cleaned up.",
+        "usage": "Usage:\r\n  rpk group list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group offset-delete": {
+        "description": "Forcefully delete offsets for a kafka group.\r\n\r\nThe broker will only allow the request to succeed if the group is in a dead\r\nstate (no subscriptions) or there are no subscriptions for offsets for\r\ntopic/partitions requested to be deleted.\r\n\r\nUse either the --from-file or the --topic option. They are mutually exclusive.\r\nTo indicate which topics or topic partitions you'd like to remove offsets from use\r\nthe --topic (-t) flag, followed by a comma separated list of partition ids. Supplying\r\nno list will delete all offsets for all partitions for a given topic.\r\n\r\nYou may also provide a text file to indicate topic/partition tuples. Use the\r\n--from-file flag for this option. The file must contain lines of topic/partitions\r\nseparated by a tab or space. Example:\r\n\r\ntopic_a 0\r\ntopic_a 1\r\ntopic_b 0",
+        "usage": "Usage:\r\n  rpk group offset-delete [GROUP] --from-file FILE --topic foo:0,1,2 [flags]\r\n\r",
+        "flags": {
+            "-f, --from-file": {
+                "type": "string",
+                "description": "File of topic/partition tuples for which to delete offsets for."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for offset-delete."
+            },
+            "-t, --topic": {
+                "type": "stringArray",
+                "description": "topic:partition_id (repeatable; e.g. -t foo:0,1,2 )."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk group seek": {
+        "description": "Modify a group's current offsets.\r\n\r\nThis command allows you to modify a group's offsets. Sometimes, you may need to\r\nrewind a group if you had a mistaken deploy, or fast-forward a group if it is\r\nfalling behind on messages that can be skipped.\r\n\r\nThe --to option allows you to seek to the start of partitions, end of\r\npartitions, or after a specific timestamp. The default is to seek any topic\r\npreviously committed. Using --topics allows to you set commits for only the\r\nspecified topics; all other commits will remain untouched. Topics with no\r\ncommits will not be committed unless allowed with --allow-new-topics.\r\n\r\nThe --to-group option allows you to seek to commits that are in another group.\r\nThis is a merging operation: if g1 is consuming topics A and B, and g2 is\r\nconsuming only topic B, \"rpk group seek g1 --to-group g2\" will update g1's\r\ncommits for topic B only. The --topics flag can be used to further narrow which\r\ntopics are updated. Unlike --to, all non-filtered topics are committed, even\r\ntopics not yet being consumed, meaning --allow-new-topics is not needed.\r\n\r\nThe --to-file option allows to seek to offsets specified in a text file with\r\nthe following format:\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    ...\r\nEach line contains the topic, the partition, and the offset to seek to. As with\r\nthe prior options, --topics allows filtering which topics are updated. Similar\r\nto --to-group, all non-filtered topics are committed, even topics not yet being\r\nconsumed, meaning --allow-new-topics is not needed.\r\n\r\nThe --to, --to-group, and --to-file options are mutually exclusive. If you are\r\nnot authorized to describe or read some topics used in a group, you will not be\r\nable to modify offsets for those topics.\r\n\r\nEXAMPLES\r\n\r\nSeek group G to June 1st, 2021:\r\n    rpk group seek g --to 1622505600\r\n    or, rpk group seek g --to 1622505600000\r\n    or, rpk group seek g --to 1622505600000000000\r\nSeek group X to the commits of group Y topic foo:\r\n    rpk group seek X --to-group Y --topics foo\r\nSeek group G's topics foo, bar, and biz to the end:\r\n    rpk group seek G --to end --topics foo,bar,biz\r\nSeek group G to the beginning of a topic it was not previously consuming:\r\n    rpk group seek G --to start --topics foo --allow-new-topics",
+        "usage": "Usage:\r\n  rpk group seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ... [flags]\r\n\r",
+        "flags": {
+            "--allow-new-topics": {
+                "type": "-",
+                "description": "Allow seeking to new topics not currently consumed (implied with --to-group or --to-file)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for seek."
+            },
+            "--to": {
+                "type": "string",
+                "description": "Where to seek (start, end, unix second | millisecond | nanosecond)."
+            },
+            "--to-file": {
+                "type": "string",
+                "description": "Seek to offsets as specified in the file."
+            },
+            "--to-group": {
+                "type": "string",
+                "description": "Seek to the commits of another group."
+            },
+            "--topics": {
+                "type": "strings",
+                "description": "Only seek these topics, if any are specified."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk help": {
+        "description": "Help provides help for any command in the application.\r\nSimply type rpk help [path to command] for full details.",
+        "usage": "Usage:\r\n  rpk help [command] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "help for help."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk iotune": {
+        "description": "Measure filesystem performance and create IO configuration file",
+        "usage": "Usage:\r\n  rpk iotune [flags]\r\n\r",
+        "flags": {
+            "--directories": {
+                "type": "strings",
+                "description": "List of directories to evaluate."
+            },
+            "--duration": {
+                "type": "duration",
+                "description": "Duration of tests (e.g. 300ms, 1.5s, 2h45m) (default 10m0s)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for iotune."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt if the iotune file already exists."
+            },
+            "--out": {
+                "type": "string",
+                "description": "The file path where the IO config will be written (default \"/etc/redpanda/io-config.yaml\")."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time after -- to wait for iotune to complete (e.g. 300ms, 1.5s, 2h45m) (default 1h0m0s)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk plugin": {
+        "description": "List, download, update, and remove rpk plugins.\r\n\t\r\nPlugins augment rpk with new commands.\r\n\r\nFor a plugin to be used, it must be in $HOME/.local/bin or somewhere \r\ndiscoverable by rpk in your $PATH. All plugins follow a defined naming scheme:\r\n\r\n  .rpk-<name>\r\n  .rpk.ac-<name>\r\n\r\nAll plugins are prefixed with either .rpk- or .rpk.ac-. When rpk starts up, it\r\nsearches all directories in your $PATH for any executable binary that begins\r\nwith either of those prefixes. For any binary it finds, rpk adds a command for\r\nthat name to the rpk command space itself.\r\n\r\nNo plugin name can shadow an existing rpk command, and only one plugin can\r\nexist under a given name at once. Plugins are added to the rpk command space on\r\na first-seen basis. If you have two plugins rpk-foo, and the second is\r\ndiscovered later on in the $PATH directories, then only the first will be used.\r\nThe second will be ignored.\r\n\r\nPlugins that have an .rpk.ac- prefix indicate that they support the\r\n--help-autocomplete flag. If rpk sees this, rpk will exec the plugin with that\r\nflag when rpk starts up, and the plugin will return all commands it supports as\r\nwell as short and long help test for each command. Rpk uses this return to\r\nbuild a shadow command space within rpk itself so that it looks as if the\r\nplugin exists within rpk. This is particularly useful if you enable\r\nautocompletion.\r\n\r\nThe expected return for plugins from --help-autocomplete is an array of the\r\nfollowing:\r\n\r\n  type pluginHelp struct {\r\n          Path    string   `json:\"path,omitempty\"`\r\n          Short   string   `json:\"short,omitempty\"`\r\n          Long    string   `json:\"long,omitempty\"`\r\n          Example string   `json:\"example,omitempty\"`\r\n          Args    []string `json:\"args,omitempty\"`\r\n  }\r\n\r\nwhere \"path\" is an underscore delimited argument path to a command. For\r\nexample, \"foo_bar_baz\" corresponds to the command \"rpk foo bar baz\".",
+        "usage": "Usage:\r\n  rpk plugin [flags]\r\n  rpk plugin [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for plugin."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk plugin install": {
+        "description": "Install an rpk plugin.\r\n\r\nAn rpk plugin must be saved in $HOME/.local/bin or in a directory that is in \r\nyour $PATH. By default, this command installs plugins to $HOME/.local/bin. This \r\ncan be overridden by specifying the --dir flag.\r\n\r\nIf --dir is not present, rpk will create $HOME/.local/bin if it does not exist.",
+        "usage": "Usage:\r\n  rpk plugin install [PLUGIN] [flags]\r\n\r\nAliases:\r\n  install, download\r\n\r",
+        "flags": {
+            "--dir": {
+                "type": "string",
+                "description": "Destination directory to save the installed plugin (defaults to $HOME/.local/bin) (default \"/var/lib/redpanda/.local/bin\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for install."
+            },
+            "-u, --update": {
+                "type": "-",
+                "description": "Update a locally installed plugin if it differs from the current remote version."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk plugin list": {
+        "description": "List all available plugins.\r\n\r\nBy default, this command fetches the remote manifest and prints plugins\r\navailable for download. Any plugin that is already downloaded is prefixed with\r\nan asterisk. If a locally installed plugin has a different sha256sum as the one\r\nspecified in the manifest, or if the sha256sum could not be calculated for the\r\nlocal plugin, an additional message is printed.\r\n\r\nYou can specify --local to print all locally installed plugins, as well as\r\nwhether you have \"shadowed\" plugins (the same plugin specified multiple times).",
+        "usage": "Usage:\r\n  rpk plugin list [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-l, --local": {
+                "type": "-",
+                "description": "List locally installed plugins and shadowed plugins."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk plugin uninstall": {
+        "description": "Uninstall / remove an existing local plugin.\r\n\r\nThis command lists locally installed plugins and removes the first plugin that\r\nmatches the requested removal. If --include-shadowed is specified, this command\r\nalso removes all shadowed plugins of the same name. To remove a command under a\r\nnested namespace (\"rpk foo bar\"), you can use \"foo_bar\".",
+        "usage": "Usage:\r\n  rpk plugin uninstall [NAME] [flags]\r\n\r\nAliases:\r\n  uninstall, rm\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for uninstall."
+            },
+            "--include-shadowed": {
+                "type": "-",
+                "description": "Also remove shadowed plugins that have the same name."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile": {
+        "description": "Manage rpk profiles.\r\n\r\nAn rpk profile talks to a single Redpanda cluster. You can create multiple\r\nprofiles for multiple clusters and swap between them with 'rpk profile use'.\r\nMultiple profiles may be useful if, for example, you use rpk to talk to\r\na localhost cluster, a dev cluster, and a prod cluster, and you want to keep\r\nyour configuration in one place.",
+        "usage": "Usage:\r\n  rpk profile [flags]\r\n  rpk profile [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for profile."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile clear": {
+        "description": "Clear the current profile\r\n\r\nThis small command clears the current profile, which can be useful to unset an\r\nprod cluster profile.",
+        "usage": "Usage:\r\n  rpk profile clear [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for clear."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile create": {
+        "description": "Create an rpk profile.\r\n\r\nThere are multiple ways to create a profile. A name must be provided if not\r\nusing --from-cloud or --from-rpk-container.\r\n\r\n* You can use --from-redpanda to generate a new profile from an existing\r\n  redpanda.yaml file. The special values \"current\" create a profile from the\r\n  current redpanda.yaml as it is loaded within rpk.\r\n\r\n* You can use --from-profile to generate a profile from an existing profile or\r\n  from from a profile in a yaml file. First, the filename is checked, then an\r\n  existing profile name is checked. The special value \"current\" creates a new\r\n  profile from the existing profile.\r\n\r\n* You can use --from-cloud to generate a profile from an existing cloud cluster\r\n  id. Note that you must be logged in with 'rpk cloud login' first. The special\r\n  value \"prompt\" will prompt to select a cloud cluster to create a profile for.\r\n\r\n* You can use --from-rpk-container to generate a profile from an existing\r\n  cluster created using 'rpk container start' command. The name is not needed\r\n  when using this flag.\r\n\r\n* You can use --set key=value to directly set fields. The key can either be\r\n  the name of a -X flag or the path to the field in the profile's YAML format.\r\n  For example, using --set tls.enabled=true OR --set kafka_api.tls.enabled=true\r\n  is equivalent. The former corresponds to the -X flag tls.enabled, while the\r\n  latter corresponds to the path kafka_api.tls.enabled in the profile's YAML.\r\n\r\nThe --set flag is always applied last and can be used to set additional fields\r\nin tandem with --from-redpanda or --from-cloud.\r\n\r\nThe --set flag supports autocompletion, suggesting the -X key format. If you\r\nbegin writing a YAML path, the flag will suggest the rest of the path.\r\n\r\nIt is recommended to always use the --description flag; the description is\r\nprinted in the output of 'rpk profile list'.\r\n\r\nrpk always switches to the newly created profile.",
+        "usage": "Usage:\r\n  rpk profile create [NAME] [flags]\r\n\r",
+        "flags": {
+            "-d, --description": {
+                "type": "string",
+                "description": "Optional description of the profile."
+            },
+            "--from-cloud": {
+                "type": "string",
+                "description": "[=\"prompt\"]   Create and switch to a new profile generated from a Redpanda Cloud cluster ID."
+            },
+            "--from-profile": {
+                "type": "string",
+                "description": "Create and switch to a new profile from an existing profile or from a profile in a yaml file."
+            },
+            "--from-redpanda": {
+                "type": "string",
+                "description": "Create and switch to a new profile from a redpanda.yaml file."
+            },
+            "--from-rpk-container": {
+                "type": "-",
+                "description": "Create and switch to a new profile generated from a running cluster created with rpk container."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "-s, --set": {
+                "type": "stringArray",
+                "description": "Create and switch to a new profile, setting profile fields with key=value pairs."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile current": {
+        "description": "Print the current profile name.\r\n\r\nThis is a tiny command that simply prints the current profile name, which may\r\nbe useful in scripts, or a PS1, or to confirm what you have selected.",
+        "usage": "Usage:\r\n  rpk profile current [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for current."
+            },
+            "-n, --no-newline": {
+                "type": "-",
+                "description": "Do not print a newline after the profile name."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile delete": {
+        "description": "Delete an rpk profile.\r\n\r\nDeleting a profile removes it from the rpk.yaml file. If the deleted profile\r\nwas the selected profile, rpk will use in-memory defaults until a new profile\r\nis selected.",
+        "usage": "Usage:\r\n  rpk profile delete [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile edit": {
+        "description": "Edit an rpk profile.\r\n\r\nThis command opens your default editor to edit the specified profile, or\r\nthe current profile if no profile is specified. If the profile does not\r\nexist, this command creates it and switches to it.",
+        "usage": "Usage:\r\n  rpk profile edit [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for edit."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile edit-globals": {
+        "description": "Edit rpk globals.\r\n\r\nThis command opens your default editor to edit the rpk global configurations.",
+        "usage": "Usage:\r\n  rpk profile edit-globals [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for edit-globals."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile list": {
+        "description": "List rpk profiles",
+        "usage": "Usage:\r\n  rpk profile list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile print": {
+        "description": "Print rpk profile configuration.\r\n\r\nIf no name is specified, this command prints the current profile as it exists\r\nin the rpk.yaml file.",
+        "usage": "Usage:\r\n  rpk profile print [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for print."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile print-globals": {
+        "description": "Print rpk global configuration",
+        "usage": "Usage:\r\n  rpk profile print-globals [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for print-globals."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile prompt": {
+        "description": "Prompt a profile name formatted for a PS1 prompt.\r\n\r\nThis command prints ANSI-escaped text per your current profile's \"prompt\"\r\nfield. If the current profile does not have a prompt, this prints nothing.\r\nIf the prompt is invalid, this exits 0 with no message. To validate the\r\ncurrent prompt, use the --validate flag.\r\n\r\nThis command may introduce other % variables in the future, if you want to\r\nprint a % directly, use %% to escape it.\r\n\r\nTo use this in zsh, be sure to add setopt PROMPT_SUBST to your .zshrc.\r\nTo edit your PS1, use something like PS1='$(rpk profile prompt)' in your\r\nshell rc file.\r\n\r\nFORMAT\r\n\r\nThe \"prompt\" field supports space or comma separated modifiers and a quoted\r\nstring that is be modified. Inside the string, the variable %p or %n refers to\r\nthe profile name. As a few examples:\r\n\r\n    prompt: hi-white, bg-red, bold, \"[%p]\"\r\n    prompt: hi-red  \"PROD\"\r\n    prompt: white, \"dev-%n\r\n\r\nIf you want to have multiple formats, you can wrap each formatted section in\r\nparentheses.\r\n\r\n    prompt: (\"--\") (hi-white bg-red bold \"[%p]\")\r\n\r\nCOLORS\r\n\r\nAll ANSI colors are supported, with names matching the color name:\r\n\"black\", \"red\", \"green\", \"yellow\", \"blue\", \"magenta\", \"cyan\", \"white\".\r\n\r\nThe \"hi-\" prefix indicates a high-intensity color: \"hi-black\", \"hi-red\", etc.\r\nThe \"bg-\" prefix modifies the background color: \"bg-black\", \"bg-hi-red\", etc.\r\n\r\nMODIFIERS\r\n\r\nFour modifiers are supported, \"bold\", \"faint\", \"underline\", and \"invert\".",
+        "usage": "Usage:\r\n  rpk profile prompt [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for prompt."
+            },
+            "--validate": {
+                "type": "-",
+                "description": "Exit with an error message if the prompt is invalid."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile rename-to": {
+        "description": "Rename the current rpk profile",
+        "usage": "Usage:\r\n  rpk profile rename-to [NAME] [flags]\r\n\r\nAliases:\r\n  rename-to, rename\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for rename-to."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile set": {
+        "description": "Set fields in the current rpk profile.\r\n\r\nAs in the create command, this command takes a list of key=value pairs to write\r\nto the current profile.\r\n\r\nThe key can either be the name of a -X flag or the path to the field in the\r\nprofile's yaml format. For example, using --set tls.enabled=true OR --set\r\nkafka_api.tls.enabled=true is equivalent. The former corresponds to the -X flag\r\ntls.enabled, while the latter corresponds to the path kafka_api.tls.enabled in\r\nthe profile's yaml.\r\n\r\nThis command supports autocompletion of valid keys, suggesting the -X key\r\nformat. If you begin writing a YAML path, this command will suggest the rest of\r\nthe path.\r\n\r\nYou can also use the format 'set key value' if you intend to only set one key.",
+        "usage": "Usage:\r\n  rpk profile set [KEY=VALUE]+ [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile set-globals": {
+        "description": "Set rpk globals fields.\r\n\r\nThis command takes a list of key=value pairs to write to the global config \r\nsection of rpk.yaml. The globals section contains a set of settings that apply\r\nto all profiles and changes the way that rpk acts. For a list of global flags\r\nand what they mean, check 'rpk -X help' and look for any key that begins with\r\n\"globals\".\r\n\r\nThis command supports autocompletion of valid keys. You can also use the\r\nformat 'set key value' if you intend to only set one key.",
+        "usage": "Usage:\r\n  rpk profile set-globals [KEY=VALUE]+ [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set-globals."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk profile use": {
+        "description": "Select the rpk profile to use",
+        "usage": "Usage:\r\n  rpk profile use [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for use."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda": {
+        "description": "Interact with a local Redpanda process",
+        "usage": "Usage:\r\n  rpk redpanda [flags]\r\n  rpk redpanda [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for redpanda."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin": {
+        "description": "Talk to the Redpanda admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin [flags]\r\n  rpk redpanda admin [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for admin."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin brokers": {
+        "description": "View and configure Redpanda brokers through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers [flags]\r\n  rpk redpanda admin brokers [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for brokers."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin brokers decommission": {
+        "description": "Decommission the given broker.\r\n\r\nDecommissioning a broker removes it from the cluster.\r\n\r\nA decommission request is sent to every broker in the cluster, only the cluster\r\nleader handles the request.\r\n\r\nFor safety on v22.x clusters, this command will not run if the requested \r\nbroker is in maintenance mode. As of v23.x, Redpanda supports \r\ndecommissioning a node that is currently in maintenance mode. If you are on \r\na v22.x cluster and need to bypass the maintenance mode check (perhaps your \r\ncluster is unreachable), use the hidden --force flag.",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers decommission [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for decommission."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin brokers decommission-status": {
+        "description": "Show the progrss of a node decommissioning.\r\n\r\nWhen a node is being decommissioned, this command reports the decommissioning\r\nprogress as follows, where PARTITION-SIZE is in bytes. Using -H, it prints the\r\npartition size in a human-readable format.\r\n\r\n$ rpk redpanda admin brokers decommission-status 4\r\nDECOMMISSION PROGRESS\r\n=====================\r\nNAMESPACE-TOPIC              PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE\r\nkafka/test                   0          3          9             1699470920\r\nkafka/test                   4          3          0             1614258779\r\nkafka/test2                  3          3          3             2722706514\r\nkafka/test2                  4          3          4             2945518089\r\nkafka_internal/id_allocator  0          3          0             3562\r\n\r\nUsing --detailed / -d, it additionally prints granular reports.\r\n\r\n$ rpk redpanda admin brokers decommission-status 4 -d\r\nDECOMMISSION PROGRESS\r\n=====================\r\nNAMESPACE-TOPIC  PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE  BYTES-MOVED  BYTES-REMAINING\r\nkafka/test       0          3          13            1731773243      228114727    1503658516\r\nkafka/test       4          3          1             1645952961      18752660     1627200301\r\nkafka/test2      3          3          5             2752632301      140975805    2611656496\r\nkafka/test2      4          3          6             2975443783      181581219    2793862564\r\n\r\nIf a partition cannot be moved with some reason, the command reports the\r\nproblematic partition in the 'ALLOCATION FAILURES' section and decommission\r\nnever succeeds. Typical scenarios the failure occurs are; there's no node\r\nthat has enough space to allocate a partition or that can satisfy rack\r\nconstraints, etc.\r\n\r\nALLOCATION FAILURES\r\n==================\r\nkafka/foo/2\r\nkafka/test/0\r\n\r\nNote that the command reports allocation failed partitions only when\r\n'partition_autobalancing_mode' is set to 'continuous'. See the current value\r\nusing 'rpk cluster config get partition_autobalancing_mode'.",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers decommission-status [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-d, --detailed": {
+                "type": "-",
+                "description": "Print how much data moved and remaining in bytes."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for decommission-status."
+            },
+            "-H, --human-readable": {
+                "type": "-",
+                "description": "Print the partition size in a human-readable form."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin brokers list": {
+        "description": "List the brokers in your cluster",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin brokers recommission": {
+        "description": "Recommission the given broker if is is still decommissioning.\r\n\r\nRecommissioning can stop an active decommission.\r\n\r\nOnce a broker is decommissioned, it cannot be recommissioned through this\r\ncommand.\r\n\r\nA recommission request is sent to every broker in the cluster, only\r\nthe cluster leader handles the request.",
+        "usage": "Usage:\r\n  rpk redpanda admin brokers recommission [BROKER ID] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for recommission."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin config": {
+        "description": "View or modify Redpanda configuration through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin config [flags]\r\n  rpk redpanda admin config [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin config log-level": {
+        "description": "Manage a broker's log level",
+        "usage": "Usage:\r\n  rpk redpanda admin config log-level [flags]\r\n  rpk redpanda admin config log-level [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for log-level."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin config log-level set": {
+        "description": "Set broker logger's log level.\r\n\r\nThis command temporarily changes a broker logger's log level. Each Redpanda\r\nbroker has many loggers, and each can be individually changed. Any change\r\nto a logger persists for a limited amount of time, so as to ensure you do\r\nnot accidentally enable debug logging permanently.\r\n\r\nIt is optional to specify a logger; if you do not, this command will prompt\r\nfrom the set of available loggers.\r\n\r\nThe special logger \"all\" enables all loggers. Alternatively, you can specify\r\nmany loggers at once. To see all possible loggers, run the following command:\r\n\r\n  redpanda --help-loggers\r\n\r\nThis command accepts loggers that it does not know of to ensure you can\r\nindependently update your redpanda installations from rpk. The success or\r\nfailure of enabling each logger is individually printed.",
+        "usage": "Usage:\r\n  rpk redpanda admin config log-level set [LOGGERS...] [flags]\r\n\r",
+        "flags": {
+            "-e, --expiry-seconds": {
+                "type": "int",
+                "description": "seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown) (default 300)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--host": {
+                "type": "string",
+                "description": "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to."
+            },
+            "-l, --level": {
+                "type": "string",
+                "description": "log level to set (error, warn, info, debug, trace) (default \"debug\")."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin config print": {
+        "description": "Display the current Redpanda configuration",
+        "usage": "Usage:\r\n  rpk redpanda admin config print [flags]\r\n\r\nAliases:\r\n  print, dump, list, ls, display\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for print."
+            },
+            "--host": {
+                "type": "string",
+                "description": "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin partitions": {
+        "description": "View and configure Redpanda partitions through the admin listener",
+        "usage": "Usage:\r\n  rpk redpanda admin partitions [flags]\r\n  rpk redpanda admin partitions [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for partitions."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda admin partitions list": {
+        "description": "List the partitions in a broker in the cluster",
+        "usage": "Usage:\r\n  rpk redpanda admin partitions list [BROKER ID] [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-l, --leader-only": {
+                "type": "-",
+                "description": "print the partitions on broker which are leaders."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda check": {
+        "description": "Check if system meets redpanda requirements",
+        "usage": "Usage:\r\n  rpk redpanda check [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for check."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum amount of time to wait for the checks and tune process to complete (e.g. 300ms, 1.5s, 2h45m) (default 2s)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda config": {
+        "description": "Edit configuration",
+        "usage": "Usage:\r\n  rpk redpanda config [flags]\r\n  rpk redpanda config [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for config."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda config bootstrap": {
+        "description": "Initialize the configuration to bootstrap a cluster.\r\n\r\nThis command generates a redpanda.yaml configuration file to bootstrap a\r\ncluster. If you are modifying the configuration file further, it is recommended\r\nto first bootstrap and then modify. If the file already exists, this command\r\nwill set fields as requested by flags, and this may undo some of your earlier\r\nedits.\r\n\r\nThe --ips flag specifies seed servers (ips, ip:ports, or hostnames) that this\r\nbroker will use to form a cluster.\r\n\r\nBy default, redpanda expects your machine to have one private IP address, and\r\nredpanda will listen on it. If your machine has multiple private IP addresses,\r\nyou must use the --self flag to specify which ip redpanda should listen on.",
+        "usage": "Usage:\r\n  rpk redpanda config bootstrap [--self <ip>] [--ips <ip1,ip2,...>] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for bootstrap."
+            },
+            "--ips": {
+                "type": "strings",
+                "description": "Comma-separated list of the seed node addresses or hostnames; at least three are recommended."
+            },
+            "--self": {
+                "type": "string",
+                "description": "Optional IP address for redpanda to listen on; if empty, defaults to a private address."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda config init": {
+        "description": "This command has been deprecated.",
+        "usage": "Usage:\r\n  rpk redpanda config init [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for init."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda config set": {
+        "description": "Set configuration values, such as the redpanda node ID or the list of seed servers\r\n\r\nThis command modifies the redpanda.yaml you have locally on disk. The first\r\nargument is the key within the yaml representing a property / field that you\r\nwould like to set. Nested fields can be accessed through a dot:\r\n\r\n  rpk redpanda config set redpanda.developer_mode true\r\n\r\nAll values are parsed as yaml and, since yaml is a superset of json, you can\r\nalso format your input as json. Individual specific fields or full structs can\r\nbe set:\r\n\r\n  rpk redpanda config set rpk.tune_disk_irq true\r\n  rpk redpanda config set redpanda.rpc_server '{address: 3.250.158.1, port: 9092}'\r\n\r\nYou can set an entire array by wrapping all items with braces, or by using one\r\nstruct:\r\n\r\n  rpk redpanda config set redpanda.advertised_kafka_api '[{address: 0.0.0.0, port: 9092}]'\r\n  rpk redpanda config set redpanda.advertised_kafka_api '{address: 0.0.0.0, port: 9092}' # same\r\n\r\nIndexing can be used to set specific items in an array. You can index one past\r\nthe end of an array to extend it:\r\n\r\n  rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 0.0.0.0, port: 9092}'\r\n\r\nYou may also use <key>=<value> notation for setting configuration properties:\r\n\r\n  rpk redpanda config set redpanda.kafka_api[0].port=9092",
+        "usage": "Usage:\r\n  rpk redpanda config set [KEY] [VALUE] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda mode": {
+        "description": "Enable a default configuration mode",
+        "usage": "Usage:\r\n  rpk redpanda mode [MODE] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for mode."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda start": {
+        "description": "Start redpanda",
+        "usage": "Usage:\r\n  rpk redpanda start [flags]\r\n\r",
+        "flags": {
+            "--advertise-kafka-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Kafka addresses to advertise (scheme://host:port|name)."
+            },
+            "--advertise-pandaproxy-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Pandaproxy addresses to advertise (scheme://host:port|name)."
+            },
+            "--advertise-rpc-addr": {
+                "type": "string",
+                "description": "The advertised RPC address (host:port)."
+            },
+            "--check": {
+                "type": "-",
+                "description": "When set to false will disable system checking before starting redpanda (default true)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for start."
+            },
+            "--install-dir": {
+                "type": "string",
+                "description": "Directory where redpanda has been installed."
+            },
+            "--kafka-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Kafka listener addresses to bind to (scheme://host:port|name)."
+            },
+            "--mode": {
+                "type": "string",
+                "description": "Mode sets well-known configuration properties for development or test environments; use --mode help for more info."
+            },
+            "--pandaproxy-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Pandaproxy listener addresses to bind to (scheme://host:port|name)."
+            },
+            "--rpc-addr": {
+                "type": "string",
+                "description": "The RPC address to bind to (host:port)."
+            },
+            "--schema-registry-addr": {
+                "type": "strings",
+                "description": "A comma-separated list of Schema Registry listener addresses to bind to (scheme://host:port|name)."
+            },
+            "-s, --seeds": {
+                "type": "strings",
+                "description": "A comma-separated list of seed nodes to connect to (scheme://host:port|name)."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time to wait for the checks and tune processes to complete (e.g. 300ms, 1.5s, 2h45m) (default 10s)."
+            },
+            "--tune": {
+                "type": "-",
+                "description": "When present will enable tuning before starting redpanda."
+            },
+            "--well-known-io": {
+                "type": "string",
+                "description": "The cloud vendor and VM type, in the format <vendor>:<vm type>:<storage type>."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda stop": {
+        "description": "Stop a local redpanda process. 'rpk stop'\r\nfirst sends SIGINT, and waits for the specified timeout. Then, if redpanda\r\nhasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still\r\nrunning.",
+        "usage": "Usage:\r\n  rpk redpanda stop [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for stop."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum amount of time to wait for redpanda to stop after each signal is sent (e.g. 300ms, 1.5s, 2h45m) (default 5s)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda tune": {
+        "description": "Sets the OS parameters to tune system performance.\r\n\r\nAvailable tuners:\r\n\r\n  - all.\r\n  - disk_scheduler\r\n  - disk_nomerges\r\n  - disk_write_cache\r\n  - swappiness\r\n  - disk_irq\r\n  - clocksource\r\n  - ballast_file\r\n  - cpu\r\n  - net\r\n  - aio_events\r\n  - transparent_hugepages\r\n  - coredump\r\n  - fstrim\r\n\r\nTo learn more about a tuner, run 'rpk redpanda tune help <tuner name>'.",
+        "usage": "Usage:\r\n  rpk redpanda tune [list of elements to tune] [flags]\r\n  rpk redpanda tune [command]\r\n\r",
+        "flags": {
+            "--cpu-set": {
+                "type": "string",
+                "description": "Set of CPUs for tuners to use in cpuset(7) format; if not specified, tuners will use all available CPUs (default \"all\")."
+            },
+            "-r, --dirs": {
+                "type": "strings",
+                "description": "List of *data* directories or places to store data (e.g. /var/vectorized/redpanda/); usually your XFS filesystem on an NVMe SSD device."
+            },
+            "-d, --disks": {
+                "type": "strings",
+                "description": "Lists of devices to tune f.e. 'sda1'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for tune."
+            },
+            "-m, --mode": {
+                "type": "string",
+                "description": "Operation Mode: one of: [sq, sq_split, mq]."
+            },
+            "-n, --nic": {
+                "type": "strings",
+                "description": "Network Interface Controllers to tune."
+            },
+            "--output-script": {
+                "type": "string",
+                "description": "Generate a tuning file that can later be used to tune the system."
+            },
+            "--reboot-allowed": {
+                "type": "-",
+                "description": "Allow tuners to tune boot parameters and request system reboot."
+            },
+            "--timeout": {
+                "type": "duration",
+                "description": "The maximum time to wait for the tune processes to complete (e.g. 300ms, 1.5s, 2h45m) (default 10s)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda tune help": {
+        "description": "Display detailed information about the tuner",
+        "usage": "Usage:\r\n  rpk redpanda tune help [TUNER] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for help."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk redpanda tune list": {
+        "description": "List available redpanda tuners and check if they are enabled and \r\nsupported by your system\r\n\r\nTo enable a tuner it must be set in the redpanda.yaml configuration file\r\nunder rpk section, e.g:\r\n\r\n  rpk:\r\n      tune_cpu: true\r\n      tune_swappiness: true\r\n\r\nYou may use 'rpk redpanda config set' to enable or disable a tuner.",
+        "usage": "Usage:\r\n  rpk redpanda tune list [flags]\r\n\r",
+        "flags": {
+            "-r, --dirs": {
+                "type": "strings",
+                "description": "List of *data* directories or places to store data (e.g. /var/vectorized/redpanda/); usually your XFS filesystem on an NVMe SSD device."
+            },
+            "-d, --disks": {
+                "type": "strings",
+                "description": "Lists of devices to tune f.e. 'sda1'."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-m, --mode": {
+                "type": "string",
+                "description": "Operation Mode: one of: [sq, sq_split, mq]."
+            },
+            "-n, --nic": {
+                "type": "strings",
+                "description": "Network Interface Controllers to tune."
+            },
+            "--reboot-allowed": {
+                "type": "-",
+                "description": "Allow tuners to tune boot parameters and request system reboot."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry": {
+        "description": "Commands to interact with the schema registry",
+        "usage": "Usage:\r\n  rpk registry [flags]\r\n  rpk registry [command]\r\n\r\nAliases:\r\n  registry, sr\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for registry."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry compatibility-level": {
+        "description": "Manage global or per-subject compatibility levels",
+        "usage": "Usage:\r\n  rpk registry compatibility-level [flags]\r\n  rpk registry compatibility-level [command]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for compatibility-level."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry compatibility-level get": {
+        "description": "Get the global or per-subject compatibility levels.\r\n\r\nRunning this command with no subject returns the global level, alternatively\r\nyou can use the --global flag to get the global level at the same time as\r\nper-subject levels.",
+        "usage": "Usage:\r\n  rpk registry compatibility-level get [SUBJECT...] [flags]\r\n\r",
+        "flags": {
+            "--global": {
+                "type": "-",
+                "description": "Return the global level in addition to subject levels."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for get."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry compatibility-level set": {
+        "description": "Set the global or per-subject compatibility levels.\r\n\r\nRunning this command with no subject returns the global level, alternatively\r\nyou can use the --global flag to set the global level at the same time as\r\nper-subject levels.",
+        "usage": "Usage:\r\n  rpk registry compatibility-level set [SUBJECT...] [flags]\r\n\r",
+        "flags": {
+            "--global": {
+                "type": "-",
+                "description": "Set the global level in addition to subject levels."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for set."
+            },
+            "--level": {
+                "type": "string",
+                "description": "Level to set, one of NONE, {BACKWARD,FORWARD,FULL}{,_TRANSITIVE}."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry schema": {
+        "description": "Manage your schema registry schemas",
+        "usage": "Usage:\r\n  rpk registry schema [flags]\r\n  rpk registry schema [command]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for schema."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry schema check-compatibility": {
+        "description": "Check schema compatibility with existing schemas in the subject",
+        "usage": "Usage:\r\n  rpk registry schema check-compatibility SUBJECT [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for check-compatibility."
+            },
+            "--references": {
+                "type": "string",
+                "description": "Comma-separated list of references (name:subject:version) or path to reference file."
+            },
+            "--schema": {
+                "type": "string",
+                "description": "Schema filepath to check, must be .avro or .proto."
+            },
+            "--schema-version": {
+                "type": "string",
+                "description": "Schema version to check compatibility with (latest, 0, 1...)."
+            },
+            "--type": {
+                "type": "string",
+                "description": "Schema type (avro,protobuf); overrides schema file extension."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry schema create": {
+        "description": "Create a schema for the given subject.\r\n\r\nThis uploads a schema to the registry, creating the schema if it does not\r\nexist. The schema type is detected by the filename extension: \".avro\" or \".avsc\"\r\nfor Avro and \".proto\" for Protobuf. You can manually specify the type with the \r\n--type flag.\r\n\r\nYou may pass the references using the --reference flag, which accepts either a\r\ncomma separated list of <name>:<subject>:<version> or a path to a file. The file \r\nmust contain lines of name, subject, and version separated by a tab or space, or \r\nthe equivalent in json / yaml format.\r\n\r\nEXAMPLES\r\n\r\nCreate a protobuf schema with subject 'foo':\r\n  rpk registry schema create foo --schema path/to/file.proto\r\n\r\nCreate an avro schema, passing the type via flags:\r\n  rpk registry schema create foo --schema /path/to/file --type avro\r\n\r\nCreate a protobuf schema that references the schema in subject 'my_subject', \r\nversion 1:\r\n  rpk registry schema create foo --schema /path/to/file.proto --references my_name:my_subject:1",
+        "usage": "Usage:\r\n  rpk registry schema create SUBJECT --schema {filename} [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "--references": {
+                "type": "string",
+                "description": "Comma-separated list of references (name:subject:version) or path to reference file."
+            },
+            "--schema": {
+                "type": "string",
+                "description": "Schema filepath to upload, must be .avro, .avsc, or .proto."
+            },
+            "--type": {
+                "type": "string",
+                "description": "Schema type (avro,protobuf); overrides schema file extension."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry schema delete": {
+        "description": "Delete a specific schema for the given subject",
+        "usage": "Usage:\r\n  rpk registry schema delete SUBJECT --schema-version {version} [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--permanent": {
+                "type": "-",
+                "description": "Perform a hard (permanent) delete of the schema."
+            },
+            "--schema-version": {
+                "type": "string",
+                "description": "Schema version to delete (latest, 0, 1...)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry schema get": {
+        "description": "Get a schema by version, ID, or by an existing schema.\r\n\r\nThis returns a lookup of an existing schema or schemas in one of a few\r\npotential (mutually exclusive) ways:\r\n\r\n* By version, returning a schema for a required subject and version\r\n* By ID, returning all subjects using the schema, or filtering for one subject\r\n* By schema, checking if the schema has been created in the subject",
+        "usage": "Usage:\r\n  rpk registry schema get [SUBJECT] [flags]\r\n\r",
+        "flags": {
+            "--deleted": {
+                "type": "-",
+                "description": "If true, also return deleted schemas."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for get."
+            },
+            "--id": {
+                "type": "int",
+                "description": "ID to lookup schemas usages of; subject optional."
+            },
+            "--schema": {
+                "type": "string",
+                "description": "Schema file to check existence of, must be .avro or .proto; subject required."
+            },
+            "--schema-version": {
+                "type": "string",
+                "description": "Schema version to lookup (latest, 0, 1...); subject required."
+            },
+            "--type": {
+                "type": "string",
+                "description": "Schema type of the file used to lookup (avro,protobuf); overrides schema file extension."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry schema list": {
+        "description": "List the schemas for the requested subjects, or list all schemas",
+        "usage": "Usage:\r\n  rpk registry schema list [SUBJECT...] [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "--deleted": {
+                "type": "-",
+                "description": "If true, list deleted schemas as well."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry schema references": {
+        "description": "Retrieve a list of schemas that reference the subject",
+        "usage": "Usage:\r\n  rpk registry schema references SUBJECT --schema-version {version} [flags]\r\n\r",
+        "flags": {
+            "--deleted": {
+                "type": "-",
+                "description": "If true, list deleted schemas as well."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for references."
+            },
+            "--schema-version": {
+                "type": "string",
+                "description": "Schema version to check references with (latest, 0, 1...)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry subject": {
+        "description": "List or delete schema registry subjects",
+        "usage": "Usage:\r\n  rpk registry subject [flags]\r\n  rpk registry subject [command]\r\n\r",
+        "flags": {
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for subject."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry subject delete": {
+        "description": "Soft or hard deletion of subjects",
+        "usage": "Usage:\r\n  rpk registry subject delete [SUBJECT...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--permanent": {
+                "type": "-",
+                "description": "Perform a hard (permanent) delete of the subject."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk registry subject list": {
+        "description": "Display all subjects",
+        "usage": "Usage:\r\n  rpk registry subject list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "--deleted": {
+                "type": "-",
+                "description": "If true, list deleted subjects as well."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic": {
+        "description": "Create, delete, produce to and consume from Redpanda topics",
+        "usage": "Usage:\r\n  rpk topic [flags]\r\n  rpk topic [command]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for topic."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic add-partitions": {
+        "description": "Add partitions to existing topics.",
+        "usage": "Usage:\r\n  rpk topic add-partitions [TOPICS...] --num [#] [flags]\r\n\r",
+        "flags": {
+            "-f, --force": {
+                "type": "-",
+                "description": "Force change the partition count in internal topics, e.g. __consumer_offsets."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for add-partitions."
+            },
+            "-n, --num": {
+                "type": "int",
+                "description": "Number of partitions to add to each topic."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic alter-config": {
+        "description": "Set, delete, add, and remove key/value configs for a topic.\r\n\r\nThis command allows you to incrementally alter the configuration for multiple\r\ntopics at a time.\r\n\r\nIncremental altering supports four operations:\r\n\r\n  1) Setting a key=value pair\r\n  2) Deleting a key's value\r\n  3) Appending a new value to a list-of-values key\r\n  4) Subtracting (removing) an existing value from a list-of-values key\r\n\r\nThe --dry option will validate whether the requested configuration change is\r\nvalid, but does not apply it.",
+        "usage": "Usage:\r\n  rpk topic alter-config [TOPICS...] --set key=value --delete key2,key3 [flags]\r\n\r",
+        "flags": {
+            "--append": {
+                "type": "stringArray",
+                "description": "key=value; Value to append to a list-of-values key (repeatable)."
+            },
+            "-d, --delete": {
+                "type": "stringArray",
+                "description": "Key to delete (repeatable)."
+            },
+            "--dry": {
+                "type": "-",
+                "description": "Dry run: validate the alter request, but do not apply."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for alter-config."
+            },
+            "-s, --set": {
+                "type": "stringArray",
+                "description": "key=value; Pair to set (repeatable)."
+            },
+            "--subtract": {
+                "type": "stringArray",
+                "description": "key=value; Value to remove from list-of-values key (repeatable)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic consume": {
+        "description": "Consume records from topics.\r\n\r\nConsuming records reads from any amount of input topics, formats each record\r\naccording to --format, and prints them to STDOUT. The output formatter\r\nunderstands a wide variety of formats.\r\n\r\nThe default output format \"--format json\" is a special format that outputs each\r\nrecord as JSON. There may be more single-word-no-escapes formats added later.\r\nOutside of these special formats, formatting follows the rules described below.\r\n\r\nFormatting output is based on percent escapes and modifiers. Slashes can be\r\nused for common escapes:\r\n\r\n    \\t \\n \\r \\\\ \\xNN\r\n\r\nprints tabs, newlines, carriage returns, slashes, or hex encoded characters.p\r\n\r\nPercent encoding prints record fields, fetch partition fields, or extra values:\r\n\r\n    %t    topic\r\n    %T    topic length\r\n    %k    key\r\n    %K    key length\r\n    %v    value\r\n    %V    value length\r\n    %h    begin the header specification\r\n    %H    number of headers\r\n    %p    partition\r\n    %o    offset\r\n    %e    leader epoch\r\n    %d    timestamp (formatting described below)\r\n    %a    record attributes (formatting described below)\r\n    %x    producer id\r\n    %y    producer epoch\r\n\r\n    %[    partition log start offset\r\n    %|    partition last stable offset\r\n    %]    partition high watermark\r\n\r\n    %%    percent sign\r\n    %{    left brace\r\n    %}    right brace\r\n\r\n    %i    the number of records formatted\r\n\r\nMODIFIERS\r\n\r\nText and numbers can be formatted in many different ways, and the default\r\nformat can be changed within brace modifiers. %v prints a value, while %v{hex}\r\nprints the value hex encoded. %T prints the length of a topic in ascii, while\r\n%T{big8} prints the length of the topic as an eight byte big endian.\r\n\r\nAll modifiers go within braces following a percent-escape.\r\n\r\nNUMBERS\r\n\r\nFormatting number values can have the following modifiers:\r\n\r\n     ascii       print the number as ascii (default)\r\n\r\n     hex64       sixteen hex characters\r\n     hex32       eight hex characters\r\n     hex16       four hex characters\r\n     hex8        two hex characters\r\n     hex4        one hex character\r\n\r\n     big64       eight byte big endian number\r\n     big32       four byte big endian number\r\n     big16       two byte big endian number\r\n     big8        alias for byte\r\n\r\n     little64    eight byte little endian number\r\n     little32    four byte little endian number\r\n     little16    two byte little endian number\r\n     little8     alias for byte\r\n\r\n     byte        one byte number\r\n     bool        \"true\" if the number is non-zero, \"false\" if the number is zero\r\n\r\nAll numbers are truncated as necessary per the modifier. Printing %V{byte} for\r\na length 256 value will print a single null, whereas printing %V{big8} would\r\nprint the bytes 1 and 0.\r\n\r\nWhen writing number sizes, the size corresponds to the size of the raw values,\r\nnot the size of encoded values. \"%T% t{hex}\" for the topic \"foo\" will print\r\n\"3 666f6f\", not \"6 666f6f\".\r\n\r\nTIMESTAMPS\r\n\r\nBy default, the timestamp field is printed as a millisecond number value. In\r\naddition to the number modifiers above, timestamps can be printed with either\r\nGo formatting or strftime formatting:\r\n\r\n    %d{go[2006-01-02T15:04:05Z07:00]}\r\n    %d{strftime[%F]}\r\n\r\nAn arbitrary amount of brackets (or braces, or # symbols) can wrap your date\r\nformatting:\r\n\r\n    %d{strftime### [%F] ###}\r\n\r\nThe above will print \" [YYYY-MM-DD] \", while the surrounding three # on each\r\nside are used to wrap the formatting. Further details on Go time formatting can\r\nbe found at https://pkg.go.dev/time, while further details on strftime\r\nformatting can be read by checking \"man strftime\".\r\n\r\nATTRIBUTES\r\n\r\nEach record (or batch of records) has a set of possible attributes. Internally,\r\nthese are packed into bit flags. Printing an attribute requires first selecting\r\nwhich attribute you want to print, and then optionally specifying how you want\r\nit to be printed:\r\n\r\n     %a{compression}\r\n     %a{compression;number}\r\n     %a{compression;big64}\r\n     %a{compression;hex8}\r\n\r\nCompression is by default printed as text (\"none\", \"gzip\", ...). Compression\r\ncan be printed as a number with \";number\", where number is any number\r\nformatting option described above. No compression is 0, gzip is 1, etc.\r\n\r\n     %a{timestamp-type}\r\n     %a{timestamp-type;big64}\r\n\r\nThe record's timestamp type is printed as -1 for very old records (before\r\ntimestamps existed), 0 for client generated timestamps, and 1 for broker\r\ngenerated timestamps. Number formatting can be controlled with \";number\".\r\n\r\n     %a{transactional-bit}\r\n     %a{transactional-bit;bool}\r\n\r\nPrints 1 if the record a part of a transaction or 0 if it is not.\r\nNumber formatting can be controlled with \";number\".\r\n\r\n     %a{control-bit}\r\n     %a{control-bit;bool}\r\n\r\nPrints 1 if the record is a commit marker or 0 if it is not.\r\nNumber formatting can be controlled with \";number\".\r\n\r\nTEXT\r\n\r\nText fields without modifiers default to writing the raw bytes. Alternatively,\r\nthere are the following modifiers:\r\n\r\n    %t{hex}\r\n    %k{base64}\r\n    %v{base64raw}\r\n    %v{unpack[<bBhH>iIqQc.$]}\r\n\r\nThe hex modifier hex encodes the text, the base64 modifier base64 encodes the\r\ntext with standard encoding, and the base64raw modifier encodes the text with\r\nraw standard encoding. The unpack modifier has a further internal\r\nspecification, similar to timestamps above:\r\n\r\n    x    pad character (does not parse input)\r\n    <    switch what follows to little endian\r\n    >    switch what follows to big endian\r\n\r\n    b    signed byte\r\n    B    unsigned byte\r\n    h    int16  (\"half word\")\r\n    H    uint16 (\"half word\")\r\n    i    int32\r\n    I    uint32\r\n    q    int64  (\"quad word\")\r\n    Q    uint64 (\"quad word\")\r\n\r\n    c    any character\r\n    .    alias for c\r\n    s    consume the rest of the input as a string\r\n    $    match the end of the line (append error string if anything remains)\r\n\r\nUnpacking text can allow translating binary input into readable output. If a\r\nvalue is a big-endian uint32, %v will print the raw four bytes, while\r\n%v{unpack[>I]} will print the number in as ascii. If unpacking exhausts the\r\ninput before something is unpacked fully, an error message is appended to the\r\noutput.\r\n\r\nHEADERS\r\n\r\nHeaders are formatted with percent encoding inside of the modifier:\r\n\r\n    %h{ %k=%v{hex} }\r\n\r\nwill print all headers with a space before the key and after the value, an\r\nequals sign between the key and value, and with the value hex encoded. Header\r\nformatting actually just parses the internal format as a record format, so all\r\nof the above rules about %K, %V, text, and numbers apply.\r\n\r\nEXAMPLES\r\n\r\nA key and value, separated by a space and ending in newline:\r\n    -f '%k %v\\n'\r\nA key length as four big endian bytes, and the key as hex:\r\n    -f '%K{big32}%k{hex}'\r\nA little endian uint32 and a string unpacked from a value:\r\n    -f '%v{unpack[is$]}'\r\n\r\nOFFSETS\r\n\r\nThe --offset flag allows for specifying where to begin consuming, and\r\noptionally, where to stop consuming. The literal words \"start\" and \"end\"\r\nspecify consuming from the start and the end.\r\n\r\n    start     consume from the beginning\r\n    end       consume from the end\r\n    :end      consume until the current end\r\n    +oo       consume oo after the current start offset\r\n    -oo       consume oo before the current end offset\r\n    oo        consume after an exact offset\r\n    oo:       alias for oo\r\n    :oo       consume until an exact offset\r\n    o1:o2     consume from exact offset o1 until exact offset o2\r\n    @t        consume starting from a given timestamp\r\n    @t:       alias for @t\r\n    @:t       consume until a given timestamp\r\n    @t1:t2    consume from timestamp t1 until timestamp t2\r\n\r\nThere are a few options for timestamps, with each option being evaluated\r\nuntil one succeeds:\r\n\r\n    13 digits             parsed as a unix millisecond\r\n    9 digits              parsed as a unix second\r\n    YYYY-MM-DD            parsed as a day, UTC\r\n    YYYY-MM-DDTHH:MM:SSZ  parsed as RFC3339, UTC; fractional seconds optional (.MMM)\r\n    end                   for t2 in @t1:t2, the current end of the partition\r\n    -dur                  a negative duration from now or from a timestamp\r\n    dur                   a positive duration from now or from a timestamp\r\n\r\nDurations can be relative to the current time or relative to a timestamp.\r\nIf a duration is used for t1, that duration is relative to now.\r\nIf a duration is used for t2, if t1 is a timestamp, then t2 is relative to t1.\r\nIf a duration is used for t2, if t1 is a duration, then t2 is relative to now.\r\n\r\nDurations are parsed simply:\r\n\r\n    3ms    three milliseconds\r\n    10s    ten seconds\r\n    9m     nine minutes\r\n    1h     one hour\r\n    1m3ms  one minute and three milliseconds\r\n\r\nFor example,\r\n\r\n    -o @2022-02-14:1h   consume 1h of time on Valentine's Day 2022\r\n    -o @-48h:-24h       consume from 2 days ago to 1 day ago\r\n    -o @-1m:end         consume from 1m ago until now\r\n    -o @:-1hr           consume from the start until an hour ago",
+        "usage": "Usage:\r\n  rpk topic consume TOPICS... [flags]\r\n\r",
+        "flags": {
+            "-b, --balancer": {
+                "type": "string",
+                "description": "Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky) (default \"cooperative-sticky\")."
+            },
+            "--fetch-max-bytes": {
+                "type": "int32",
+                "description": "Maximum amount of bytes per fetch request per broker (default 1048576)."
+            },
+            "--fetch-max-wait": {
+                "type": "duration",
+                "description": "Maximum amount of time to wait when fetching from a broker before the broker replies (default 5s)."
+            },
+            "-f, --format": {
+                "type": "string",
+                "description": "Output format (see --help for details) (default \"json\")."
+            },
+            "-g, --group": {
+                "type": "string",
+                "description": "Group to use for consuming (incompatible with -p)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for consume."
+            },
+            "--meta-only": {
+                "type": "-",
+                "description": "Print all record info except the record value (for -f json)."
+            },
+            "-n, --num": {
+                "type": "int",
+                "description": "Quit after consuming this number of records (0 is unbounded)."
+            },
+            "-o, --offset": {
+                "type": "string",
+                "description": "Offset to consume from / to (start, end, 47, +2, -3) (default \"start\")."
+            },
+            "-p, --partitions": {
+                "type": "int32",
+                "description": "int32Slice                     Comma delimited list of specific partitions to consume (default [])."
+            },
+            "--pretty-print": {
+                "type": "-",
+                "description": "Pretty print each record over multiple lines (for -f json) (default true)."
+            },
+            "--print-control-records": {
+                "type": "-",
+                "description": "Opt in to printing control records."
+            },
+            "--rack": {
+                "type": "string",
+                "description": "Rack to use for consuming, which opts into follower fetching."
+            },
+            "--read-committed": {
+                "type": "-",
+                "description": "Opt in to reading only committed offsets."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; consume any topic that matches any expression."
+            },
+            "--use-schema-registry": {
+                "type": "strings",
+                "description": "[=key,value]   If present, rpk will decode the key and the value with the schema registry. Also accepts use-schema-registry=key or use-schema-registry=value."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic create": {
+        "description": "Create topics.\r\n\r\nAll topics created with this command will have the same number of partitions,\r\nreplication factor, and key/value configs.\r\n\r\nFor example,\r\n\r\n\tcreate -c cleanup.policy=compact -r 3 -p 20 foo bar\r\n\r\nwill create two topics, foo and bar, each with 20 partitions, 3 replicas, and\r\nthe cleanup.policy=compact config option set.",
+        "usage": "Usage:\r\n  rpk topic create [TOPICS...] [flags]\r\n\r",
+        "flags": {
+            "-d, --dry": {
+                "type": "-",
+                "description": "Dry run: validate the topic creation request; do not create topics."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for create."
+            },
+            "-p, --partitions": {
+                "type": "int32",
+                "description": "Number of partitions to create per topic; -1 defaults to the cluster's default_topic_partitions (default -1)."
+            },
+            "-r, --replicas": {
+                "type": "int16",
+                "description": "Replication factor (must be odd); -1 defaults to the cluster's default_topic_replications (default -1)."
+            },
+            "-c, --topic-config": {
+                "type": "stringArray",
+                "description": "key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact)."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic delete": {
+        "description": "Delete topics.\r\n\r\nThis command deletes all requested topics, printing the success or fail status\r\nper topic.\r\n\r\nThe --regex flag (-r) opts into parsing the input topics as regular expressions\r\nand deleting any non-internal topic that matches any of expressions. The input\r\nexpressions are wrapped with ^ and $ so that the expression must match the\r\nwhole topic name (which also prevents accidental delete-everything mistakes).\r\n\r\nThe topic list command accepts the same input regex format as this delete\r\ncommand. If you want to check what your regular expressions will delete before\r\nactually deleting them, you can check the output of 'rpk topic list -r'.\r\n\r\nFor example,\r\n\r\n    delete foo bar            # deletes topics foo and bar\r\n    delete -r '^f.*' '.*r$'   # deletes any topic starting with f and any topics ending in r\r\n    delete -r '.*'            # deletes all topics\r\n    delete -r .               # deletes any one-character topics",
+        "usage": "Usage:\r\n  rpk topic delete [TOPICS...] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; delete any topic that matches any input topic expression."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic describe": {
+        "description": "Describe a topic.\r\n\r\nThis command prints detailed information about a topic. There are three\r\npotential sections: a summary of the topic, the topic configs, and a detailed\r\npartitions section. By default, the summary and configs sections are printed.",
+        "usage": "Usage:\r\n  rpk topic describe [TOPIC] [flags]\r\n\r\nAliases:\r\n  describe, info\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe."
+            },
+            "-a, --print-all": {
+                "type": "-",
+                "description": "Print all sections."
+            },
+            "-c, --print-configs": {
+                "type": "-",
+                "description": "Print the config section."
+            },
+            "-p, --print-partitions": {
+                "type": "-",
+                "description": "Print the detailed partitions section."
+            },
+            "-s, --print-summary": {
+                "type": "-",
+                "description": "Print the summary section."
+            },
+            "--stable": {
+                "type": "-",
+                "description": "Include the stable offsets column in the partitions section; only relevant if you produce to this topic transactionally."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic describe-storage": {
+        "description": "Describe the topic storage status.\r\n\r\nThis commands prints detailed information about the cloud storage status of a\r\ngiven topic, the information is divided in 4 sections:\r\n\r\nSUMMARY\r\n\r\nThe summary section contains general information about the topic, the cloud\r\nstorage mode (one of disabled, write_only, read_only, full, and read_replica),\r\nand the delta in milliseconds since the last upload of either the partition\r\nmanifest or a segment.\r\n\r\nOFFSET\r\n\r\nThe offset section contains the start and last offsets (inclusive) per\r\npartition of data available in both the cloud and on local disk.\r\n\r\nSIZE\r\n\r\nThe size section contains the total bytes per partition in the cloud and on\r\nlocal disk, the total size of the log of each partition (excluding cloud and\r\nlocal overlap), and the number of segments in the cloud and on local disk. The\r\ncloud segment count does not include segments queued for deletion.\r\n\r\nSYNC\r\n\r\nThe sync section contains the state of cloud synchronization: milliseconds\r\nsince the last upload of the partition manifest, milliseconds since the last\r\nsegment upload, milliseconds since the last manifest sync (for read replicas),\r\nand whether the remote metadata has a pending update to include all uploaded\r\nsegments.",
+        "usage": "Usage:\r\n  rpk topic describe-storage [TOPIC] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for describe-storage."
+            },
+            "-H, --human-readable": {
+                "type": "-",
+                "description": "Print the times and bytes in a human-readable form."
+            },
+            "-a, --print-all": {
+                "type": "-",
+                "description": "Print all cloud storage status."
+            },
+            "-o, --print-offset": {
+                "type": "-",
+                "description": "Print the offset section."
+            },
+            "-z, --print-size": {
+                "type": "-",
+                "description": "Print the log size section."
+            },
+            "-s, --print-summary": {
+                "type": "-",
+                "description": "Print the summary section."
+            },
+            "-y, --print-sync": {
+                "type": "-",
+                "description": "Print the sync section."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic list": {
+        "description": "List topics, optionally listing specific topics.\r\n\r\nThis command lists all topics that you have access to by default. If specifying\r\ntopics or regular expressions, this command can be used to know exactly what\r\ntopics you would delete if using the same input to the delete command.\r\n\r\nAlternatively, you can request specific topics to list, which can be used to\r\ncheck authentication errors (do you not have access to a topic you were\r\nexpecting to see?), or to list all topics that match regular expressions.\r\n\r\nThe --regex flag (-r) opts into parsing the input topics as regular expressions\r\nand listing any non-internal topic that matches any of expressions. The input\r\nexpressions are wrapped with ^ and $ so that the expression must match the\r\nwhole topic name. Regular expressions cannot be used to match internal topics,\r\nas such, specifying both -i and -r will exit with failure.\r\n\r\nLastly, --detailed flag (-d) opts in to printing extra per-partition\r\ninformation.",
+        "usage": "Usage:\r\n  rpk topic list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-d, --detailed": {
+                "type": "-",
+                "description": "Print per-partition information for topics."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "-i, --internal": {
+                "type": "-",
+                "description": "Print internal topics."
+            },
+            "-r, --regex": {
+                "type": "-",
+                "description": "Parse topics as regex; list any topic that matches any input topic expression."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic produce": {
+        "description": "Produce records to a topic.\r\n\r\nProducing records reads from STDIN, parses input according to --format, and\r\nproduce records to Redpanda. The input formatter understands a wide variety of\r\nformats.\r\n\r\nParsing input operates on either sizes or on delimiters, both of which can be\r\nspecified in the same formatting options. If using sizes to specify something,\r\nthe size must come before what it is specifying. Delimiters match on an exact\r\ntext basis. This command will quit with an error if any input fails to match\r\nyour specified format.\r\n\r\nSlashes can be used for common escapes:\r\n\r\n    \\t \\n \\r \\\\ \\xNN\r\n\r\nmatches tabs, newlines, carriage returns, slashes, and hex encoded characters.\r\n\r\nPercent encoding reads into specific values of a record:\r\n\r\n    %t    topic\r\n    %T    topic length\r\n    %k    key\r\n    %K    key length\r\n    %v    value\r\n    %V    value length\r\n    %h    begin the header specification\r\n    %H    number of headers\r\n    %p    partition (if using the --partition flag)\r\n\r\nThree escapes exist to parse characters that are used to modify the previous\r\nescapes:\r\n\r\n    %%    percent sign\r\n    %{    left brace\r\n    %}    right brace\r\n\r\nMODIFIERS\r\n\r\nText and numbers can be read in multiple formats, and the default format can be\r\nchanged within brace modifiers. %v reads a value, while %v{hex} reads a value\r\nand then hex decodes it before producing. %T reads the length of a topic from\r\nthe input, while %T{3} reads exactly three bytes for a topic from the input.\r\n\r\nAll modifiers go within braces following a percent-escape.\r\n\r\nNUMBERS\r\n\r\nReading number values can have the following modifiers:\r\n\r\n     ascii       parse numeric digits until a non-numeric (default)\r\n\r\n     hex64       sixteen hex characters\r\n     hex32       eight hex characters\r\n     hex16       four hex characters\r\n     hex8        two hex characters\r\n     hex4        one hex character\r\n\r\n     big64       eight byte big endian number\r\n     big32       four byte big endian number\r\n     big16       two byte big endian number\r\n     big8        alias for byte\r\n\r\n     little64    eight byte little endian number\r\n     little32    four byte little endian number\r\n     little16    two byte little endian number\r\n     little8     alias for byte\r\n\r\n     byte        one byte number\r\n     <digits>    directly specify the length as this many digits\r\n     bool        read \"true\" as 1, \"false\" as 0\r\n\r\nWhen reading number sizes, the size corresponds to the size of the encoded\r\nvalues, not the decoded values. \"%T{6}%t{hex}\" will read six hex bytes and\r\ndecode into three.\r\n\r\nTEXT\r\n\r\nReading text values can have the following modifiers:\r\n\r\n    hex       read text then hex decode it\r\n    base64    read text then std-encoding base64 decode it\r\n    re        read text matching a regular expression\r\n    json      read text as json then compact it\r\n\r\nHEADERS\r\n\r\nHeaders are parsed with an internal key / value specifier format. For example,\r\nthe following will read three headers that begin and end with a space and are\r\nseparated by an equal:\r\n\r\n    %H{3}%h{ %k=%v }\r\n\r\nSCHEMA-REGISTRY\r\n\r\nRecords can be encoded using a specified schema from our schema registry. Use\r\nthe '--schema-id' or '--schema-key-id' flags to define the schema ID, rpk will\r\nretrieve the schemas and encode the record accordingly.\r\n\r\nAdditionally, utilizing 'topic' in the mentioned flags allows for the use of the\r\nTopic Name Strategy. This strategy identifies a schema subject name based on the\r\ntopic itself. For example:\r\n\r\nProduce to 'foo', encode using the latest schema in the subject 'foo-value':\r\n    rpk topic produce foo --schema-id=topic\r\n\r\nFor protobuf schemas, you can specify the fully qualified name of the message\r\nyou want the record to be encoded with. Use the 'schema-type' flag or\r\n'schema-key-type'. If the schema contains only one message, specifying the\r\nmessage name is unnecessary. For example:\r\n\r\nProduce to 'foo', using schema ID 1, message FQN Person.Name\r\n    rpk topic produce foo --schema-id 1 --schema-type Person.Name\r\n\r\nEXAMPLES\r\n\r\nIn the below examples, we can parse many records at once. The produce command\r\nreads input and tokenizes based on your specified format. Every time the format\r\nis completely matched, a record is produced and parsing begins anew.\r\n\r\nA key and value, separated by a space and ending in newline:\r\n    -f '%k %v\\n'\r\nA four byte topic, four byte key, and four byte value:\r\n    -f '%T{4}%K{4}%V{4}%t%k%v'\r\nA value to a specific partition, if using a non-negative --partition flag:\r\n    -f '%p %v\\n'\r\nA big-endian uint16 key size, the text \" foo \", and then that key:\r\n    -f '%K{big16} foo %k'\r\nA value that can be two or three characters followed by a newline:\r\n    -f '%v{re#...?#}\\n'\r\nA key and a json value, separated by a space:\r\n    -f '%k %v{json}'\r\n\r\nMISC\r\n\r\nProducing requires a topic to produce to. The topic can be specified either\r\ndirectly on as an argument, or in the input text through %t. A parsed topic\r\ntakes precedence over the default passed in topic. If no topic is specified\r\ndirectly and no topic is parsed, this command will quit with an error.\r\n\r\nThe input format can parse partitions to produce directly to with %p. Doing so\r\nrequires specifying a non-negative --partition flag. Any parsed partition\r\ntakes precedence over the --partition flag; specifying the flag is the main\r\nrequirement for being able to directly control which partition to produce to.\r\n\r\nYou can also specify an output format to write when a record is produced\r\nsuccessfully. The output format follows the same formatting rules as the topic\r\nconsume command. See that command's help text for a detailed description.",
+        "usage": "Usage:\r\n  rpk topic produce [TOPIC] [flags]\r\n\r",
+        "flags": {
+            "--acks": {
+                "type": "int",
+                "description": "Number of acks required for producing (-1=all, 0=none, 1=leader) (default -1)."
+            },
+            "--allow-auto-topic-creation": {
+                "type": "-",
+                "description": "Auto-create non-existent topics; requires auto_create_topics_enabled on the broker."
+            },
+            "-z, --compression": {
+                "type": "string",
+                "description": "Compression to use for producing batches (none, gzip, snappy, lz4, zstd) (default \"snappy\")."
+            },
+            "--delivery-timeout": {
+                "type": "duration",
+                "description": "Per-record delivery timeout, if non-zero, min 1s."
+            },
+            "-f, --format": {
+                "type": "string",
+                "description": "Input record format (default \"%v\\n\")."
+            },
+            "-H, --header": {
+                "type": "stringArray",
+                "description": "Headers in format key:value to add to each record (repeatable)."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for produce."
+            },
+            "-k, --key": {
+                "type": "string",
+                "description": "A fixed key to use for each record (parsed input keys take precedence)."
+            },
+            "--max-message-bytes": {
+                "type": "int32",
+                "description": "If non-negative, maximum size of a record batch before compression (default -1)."
+            },
+            "-o, --output-format": {
+                "type": "string",
+                "description": "what to write to stdout when a record is successfully produced (default \"Produced to partition %p at offset %o with timestamp %d.\\n\")."
+            },
+            "-p, --partition": {
+                "type": "int32",
+                "description": "Partition to directly produce to, if non-negative (also allows %p parsing to set partitions) (default -1)."
+            },
+            "--schema-id": {
+                "type": "string",
+                "description": "Schema ID to encode the record value with, use 'topic' for TopicName strategy."
+            },
+            "--schema-key-id": {
+                "type": "string",
+                "description": "Schema ID to encode the record key with, use 'topic' for TopicName strategy."
+            },
+            "--schema-key-type": {
+                "type": "string",
+                "description": "Name of the protobuf message type to be used to encode the record key using schema registry."
+            },
+            "--schema-type": {
+                "type": "string",
+                "description": "Name of the protobuf message type to be used to encode the record value using schema registry."
+            },
+            "-Z, --tombstone": {
+                "type": "-",
+                "description": "Produce empty values as tombstones."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk topic trim-prefix": {
+        "description": "Trim records from topics\r\n\r\nThis command allows you to trim records from topics, to trim the topics Redpanda\r\nsets the LogStartOffset for partitions to the requested offset. All segments\r\nwhose base offset is less then the requested offset are deleted, and any records\r\nwithin the segment before the requested offset can no longer be read.\r\n\r\nThe --offset/-o flag allows you to indicate which index you want to set the\r\npartition's low watermark (start offset) to. It can be a single integer value\r\ndenoting the offset or a timestamp if you prefix the offset with an '@'. You may\r\nselect which partition you want to trim the offset from with the --partition/-p\r\nflag.\r\n\r\nThe --from-file option allows to trim the offsets specified in a text file with\r\nthe following format:\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    [TOPIC] [PARTITION] [OFFSET]\r\n    ...\r\nor the equivalent keyed JSON/YAML file.\r\n\r\nEXAMPLES\r\n\r\nTrim records in 'foo' topic to offset 120 in partition 1\r\n    rpk topic trim-prefix foo --offset 120 --partition 1\r\n\r\nTrim records in all partitions of topic foo previous to an specific timestamp\r\n    rpk topic trim-prefix foo -o \"@1622505600\"\r\n\r\nTrim records from a JSON file\r\n    rpk topic trim-prefix --from-file /tmp/to_trim.json",
+        "usage": "Usage:\r\n  rpk topic trim-prefix [TOPIC] [flags]\r\n\r\nAliases:\r\n  trim-prefix, trim\r\n\r",
+        "flags": {
+            "-f, --from-file": {
+                "type": "string",
+                "description": "File of topic/partition/offset for which to trim offsets for."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for trim-prefix."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "-o, --offset": {
+                "type": "string",
+                "description": "Offset to set the partition's start offset to (end, 47, @<timestamp>)."
+            },
+            "-p, --partitions": {
+                "type": "int32",
+                "description": "int32Slice   Comma-separated list of partitions to trim records from (default to all) (default [])."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk transform": {
+        "description": "Develop, deploy and manage Redpanda data transforms",
+        "usage": "Usage:\r\n  rpk transform [flags]\r\n  rpk transform [command]\r\n\r\nAliases:\r\n  transform, wasm, transfrom\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for transform."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk transform build": {
+        "description": "Build a transform.\r\n\r\nThis command looks in the current working directory for a transform.yaml file.\r\nIt installs the appropriate build plugin, then builds a .wasm file.\r\n\r\nWhen invoked, it passes extra arguments directly to the underlying toolchain.\r\n\r\nFor example to add debug symbols for tinygo:\r\n\r\n  rpk transform build -- -no-debug=false\r\n\r\nLANGUAGES\r\n\r\nTinygo - By default tinygo are release builds (-opt=2) for maximum performance.",
+        "usage": "Usage:\r\n  rpk transform build [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for build."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk transform delete": {
+        "description": "Delete a data transform",
+        "usage": "Usage:\r\n  rpk transform delete [NAME] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for delete."
+            },
+            "--no-confirm": {
+                "type": "-",
+                "description": "Disable confirmation prompt."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk transform deploy": {
+        "description": "Deploy a transform.\r\n\r\nWhen run in the same directory as a transform.yaml, this reads the configuration\r\nfile, then looks for a .wasm file with the same name as your project. If the\r\ninput and output topics are specified in the configuration file, those are used.\r\nOtherwise, the topics can be specified on the command line using the \r\n--input-topic and --output-topic flags.\r\n\r\nTo deploy Wasm files directly without a transform.yaml file:\r\n\r\n  rpk transform deploy transform.wasm --name myTransform \\\r\n    --input-topic my-topic-1 \\\r\n    --output-topic my-topic-2\r\n\r\nEnvironment variables can be specified for the transform using the --var flag, these\r\nare separated by an equals for example: --var=KEY=VALUE\r\n\r\nThe --var flag can be repeated to specify multiple variables like so:\r\n\r\n  rpk transform deploy --var FOO=BAR --var FIZZ=BUZZ",
+        "usage": "Usage:\r\n  rpk transform deploy [WASM] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for deploy."
+            },
+            "-i, --input-topic": {
+                "type": "string",
+                "description": "The input topic to apply the transform to."
+            },
+            "--name": {
+                "type": "string",
+                "description": "The name of the transform."
+            },
+            "-o, --output-topic": {
+                "type": "string",
+                "description": "The output topic to write the transform results to."
+            },
+            "--var": {
+                "type": "-",
+                "description": "environmentVariable   Specify an environment variable in the form of KEY=VALUE."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk transform init": {
+        "description": "Initialize a transform.\r\n\r\nCreate a new transform using a template in the current directory.\r\n\r\nA new directory to create by specifying it in the command:\r\n\r\n  rpk transform init foobar\r\n\r\nThis initializes a transform project in the foobar directory.",
+        "usage": "Usage:\r\n  rpk transform init [DIRECTORY] [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for init."
+            },
+            "--install-deps": {
+                "type": "-",
+                "description": "If dependencies should be installed for the project (default prompt)."
+            },
+            "-l, --language": {
+                "type": "string",
+                "description": "The language used to develop the transform."
+            },
+            "--name": {
+                "type": "string",
+                "description": "The name of the transform."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk transform list": {
+        "description": "List data transforms.\r\n\r\nThis command lists all data transforms in a cluster, as well as showing the\r\nstate of a individual transform processor, such as if it's errored or how many\r\nrecords are pending to be processed (lag).\r\n\r\nThere is a processor assigned to each partition on the input topic, and each\r\nprocessor is a separate entity that can make progress or fail independently.\r\n\r\nThe --detailed flag (-d) opts in to printing extra per-processor information.",
+        "usage": "Usage:\r\n  rpk transform list [flags]\r\n\r\nAliases:\r\n  list, ls\r\n\r",
+        "flags": {
+            "-d, --detailed": {
+                "type": "-",
+                "description": "Print per-partition information for data transforms."
+            },
+            "--format": {
+                "type": "string",
+                "description": "Output format (json,yaml,text,wide,help) (default \"text\")."
+            },
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for list."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk version": {
+        "description": "Prints the current rpk and Redpanda version.\r\n\r\nThis command prints the current rpk version and allows you to list the Redpanda \r\nversion running on each node in your cluster.\r\n\r\nTo list the Redpanda version of each node in your cluster you may pass the\r\nAdmin API hosts via flags, profile, or environment variables.",
+        "usage": "Usage:\r\n  rpk version [flags]\r\n\r",
+        "flags": {
+            "-h, --help": {
+                "type": "-",
+                "description": "Help for version."
+            },
+            "--config": {
+                "type": "string",
+                "description": "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml."
+            },
+            "-X, --config-opt": {
+                "type": "stringArray",
+                "description": "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail."
+            },
+            "--profile": {
+                "type": "string",
+                "description": "rpk profile to use."
+            },
+            "-v, --verbose": {
+                "type": "-",
+                "description": "Enable verbose logging."
+            }
+        }
+    },
+    "rpk_version": "Version:     v0.0.0-20231206git4fb6164\r\nGit ref:     4fb6164a27\r\nBuild date:  2023-12-06T01:35:05Z\r\nOS/Arch:     linux/amd64\r\nGo version:  go1.21.3\r\n\r\nRedpanda Cluster\r\n  node-0  v23.3.1-rc2-131-g4fb6164a27 - 4fb6164a272aadedffce8657b95e8398515b12bc\r"
+}

--- a/tools/gen/23.3-beta/rpk-acl-create.adoc
+++ b/tools/gen/23.3-beta/rpk-acl-create.adoc
@@ -1,0 +1,64 @@
+= rpk acl create
+:description: rpk acl create
+
+Create ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. Following the
+multiplying effect of combining flags, the create command works on a
+straightforward basis: every ACL combination is a created ACL.
+
+As mentioned in the 'rpk acl' help text, if no host is specified, an allowed
+principal is allowed access from all hosts. The wildcard principal '*' allows
+all principals. At least one principal, one host, one resource, and one
+operation is required to create a single ACL.
+
+Allow all permissions to user bar on topic "foo" and group "g":
+    --allow-principal bar --operation all --topic foo --group g
+Allow read permissions to all users on topics biz and baz:
+    --allow-principal '*' --operation read --topic biz,baz
+Allow write permissions to user buzz to transactional id "txn":
+    --allow-principal User:buzz --operation write --transactional-id txn
+
+== Usage
+
+[,bash]
+----
+rpk acl create [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Hosts from which access will be granted (repeatable).
+
+|`--allow-principal` |strings |Principals for which these permissions will be granted (repeatable).
+
+|`--cluster` |- |Whether to grant ACLs to the cluster.
+
+|`--deny-host` |strings |Hosts from from access will be denied (repeatable).
+
+|`--deny-principal` |strings |Principal for which these permissions will be denied (repeatable).
+
+|`--group` |strings |Group to grant ACLs for (repeatable).
+
+|`-h, --help` |- |Help for create.
+
+|`--operation` |strings |Operation to grant (repeatable).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (literal or prefixed) (default "literal").
+
+|`--topic` |strings |Topic to grant ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to grant ACLs for (repeatable).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-acl-delete.adoc
+++ b/tools/gen/23.3-beta/rpk-acl-delete.adoc
@@ -1,0 +1,74 @@
+= rpk acl delete
+:description: rpk acl delete
+
+Delete ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. Delete flags work in a
+similar multiplying effect as creating ACLs, but delete is more advanced:
+deletion works on a filter basis. Any unspecified flag defaults to matching
+everything (all operations, or all allowed principals, etc). To ensure that you
+do not accidentally delete more than you intend, this command prints everything
+that matches your input filters and prompts for a confirmation before the
+delete request is issued. Anything matching more than 10 ACLs doubly confirms.
+
+As mentioned, not specifying flags matches everything. If no resources are
+specified, all resources are matched. If no operations are specified, all
+operations are matched. You can also opt in to matching everything with "any":
+--operation any matches any operation.
+
+The --resource-pattern-type, defaulting to "any", configures how to filter
+resource names:
+  * "any" returns exact name matches of either prefixed or literal pattern type
+  * "match" returns wildcard matches, prefix patterns that match your input, and literal matches
+  * "prefix" returns prefix patterns that match your input (prefix "fo" matches "foo")
+  * "literal" returns exact name matches
+
+== Usage
+
+[,bash]
+----
+rpk acl delete [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Allowed host ACLs to remove (repeatable).
+
+|`--allow-principal` |strings |Allowed principal ACLs to remove (repeatable).
+
+|`--cluster` |- |Whether to remove ACLs to the cluster.
+
+|`--deny-host` |strings |Denied host ACLs to remove (repeatable).
+
+|`--deny-principal` |strings |Denied principal ACLs to remove (repeatable).
+
+|`-d, --dry` |- |Dry run: validate what would be deleted.
+
+|`--group` |strings |Group to remove ACLs for (repeatable).
+
+|`-h, --help` |- |Help for delete.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`--operation` |strings |Operation to remove (repeatable).
+
+|`-f, --print-filters` |- |Print the filters that were requested (failed filters are always printed).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (any, match, literal, or prefixed) (default "any").
+
+|`--topic` |strings |Topic to remove ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to remove ACLs for (repeatable).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-acl-list.adoc
+++ b/tools/gen/23.3-beta/rpk-acl-list.adoc
@@ -1,0 +1,74 @@
+= rpk acl list
+:description: rpk acl list
+
+List ACLs.
+
+See the 'rpk acl' help text for a full write up on ACLs. List flags work in a
+similar multiplying effect as creating ACLs, but list is more advanced:
+listing works on a filter basis. Any unspecified flag defaults to matching
+everything (all operations, or all allowed principals, etc).
+
+As mentioned, not specifying flags matches everything. If no resources are
+specified, all resources are matched. If no operations are specified, all
+operations are matched. You can also opt in to matching everything with "any":
+--operation any matches any operation.
+
+The --resource-pattern-type, defaulting to "any", configures how to filter
+resource names:
+  * "any" returns exact name matches of either prefixed or literal pattern type
+  * "match" returns wildcard matches, prefix patterns that match your input, and literal matches
+  * "prefix" returns prefix patterns that match your input (prefix "fo" matches "foo")
+  * "literal" returns exact name matches
+
+== Usage
+
+[,bash]
+----
+rpk acl list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls, describe
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-host` |strings |Allowed host ACLs to match (repeatable).
+
+|`--allow-principal` |strings |Allowed principal ACLs to match (repeatable).
+
+|`--cluster` |- |Whether to match ACLs to the cluster.
+
+|`--deny-host` |strings |Denied host ACLs to match (repeatable).
+
+|`--deny-principal` |strings |Denied principal ACLs to match (repeatable).
+
+|`--group` |strings |Group to match ACLs for (repeatable).
+
+|`-h, --help` |- |Help for list.
+
+|`--operation` |strings |Operation to match (repeatable).
+
+|`-f, --print-filters` |- |Print the filters that were requested (failed filters are always printed).
+
+|`--resource-pattern-type` |string |Pattern to use when matching resource names (any, match, literal, or prefixed) (default "any").
+
+|`--topic` |strings |Topic to match ACLs for (repeatable).
+
+|`--transactional-id` |strings |Transactional IDs to match ACLs for (repeatable).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-acl-user-create.adoc
+++ b/tools/gen/23.3-beta/rpk-acl-user-create.adoc
@@ -1,0 +1,47 @@
+= rpk acl user create
+:description: rpk acl user create
+
+Create a SASL user.
+
+This command creates a single SASL user with the given password, optionally
+with a custom "mechanism". SASL consists of three parts: a username, a
+password, and a mechanism. The mechanism determines which authentication flow
+the client will use for this user/pass.
+
+Redpanda currently supports two mechanisms: SCRAM-SHA-256, the default, and
+SCRAM-SHA-512, which is the same flow but uses sha512 rather than sha256.
+
+Using SASL requires setting "enable_sasl: true" in the redpanda section of your
+`redpanda.yaml`. Before a created SASL account can be used, you must also create
+ACLs to grant the account access to certain resources in your cluster. See the
+acl help text for more info.
+
+== Usage
+
+[,bash]
+----
+rpk acl user create [USER] -p [PASS] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for create.
+
+|`--mechanism` |string |SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive) (default "scram-sha-256").
+
+|`--password` |string |New user's password (NOTE: if using --password for the admin API, use --new-password).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-acl-user-delete.adoc
+++ b/tools/gen/23.3-beta/rpk-acl-user-delete.adoc
@@ -1,0 +1,33 @@
+= rpk acl user delete
+:description: rpk acl user delete
+
+Delete a SASL user.
+
+This command deletes the specified SASL account from Redpanda. This does not
+delete any ACLs that may exist for this user.
+
+== Usage
+
+[,bash]
+----
+rpk acl user delete [USER] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-acl-user-list.adoc
+++ b/tools/gen/23.3-beta/rpk-acl-user-list.adoc
@@ -1,0 +1,37 @@
+= rpk acl user list
+:description: rpk acl user list
+
+List SASL users
+
+== Usage
+
+[,bash]
+----
+rpk acl user list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-acl-user-update.adoc
+++ b/tools/gen/23.3-beta/rpk-acl-user-update.adoc
@@ -1,0 +1,34 @@
+= rpk acl user update
+:description: rpk acl user update
+
+Update SASL user credentials
+
+== Usage
+
+[,bash]
+----
+rpk acl user update [USER] --new-password [PW] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for update.
+
+|`--mechanism` |string |SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive) (default "SCRAM-SHA-256").
+
+|`--new-password` |string |New user's password.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-acl-user.adoc
+++ b/tools/gen/23.3-beta/rpk-acl-user.adoc
@@ -1,0 +1,37 @@
+= rpk acl user
+:description: rpk acl user
+
+Manage SASL users.
+
+If SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs
+control what your user has access to. See 'rpk acl --help' for more information
+about ACLs, and 'rpk acl user create --help' for more information about
+creating SASL users. Using SASL requires setting "enable_sasl: true" in the
+redpanda section of your `redpanda.yaml`.
+
+== Usage
+
+[,bash]
+----
+rpk acl user [flags]
+  rpk acl user [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`-h, --help` |- |Help for user.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-acl.adoc
+++ b/tools/gen/23.3-beta/rpk-acl.adoc
@@ -1,0 +1,139 @@
+= rpk acl
+:description: rpk acl
+
+Manage ACLs and SASL users.
+
+This command space creates, lists, and deletes ACLs, as well as creates SASL
+users. The help text below is specific to ACLs. To learn about SASL users,
+check the help text under the "user" command.
+
+When using SASL, ACLs allow or deny you access to certain requests. The
+"create", "delete", and "list" commands help you manage your ACLs.
+
+An ACL is made up of five components:
+
+  * a principal (the user)
+  * a host the principal is allowed or denied requests from
+  * what resource to access (topic name, group ID, ...)
+  * the operation (read, write, ...)
+  * the permission: whether to allow or deny the above
+
+ACL commands work on a multiplicative basis. If creating, specifying two
+principals and two permissions creates four ACLs: both permissions for the
+first principal, as well as both permissions for the second principal. Adding
+two resources further doubles the ACLs created.
+
+It is recommended to be as specific as possible when granting ACLs. Granting
+more ACLs than necessary per principal may inadvertently allow clients to do
+things they should not, such as deleting topics or joining the wrong consumer
+group.
+
+PRINCIPALS
+
+All ACLs require a principal. A principal is composed of two parts: the type
+and the name. Within Redpanda, only one type is supported, "User". The reason
+for the prefix is that a potential future authorizer may add support for
+authorizing by Group or anything else.
+
+When you create a user, you need to add ACLs for it before it can be used. You
+can create / delete / list ACLs for that user with either "User:bar" or "bar"
+in the --allow-principal and --deny-principal flags. This command will add the
+"User:" prefix for you if it is missing. The wildcard '*' matches any user.
+Creating an ACL with user '*' grants or denies the permission for all users.
+
+HOSTS
+
+Hosts can be seen as an extension of the principal, and effectively gate where
+the principal can connect from. When creating ACLs, unless otherwise specified,
+the default host is the wildcard '*' which allows or denies the principal from
+all hosts (where allow & deny are based on whether --allow-principal or
+--deny-principal is used). If specifying hosts, you must pair the --allow-host
+flag with the --allow-principal flag, and the --deny-host flag with the
+--deny-principal flag.
+
+RESOURCES
+
+A resource is what an ACL allows or denies access to. There are four resources
+within Redpanda: topics, groups, the cluster itself, and transactional IDs.
+Names for each of these resources can be specified with their respective flags.
+
+Resources combine with the operation that is allowed or denied on that
+resource. The next section describes which operations are required for which
+requests, and further fleshes out the concept of a resource.
+
+By default, resources are specified on an exact name match (a "literal" match).
+The --resource-pattern-type flag can be used to specify that a resource name is
+"prefixed", meaning to allow anything with the given prefix. A literal name of
+"foo" will match only the topic "foo", while the prefixed name of "foo-" will
+match both "foo-bar" and "foo-baz". The special wildcard resource name '*'
+matches any name of the given resource type (--topic '*' matches all topics).
+
+OPERATIONS
+
+Pairing with resources, operations are the actions that are allowed or denied.
+Redpanda has the following operations:
+
+    ALL                 Allows all operations below.
+    READ                Allows reading a given resource.
+    WRITE               Allows writing to a given resource.
+    CREATE              Allows creating a given resource.
+    DELETE              Allows deleting a given resource.
+    ALTER               Allows altering non-configurations.
+    DESCRIBE            Allows querying non-configurations.
+    DESCRIBE_CONFIGS    Allows describing configurations.
+    ALTER_CONFIGS       Allows altering configurations.
+
+Check --help-operations to see which operations are required for which
+requests. In flag form to set up a general producing/consuming client, you can
+invoke 'rpk acl create' three times with the following (including your
+--allow-principal):
+
+    --operation write,read,describe --topic [topics]
+    --operation describe,read --group [group.id]
+    --operation describe,write --transactional-id [transactional.id]
+
+PERMISSIONS
+
+A client can be allowed access or denied access. By default, all permissions
+are denied. You only need to specifically deny a permission if you allow a wide
+set of permissions and then want to deny a specific permission in that set.
+You could allow all operations, and then specifically deny writing to topics.
+
+MANAGEMENT
+
+Creating ACLs works on a specific ACL basis, but listing and deleting ACLs
+works on filters. Filters allow matching many ACLs to be printed listed and
+deleted at once. Because this can be risky for deleting, the delete command
+prompts for confirmation by default. More details and examples for creating,
+listing, and deleting can be seen in each of the commands.
+
+Using SASL requires setting "enable_sasl: true" in the redpanda section of your
+`redpanda.yaml`. User management is a separate, simpler concept that is
+described in the user command.
+
+== Usage
+
+[,bash]
+----
+rpk acl [flags]
+  rpk acl [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for acl.
+
+|`--help-operations` |- |Print more help about ACL operations.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-auth-create.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-auth-create.adoc
@@ -1,0 +1,42 @@
+= rpk cloud auth create
+:description: rpk cloud auth create
+
+Create an rpk cloud auth.
+
+This command creates a new rpk cloud auth. The default SSO login does not need
+any additional auth values (the token is populated on login) so you can just
+create an empty auth. You can also use --set to set key=value pairs for client
+credentials.
+
+The --set flag supports autocompletion, suggesting the -X key format. If you
+begin writing a YAML path, the flag will suggest the rest of the path.
+
+rpk always switches the current cloud auth to the newly created auth.
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth create [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--description` |string |Optional description of the auth.
+
+|`-h, --help` |- |Help for create.
+
+|`-s, --set` |strings |A key=value pair to set in the cloud auth.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-auth-delete.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-auth-delete.adoc
@@ -1,0 +1,32 @@
+= rpk cloud auth delete
+:description: rpk cloud auth delete
+
+Delete an rpk cloud auth.
+
+Deleting a cloud auth removes it from the rpk.yaml file. If the deleted
+auth was the current auth, rpk will use a default SSO auth the next time
+you try to login and, if the login is successful, will safe that auth.
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth delete [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-auth-edit.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-auth-edit.adoc
@@ -1,0 +1,31 @@
+= rpk cloud auth edit
+:description: rpk cloud auth edit
+
+Edit an rpk auth.
+
+This command opens your default editor to edit the specified cloud auth, or the
+current cloud auth if no cloud auth is specified.
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth edit [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for edit.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-auth-list.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-auth-list.adoc
@@ -1,0 +1,35 @@
+= rpk cloud auth list
+:description: rpk cloud auth list
+
+List rpk cloud auths
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-auth-rename-to.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-auth-rename-to.adoc
@@ -1,0 +1,35 @@
+= rpk cloud auth rename-to
+:description: rpk cloud auth rename-to
+
+Rename the current rpk auth
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth rename-to [NAME] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+rename-to, rename
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for rename-to.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-auth-use.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-auth-use.adoc
@@ -1,0 +1,28 @@
+= rpk cloud auth use
+:description: rpk cloud auth use
+
+Select the rpk cloud auth to use
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth use [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for use.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-auth.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-auth.adoc
@@ -1,0 +1,36 @@
+= rpk cloud auth
+:description: rpk cloud auth
+
+Manage rpk cloud authentications.
+
+An rpk cloud authentication allows you to talk to Redpanda Cloud. Most likely,
+you will only ever need to use a single SSO based login and you will not need
+this command space. Multiple authentications can be useful if you have multiple
+Redpanda Cloud accounts for different organizations and want to swap between
+them, or if you use SSO as well as client credentials. It is recommended to
+only use a single SSO based login.
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth [flags]
+  rpk cloud auth [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for auth.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-byoc-install.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-byoc-install.adoc
@@ -1,0 +1,34 @@
+= rpk cloud byoc install
+:description: rpk cloud byoc install
+
+Install the BYOC plugin
+
+This command downloads the BYOC managed plugin if necessary. The plugin is
+installed by default if you try to run a non-install command, but this command
+exists if you want to download the plugin ahead of time.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc install [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for install.
+
+|`--redpanda-id` |string |The redpanda ID of the cluster you are creating.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-byoc-uninstall.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-byoc-uninstall.adoc
@@ -1,0 +1,33 @@
+= rpk cloud byoc uninstall
+:description: rpk cloud byoc uninstall
+
+Uninstall the BYOC plugin
+
+This command deletes your locally downloaded BYOC managed plugin if it exists.
+Often, you only need to download the plugin to create your cluster once, and
+then you never need the plugin again. You can uninstall to save a small bit of
+disk space.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc uninstall [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for uninstall.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-byoc.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-byoc.adoc
@@ -1,0 +1,44 @@
+= rpk cloud byoc
+:description: rpk cloud byoc
+
+Manage a Redpanda cloud BYOC agent
+
+For BYOC, Redpanda installs an agent service in your owned cluster. The agent
+then proceeds to provision further infrastructure and eventually, a full
+Redpanda cluster.
+
+The BYOC command runs Terraform to create and start the agent. You first need
+a redpanda-id (or cluster ID); this is used to get the details of how your
+agent should be provisioned. You can create a BYOC cluster in our cloud UI
+and then come back to this command to complete the process.
+
+== Usage
+
+[,bash]
+----
+rpk cloud byoc [flags]
+  rpk cloud byoc [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--client-id` |string |The client ID of the organization in Redpanda Cloud.
+
+|`--client-secret` |string |The client secret of the organization in Redpanda Cloud.
+
+|`-h, --help` |- |Help for byoc.
+
+|`--redpanda-id` |string |The redpanda ID of the cluster you are creating.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-login.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-login.adoc
@@ -1,0 +1,76 @@
+= rpk cloud login
+:description: rpk cloud login
+
+Log in to the Redpanda cloud
+
+This command checks for an existing Redpanda Cloud API token and, if present, 
+ensures it is still valid. If no token is found or the token is no longer valid, 
+this command will login and save your token along with the client ID used to 
+request the token.
+
+You may use either SSO or client credentials to log in.
+
+SSO
+
+This will automatically launch your default web browser and prompt you to 
+authenticate via our Redpanda Cloud page. Once you have successfully 
+authenticated, you will be ready to use rpk cloud commands.
+
+You may opt out of auto-opening the browser by passing the '--no-browser' flag.
+
+CLIENT CREDENTIALS
+
+Cloud client credentials can be used to login to Redpanda, they can be created 
+in the Clients tab of the Users section in the Redpanda Cloud online interface. 
+client credentials can be provided in three ways, in order of preference:
+
+* In your rpk cloud auth, 'client_id' and 'client_secret' fields
+* Through RPK_CLOUD_CLIENT_ID and RPK_CLOUD_CLIENT_SECRET environment variables
+* Through the --client-id and --client-secret flags
+
+If none of these are provided, rpk will use the SSO method to login. 
+If you specify environment variables or flags, they will not be synced to the
+rpk.yaml file unless the --save flag is passed. The cloud authorization 
+token and client ID is always synced.
+
+PROFILE SELECTION
+
+This command by default attempts to populate a new profile that talks to a
+cloud cluster for you. If you have an existing cloud profile, this will select
+it, prompting which to use if you have many. If you have no cloud profile, this
+command will prompt you to select one that exists in your organization. If you
+want to disable automatic profile creation and selection, use --no-profile.
+
+== Usage
+
+[,bash]
+----
+rpk cloud login [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--client-id` |string |The client ID of the organization in Redpanda Cloud.
+
+|`--client-secret` |string |The client secret of the organization in Redpanda Cloud.
+
+|`-h, --help` |- |Help for login.
+
+|`--no-browser` |- |Opt out of auto-opening authentication URL.
+
+|`--no-profile` |- |Skip automatic profile creation and any associated prompts.
+
+|`--save` |- |Save environment or flag specified client ID and client secret to the configuration file.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud-logout.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud-logout.adoc
@@ -1,0 +1,34 @@
+= rpk cloud logout
+:description: rpk cloud logout
+
+Log out from Redpanda cloud
+
+This command deletes your cloud auth token. If you want to log out entirely and
+switch to a different organization, you can use the --clear-credentials flag to
+additionally clear your client ID and client secret.
+
+== Usage
+
+[,bash]
+----
+rpk cloud logout [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-c, --clear-credentials` |- |Clear the client ID and client secret in addition to the auth token.
+
+|`-h, --help` |- |Help for logout.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cloud.adoc
+++ b/tools/gen/23.3-beta/rpk-cloud.adoc
@@ -1,0 +1,29 @@
+= rpk cloud
+:description: rpk cloud
+
+Interact with Redpanda cloud
+
+== Usage
+
+[,bash]
+----
+rpk cloud [flags]
+  rpk cloud [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for cloud.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-config-edit.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-config-edit.adoc
@@ -1,0 +1,43 @@
+= rpk cluster config edit
+:description: rpk cluster config edit
+
+Edit cluster-wide configuration properties.
+
+This command opens a text editor to modify the cluster's configuration.
+
+Cluster properties are redpanda settings which apply to all nodes in
+the cluster.  These are separate to node properties, which are set with
+'rpk redpanda config'.
+
+Modified values are written back when the file is saved and the editor
+is closed.  Properties which are deleted are reset to their default
+values.
+
+By default, low level tunables are excluded: use the '--all' flag
+to edit all properties including these tunables.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config edit [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for edit.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-config-export.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-config-export.adoc
@@ -1,0 +1,39 @@
+= rpk cluster config export
+:description: rpk cluster config export
+
+Export cluster configuration.
+
+Writes out a YAML representation of the cluster configuration to a file,
+suitable for editing and later applying with the corresponding 'import'
+command.
+
+By default, low level tunables are excluded: use the '--all' flag
+to include all properties including these low level tunables.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config export [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --filename` |string |path to file to export to, e.g. './config.yml'.
+
+|`-h, --help` |- |Help for export.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-config-force-reset.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-config-force-reset.adoc
@@ -1,0 +1,45 @@
+= rpk cluster config force-reset
+:description: rpk cluster config force-reset
+
+Forcibly clear a cluster configuration property on this node.
+
+This command is not for general changes to cluster configuration: use this only
+when redpanda will not start due to a configuration issue.
+
+If your cluster is working properly and you would like to reset a property
+to its default, you may use the 'set' command with an empty string, or
+use the 'edit' command and delete the property's line.
+
+This command erases a named property from an internal cache of the cluster
+configuration on the local node, so that on next startup redpanda will treat
+the setting as if it was set to the default.
+
+WARNING: this should only be used when redpanda is not running.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config force-reset [PROPERTY...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--cache-file` |string |location of configuration cache file (defaults to redpanda data directory).
+
+|`-h, --help` |- |Help for force-reset.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-config-get.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-config-get.adoc
@@ -1,0 +1,33 @@
+= rpk cluster config get
+:description: rpk cluster config get
+
+Get a cluster configuration property.
+
+This command is provided for use in scripts.  For interactive editing, or bulk
+output, use the 'edit' and 'export' commands respectively.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config get [KEY] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for get.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-config-import.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-config-import.adoc
@@ -1,0 +1,38 @@
+= rpk cluster config import
+:description: rpk cluster config import
+
+Import cluster configuration from a file.
+
+Import configuration from a YAML file, usually generated with
+corresponding 'export' command.  This downloads the current cluster
+configuration, calculates the difference with the YAML file, and
+updates any properties that were changed.  If a property is removed
+from the YAML file, it is reset to its default value.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config import [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --filename` |string |full path to file to import, e.g. '/tmp/config.yml'.
+
+|`-h, --help` |- |Help for import.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-config-lint.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-config-lint.adoc
@@ -1,0 +1,34 @@
+= rpk cluster config lint
+:description: rpk cluster config lint
+
+Remove any deprecated content from `redpanda.yaml`.
+
+Deprecated content includes properties which were set via `redpanda.yaml`
+in earlier versions of redpanda, but are now managed via Redpanda's
+central configuration store (and via 'rpk cluster config edit').
+
+== Usage
+
+[,bash]
+----
+rpk cluster config lint [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for lint.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-config-set.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-config-set.adoc
@@ -1,0 +1,39 @@
+= rpk cluster config set
+:description: rpk cluster config set
+
+Set a single cluster configuration property.
+
+This command is provided for use in scripts.  For interactive editing, or bulk
+changes, use the 'edit' and 'import' commands respectively.
+
+You may also use <key>=<value> notation for setting configuration properties:
+
+  rpk cluster config set log_retention_ms=-1
+
+If an empty string is given as the value, the property is reset to its default.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config set [KEY] [VALUE] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-config-status.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-config-status.adoc
@@ -1,0 +1,39 @@
+= rpk cluster config status
+:description: rpk cluster config status
+
+Get configuration status of redpanda nodes.
+
+For each node, indicate whether a restart is required for settings to
+take effect, and any settings that the node has identified as invalid
+or unknown properties.
+
+Additionally show the version of cluster configuration that each node
+has applied: under normal circumstances these should all be equal,
+a lower number shows that a node is out of sync, perhaps because it
+is offline.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--all` |- |Include all properties, including tunables.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-config.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-config.adoc
@@ -1,0 +1,49 @@
+= rpk cluster config
+:description: rpk cluster config
+
+Interact with cluster configuration properties.
+
+Cluster properties are redpanda settings which apply to all nodes in
+the cluster.  These are separate to node properties, which are set with
+'rpk redpanda config'.
+
+Use the 'edit' subcommand to interactively modify the cluster configuration, or
+'export' and 'import' to write configuration to a file that can be edited and
+read back later.
+
+These commands take an optional '--all' flag to include all properties including
+low level tunables such as internal buffer sizes, that do not usually need
+to be changed during normal operations.  These properties generally require
+some expertize to set safely, so if in doubt, avoid using '--all'.
+
+Modified properties are propagated immediately to all nodes.  The 'status'
+subcommand can be used to verify that all nodes are up to date, and identify
+any settings which were rejected by a node, for example if a node is running a
+different redpanda version that does not recognize certain properties.
+
+== Usage
+
+[,bash]
+----
+rpk cluster config [flags]
+  rpk cluster config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--all` |- |Include all properties, including tunables.
+
+|`-h, --help` |- |Help for config.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-health.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-health.adoc
@@ -1,0 +1,40 @@
+= rpk cluster health
+:description: rpk cluster health
+
+Queries health overview.
+
+Health overview is created based on the health reports collected periodically
+from all nodes in the cluster. A cluster is considered healthy when the
+following conditions are met:
+
+* all cluster nodes are responding
+* all partitions have leaders
+* the cluster controller is present
+
+== Usage
+
+[,bash]
+----
+rpk cluster health [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-e, --exit-when-healthy` |- |When used with watch, exits after cluster is back in healthy state.
+
+|`-h, --help` |- |Help for health.
+
+|`-w, --watch` |- |Blocks and writes out all cluster health changes.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-license-info.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-license-info.adoc
@@ -1,0 +1,35 @@
+= rpk cluster license info
+:description: rpk cluster license info
+
+Retrieve license information:
+
+    Organization:    Organization the license was generated for.
+    Type:            Type of license: free, enterprise, etc.
+    Expires:         Expiration date of the license
+    Version:         License schema version.
+
+== Usage
+
+[,bash]
+----
+rpk cluster license info [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (text, json) (default "text").
+
+|`-h, --help` |- |Help for info.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-license-set.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-license-set.adoc
@@ -1,0 +1,41 @@
+= rpk cluster license set
+:description: rpk cluster license set
+
+Upload license to the cluster
+
+You can either provide a path to a file containing the license:
+
+    rpk cluster license set --path /home/organization/redpanda.license
+
+Or inline the license string:
+
+    rpk cluster license set <license string>
+
+If neither are present, rpk will look for the license in the
+default location '/etc/redpanda/redpanda.license'.
+
+== Usage
+
+[,bash]
+----
+rpk cluster license set [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--path` |string |Path to the license file.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-license.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-license.adoc
@@ -1,0 +1,29 @@
+= rpk cluster license
+:description: rpk cluster license
+
+Manage cluster license
+
+== Usage
+
+[,bash]
+----
+rpk cluster license [flags]
+  rpk cluster license [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for license.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-logdirs-describe.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-logdirs-describe.adoc
@@ -1,0 +1,52 @@
+= rpk cluster logdirs describe
+:description: rpk cluster logdirs describe
+
+Describe log directories on Redpanda brokers.
+
+This command prints information about log directories on brokers, particularly,
+the base directory that topics and partitions are located in, and the size of
+data that has been written to the partitions. The size you see may not exactly
+match the size on disk as reported by du: Redpanda allocates files in chunks.
+The chunks will show up in du, while the actual bytes so far written to the
+file will show up in this command.
+
+The directory returned is the root directory for partitions. Within Redpanda,
+the partition data lives underneath the the returned root directory in
+
+    kafka/{topic}/{partition}_{revision}/
+
+where revision is a Redpanda internal concept.
+
+== Usage
+
+[,bash]
+----
+rpk cluster logdirs describe [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--aggregate-into` |string |If non-empty, what column to aggregate into starting from the partition column (broker, dir, topic).
+
+|`-b, --broker` |int32 |If non-negative, the specific broker to describe (default -1).
+
+|`-h, --help` |- |Help for describe.
+
+|`-H, --human-readable` |- |Print the logdirs size in a human-readable form.
+
+|`--sort-by-size` |- |If true, sort by size.
+
+|`--topics` |strings |Specific topics to describe.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-logdirs.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-logdirs.adoc
@@ -1,0 +1,29 @@
+= rpk cluster logdirs
+:description: rpk cluster logdirs
+
+Describe log directories on Redpanda brokers
+
+== Usage
+
+[,bash]
+----
+rpk cluster logdirs [flags]
+  rpk cluster logdirs [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for logdirs.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-maintenance-disable.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-maintenance-disable.adoc
@@ -1,0 +1,28 @@
+= rpk cluster maintenance disable
+:description: rpk cluster maintenance disable
+
+Disable maintenance mode for a node.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance disable [BROKER-ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for disable.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-maintenance-enable.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-maintenance-enable.adoc
@@ -1,0 +1,33 @@
+= rpk cluster maintenance enable
+:description: rpk cluster maintenance enable
+
+Enable maintenance mode for a node.
+
+This command enables maintenance mode for the node with the specified ID. If a
+node exists that is already in maintenance mode then an error will be returned.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance enable [BROKER-ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for enable.
+
+|`-w, --wait` |- |Wait until node is drained.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-maintenance-status.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-maintenance-status.adoc
@@ -1,0 +1,54 @@
+= rpk cluster maintenance status
+:description: rpk cluster maintenance status
+
+Report maintenance status.
+
+This command reports maintenance status for each node in the cluster. The output
+is presented as a table with each row representing a node in the cluster.  The
+output can be used to monitor the progress of node draining.
+
+   NODE-ID  ENABLED  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
+   1        false     false     false   0           0         0             0
+
+Field descriptions:
+
+        NODE-ID: the node ID
+        ENABLED: true if the node is currently in maintenance mode
+       FINISHED: leadership draining has completed
+         ERRORS: errors have been encountered while draining
+     PARTITIONS: number of partitions whose leadership has moved
+       ELIGIBLE: number of partitions with leadership eligible to move
+   TRANSFERRING: current active number of leadership transfers
+         FAILED: number of failed leadership transfers
+
+Notes:
+
+   - When errors are present further information will be available in the logs
+     for the corresponding node.
+
+   - Only partitions with more than one replica are eligible for leadership
+     transfer.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-maintenance.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-maintenance.adoc
@@ -1,0 +1,47 @@
+= rpk cluster maintenance
+:description: rpk cluster maintenance
+
+Interact with cluster maintenance mode.
+
+Maintenance mode is a state that a node may be placed into in which the node
+may be shutdown or restarted with minimal disruption to client workloads. The
+primary use of maintenance mode is to perform a rolling upgrade in which each
+node is placed into maintenance mode prior to upgrading the node.
+
+Use the 'enable' and 'disable' subcommands to place a node into maintenance mode
+or remove it, respectively. Only one node at a time may be in maintenance mode.
+
+When a node is placed into maintenance mode the following occurs:
+
+Leadership draining. All raft leadership is transferred to another eligible
+node, and the node in maintenance mode rejects new leadership requests. By
+transferring leadership off of the node in maintenance mode all client traffic
+and requests are directed to other nodes minimizing disruption to client
+workloads when the node is shutdown.
+
+Currently leadership is not transferred for partitions with one replica.
+
+== Usage
+
+[,bash]
+----
+rpk cluster maintenance [flags]
+  rpk cluster maintenance [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for maintenance.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-metadata.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-metadata.adoc
@@ -1,0 +1,59 @@
+= rpk cluster metadata
+:description: rpk cluster metadata
+
+Request broker metadata.
+
+The Kafka protocol's metadata contains information about brokers, topics, and
+the cluster as a whole.
+
+This command only runs if specific sections of metadata are requested. There
+are currently three sections: the cluster, the list of brokers, and the topics.
+If no section is specified, this defaults to printing all sections.
+
+If the topic section is requested, all topics are requested by default unless
+some are manually specified as arguments. Expanded per-partition information
+can be printed with the -d flag, and internal topics can be printed with the -i
+flag.
+
+In the broker section, the controller node is suffixed with *.
+
+== Usage
+
+[,bash]
+----
+rpk cluster metadata [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+metadata, status, info
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for metadata.
+
+|`-b, --print-brokers` |- |Print brokers section.
+
+|`-c, --print-cluster` |- |Print cluster section.
+
+|`-d, --print-detailed-topics` |- |Print per-partition information for topics (implies -t).
+
+|`-i, --print-internal-topics` |- |Print internal topics (if all topics requested, implies -t).
+
+|`-t, --print-topics` |- |Print topics section (implied if any topics are specified).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-partitions-balancer-status.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-partitions-balancer-status.adoc
@@ -1,0 +1,78 @@
+= rpk cluster partitions balancer-status
+:description: rpk cluster partitions balancer-status
+
+Queries cluster for partition balancer status:
+
+If continuous partition balancing is enabled, redpanda will continuously
+reassign partitions from both unavailable nodes and from nodes using more disk
+space than the configured limit.
+
+This command can be used to monitor the partition balancer status.
+
+FIELDS
+
+    Status:                        Either off, ready, starting, in progress, or
+                                   stalled.
+    Seconds Since Last Tick:       The last time the partition balancer ran.
+    Current Reassignments Count:   Current number of partition reassignments in
+                                   progress.
+    Unavailable Nodes:             The nodes that have been unavailable after a
+                                   time set by the
+                                   "partition_autobalancing_node_availability_timeout_sec"
+                                   cluster property.
+    Over Disk Limit Nodes:         The nodes that surpassed the threshold of
+                                   used disk percentage specified in the
+                                   "partition_autobalancing_max_disk_usage_percent"
+                                   cluster property.
+
+BALANCER STATUS
+
+    off:          The balancer is disabled.
+    ready:        The balancer is active but there is nothing to do.
+    starting:     The balancer is starting but has not run yet.
+    in_progress:  The balancer is active and is in the process of scheduling
+                  partition movements.
+    stalled:      Violations have been detected and the balancer cannot correct
+                  them.
+
+STALLED BALANCER
+
+A stalled balancer can occur for a few reasons and requires a bit of manual
+investigation. A few areas to investigate:
+
+* Are there are enough healthy nodes to which to move partitions? For example,
+  in a three node cluster, no movements are possible for partitions with three
+  replicas. You will see a stall every time there is a violation.
+
+* Does the cluster have sufficient space? If all nodes in the cluster are
+  utilizing more than 80% of their disk space, rebalancing cannot proceed.
+
+* Do all partitions have quorum? If the majority of a partition's replicas are
+  down, the partition cannot be moved.
+
+* Are any nodes in maintenance mode? Partitions are not moved if any node is in
+  maintenance mode.
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions balancer-status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for balancer-status.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-partitions-disable.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-partitions-disable.adoc
@@ -1,0 +1,62 @@
+= rpk cluster partitions disable
+:description: rpk cluster partitions disable
+
+Disable partitions of a topic
+
+You may disable all partitions of a topic using the --all flag or you may select 
+a set of topic/partitions to disable with the '--partitions/-p' flag.
+
+The partition flag accepts the format {namespace}/{topic}/[partitions...]
+where namespace and topic are optional parameters. If the namespace is not
+provided, rpk will assume 'kafka'. If the topic is not provided in the flag, rpk
+will use the topic provided as an argument to this command.
+
+DISABLED PARTITIONS
+
+Disabling a partition in Redpanda involves prohibiting any data consumption or
+production to and from it. All internal processes associated with the partition
+are stopped, and it remains unloaded during system startup. This measure aims to
+maintain cluster health by preventing issues caused by specific corrupted
+partitions that may lead to Redpanda crashes. Although the data remains stored
+on disk, Redpanda ceases interaction with the disabled partitions to ensure
+system stability.
+
+EXAMPLES
+
+Disable all partitions in topic 'foo'
+    rpk cluster partitions disable foo --all
+
+Disable partitions 1,2 and 3 of topic 'bar' in the namespace 'internal'
+    rpk cluster partitions disable internal/bar --partitions 1,2,3
+
+Disable partition 1, and 2 of topic 'foo', and partition 5 of topic 'bar' in the 
+'internal' namespace' 
+    rpk cluster partitions disable -p foo/1,2 -p internal/bar/5
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions disable [TOPIC] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-a, --all` |- |If true, disable all partitions for the specified topic.
+
+|`-h, --help` |- |Help for disable.
+
+|`-p, --partitions` |stringArray |Comma-separated list of partitions you want to disable. Use --help for additional information.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-partitions-enable.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-partitions-enable.adoc
@@ -1,0 +1,52 @@
+= rpk cluster partitions enable
+:description: rpk cluster partitions enable
+
+Enable partitions of a topic
+
+You may enable all partitions of a topic using the --all flag or you may select 
+a set of topic/partitions to enable with the '--partitions/-p' flag.
+
+The partition flag accepts the format {namespace}/{topic}/[partitions...]
+where namespace and topic are optional parameters. If the namespace is not
+provided, rpk will assume 'kafka'. If the topic is not provided in the flag, rpk
+will use the topic provided as an argument to this command.
+
+EXAMPLES
+
+Enable all partitions in topic 'foo'
+    rpk cluster partitions enable foo --all
+
+Enable partitions 1,2 and 3 of topic 'bar' in the namespace 'internal'
+    rpk cluster partitions enable internal/bar --partitions 1,2,3
+
+Enable partition 1, and 2 of topic 'foo', and partition 5 of topic 'bar' in the 
+'internal' namespace'
+    rpk cluster partitions enable -p foo/1,2 -p internal/bar/5
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions enable [TOPIC] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-a, --all` |- |If true, enable all partitions for the specified topic.
+
+|`-h, --help` |- |Help for enable.
+
+|`-p, --partitions` |stringArray |Comma-separated list of partitions you want to enable. Check help for extended usage.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-partitions-list.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-partitions-list.adoc
@@ -1,0 +1,80 @@
+= rpk cluster partitions list
+:description: rpk cluster partitions list
+
+List partitions in the cluster
+
+This commands lists the cluster-level metadata of all partitions in the cluster.
+It shows the current replica assignments on both brokers and CPU cores for given
+topics. By default, it assumes the "kafka" namespace, but you can specify an
+internal namespace using the "{namespace}/" prefix.
+
+The REPLICA-CORE column displayed in the output table contains a list of
+replicas assignments in the form of: <Node-ID>-<Core>.
+
+If the DISABLED column contains a '-' value, then it means you are running this
+command against a cluster that does not support the underlying API.
+
+ENABLED/DISABLED
+
+Disabling a partition in Redpanda involves prohibiting any data consumption or
+production to and from it. All internal processes associated with the partition
+are stopped, and it remains unloaded during system startup. This measure aims to
+maintain cluster health by preventing issues caused by specific corrupted
+partitions that may lead to Redpanda crashes. Although the data remains stored
+on disk, Redpanda ceases interaction with the disabled partitions to ensure
+system stability.
+
+You may disable/enable partition using 'rpk cluster partitions enable/disable'.	
+
+EXAMPLES
+
+List all partitions in the cluster.
+  rpk cluster partitions list --all
+
+List all partitions in the cluster, filtering for topic foo and bar.
+  rpk cluster partitions list foo bar
+
+List only the disabled partitions.
+  rpk cluster partitions list -a --disabled-only
+
+List all in json format.
+  rpk cluster partition list -a --format json
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions list [TOPICS...] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls, describe
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-a, --all` |- |If true, list all partitions in the cluster.
+
+|`--disabled-only` |- |If true, list disabled partitions only.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`-h, --help` |- |Help for list.
+
+|`-p, --partition` |- |ints   List of comma-separated partitions IDs that you wish to filter the results with.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-partitions-move-cancel.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-partitions-move-cancel.adoc
@@ -1,0 +1,51 @@
+= rpk cluster partitions move-cancel
+:description: rpk cluster partitions move-cancel
+
+Cancel ongoing partition movements.
+
+By default, this command cancels all the partition movements in the cluster. 
+To ensure that you do not accidentally cancel all partition movements, this 
+command prompts users for confirmation before issuing the cancellation request. 
+You can use "--no-confirm" to disable the confirmation prompt:
+
+    rpk cluster partitions move-cancel --no-confirm
+
+If "--node" is set, this command will only stop the partition movements 
+occurring in the specified node:
+
+    rpk cluster partitions move-cancel --node 1
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions move-cancel [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+move-cancel, alter-cancel
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for move-cancel.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`--node` |int |ID of a specific node on which to cancel ongoing partition movements (default -1).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-partitions-move-status.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-partitions-move-status.adoc
@@ -1,0 +1,63 @@
+= rpk cluster partitions move-status
+:description: rpk cluster partitions move-status
+
+Show ongoing partition movements.
+
+By default this command lists all ongoing partition movements in the cluster.
+Topics can be specified to print the move status of specific topics. By default,
+this command assumes the "kafka" namespace, but you can use a "namespace/" to
+specify internal namespaces.
+
+    rpk cluster partitions move-status
+    rpk cluster partitions move-status foo bar kafka_internal/tx
+
+The "--partition / -p" flag can be used with topics to additional filter
+requested partitions:
+
+    rpk cluster partitions move-status foo bar --partition 0,1,2
+
+The output contains the following columns with PARTITION-SIZE in bytes.
+Using -H, it prints the partition size in a human-readable format
+
+    NAMESPACE-TOPIC
+    PARTITION
+    MOVING-FROM
+    MOVING-TO
+    COMPLETION-%
+    PARTITION-SIZE
+    BYTES-MOVED
+    BYTES-REMAINING
+
+Using "--print-all / -a" the command additionally prints the column
+"RECONCILIATION STATUSES", which reveals the internal status of the ongoing
+reconciliations. Reported errors do not necessarily mean real problems.
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions move-status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for move-status.
+
+|`-H, --human-readable` |- |Print the partition size in a human-readable form.
+
+|`-p, --partition` |strings |Partitions to filter ongoing movements status (repeatable).
+
+|`-a, --print-all` |- |Print internal states about movements for debugging.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-partitions-move.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-partitions-move.adoc
@@ -1,0 +1,59 @@
+= rpk cluster partitions move
+:description: rpk cluster partitions move
+
+Move partition replicas across nodes / cores.
+
+This command changes replica assignments for given partitions. By default, it
+assumes the "kafka" namespace, but you can specify an internal namespace using
+the "{namespace}/" prefix.
+
+To move replicas, use the following syntax:
+
+    rpk cluster partitions move foo --partition 0:1,2,3 -p 1:2,3,4
+
+Here, the command assigns new replicas for partition 0 to brokers [1, 2, 3] and
+for partition 1 to brokers [2, 3, 4] for the topic "foo".
+
+You can also specify the core id with "-{core_id}" where the new replicas
+should be placed:
+
+    rpk cluster partitions move foo -p 0:1-0,2-0,3-0
+
+Here all new replicas [1, 2, 3] will be assigned on core 0 on the nodes.
+
+The command does not change a "core" assignment unless it is explicitly
+specified. When a core is not specified for a new node, the command randomly
+picks a core and assign a replica on the core.
+
+Topic arguments are optional. For more control, you can specify the topic name
+in the "--partition" flag:
+
+    rpk cluster partitions move -p foo/0:1,2,3 -p kafka_internal/tx/0:1-0,2-0,3-0
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions move [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`-h, --help` |- |Help for move.
+
+|`-p, --partition` |stringArray |Topic-partitions to move and new replica locations (repeatable).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-partitions.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-partitions.adoc
@@ -1,0 +1,29 @@
+= rpk cluster partitions
+:description: rpk cluster partitions
+
+Manage cluster partitions
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions [flags]
+  rpk cluster partitions [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for partitions.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-self-test-start.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-self-test-start.adoc
@@ -1,0 +1,56 @@
+= rpk cluster self-test start
+:description: rpk cluster self-test start
+
+Starts one or more benchmark tests on one or more nodes
+of the cluster. Available tests to run:
+
+* Disk tests:
+  * Throughput test: 512 KB messages, sequential read/write
+    * Uses a larger request message sizes and deeper I/O queue depth to write/read more bytes in a shorter amount of time, at the cost of IOPS/latency.
+  * Latency test: 4 KB messages, sequential read/write
+    * Uses smaller request message sizes and lower levels of parallelism to achieve higher IOPS and lower latency.
+
+* Network tests:
+  * Throughput test: 8192-bit messages
+    * Unique pairs of Redpanda nodes each act as a client and a server.
+    * The test pushes as much data over the wire, within the test parameters.
+
+This command immediately returns on success, and the tests run asynchronously. The
+user polls for results with the 'self-test status'
+command.
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--disk-duration-ms` |duration |uint       The  in milliseconds of individual disk test runs (default 30000).
+
+|`-h, --help` |- |Help for start.
+
+|`--network-duration-ms` |duration |uint    The  in milliseconds of individual network test runs (default 30000).
+
+|`--no-confirm` |- |Acknowledge warning prompt skipping read from stdin.
+
+|`--only-disk-test` |- |Runs only the disk benchmarks.
+
+|`--only-network-test` |- |Runs only network benchmarks.
+
+|`--participant-node-ids` |- |ints   IDs of nodes that the tests will run on. If not set, tests will run for all node IDs.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-self-test-status.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-self-test-status.adoc
@@ -1,0 +1,39 @@
+= rpk cluster self-test status
+:description: rpk cluster self-test status
+
+Returns the status of the currently running or last completed self-test run.
+
+Use this command after invoking 'self-test start' to determine the status of
+the jobs launched. Possible results are:
+
+* One or more jobs still running
+  * Returns the IDs of Redpanda nodes still running self-tests.
+
+* No jobs running:
+  * Returns cached results for all nodes of the last completed test.
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (text, json) (default "text").
+
+|`-h, --help` |- |Help for status.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-self-test-stop.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-self-test-stop.adoc
@@ -1,0 +1,31 @@
+= rpk cluster self-test stop
+:description: rpk cluster self-test stop
+
+Stops all self-test tests.
+
+This command stops all currently running self-tests. The command is synchronous and returns
+success when all jobs have been stopped or reports errors if broker timeouts have expired.
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for stop.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-self-test.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-self-test.adoc
@@ -1,0 +1,29 @@
+= rpk cluster self-test
+:description: rpk cluster self-test
+
+Start, stop and query runs of Redpanda self-test through the Admin API listener
+
+== Usage
+
+[,bash]
+----
+rpk cluster self-test [flags]
+  rpk cluster self-test [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for self-test.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-storage-restore-start.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-storage-restore-start.adoc
@@ -1,0 +1,38 @@
+= rpk cluster storage restore start
+:description: rpk cluster storage restore start
+
+Start the topic restoration process.
+		
+This command starts the process of restoring topics from the archival bucket.
+If the wait flag (--wait/-w) is set, the command will poll the status of the
+recovery process until it's finished.
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage restore start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for start.
+
+|`--polling-interval` |duration |The status check interval (e.g. '30s', '1.5m'); ignored if --wait is not used (default 5s).
+
+|`--topic-name-pattern` |string |A regex pattern that restores any matching topics (default ".*").
+
+|`-w, --wait` |- |Wait until auto-restore is complete.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-storage-restore-status.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-storage-restore-status.adoc
@@ -1,0 +1,31 @@
+= rpk cluster storage restore status
+:description: rpk cluster storage restore status
+
+Fetch the status of the topic restoration process.
+		
+This command fetches the status of the process of restoring topics from the 
+archival bucket.
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage restore status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-storage-restore.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-storage-restore.adoc
@@ -1,0 +1,47 @@
+= rpk cluster storage restore
+:description: rpk cluster storage restore
+
+Interact with the topic restoration process.
+		
+This command is used to restore topics from the archival bucket, which can be 
+useful for disaster recovery or if a topic was accidentally deleted.
+
+To begin the recovery process, use the "restore start" command. Note that this 
+process can take a while to complete, so the command will exit after starting 
+it. If you want the command to wait for the process to finish, use the "--wait"
+or "-w" flag.
+
+You can check the status of the recovery process with the "restore status" 
+command after it has been started.
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage restore [flags]
+  rpk cluster storage restore [command]
+----
+
+== Aliases
+
+[,bash]
+----
+restore, recovery
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for restore.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster-storage.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster-storage.adoc
@@ -1,0 +1,29 @@
+= rpk cluster storage
+:description: rpk cluster storage
+
+Manage the cluster storage
+
+== Usage
+
+[,bash]
+----
+rpk cluster storage [flags]
+  rpk cluster storage [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for storage.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-cluster.adoc
+++ b/tools/gen/23.3-beta/rpk-cluster.adoc
@@ -1,0 +1,29 @@
+= rpk cluster
+:description: rpk cluster
+
+Interact with a Redpanda cluster
+
+== Usage
+
+[,bash]
+----
+rpk cluster [flags]
+  rpk cluster [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for cluster.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-container-purge.adoc
+++ b/tools/gen/23.3-beta/rpk-container-purge.adoc
@@ -1,0 +1,28 @@
+= rpk container purge
+:description: rpk container purge
+
+Stop and remove an existing local container cluster's data
+
+== Usage
+
+[,bash]
+----
+rpk container purge [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for purge.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-container-start.adoc
+++ b/tools/gen/23.3-beta/rpk-container-start.adoc
@@ -1,0 +1,38 @@
+= rpk container start
+:description: rpk container start
+
+Start a local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for start.
+
+|`--image` |string |An arbitrary container image to use (default "redpandadata/redpanda:v0.0.0-20231206git4fb6164").
+
+|`--no-profile` |- |If true, rpk will not create an rpk profile after creating a cluster.
+
+|`-n, --nodes` |- |uint     The number of nodes to start (default 1).
+
+|`--pull` |- |Force pull the container image used.
+
+|`--retries` |- |uint   The amount of times to check for the cluster before considering it unstable and exiting (default 10).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-container-status.adoc
+++ b/tools/gen/23.3-beta/rpk-container-status.adoc
@@ -1,0 +1,28 @@
+= rpk container status
+:description: rpk container status
+
+Get status
+
+== Usage
+
+[,bash]
+----
+rpk container status [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for status.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-container-stop.adoc
+++ b/tools/gen/23.3-beta/rpk-container-stop.adoc
@@ -1,0 +1,28 @@
+= rpk container stop
+:description: rpk container stop
+
+Stop an existing local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for stop.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-container.adoc
+++ b/tools/gen/23.3-beta/rpk-container.adoc
@@ -1,0 +1,29 @@
+= rpk container
+:description: rpk container
+
+Manage a local container cluster
+
+== Usage
+
+[,bash]
+----
+rpk container [flags]
+  rpk container [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for container.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-debug-bundle.adoc
+++ b/tools/gen/23.3-beta/rpk-debug-bundle.adoc
@@ -1,0 +1,138 @@
+= rpk debug bundle
+:description: rpk debug bundle
+
+'rpk debug bundle' collects environment data that can help debug and diagnose
+issues with a redpanda cluster, a broker, or the machine it's running on. It
+then bundles the collected data into a ZIP file, called a diagnostics bundle.
+
+The files and directories in the diagnostics bundle differ depending on the 
+environment in which Redpanda is running:
+
+COMMON FILES
+
+ - Kafka metadata: Broker configs, topic configs, start/committed/end offsets,
+   groups, group commits.
+
+ - Controller logs: The controller logs directory up to a limit set by
+   --controller-logs-size-limit flag
+
+ - Data directory structure: A file describing the data directory's contents.
+
+ - Redpanda configuration: The redpanda configuration file (`redpanda.yaml`;
+   SASL credentials are stripped).
+
+ - Runtime system information (/proc): Process information, by reading /proc 
+  files like core count, cache, frequency, interrupts, mounted file systems, 
+  memory usage, kernel command line.
+
+ - Resource usage data: CPU usage percentage, free memory available for the
+   redpanda process.
+
+ - Clock drift: The ntp clock delta (using pool.ntp.org as a reference) & round
+   trip time.
+
+ - Admin API calls: Multiple requests to gather information such as: Cluster and
+   broker configurations, cluster health data, balancer status, cloud storage
+   status, and license key information.
+
+ - Broker metrics: The broker's Prometheus metrics, fetched through its
+   admin API (/metrics and /public_metrics).
+
+BARE-METAL
+
+ - Kernel: The kernel logs ring buffer (syslog) and parameters (sysctl).
+
+ - DNS: The DNS info as reported by 'dig', using the hosts in
+   /etc/resolv.conf.
+
+ - Disk usage: The disk usage for the data directory, as output by 'du'.
+
+ - redpanda logs: The node's redpanda logs written to journald. If --logs-since 
+   or --logs-until are passed, then only the logs within the resulting time frame
+   will be included.
+
+ - Socket info: The active sockets data output by 'ss'.
+
+ - Running process info: As reported by 'top'.
+
+ - Virtual memory stats: As reported by 'vmstat'.
+
+ - Network config: As reported by 'ip addr'.
+
+ - lspci: List the PCI buses and the devices connected to them.
+
+ - dmidecode: The DMI table contents. Only included if this command is run
+   as root.
+
+KUBERNETES
+
+ - Kubernetes Resources: Kubernetes manifests for all resources in the given 
+   Kubernetes namespace (via --namespace).
+
+ - redpanda logs: Logs of each Pod in the the given Kubernetes namespace. If 
+   --logs-since is passed, only the logs within the given timeframe are 
+   included.
+
+EXTRA REQUESTS FOR PARTITIONS
+
+You can provide a list of partitions to save additional admin API requests
+specifically for those partitions.
+
+The partition flag accepts the format {namespace}/[topic]/[partitions...]
+where the namespace is optional, if the namespace is not provided, rpk will 
+assume 'kafka'. For example:
+
+Topic 'foo', partitions 1, 2 and 3:
+  --partitions foo/1,2,3
+
+Namespace _redpanda-internal, topic 'bar', partition 2
+  --partitions _redpanda-internal/bar/2
+
+If you have an upload URL from the Redpanda support team, provide it in the 
+--upload-url flag to upload your diagnostics bundle to Redpanda.
+
+== Usage
+
+[,bash]
+----
+rpk debug bundle [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--controller-logs-size-limit` |string |The size limit of the controller logs that can be stored in the bundle (e.g. 3MB, 1GiB) (default "20MB").
+
+|`-h, --help` |- |Help for bundle.
+
+|`-l, --label-selector` |stringArray |Comma-separated label selectors to filter your resources. e.g: <label>=<value>,<label>=<value> (k8s only) (default [app.kubernetes.io/name=redpanda]).
+
+|`--logs-since` |string |Include log entries on or newer than the specified date (journalctl date format, e.g. YYYY-MM-DD.
+
+|`--logs-size-limit` |string |Read the logs until the given size is reached (e.g. 3MB, 1GiB) (default "100MiB").
+
+|`--logs-until` |string |Include log entries on or older than the specified date (journalctl date format, e.g. YYYY-MM-DD.
+
+|`--metrics-interval` |duration |Interval between metrics snapshots (e.g. 30s, 1.5m) (default 10s).
+
+|`-n, --namespace` |string |The namespace to use to collect the resources from (k8s only) (default "redpanda").
+
+|`-o, --output` |string |The file path where the debug file will be written (default ./&lt;timestamp&gt;-bundle.zip).
+
+|`-p, --partition` |stringArray |Comma-separated partition IDs; when provided, rpk saves extra admin API requests for those partitions. Check help for extended usage.
+
+|`--timeout` |duration |How long to wait for child commands to execute (e.g. 30s, 1.5m) (default 12s).
+
+|`--upload-url` |string |If provided, where to upload the bundle in addition to creating a copy on disk.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-debug.adoc
+++ b/tools/gen/23.3-beta/rpk-debug.adoc
@@ -1,0 +1,29 @@
+= rpk debug
+:description: rpk debug
+
+Debug the local Redpanda process
+
+== Usage
+
+[,bash]
+----
+rpk debug [flags]
+  rpk debug [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for debug.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-generate-app.adoc
+++ b/tools/gen/23.3-beta/rpk-generate-app.adoc
@@ -1,0 +1,68 @@
+= rpk generate app
+:description: rpk generate app
+
+Generate a sample application to connect with Redpanda.
+
+This command generates a starter application to produce and consume from the
+settings defined in the rpk profile. Its goal is to get you producing and
+consuming quickly with Redpanda in a language that is familiar to you.
+
+By default, this will run interactively, prompting you to select a language and
+a user with which to create your application. To use this without interactivity,
+specify how you would like your application to be created using flags.
+
+The --language option allows you to specify the language. There is no default.
+
+The --new-sasl-credentials <user>:<password> allows you to generate a new SASL
+user with admin ACLs. If you don't want to use your current profile user nor
+create a new one, you may use --no-user flag to generate the starter app without
+the user.
+
+If you are having trouble connecting to your cluster, you can use -X
+admin.hosts=comma,delimited,host:ports to pass a specific admin api address.
+
+EXAMPLES
+
+Generate an app with interactive prompts:
+  rpk generate app
+
+Generate an app in a specified language with the existing SASL user:
+  rpk generate app --language <lang>
+
+Generate an app in the specified language with a new SASL user:
+  rpk generate app -l <lang> --new-sasl-credentials <user>:<password>
+
+Generate an app in the 'tmp' dir, but take no action on the user:
+  rpk generate app -l <lang> --no-user --output /tmp
+
+== Usage
+
+[,bash]
+----
+rpk generate app [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for app.
+
+|`-l, --language` |string |The language you want the code sample to be generated with.
+
+|`--new-sasl-credentials` |string |If provided, rpk will generate and use these credentials (<user>:<password>).
+
+|`--no-user` |- |Generates the sample app without SASL user.
+
+|`-o, --output` |string |The path where the app will be written.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-generate-grafana-dashboard.adoc
+++ b/tools/gen/23.3-beta/rpk-generate-grafana-dashboard.adoc
@@ -1,0 +1,48 @@
+= rpk generate grafana-dashboard
+:description: rpk generate grafana-dashboard
+
+Generate Grafana Dashboards for Redpanda Metrics
+
+Use this command to generate sample Grafana dashboards for Redpanda metrics. 
+These dashboards can be imported into a Grafana or Grafana Cloud instance.
+
+To select a specific dashboard, use the '--dashboard' flag followed by the 
+dashboard name. For example, to generate the operations dashboard, run:
+
+    rpk generate grafana-dashboard --dashboard operations
+
+The selected dashboard will be downloaded from our GitHub repository:
+
+  https://github.com/redpanda-data/observability
+
+Note that the legacy dashboard is still available as an option, and will not be 
+downloaded from github. Instead, the dashboard will be generated based on the 
+metrics endpoint used.
+
+To see a list of all available dashboards, use the '--dashboard help' flag.
+
+== Usage
+
+[,bash]
+----
+rpk generate grafana-dashboard [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--dashboard` |string |The name of the dashboard you wish to download; use --dashboard help for more info (default "operations").
+
+|`-h, --help` |- |Help for grafana-dashboard.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-generate-prometheus-config.adoc
+++ b/tools/gen/23.3-beta/rpk-generate-prometheus-config.adoc
@@ -1,0 +1,90 @@
+= rpk generate prometheus-config
+:description: rpk generate prometheus-config
+
+Generate the Prometheus configuration to scrape Redpanda nodes. 
+
+The output of this command should be included in the 'scrape_configs' array 
+within the YAML configuration file of your Prometheus instance.
+
+There are different options you can use when generating the configuration:
+
+ - If you provide the --seed-addr flag, the command will use the address to 
+   discover the rest of the cluster hosts using Redpanda's Kafka API.
+ - If you provide the --node-addrs flag, the command will directly use the 
+   provided addresses.
+ - If neither --seed-addr nor --node-addrs are passed, the command will read the 
+   redpanda config file and use the node IP configured there.
+
+If the node you want to scrape uses TLS, you can provide the TLS flags 
+(--tls-key, --tls-cert, and --tls-truststore). The command will generate the 
+required tls_config section in the scrape configuration.
+
+Additionally, you have the option to define labels for the target in the 
+static-config section by using the --labels flag. You can specify the desired 
+metric that the label should target, either internal (/metrics) or public 
+(/public_metrics).
+
+For example:
+
+  --job-name test --labels "public:group=one,internal:group=two"
+
+This will result in two separate configs for the test job, each with a 
+different label:
+
+  - job_name: test
+    static_configs:
+      - targets: [<targets>]
+        labels:
+          group: one
+    metrics_path: /public_metrics
+  - job_name: test
+    static_configs:
+      - targets: [<targets>]
+        labels:
+          group: two
+    metrics_path: /metrics
+
+You can only provide one label per job. By default, if no metric target is 
+specified, the label will be shared across the jobs.
+
+== Usage
+
+[,bash]
+----
+rpk generate prometheus-config [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for prometheus-config.
+
+|`--internal-metrics` |- |Include scrape config for internal metrics (/metrics).
+
+|`--job-name` |string |The prometheus job name by which to identify the Redpanda nodes (default "redpanda").
+
+|`--labels` |strings |Comma-separated labels and their target metric (int or pub): [metric|labelName:labelValue, ...].
+
+|`--node-addrs` |strings |Comma-separated list of admin API host:ports.
+
+|`--seed-addr` |string |The URL of a Redpanda node with which to discover the rest.
+
+|`--tls-cert` |string |The certificate to be used for TLS authentication with the broker.
+
+|`--tls-enabled` |- |Enable TLS for the Kafka API (not necessary if specifying custom certs).
+
+|`--tls-key` |string |The certificate key to be used for TLS authentication with the broker.
+
+|`--tls-truststore` |string |The CA certificate to be used for TLS communication with the broker.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-generate-shell-completion.adoc
+++ b/tools/gen/23.3-beta/rpk-generate-shell-completion.adoc
@@ -1,0 +1,76 @@
+= rpk generate shell-completion
+:description: rpk generate shell-completion
+
+Shell completion can help autocomplete rpk commands when you press tab.
+
+BASH
+
+Bash autocompletion relies on the bash-completion package. You can test if you
+have this by running "type _init_completion", if you do not, you can install
+the package through your package manager.
+
+If you have bash-completion installed, and the command still fails, you likely
+need to add the following line to your ~/.bashrc:
+
+    source /usr/share/bash-completion/bash_completion
+
+To ensure autocompletion of rpk exists in all shell sessions, add the following
+to your ~/.bashrc:
+
+    command -v rpk >/dev/null && . <(rpk generate shell-completion bash)
+
+Alternatively, to globally enable rpk completion, you can run the following:
+
+    rpk generate shell-completion bash > /etc/bash_completion.d/rpk
+
+ZSH
+
+If shell completion is not already enabled in your environment, you will need to
+enable it. You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To enable autocompletion in any zsh session for any user, run this once:
+
+# Linux:
+
+    rpk generate shell-completion zsh > "${fpath[1]}/_rpk"
+
+# macOS:
+
+     rpk generate shell-completion zsh > "$(brew --prefix)/share/zsh/site-functions/_rpk"
+
+You can also place that command in your ~/.zshrc to ensure that when you update
+rpk, you update autocompletion. If you initially require sudo to edit that
+file, you can chmod it to be world writeable, after which you will always be
+able to update it from ~/.zshrc.
+
+FISH
+
+To enable autocompletion in any fish session, run:
+
+    rpk generate shell-completion fish > ~/.config/fish/completions/rpk.fish
+
+== Usage
+
+[,bash]
+----
+rpk generate shell-completion [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for shell-completion.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-generate.adoc
+++ b/tools/gen/23.3-beta/rpk-generate.adoc
@@ -1,0 +1,29 @@
+= rpk generate
+:description: rpk generate
+
+Generate a configuration template for related services
+
+== Usage
+
+[,bash]
+----
+rpk generate [template] [flags]
+  rpk generate [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for generate.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-group-delete.adoc
+++ b/tools/gen/23.3-beta/rpk-group-delete.adoc
@@ -1,0 +1,45 @@
+= rpk group delete
+:description: rpk group delete
+
+Delete groups from brokers.
+
+Older versions of the Kafka protocol included a retention_millis field in
+offset commit requests. Group commits persisted for this retention and then
+eventually expired. Once all commits for a group expired, the group would be
+considered deleted.
+
+The retention field was removed because it proved problematic for infrequently
+committing consumers: the offsets could be expired for a group that was still
+active. If clients use new enough versions of OffsetCommit (versions that have
+removed the retention field), brokers expire offsets only when the group is
+empty for offset.retention.minutes. Redpanda does not currently support that
+configuration (see #2904), meaning offsets for empty groups expire only when
+they are explicitly deleted.
+
+You may want to delete groups to clean up offsets sooner than when they
+automatically are cleaned up, such as when you create temporary groups for
+quick investigation or testing. This command helps you do that.
+
+== Usage
+
+[,bash]
+----
+rpk group delete [GROUPS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-group-describe.adoc
+++ b/tools/gen/23.3-beta/rpk-group-describe.adoc
@@ -1,0 +1,37 @@
+= rpk group describe
+:description: rpk group describe
+
+Describe group offset status & lag.
+
+This command describes group members, calculates their lag, and prints detailed
+information about the members.
+
+== Usage
+
+[,bash]
+----
+rpk group describe [GROUPS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for describe.
+
+|`-c, --print-commits` |- |Print only the group commits section.
+
+|`-t, --print-lag-per-topic` |- |Print the aggregated lag per topic.
+
+|`-s, --print-summary` |- |Print only the group summary section.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-group-list.adoc
+++ b/tools/gen/23.3-beta/rpk-group-list.adoc
@@ -1,0 +1,40 @@
+= rpk group list
+:description: rpk group list
+
+List all groups.
+
+This command lists all groups currently known to Redpanda, including empty
+groups that have not yet expired. The BROKER column is which broker node is the
+coordinator for the group. This command can be used to track down unknown
+groups, or to list groups that need to be cleaned up.
+
+== Usage
+
+[,bash]
+----
+rpk group list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-group-offset-delete.adoc
+++ b/tools/gen/23.3-beta/rpk-group-offset-delete.adoc
@@ -1,0 +1,49 @@
+= rpk group offset-delete
+:description: rpk group offset-delete
+
+Forcefully delete offsets for a kafka group.
+
+The broker will only allow the request to succeed if the group is in a dead
+state (no subscriptions) or there are no subscriptions for offsets for
+topic/partitions requested to be deleted.
+
+Use either the --from-file or the --topic option. They are mutually exclusive.
+To indicate which topics or topic partitions you'd like to remove offsets from use
+the --topic (-t) flag, followed by a comma separated list of partition ids. Supplying
+no list will delete all offsets for all partitions for a given topic.
+
+You may also provide a text file to indicate topic/partition tuples. Use the
+--from-file flag for this option. The file must contain lines of topic/partitions
+separated by a tab or space. Example:
+
+topic_a 0
+topic_a 1
+topic_b 0
+
+== Usage
+
+[,bash]
+----
+rpk group offset-delete [GROUP] --from-file FILE --topic foo:0,1,2 [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --from-file` |string |File of topic/partition tuples for which to delete offsets for.
+
+|`-h, --help` |- |Help for offset-delete.
+
+|`-t, --topic` |stringArray |topic:partition_id (repeatable; e.g. -t foo:0,1,2 ).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-group-seek.adoc
+++ b/tools/gen/23.3-beta/rpk-group-seek.adoc
@@ -1,0 +1,82 @@
+= rpk group seek
+:description: rpk group seek
+
+Modify a group's current offsets.
+
+This command allows you to modify a group's offsets. Sometimes, you may need to
+rewind a group if you had a mistaken deploy, or fast-forward a group if it is
+falling behind on messages that can be skipped.
+
+The --to option allows you to seek to the start of partitions, end of
+partitions, or after a specific timestamp. The default is to seek any topic
+previously committed. Using --topics allows to you set commits for only the
+specified topics; all other commits will remain untouched. Topics with no
+commits will not be committed unless allowed with --allow-new-topics.
+
+The --to-group option allows you to seek to commits that are in another group.
+This is a merging operation: if g1 is consuming topics A and B, and g2 is
+consuming only topic B, "rpk group seek g1 --to-group g2" will update g1's
+commits for topic B only. The --topics flag can be used to further narrow which
+topics are updated. Unlike --to, all non-filtered topics are committed, even
+topics not yet being consumed, meaning --allow-new-topics is not needed.
+
+The --to-file option allows to seek to offsets specified in a text file with
+the following format:
+    [TOPIC] [PARTITION] [OFFSET]
+    [TOPIC] [PARTITION] [OFFSET]
+    ...
+Each line contains the topic, the partition, and the offset to seek to. As with
+the prior options, --topics allows filtering which topics are updated. Similar
+to --to-group, all non-filtered topics are committed, even topics not yet being
+consumed, meaning --allow-new-topics is not needed.
+
+The --to, --to-group, and --to-file options are mutually exclusive. If you are
+not authorized to describe or read some topics used in a group, you will not be
+able to modify offsets for those topics.
+
+EXAMPLES
+
+Seek group G to June 1st, 2021:
+    rpk group seek g --to 1622505600
+    or, rpk group seek g --to 1622505600000
+    or, rpk group seek g --to 1622505600000000000
+Seek group X to the commits of group Y topic foo:
+    rpk group seek X --to-group Y --topics foo
+Seek group G's topics foo, bar, and biz to the end:
+    rpk group seek G --to end --topics foo,bar,biz
+Seek group G to the beginning of a topic it was not previously consuming:
+    rpk group seek G --to start --topics foo --allow-new-topics
+
+== Usage
+
+[,bash]
+----
+rpk group seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ... [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--allow-new-topics` |- |Allow seeking to new topics not currently consumed (implied with --to-group or --to-file).
+
+|`-h, --help` |- |Help for seek.
+
+|`--to` |string |Where to seek (start, end, unix second | millisecond | nanosecond).
+
+|`--to-file` |string |Seek to offsets as specified in the file.
+
+|`--to-group` |string |Seek to the commits of another group.
+
+|`--topics` |strings |Only seek these topics, if any are specified.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-group.adoc
+++ b/tools/gen/23.3-beta/rpk-group.adoc
@@ -1,0 +1,74 @@
+= rpk group
+:description: rpk group
+
+Describe, list, and delete consumer groups and manage their offsets.
+
+Consumer groups allow you to horizontally scale consuming from topics. A
+non-group consumer consumes all records from all partitions you assign it. In
+contrast, consumer groups allow many consumers to coordinate and divide work.
+If you have two members in a group consuming topics A and B, each with three
+partitions, then both members consume three partitions. If you add another
+member to the group, then each of the three members will consume two
+partitions. This allows you to horizontally scale consuming of topics.
+
+The unit of scaling is a single partition. If you add more consumers to a group
+than there are are total partitions to consume, then some consumers will be
+idle. More commonly, you have many more partitions than consumer group members
+and each member consumes a chunk of available partitions. One scenario where
+you may want more members than partitions is if you want active standby's to
+take over load immediately if any consuming member dies.
+
+How group members divide work is entirely client driven (the "partition
+assignment strategy" or "balancer" depending on the client). Brokers know
+nothing about how consumers are assigning partitions. A broker's role in group
+consuming is to choose which member is the leader of a group, forward that
+member's assignment to every other member, and ensure all members are alive
+through heartbeats.
+
+Consumers periodically commit their progress when consuming partitions. Through
+these commits, you can monitor just how far behind a consumer is from the
+latest messages in a partition. This is called "lag". Large lag implies that
+the client is having problems, which could be from the server being too slow,
+or the client being oversubscribed in the number of partitions it is consuming,
+or the server being in a bad state that requires restarting or removing from
+the server pool, and so on.
+
+You can manually manage offsets for a group, which allows you to rewind or
+forward commits. If you notice that a recent deploy of your consumers had a
+bug, you may want to stop all members, rewind the commits to before the latest
+deploy, and restart the members with a patch.
+
+This command allows you to list all groups, describe a group (to view the
+members and their lag), and manage offsets.
+
+== Usage
+
+[,bash]
+----
+rpk group [flags]
+  rpk group [command]
+----
+
+== Aliases
+
+[,bash]
+----
+group, g
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for group.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-help.adoc
+++ b/tools/gen/23.3-beta/rpk-help.adoc
@@ -1,0 +1,29 @@
+= rpk help
+:description: rpk help
+
+Help provides help for any command in the application.
+Simply type rpk help [path to command] for full details.
+
+== Usage
+
+[,bash]
+----
+rpk help [command] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |help for help.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-iotune.adoc
+++ b/tools/gen/23.3-beta/rpk-iotune.adoc
@@ -1,0 +1,38 @@
+= rpk iotune
+:description: rpk iotune
+
+Measure filesystem performance and create IO configuration file
+
+== Usage
+
+[,bash]
+----
+rpk iotune [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--directories` |strings |List of directories to evaluate.
+
+|`--duration` |duration |Duration of tests (e.g. 300ms, 1.5s, 2h45m) (default 10m0s).
+
+|`-h, --help` |- |Help for iotune.
+
+|`--no-confirm` |- |Disable confirmation prompt if the iotune file already exists.
+
+|`--out` |string |The file path where the IO config will be written (default "/etc/redpanda/io-config.yaml").
+
+|`--timeout` |duration |The maximum time after -- to wait for iotune to complete (e.g. 300ms, 1.5s, 2h45m) (default 1h0m0s).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-plugin-install.adoc
+++ b/tools/gen/23.3-beta/rpk-plugin-install.adoc
@@ -1,0 +1,45 @@
+= rpk plugin install
+:description: rpk plugin install
+
+Install an rpk plugin.
+
+An rpk plugin must be saved in $HOME/.local/bin or in a directory that is in 
+your $PATH. By default, this command installs plugins to $HOME/.local/bin. This 
+can be overridden by specifying the --dir flag.
+
+If --dir is not present, rpk will create $HOME/.local/bin if it does not exist.
+
+== Usage
+
+[,bash]
+----
+rpk plugin install [PLUGIN] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+install, download
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--dir` |string |Destination directory to save the installed plugin (defaults to $HOME/.local/bin) (default "/var/lib/redpanda/.local/bin").
+
+|`-h, --help` |- |Help for install.
+
+|`-u, --update` |- |Update a locally installed plugin if it differs from the current remote version.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-plugin-list.adoc
+++ b/tools/gen/23.3-beta/rpk-plugin-list.adoc
@@ -1,0 +1,39 @@
+= rpk plugin list
+:description: rpk plugin list
+
+List all available plugins.
+
+By default, this command fetches the remote manifest and prints plugins
+available for download. Any plugin that is already downloaded is prefixed with
+an asterisk. If a locally installed plugin has a different sha256sum as the one
+specified in the manifest, or if the sha256sum could not be calculated for the
+local plugin, an additional message is printed.
+
+You can specify --local to print all locally installed plugins, as well as
+whether you have "shadowed" plugins (the same plugin specified multiple times).
+
+== Usage
+
+[,bash]
+----
+rpk plugin list [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`-l, --local` |- |List locally installed plugins and shadowed plugins.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-plugin-uninstall.adoc
+++ b/tools/gen/23.3-beta/rpk-plugin-uninstall.adoc
@@ -1,0 +1,42 @@
+= rpk plugin uninstall
+:description: rpk plugin uninstall
+
+Uninstall / remove an existing local plugin.
+
+This command lists locally installed plugins and removes the first plugin that
+matches the requested removal. If --include-shadowed is specified, this command
+also removes all shadowed plugins of the same name. To remove a command under a
+nested namespace ("rpk foo bar"), you can use "foo_bar".
+
+== Usage
+
+[,bash]
+----
+rpk plugin uninstall [NAME] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+uninstall, rm
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for uninstall.
+
+|`--include-shadowed` |- |Also remove shadowed plugins that have the same name.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-plugin.adoc
+++ b/tools/gen/23.3-beta/rpk-plugin.adoc
@@ -1,0 +1,70 @@
+= rpk plugin
+:description: rpk plugin
+
+List, download, update, and remove rpk plugins.
+	
+Plugins augment rpk with new commands.
+
+For a plugin to be used, it must be in $HOME/.local/bin or somewhere 
+discoverable by rpk in your $PATH. All plugins follow a defined naming scheme:
+
+  .rpk-|name|
+  .rpk.ac-|name|
+
+All plugins are prefixed with either .rpk- or .rpk.ac-. When rpk starts up, it
+searches all directories in your $PATH for any executable binary that begins
+with either of those prefixes. For any binary it finds, rpk adds a command for
+that name to the rpk command space itself.
+
+No plugin name can shadow an existing rpk command, and only one plugin can
+exist under a given name at once. Plugins are added to the rpk command space on
+a first-seen basis. If you have two plugins rpk-foo, and the second is
+discovered later on in the $PATH directories, then only the first will be used.
+The second will be ignored.
+
+Plugins that have an .rpk.ac- prefix indicate that they support the
+--help-autocomplete flag. If rpk sees this, rpk will exec the plugin with that
+flag when rpk starts up, and the plugin will return all commands it supports as
+well as short and long help test for each command. Rpk uses this return to
+build a shadow command space within rpk itself so that it looks as if the
+plugin exists within rpk. This is particularly useful if you enable
+autocompletion.
+
+The expected return for plugins from --help-autocomplete is an array of the
+following:
+
+  type pluginHelp struct {
+          Path    string   `json:"path,omitempty"`
+          Short   string   `json:"short,omitempty"`
+          Long    string   `json:"long,omitempty"`
+          Example string   `json:"example,omitempty"`
+          Args    []string `json:"args,omitempty"`
+  }
+
+where "path" is an underscore delimited argument path to a command. For
+example, "foo_bar_baz" corresponds to the command "rpk foo bar baz".
+
+== Usage
+
+[,bash]
+----
+rpk plugin [flags]
+  rpk plugin [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for plugin.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-clear.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-clear.adoc
@@ -1,0 +1,31 @@
+= rpk profile clear
+:description: rpk profile clear
+
+Clear the current profile
+
+This small command clears the current profile, which can be useful to unset an
+prod cluster profile.
+
+== Usage
+
+[,bash]
+----
+rpk profile clear [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for clear.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-create.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-create.adoc
@@ -1,0 +1,77 @@
+= rpk profile create
+:description: rpk profile create
+
+Create an rpk profile.
+
+There are multiple ways to create a profile. A name must be provided if not
+using --from-cloud or --from-rpk-container.
+
+* You can use --from-redpanda to generate a new profile from an existing
+  `redpanda.yaml` file. The special values "current" create a profile from the
+  current `redpanda.yaml` as it is loaded within rpk.
+
+* You can use --from-profile to generate a profile from an existing profile or
+  from from a profile in a yaml file. First, the filename is checked, then an
+  existing profile name is checked. The special value "current" creates a new
+  profile from the existing profile.
+
+* You can use --from-cloud to generate a profile from an existing cloud cluster
+  id. Note that you must be logged in with 'rpk cloud login' first. The special
+  value "prompt" will prompt to select a cloud cluster to create a profile for.
+
+* You can use --from-rpk-container to generate a profile from an existing
+  cluster created using 'rpk container start' command. The name is not needed
+  when using this flag.
+
+* You can use --set key=value to directly set fields. The key can either be
+  the name of a -X flag or the path to the field in the profile's YAML format.
+  For example, using --set tls.enabled=true OR --set kafka_api.tls.enabled=true
+  is equivalent. The former corresponds to the -X flag tls.enabled, while the
+  latter corresponds to the path kafka_api.tls.enabled in the profile's YAML.
+
+The --set flag is always applied last and can be used to set additional fields
+in tandem with --from-redpanda or --from-cloud.
+
+The --set flag supports autocompletion, suggesting the -X key format. If you
+begin writing a YAML path, the flag will suggest the rest of the path.
+
+It is recommended to always use the --description flag; the description is
+printed in the output of 'rpk profile list'.
+
+rpk always switches to the newly created profile.
+
+== Usage
+
+[,bash]
+----
+rpk profile create [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --description` |string |Optional description of the profile.
+
+|`--from-cloud` |string |[="prompt"]   Create and switch to a new profile generated from a Redpanda Cloud cluster ID.
+
+|`--from-profile` |string |Create and switch to a new profile from an existing profile or from a profile in a yaml file.
+
+|`--from-redpanda` |string |Create and switch to a new profile from a `redpanda.yaml` file.
+
+|`--from-rpk-container` |- |Create and switch to a new profile generated from a running cluster created with rpk container.
+
+|`-h, --help` |- |Help for create.
+
+|`-s, --set` |stringArray |Create and switch to a new profile, setting profile fields with key=value pairs.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-current.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-current.adoc
@@ -1,0 +1,33 @@
+= rpk profile current
+:description: rpk profile current
+
+Print the current profile name.
+
+This is a tiny command that simply prints the current profile name, which may
+be useful in scripts, or a PS1, or to confirm what you have selected.
+
+== Usage
+
+[,bash]
+----
+rpk profile current [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for current.
+
+|`-n, --no-newline` |- |Do not print a newline after the profile name.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-delete.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-delete.adoc
@@ -1,0 +1,32 @@
+= rpk profile delete
+:description: rpk profile delete
+
+Delete an rpk profile.
+
+Deleting a profile removes it from the rpk.yaml file. If the deleted profile
+was the selected profile, rpk will use in-memory defaults until a new profile
+is selected.
+
+== Usage
+
+[,bash]
+----
+rpk profile delete [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-edit-globals.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-edit-globals.adoc
@@ -1,0 +1,30 @@
+= rpk profile edit-globals
+:description: rpk profile edit-globals
+
+Edit rpk globals.
+
+This command opens your default editor to edit the rpk global configurations.
+
+== Usage
+
+[,bash]
+----
+rpk profile edit-globals [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for edit-globals.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-edit.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-edit.adoc
@@ -1,0 +1,32 @@
+= rpk profile edit
+:description: rpk profile edit
+
+Edit an rpk profile.
+
+This command opens your default editor to edit the specified profile, or
+the current profile if no profile is specified. If the profile does not
+exist, this command creates it and switches to it.
+
+== Usage
+
+[,bash]
+----
+rpk profile edit [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for edit.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-list.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-list.adoc
@@ -1,0 +1,35 @@
+= rpk profile list
+:description: rpk profile list
+
+List rpk profiles
+
+== Usage
+
+[,bash]
+----
+rpk profile list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-print-globals.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-print-globals.adoc
@@ -1,0 +1,28 @@
+= rpk profile print-globals
+:description: rpk profile print-globals
+
+Print rpk global configuration
+
+== Usage
+
+[,bash]
+----
+rpk profile print-globals [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for print-globals.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-print.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-print.adoc
@@ -1,0 +1,31 @@
+= rpk profile print
+:description: rpk profile print
+
+Print rpk profile configuration.
+
+If no name is specified, this command prints the current profile as it exists
+in the rpk.yaml file.
+
+== Usage
+
+[,bash]
+----
+rpk profile print [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for print.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-prompt.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-prompt.adoc
@@ -1,0 +1,69 @@
+= rpk profile prompt
+:description: rpk profile prompt
+
+Prompt a profile name formatted for a PS1 prompt.
+
+This command prints ANSI-escaped text per your current profile's "prompt"
+field. If the current profile does not have a prompt, this prints nothing.
+If the prompt is invalid, this exits 0 with no message. To validate the
+current prompt, use the --validate flag.
+
+This command may introduce other % variables in the future, if you want to
+print a % directly, use %% to escape it.
+
+To use this in zsh, be sure to add setopt PROMPT_SUBST to your .zshrc.
+To edit your PS1, use something like PS1='$(rpk profile prompt)' in your
+shell rc file.
+
+FORMAT
+
+The "prompt" field supports space or comma separated modifiers and a quoted
+string that is be modified. Inside the string, the variable %p or %n refers to
+the profile name. As a few examples:
+
+    prompt: hi-white, bg-red, bold, "[%p]"
+    prompt: hi-red  "PROD"
+    prompt: white, "dev-%n
+
+If you want to have multiple formats, you can wrap each formatted section in
+parentheses.
+
+    prompt: ("--") (hi-white bg-red bold "[%p]")
+
+COLORS
+
+All ANSI colors are supported, with names matching the color name:
+"black", "red", "green", "yellow", "blue", "magenta", "cyan", "white".
+
+The "hi-" prefix indicates a high-intensity color: "hi-black", "hi-red", etc.
+The "bg-" prefix modifies the background color: "bg-black", "bg-hi-red", etc.
+
+MODIFIERS
+
+Four modifiers are supported, "bold", "faint", "underline", and "invert".
+
+== Usage
+
+[,bash]
+----
+rpk profile prompt [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for prompt.
+
+|`--validate` |- |Exit with an error message if the prompt is invalid.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-rename-to.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-rename-to.adoc
@@ -1,0 +1,35 @@
+= rpk profile rename-to
+:description: rpk profile rename-to
+
+Rename the current rpk profile
+
+== Usage
+
+[,bash]
+----
+rpk profile rename-to [NAME] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+rename-to, rename
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for rename-to.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-set-globals.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-set-globals.adoc
@@ -1,0 +1,37 @@
+= rpk profile set-globals
+:description: rpk profile set-globals
+
+Set rpk globals fields.
+
+This command takes a list of key=value pairs to write to the global config 
+section of rpk.yaml. The globals section contains a set of settings that apply
+to all profiles and changes the way that rpk acts. For a list of global flags
+and what they mean, check 'rpk -X help' and look for any key that begins with
+"globals".
+
+This command supports autocompletion of valid keys. You can also use the
+format 'set key value' if you intend to only set one key.
+
+== Usage
+
+[,bash]
+----
+rpk profile set-globals [KEY=VALUE]+ [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set-globals.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-set.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-set.adoc
@@ -1,0 +1,43 @@
+= rpk profile set
+:description: rpk profile set
+
+Set fields in the current rpk profile.
+
+As in the create command, this command takes a list of key=value pairs to write
+to the current profile.
+
+The key can either be the name of a -X flag or the path to the field in the
+profile's yaml format. For example, using --set tls.enabled=true OR --set
+kafka_api.tls.enabled=true is equivalent. The former corresponds to the -X flag
+tls.enabled, while the latter corresponds to the path kafka_api.tls.enabled in
+the profile's yaml.
+
+This command supports autocompletion of valid keys, suggesting the -X key
+format. If you begin writing a YAML path, this command will suggest the rest of
+the path.
+
+You can also use the format 'set key value' if you intend to only set one key.
+
+== Usage
+
+[,bash]
+----
+rpk profile set [KEY=VALUE]+ [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile-use.adoc
+++ b/tools/gen/23.3-beta/rpk-profile-use.adoc
@@ -1,0 +1,28 @@
+= rpk profile use
+:description: rpk profile use
+
+Select the rpk profile to use
+
+== Usage
+
+[,bash]
+----
+rpk profile use [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for use.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-profile.adoc
+++ b/tools/gen/23.3-beta/rpk-profile.adoc
@@ -1,0 +1,35 @@
+= rpk profile
+:description: rpk profile
+
+Manage rpk profiles.
+
+An rpk profile talks to a single Redpanda cluster. You can create multiple
+profiles for multiple clusters and swap between them with 'rpk profile use'.
+Multiple profiles may be useful if, for example, you use rpk to talk to
+a localhost cluster, a dev cluster, and a prod cluster, and you want to keep
+your configuration in one place.
+
+== Usage
+
+[,bash]
+----
+rpk profile [flags]
+  rpk profile [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for profile.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-brokers-decommission-status.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-brokers-decommission-status.adoc
@@ -1,0 +1,72 @@
+= rpk redpanda admin brokers decommission-status
+:description: rpk redpanda admin brokers decommission-status
+
+Show the progrss of a node decommissioning.
+
+When a node is being decommissioned, this command reports the decommissioning
+progress as follows, where PARTITION-SIZE is in bytes. Using -H, it prints the
+partition size in a human-readable format.
+
+$ rpk redpanda admin brokers decommission-status 4
+DECOMMISSION PROGRESS
+=====================
+NAMESPACE-TOPIC              PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE
+kafka/test                   0          3          9             1699470920
+kafka/test                   4          3          0             1614258779
+kafka/test2                  3          3          3             2722706514
+kafka/test2                  4          3          4             2945518089
+kafka_internal/id_allocator  0          3          0             3562
+
+Using --detailed / -d, it additionally prints granular reports.
+
+$ rpk redpanda admin brokers decommission-status 4 -d
+DECOMMISSION PROGRESS
+=====================
+NAMESPACE-TOPIC  PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE  BYTES-MOVED  BYTES-REMAINING
+kafka/test       0          3          13            1731773243      228114727    1503658516
+kafka/test       4          3          1             1645952961      18752660     1627200301
+kafka/test2      3          3          5             2752632301      140975805    2611656496
+kafka/test2      4          3          6             2975443783      181581219    2793862564
+
+If a partition cannot be moved with some reason, the command reports the
+problematic partition in the 'ALLOCATION FAILURES' section and decommission
+never succeeds. Typical scenarios the failure occurs are; there's no node
+that has enough space to allocate a partition or that can satisfy rack
+constraints, etc.
+
+ALLOCATION FAILURES
+==================
+kafka/foo/2
+kafka/test/0
+
+Note that the command reports allocation failed partitions only when
+'partition_autobalancing_mode' is set to 'continuous'. See the current value
+using 'rpk cluster config get partition_autobalancing_mode'.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers decommission-status [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --detailed` |- |Print how much data moved and remaining in bytes.
+
+|`-h, --help` |- |Help for decommission-status.
+
+|`-H, --human-readable` |- |Print the partition size in a human-readable form.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-brokers-decommission.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-brokers-decommission.adoc
@@ -1,0 +1,39 @@
+= rpk redpanda admin brokers decommission
+:description: rpk redpanda admin brokers decommission
+
+Decommission the given broker.
+
+Decommissioning a broker removes it from the cluster.
+
+A decommission request is sent to every broker in the cluster, only the cluster
+leader handles the request.
+
+For safety on v22.x clusters, this command will not run if the requested 
+broker is in maintenance mode. As of v23.x, Redpanda supports 
+decommissioning a node that is currently in maintenance mode. If you are on 
+a v22.x cluster and need to bypass the maintenance mode check (perhaps your 
+cluster is unreachable), use the hidden --force flag.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers decommission [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for decommission.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-brokers-list.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-brokers-list.adoc
@@ -1,0 +1,35 @@
+= rpk redpanda admin brokers list
+:description: rpk redpanda admin brokers list
+
+List the brokers in your cluster
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-brokers-recommission.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-brokers-recommission.adoc
@@ -1,0 +1,36 @@
+= rpk redpanda admin brokers recommission
+:description: rpk redpanda admin brokers recommission
+
+Recommission the given broker if is is still decommissioning.
+
+Recommissioning can stop an active decommission.
+
+Once a broker is decommissioned, it cannot be recommissioned through this
+command.
+
+A recommission request is sent to every broker in the cluster, only
+the cluster leader handles the request.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers recommission [BROKER ID] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for recommission.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-brokers.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-brokers.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda admin brokers
+:description: rpk redpanda admin brokers
+
+View and configure Redpanda brokers through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin brokers [flags]
+  rpk redpanda admin brokers [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for brokers.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-config-log-level-set.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-config-log-level-set.adoc
@@ -1,0 +1,51 @@
+= rpk redpanda admin config log-level set
+:description: rpk redpanda admin config log-level set
+
+Set broker logger's log level.
+
+This command temporarily changes a broker logger's log level. Each Redpanda
+broker has many loggers, and each can be individually changed. Any change
+to a logger persists for a limited amount of time, so as to ensure you do
+not accidentally enable debug logging permanently.
+
+It is optional to specify a logger; if you do not, this command will prompt
+from the set of available loggers.
+
+The special logger "all" enables all loggers. Alternatively, you can specify
+many loggers at once. To see all possible loggers, run the following command:
+
+  redpanda --help-loggers
+
+This command accepts loggers that it does not know of to ensure you can
+independently update your redpanda installations from rpk. The success or
+failure of enabling each logger is individually printed.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config log-level set [LOGGERS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-e, --expiry-seconds` |int |seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown) (default 300).
+
+|`-h, --help` |- |Help for set.
+
+|`--host` |string |either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to.
+
+|`-l, --level` |string |log level to set (error, warn, info, debug, trace) (default "debug").
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-config-log-level.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-config-log-level.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda admin config log-level
+:description: rpk redpanda admin config log-level
+
+Manage a broker's log level
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config log-level [flags]
+  rpk redpanda admin config log-level [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for log-level.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-config-print.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-config-print.adoc
@@ -1,0 +1,37 @@
+= rpk redpanda admin config print
+:description: rpk redpanda admin config print
+
+Display the current Redpanda configuration
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config print [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+print, dump, list, ls, display
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for print.
+
+|`--host` |string |either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-config.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-config.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda admin config
+:description: rpk redpanda admin config
+
+View or modify Redpanda configuration through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin config [flags]
+  rpk redpanda admin config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for config.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-partitions-list.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-partitions-list.adoc
@@ -1,0 +1,37 @@
+= rpk redpanda admin partitions list
+:description: rpk redpanda admin partitions list
+
+List the partitions in a broker in the cluster
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin partitions list [BROKER ID] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for list.
+
+|`-l, --leader-only` |- |print the partitions on broker which are leaders.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin-partitions.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin-partitions.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda admin partitions
+:description: rpk redpanda admin partitions
+
+View and configure Redpanda partitions through the admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin partitions [flags]
+  rpk redpanda admin partitions [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for partitions.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-admin.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-admin.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda admin
+:description: rpk redpanda admin
+
+Talk to the Redpanda admin listener
+
+== Usage
+
+[,bash]
+----
+rpk redpanda admin [flags]
+  rpk redpanda admin [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for admin.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-check.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-check.adoc
@@ -1,0 +1,30 @@
+= rpk redpanda check
+:description: rpk redpanda check
+
+Check if system meets redpanda requirements
+
+== Usage
+
+[,bash]
+----
+rpk redpanda check [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for check.
+
+|`--timeout` |duration |The maximum amount of time to wait for the checks and tune process to complete (e.g. 300ms, 1.5s, 2h45m) (default 2s).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-config-bootstrap.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-config-bootstrap.adoc
@@ -1,0 +1,45 @@
+= rpk redpanda config bootstrap
+:description: rpk redpanda config bootstrap
+
+Initialize the configuration to bootstrap a cluster.
+
+This command generates a `redpanda.yaml` configuration file to bootstrap a
+cluster. If you are modifying the configuration file further, it is recommended
+to first bootstrap and then modify. If the file already exists, this command
+will set fields as requested by flags, and this may undo some of your earlier
+edits.
+
+The --ips flag specifies seed servers (ips, ip:ports, or hostnames) that this
+broker will use to form a cluster.
+
+By default, redpanda expects your machine to have one private IP address, and
+redpanda will listen on it. If your machine has multiple private IP addresses,
+you must use the --self flag to specify which ip redpanda should listen on.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config bootstrap [--self <ip>] [--ips <ip1,ip2,...>] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for bootstrap.
+
+|`--ips` |strings |Comma-separated list of the seed node addresses or hostnames; at least three are recommended.
+
+|`--self` |string |Optional IP address for redpanda to listen on; if empty, defaults to a private address.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-config-init.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-config-init.adoc
@@ -1,0 +1,28 @@
+= rpk redpanda config init
+:description: rpk redpanda config init
+
+This command has been deprecated.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config init [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for init.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-config-set.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-config-set.adoc
@@ -1,0 +1,56 @@
+= rpk redpanda config set
+:description: rpk redpanda config set
+
+Set configuration values, such as the redpanda node ID or the list of seed servers
+
+This command modifies the `redpanda.yaml` you have locally on disk. The first
+argument is the key within the yaml representing a property / field that you
+would like to set. Nested fields can be accessed through a dot:
+
+  rpk redpanda config set redpanda.developer_mode true
+
+All values are parsed as yaml and, since yaml is a superset of json, you can
+also format your input as json. Individual specific fields or full structs can
+be set:
+
+  rpk redpanda config set rpk.tune_disk_irq true
+  rpk redpanda config set redpanda.rpc_server '{address: 3.250.158.1, port: 9092}'
+
+You can set an entire array by wrapping all items with braces, or by using one
+struct:
+
+  rpk redpanda config set redpanda.advertised_kafka_api '[{address: 0.0.0.0, port: 9092}]'
+  rpk redpanda config set redpanda.advertised_kafka_api '{address: 0.0.0.0, port: 9092}' # same
+
+Indexing can be used to set specific items in an array. You can index one past
+the end of an array to extend it:
+
+  rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 0.0.0.0, port: 9092}'
+
+You may also use <key>=<value> notation for setting configuration properties:
+
+  rpk redpanda config set redpanda.kafka_api[0].port=9092
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config set [KEY] [VALUE] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for set.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-config.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-config.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda config
+:description: rpk redpanda config
+
+Edit configuration
+
+== Usage
+
+[,bash]
+----
+rpk redpanda config [flags]
+  rpk redpanda config [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for config.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-mode.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-mode.adoc
@@ -1,0 +1,28 @@
+= rpk redpanda mode
+:description: rpk redpanda mode
+
+Enable a default configuration mode
+
+== Usage
+
+[,bash]
+----
+rpk redpanda mode [MODE] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for mode.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-start.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-start.adoc
@@ -1,0 +1,56 @@
+= rpk redpanda start
+:description: rpk redpanda start
+
+Start redpanda
+
+== Usage
+
+[,bash]
+----
+rpk redpanda start [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--advertise-kafka-addr` |strings |A comma-separated list of Kafka addresses to advertise (scheme://host:port|name).
+
+|`--advertise-pandaproxy-addr` |strings |A comma-separated list of Pandaproxy addresses to advertise (scheme://host:port|name).
+
+|`--advertise-rpc-addr` |string |The advertised RPC address (host:port).
+
+|`--check` |- |When set to false will disable system checking before starting redpanda (default true).
+
+|`-h, --help` |- |Help for start.
+
+|`--install-dir` |string |Directory where redpanda has been installed.
+
+|`--kafka-addr` |strings |A comma-separated list of Kafka listener addresses to bind to (scheme://host:port|name).
+
+|`--mode` |string |Mode sets well-known configuration properties for development or test environments; use --mode help for more info.
+
+|`--pandaproxy-addr` |strings |A comma-separated list of Pandaproxy listener addresses to bind to (scheme://host:port|name).
+
+|`--rpc-addr` |string |The RPC address to bind to (host:port).
+
+|`--schema-registry-addr` |strings |A comma-separated list of Schema Registry listener addresses to bind to (scheme://host:port|name).
+
+|`-s, --seeds` |strings |A comma-separated list of seed nodes to connect to (scheme://host:port|name).
+
+|`--timeout` |duration |The maximum time to wait for the checks and tune processes to complete (e.g. 300ms, 1.5s, 2h45m) (default 10s).
+
+|`--tune` |- |When present will enable tuning before starting redpanda.
+
+|`--well-known-io` |string |The cloud vendor and VM type, in the format |vendor|:|vm type|:|storage type|.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-stop.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-stop.adoc
@@ -1,0 +1,33 @@
+= rpk redpanda stop
+:description: rpk redpanda stop
+
+Stop a local redpanda process. 'rpk stop'
+first sends SIGINT, and waits for the specified timeout. Then, if redpanda
+hasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still
+running.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda stop [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for stop.
+
+|`--timeout` |duration |The maximum amount of time to wait for redpanda to stop after each signal is sent (e.g. 300ms, 1.5s, 2h45m) (default 5s).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-tune-help.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-tune-help.adoc
@@ -1,0 +1,28 @@
+= rpk redpanda tune help
+:description: rpk redpanda tune help
+
+Display detailed information about the tuner
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune help [TUNER] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for help.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-tune-list.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-tune-list.adoc
@@ -1,0 +1,48 @@
+= rpk redpanda tune list
+:description: rpk redpanda tune list
+
+List available redpanda tuners and check if they are enabled and 
+supported by your system
+
+To enable a tuner it must be set in the `redpanda.yaml` configuration file
+under rpk section, e.g:
+
+  rpk:
+      tune_cpu: true
+      tune_swappiness: true
+
+You may use 'rpk redpanda config set' to enable or disable a tuner.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune list [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-r, --dirs` |strings |List of *data* directories or places to store data (e.g. /var/vectorized/redpanda/); usually your XFS filesystem on an NVMe SSD device.
+
+|`-d, --disks` |strings |Lists of devices to tune f.e. 'sda1'.
+
+|`-h, --help` |- |Help for list.
+
+|`-m, --mode` |string |Operation Mode: one of: [sq, sq_split, mq].
+
+|`-n, --nic` |strings |Network Interface Controllers to tune.
+
+|`--reboot-allowed` |- |Allow tuners to tune boot parameters and request system reboot.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda-tune.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda-tune.adoc
@@ -1,0 +1,64 @@
+= rpk redpanda tune
+:description: rpk redpanda tune
+
+Sets the OS parameters to tune system performance.
+
+Available tuners:
+
+  - all.
+  - disk_scheduler
+  - disk_nomerges
+  - disk_write_cache
+  - swappiness
+  - disk_irq
+  - clocksource
+  - ballast_file
+  - cpu
+  - net
+  - aio_events
+  - transparent_hugepages
+  - coredump
+  - fstrim
+
+To learn more about a tuner, run 'rpk redpanda tune help |tuner name|'.
+
+== Usage
+
+[,bash]
+----
+rpk redpanda tune [list of elements to tune] [flags]
+  rpk redpanda tune [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--cpu-set` |string |Set of CPUs for tuners to use in cpuset(7) format; if not specified, tuners will use all available CPUs (default "all").
+
+|`-r, --dirs` |strings |List of *data* directories or places to store data (e.g. /var/vectorized/redpanda/); usually your XFS filesystem on an NVMe SSD device.
+
+|`-d, --disks` |strings |Lists of devices to tune f.e. 'sda1'.
+
+|`-h, --help` |- |Help for tune.
+
+|`-m, --mode` |string |Operation Mode: one of: [sq, sq_split, mq].
+
+|`-n, --nic` |strings |Network Interface Controllers to tune.
+
+|`--output-script` |string |Generate a tuning file that can later be used to tune the system.
+
+|`--reboot-allowed` |- |Allow tuners to tune boot parameters and request system reboot.
+
+|`--timeout` |duration |The maximum time to wait for the tune processes to complete (e.g. 300ms, 1.5s, 2h45m) (default 10s).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-redpanda.adoc
+++ b/tools/gen/23.3-beta/rpk-redpanda.adoc
@@ -1,0 +1,29 @@
+= rpk redpanda
+:description: rpk redpanda
+
+Interact with a local Redpanda process
+
+== Usage
+
+[,bash]
+----
+rpk redpanda [flags]
+  rpk redpanda [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for redpanda.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-compatibility-level-get.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-compatibility-level-get.adoc
@@ -1,0 +1,36 @@
+= rpk registry compatibility-level get
+:description: rpk registry compatibility-level get
+
+Get the global or per-subject compatibility levels.
+
+Running this command with no subject returns the global level, alternatively
+you can use the --global flag to get the global level at the same time as
+per-subject levels.
+
+== Usage
+
+[,bash]
+----
+rpk registry compatibility-level get [SUBJECT...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--global` |- |Return the global level in addition to subject levels.
+
+|`-h, --help` |- |Help for get.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-compatibility-level-set.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-compatibility-level-set.adoc
@@ -1,0 +1,38 @@
+= rpk registry compatibility-level set
+:description: rpk registry compatibility-level set
+
+Set the global or per-subject compatibility levels.
+
+Running this command with no subject returns the global level, alternatively
+you can use the --global flag to set the global level at the same time as
+per-subject levels.
+
+== Usage
+
+[,bash]
+----
+rpk registry compatibility-level set [SUBJECT...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--global` |- |Set the global level in addition to subject levels.
+
+|`-h, --help` |- |Help for set.
+
+|`--level` |string |Level to set, one of NONE, {BACKWARD,FORWARD,FULL}{,_TRANSITIVE}.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-compatibility-level.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-compatibility-level.adoc
@@ -1,0 +1,31 @@
+= rpk registry compatibility-level
+:description: rpk registry compatibility-level
+
+Manage global or per-subject compatibility levels
+
+== Usage
+
+[,bash]
+----
+rpk registry compatibility-level [flags]
+  rpk registry compatibility-level [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`-h, --help` |- |Help for compatibility-level.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-schema-check-compatibility.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-schema-check-compatibility.adoc
@@ -1,0 +1,38 @@
+= rpk registry schema check-compatibility
+:description: rpk registry schema check-compatibility
+
+Check schema compatibility with existing schemas in the subject
+
+== Usage
+
+[,bash]
+----
+rpk registry schema check-compatibility SUBJECT [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for check-compatibility.
+
+|`--references` |string |Comma-separated list of references (name:subject:version) or path to reference file.
+
+|`--schema` |string |Schema filepath to check, must be .avro or .proto.
+
+|`--schema-version` |string |Schema version to check compatibility with (latest, 0, 1...).
+
+|`--type` |string |Schema type (avro,protobuf); overrides schema file extension.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-schema-create.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-schema-create.adoc
@@ -1,0 +1,58 @@
+= rpk registry schema create
+:description: rpk registry schema create
+
+Create a schema for the given subject.
+
+This uploads a schema to the registry, creating the schema if it does not
+exist. The schema type is detected by the filename extension: ".avro" or ".avsc"
+for Avro and ".proto" for Protobuf. You can manually specify the type with the 
+--type flag.
+
+You may pass the references using the --reference flag, which accepts either a
+comma separated list of |name|:<subject>:<version> or a path to a file. The file 
+must contain lines of name, subject, and version separated by a tab or space, or 
+the equivalent in json / yaml format.
+
+EXAMPLES
+
+Create a protobuf schema with subject 'foo':
+  rpk registry schema create foo --schema path/to/file.proto
+
+Create an avro schema, passing the type via flags:
+  rpk registry schema create foo --schema /path/to/file --type avro
+
+Create a protobuf schema that references the schema in subject 'my_subject', 
+version 1:
+  rpk registry schema create foo --schema /path/to/file.proto --references my_name:my_subject:1
+
+== Usage
+
+[,bash]
+----
+rpk registry schema create SUBJECT --schema {filename} [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for create.
+
+|`--references` |string |Comma-separated list of references (name:subject:version) or path to reference file.
+
+|`--schema` |string |Schema filepath to upload, must be .avro, .avsc, or .proto.
+
+|`--type` |string |Schema type (avro,protobuf); overrides schema file extension.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-schema-delete.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-schema-delete.adoc
@@ -1,0 +1,34 @@
+= rpk registry schema delete
+:description: rpk registry schema delete
+
+Delete a specific schema for the given subject
+
+== Usage
+
+[,bash]
+----
+rpk registry schema delete SUBJECT --schema-version {version} [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--permanent` |- |Perform a hard (permanent) delete of the schema.
+
+|`--schema-version` |string |Schema version to delete (latest, 0, 1...).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-schema-get.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-schema-get.adoc
@@ -1,0 +1,47 @@
+= rpk registry schema get
+:description: rpk registry schema get
+
+Get a schema by version, ID, or by an existing schema.
+
+This returns a lookup of an existing schema or schemas in one of a few
+potential (mutually exclusive) ways:
+
+* By version, returning a schema for a required subject and version
+* By ID, returning all subjects using the schema, or filtering for one subject
+* By schema, checking if the schema has been created in the subject
+
+== Usage
+
+[,bash]
+----
+rpk registry schema get [SUBJECT] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--deleted` |- |If true, also return deleted schemas.
+
+|`-h, --help` |- |Help for get.
+
+|`--id` |int |ID to lookup schemas usages of; subject optional.
+
+|`--schema` |string |Schema file to check existence of, must be .avro or .proto; subject required.
+
+|`--schema-version` |string |Schema version to lookup (latest, 0, 1...); subject required.
+
+|`--type` |string |Schema type of the file used to lookup (avro,protobuf); overrides schema file extension.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-schema-list.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-schema-list.adoc
@@ -1,0 +1,39 @@
+= rpk registry schema list
+:description: rpk registry schema list
+
+List the schemas for the requested subjects, or list all schemas
+
+== Usage
+
+[,bash]
+----
+rpk registry schema list [SUBJECT...] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--deleted` |- |If true, list deleted schemas as well.
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-schema-references.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-schema-references.adoc
@@ -1,0 +1,34 @@
+= rpk registry schema references
+:description: rpk registry schema references
+
+Retrieve a list of schemas that reference the subject
+
+== Usage
+
+[,bash]
+----
+rpk registry schema references SUBJECT --schema-version {version} [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--deleted` |- |If true, list deleted schemas as well.
+
+|`-h, --help` |- |Help for references.
+
+|`--schema-version` |string |Schema version to check references with (latest, 0, 1...).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-schema.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-schema.adoc
@@ -1,0 +1,31 @@
+= rpk registry schema
+:description: rpk registry schema
+
+Manage your schema registry schemas
+
+== Usage
+
+[,bash]
+----
+rpk registry schema [flags]
+  rpk registry schema [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`-h, --help` |- |Help for schema.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-subject-delete.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-subject-delete.adoc
@@ -1,0 +1,32 @@
+= rpk registry subject delete
+:description: rpk registry subject delete
+
+Soft or hard deletion of subjects
+
+== Usage
+
+[,bash]
+----
+rpk registry subject delete [SUBJECT...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--permanent` |- |Perform a hard (permanent) delete of the subject.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-subject-list.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-subject-list.adoc
@@ -1,0 +1,39 @@
+= rpk registry subject list
+:description: rpk registry subject list
+
+Display all subjects
+
+== Usage
+
+[,bash]
+----
+rpk registry subject list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--deleted` |- |If true, list deleted subjects as well.
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry-subject.adoc
+++ b/tools/gen/23.3-beta/rpk-registry-subject.adoc
@@ -1,0 +1,31 @@
+= rpk registry subject
+:description: rpk registry subject
+
+List or delete schema registry subjects
+
+== Usage
+
+[,bash]
+----
+rpk registry subject [flags]
+  rpk registry subject [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`-h, --help` |- |Help for subject.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-registry.adoc
+++ b/tools/gen/23.3-beta/rpk-registry.adoc
@@ -1,0 +1,36 @@
+= rpk registry
+:description: rpk registry
+
+Commands to interact with the schema registry
+
+== Usage
+
+[,bash]
+----
+rpk registry [flags]
+  rpk registry [command]
+----
+
+== Aliases
+
+[,bash]
+----
+registry, sr
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for registry.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic-add-partitions.adoc
+++ b/tools/gen/23.3-beta/rpk-topic-add-partitions.adoc
@@ -1,0 +1,32 @@
+= rpk topic add-partitions
+:description: rpk topic add-partitions
+
+Add partitions to existing topics.
+
+== Usage
+
+[,bash]
+----
+rpk topic add-partitions [TOPICS...] --num [#] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --force` |- |Force change the partition count in internal topics, e.g. __consumer_offsets.
+
+|`-h, --help` |- |Help for add-partitions.
+
+|`-n, --num` |int |Number of partitions to add to each topic.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic-alter-config.adoc
+++ b/tools/gen/23.3-beta/rpk-topic-alter-config.adoc
@@ -1,0 +1,51 @@
+= rpk topic alter-config
+:description: rpk topic alter-config
+
+Set, delete, add, and remove key/value configs for a topic.
+
+This command allows you to incrementally alter the configuration for multiple
+topics at a time.
+
+Incremental altering supports four operations:
+
+  1) Setting a key=value pair
+  2) Deleting a key's value
+  3) Appending a new value to a list-of-values key
+  4) Subtracting (removing) an existing value from a list-of-values key
+
+The --dry option will validate whether the requested configuration change is
+valid, but does not apply it.
+
+== Usage
+
+[,bash]
+----
+rpk topic alter-config [TOPICS...] --set key=value --delete key2,key3 [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--append` |stringArray |key=value; Value to append to a list-of-values key (repeatable).
+
+|`-d, --delete` |stringArray |Key to delete (repeatable).
+
+|`--dry` |- |Dry run: validate the alter request, but do not apply.
+
+|`-h, --help` |- |Help for alter-config.
+
+|`-s, --set` |stringArray |key=value; Pair to set (repeatable).
+
+|`--subtract` |stringArray |key=value; Value to remove from list-of-values key (repeatable).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic-consume.adoc
+++ b/tools/gen/23.3-beta/rpk-topic-consume.adoc
@@ -1,0 +1,307 @@
+= rpk topic consume
+:description: rpk topic consume
+
+Consume records from topics.
+
+Consuming records reads from any amount of input topics, formats each record
+according to --format, and prints them to STDOUT. The output formatter
+understands a wide variety of formats.
+
+The default output format "--format json" is a special format that outputs each
+record as JSON. There may be more single-word-no-escapes formats added later.
+Outside of these special formats, formatting follows the rules described below.
+
+Formatting output is based on percent escapes and modifiers. Slashes can be
+used for common escapes:
+
+    \t \n \r \\ \xNN
+
+prints tabs, newlines, carriage returns, slashes, or hex encoded characters.p
+
+Percent encoding prints record fields, fetch partition fields, or extra values:
+
+    %t    topic
+    %T    topic length
+    %k    key
+    %K    key length
+    %v    value
+    %V    value length
+    %h    begin the header specification
+    %H    number of headers
+    %p    partition
+    %o    offset
+    %e    leader epoch
+    %d    timestamp (formatting described below)
+    %a    record attributes (formatting described below)
+    %x    producer id
+    %y    producer epoch
+
+    %[    partition log start offset
+    %|    partition last stable offset
+    %]    partition high watermark
+
+    %%    percent sign
+    %{    left brace
+    %}    right brace
+
+    %i    the number of records formatted
+
+MODIFIERS
+
+Text and numbers can be formatted in many different ways, and the default
+format can be changed within brace modifiers. %v prints a value, while %v{hex}
+prints the value hex encoded. %T prints the length of a topic in ascii, while
+%T{big8} prints the length of the topic as an eight byte big endian.
+
+All modifiers go within braces following a percent-escape.
+
+NUMBERS
+
+Formatting number values can have the following modifiers:
+
+     ascii       print the number as ascii (default)
+
+     hex64       sixteen hex characters
+     hex32       eight hex characters
+     hex16       four hex characters
+     hex8        two hex characters
+     hex4        one hex character
+
+     big64       eight byte big endian number
+     big32       four byte big endian number
+     big16       two byte big endian number
+     big8        alias for byte
+
+     little64    eight byte little endian number
+     little32    four byte little endian number
+     little16    two byte little endian number
+     little8     alias for byte
+
+     byte        one byte number
+     bool        "true" if the number is non-zero, "false" if the number is zero
+
+All numbers are truncated as necessary per the modifier. Printing %V{byte} for
+a length 256 value will print a single null, whereas printing %V{big8} would
+print the bytes 1 and 0.
+
+When writing number sizes, the size corresponds to the size of the raw values,
+not the size of encoded values. "%T% t{hex}" for the topic "foo" will print
+"3 666f6f", not "6 666f6f".
+
+TIMESTAMPS
+
+By default, the timestamp field is printed as a millisecond number value. In
+addition to the number modifiers above, timestamps can be printed with either
+Go formatting or strftime formatting:
+
+    %d{go[2006-01-02T15:04:05Z07:00]}
+    %d{strftime[%F]}
+
+An arbitrary amount of brackets (or braces, or # symbols) can wrap your date
+formatting:
+
+    %d{strftime### [%F] ###}
+
+The above will print " [YYYY-MM-DD] ", while the surrounding three # on each
+side are used to wrap the formatting. Further details on Go time formatting can
+be found at https://pkg.go.dev/time, while further details on strftime
+formatting can be read by checking "man strftime".
+
+ATTRIBUTES
+
+Each record (or batch of records) has a set of possible attributes. Internally,
+these are packed into bit flags. Printing an attribute requires first selecting
+which attribute you want to print, and then optionally specifying how you want
+it to be printed:
+
+     %a{compression}
+     %a{compression;number}
+     %a{compression;big64}
+     %a{compression;hex8}
+
+Compression is by default printed as text ("none", "gzip", ...). Compression
+can be printed as a number with ";number", where number is any number
+formatting option described above. No compression is 0, gzip is 1, etc.
+
+     %a{timestamp-type}
+     %a{timestamp-type;big64}
+
+The record's timestamp type is printed as -1 for very old records (before
+timestamps existed), 0 for client generated timestamps, and 1 for broker
+generated timestamps. Number formatting can be controlled with ";number".
+
+     %a{transactional-bit}
+     %a{transactional-bit;bool}
+
+Prints 1 if the record a part of a transaction or 0 if it is not.
+Number formatting can be controlled with ";number".
+
+     %a{control-bit}
+     %a{control-bit;bool}
+
+Prints 1 if the record is a commit marker or 0 if it is not.
+Number formatting can be controlled with ";number".
+
+TEXT
+
+Text fields without modifiers default to writing the raw bytes. Alternatively,
+there are the following modifiers:
+
+    %t{hex}
+    %k{base64}
+    %v{base64raw}
+    %v{unpack[<bBhH>iIqQc.$]}
+
+The hex modifier hex encodes the text, the base64 modifier base64 encodes the
+text with standard encoding, and the base64raw modifier encodes the text with
+raw standard encoding. The unpack modifier has a further internal
+specification, similar to timestamps above:
+
+    x    pad character (does not parse input)
+    <    switch what follows to little endian
+    >    switch what follows to big endian
+
+    b    signed byte
+    B    unsigned byte
+    h    int16  ("half word")
+    H    uint16 ("half word")
+    i    int32
+    I    uint32
+    q    int64  ("quad word")
+    Q    uint64 ("quad word")
+
+    c    any character
+    .    alias for c
+    s    consume the rest of the input as a string
+    $    match the end of the line (append error string if anything remains)
+
+Unpacking text can allow translating binary input into readable output. If a
+value is a big-endian uint32, %v will print the raw four bytes, while
+%v{unpack[>I]} will print the number in as ascii. If unpacking exhausts the
+input before something is unpacked fully, an error message is appended to the
+output.
+
+HEADERS
+
+Headers are formatted with percent encoding inside of the modifier:
+
+    %h{ %k=%v{hex} }
+
+will print all headers with a space before the key and after the value, an
+equals sign between the key and value, and with the value hex encoded. Header
+formatting actually just parses the internal format as a record format, so all
+of the above rules about %K, %V, text, and numbers apply.
+
+EXAMPLES
+
+A key and value, separated by a space and ending in newline:
+    -f '%k %v\n'
+A key length as four big endian bytes, and the key as hex:
+    -f '%K{big32}%k{hex}'
+A little endian uint32 and a string unpacked from a value:
+    -f '%v{unpack[is$]}'
+
+OFFSETS
+
+The --offset flag allows for specifying where to begin consuming, and
+optionally, where to stop consuming. The literal words "start" and "end"
+specify consuming from the start and the end.
+
+    start     consume from the beginning
+    end       consume from the end
+    :end      consume until the current end
+    +oo       consume oo after the current start offset
+    -oo       consume oo before the current end offset
+    oo        consume after an exact offset
+    oo:       alias for oo
+    :oo       consume until an exact offset
+    o1:o2     consume from exact offset o1 until exact offset o2
+    @t        consume starting from a given timestamp
+    @t:       alias for @t
+    @:t       consume until a given timestamp
+    @t1:t2    consume from timestamp t1 until timestamp t2
+
+There are a few options for timestamps, with each option being evaluated
+until one succeeds:
+
+    13 digits             parsed as a unix millisecond
+    9 digits              parsed as a unix second
+    YYYY-MM-DD            parsed as a day, UTC
+    YYYY-MM-DDTHH:MM:SSZ  parsed as RFC3339, UTC; fractional seconds optional (.MMM)
+    end                   for t2 in @t1:t2, the current end of the partition
+    -dur                  a negative duration from now or from a timestamp
+    dur                   a positive duration from now or from a timestamp
+
+Durations can be relative to the current time or relative to a timestamp.
+If a duration is used for t1, that duration is relative to now.
+If a duration is used for t2, if t1 is a timestamp, then t2 is relative to t1.
+If a duration is used for t2, if t1 is a duration, then t2 is relative to now.
+
+Durations are parsed simply:
+
+    3ms    three milliseconds
+    10s    ten seconds
+    9m     nine minutes
+    1h     one hour
+    1m3ms  one minute and three milliseconds
+
+For example,
+
+    -o @2022-02-14:1h   consume 1h of time on Valentine's Day 2022
+    -o @-48h:-24h       consume from 2 days ago to 1 day ago
+    -o @-1m:end         consume from 1m ago until now
+    -o @:-1hr           consume from the start until an hour ago
+
+== Usage
+
+[,bash]
+----
+rpk topic consume TOPICS... [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-b, --balancer` |string |Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky) (default "cooperative-sticky").
+
+|`--fetch-max-bytes` |int32 |Maximum amount of bytes per fetch request per broker (default 1048576).
+
+|`--fetch-max-wait` |duration |Maximum amount of time to wait when fetching from a broker before the broker replies (default 5s).
+
+|`-f, --format` |string |Output format (see --help for details) (default "json").
+
+|`-g, --group` |string |Group to use for consuming (incompatible with -p).
+
+|`-h, --help` |- |Help for consume.
+
+|`--meta-only` |- |Print all record info except the record value (for -f json).
+
+|`-n, --num` |int |Quit after consuming this number of records (0 is unbounded).
+
+|`-o, --offset` |string |Offset to consume from / to (start, end, 47, +2, -3) (default "start").
+
+|`-p, --partitions` |int32 |int32Slice                     Comma delimited list of specific partitions to consume (default []).
+
+|`--pretty-print` |- |Pretty print each record over multiple lines (for -f json) (default true).
+
+|`--print-control-records` |- |Opt in to printing control records.
+
+|`--rack` |string |Rack to use for consuming, which opts into follower fetching.
+
+|`--read-committed` |- |Opt in to reading only committed offsets.
+
+|`-r, --regex` |- |Parse topics as regex; consume any topic that matches any expression.
+
+|`--use-schema-registry` |strings |[=key,value]   If present, rpk will decode the key and the value with the schema registry. Also accepts use-schema-registry=key or use-schema-registry=value.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic-create.adoc
+++ b/tools/gen/23.3-beta/rpk-topic-create.adoc
@@ -1,0 +1,46 @@
+= rpk topic create
+:description: rpk topic create
+
+Create topics.
+
+All topics created with this command will have the same number of partitions,
+replication factor, and key/value configs.
+
+For example,
+
+	create -c cleanup.policy=compact -r 3 -p 20 foo bar
+
+will create two topics, foo and bar, each with 20 partitions, 3 replicas, and
+the cleanup.policy=compact config option set.
+
+== Usage
+
+[,bash]
+----
+rpk topic create [TOPICS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --dry` |- |Dry run: validate the topic creation request; do not create topics.
+
+|`-h, --help` |- |Help for create.
+
+|`-p, --partitions` |int32 |Number of partitions to create per topic; -1 defaults to the cluster's default_topic_partitions (default -1).
+
+|`-r, --replicas` |int16 |Replication factor (must be odd); -1 defaults to the cluster's default_topic_replications (default -1).
+
+|`-c, --topic-config` |stringArray |key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic-delete.adoc
+++ b/tools/gen/23.3-beta/rpk-topic-delete.adoc
@@ -1,0 +1,49 @@
+= rpk topic delete
+:description: rpk topic delete
+
+Delete topics.
+
+This command deletes all requested topics, printing the success or fail status
+per topic.
+
+The --regex flag (-r) opts into parsing the input topics as regular expressions
+and deleting any non-internal topic that matches any of expressions. The input
+expressions are wrapped with ^ and $ so that the expression must match the
+whole topic name (which also prevents accidental delete-everything mistakes).
+
+The topic list command accepts the same input regex format as this delete
+command. If you want to check what your regular expressions will delete before
+actually deleting them, you can check the output of 'rpk topic list -r'.
+
+For example,
+
+    delete foo bar            # deletes topics foo and bar
+    delete -r '^f.*' '.*r$'   # deletes any topic starting with f and any topics ending in r
+    delete -r '.*'            # deletes all topics
+    delete -r .               # deletes any one-character topics
+
+== Usage
+
+[,bash]
+----
+rpk topic delete [TOPICS...] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`-r, --regex` |- |Parse topics as regex; delete any topic that matches any input topic expression.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic-describe-storage.adoc
+++ b/tools/gen/23.3-beta/rpk-topic-describe-storage.adoc
@@ -1,0 +1,70 @@
+= rpk topic describe-storage
+:description: rpk topic describe-storage
+
+Describe the topic storage status.
+
+This commands prints detailed information about the cloud storage status of a
+given topic, the information is divided in 4 sections:
+
+SUMMARY
+
+The summary section contains general information about the topic, the cloud
+storage mode (one of disabled, write_only, read_only, full, and read_replica),
+and the delta in milliseconds since the last upload of either the partition
+manifest or a segment.
+
+OFFSET
+
+The offset section contains the start and last offsets (inclusive) per
+partition of data available in both the cloud and on local disk.
+
+SIZE
+
+The size section contains the total bytes per partition in the cloud and on
+local disk, the total size of the log of each partition (excluding cloud and
+local overlap), and the number of segments in the cloud and on local disk. The
+cloud segment count does not include segments queued for deletion.
+
+SYNC
+
+The sync section contains the state of cloud synchronization: milliseconds
+since the last upload of the partition manifest, milliseconds since the last
+segment upload, milliseconds since the last manifest sync (for read replicas),
+and whether the remote metadata has a pending update to include all uploaded
+segments.
+
+== Usage
+
+[,bash]
+----
+rpk topic describe-storage [TOPIC] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for describe-storage.
+
+|`-H, --human-readable` |- |Print the times and bytes in a human-readable form.
+
+|`-a, --print-all` |- |Print all cloud storage status.
+
+|`-o, --print-offset` |- |Print the offset section.
+
+|`-z, --print-size` |- |Print the log size section.
+
+|`-s, --print-summary` |- |Print the summary section.
+
+|`-y, --print-sync` |- |Print the sync section.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic-describe.adoc
+++ b/tools/gen/23.3-beta/rpk-topic-describe.adoc
@@ -1,0 +1,49 @@
+= rpk topic describe
+:description: rpk topic describe
+
+Describe a topic.
+
+This command prints detailed information about a topic. There are three
+potential sections: a summary of the topic, the topic configs, and a detailed
+partitions section. By default, the summary and configs sections are printed.
+
+== Usage
+
+[,bash]
+----
+rpk topic describe [TOPIC] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+describe, info
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for describe.
+
+|`-a, --print-all` |- |Print all sections.
+
+|`-c, --print-configs` |- |Print the config section.
+
+|`-p, --print-partitions` |- |Print the detailed partitions section.
+
+|`-s, --print-summary` |- |Print the summary section.
+
+|`--stable` |- |Include the stable offsets column in the partitions section; only relevant if you produce to this topic transactionally.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic-list.adoc
+++ b/tools/gen/23.3-beta/rpk-topic-list.adoc
@@ -1,0 +1,58 @@
+= rpk topic list
+:description: rpk topic list
+
+List topics, optionally listing specific topics.
+
+This command lists all topics that you have access to by default. If specifying
+topics or regular expressions, this command can be used to know exactly what
+topics you would delete if using the same input to the delete command.
+
+Alternatively, you can request specific topics to list, which can be used to
+check authentication errors (do you not have access to a topic you were
+expecting to see?), or to list all topics that match regular expressions.
+
+The --regex flag (-r) opts into parsing the input topics as regular expressions
+and listing any non-internal topic that matches any of expressions. The input
+expressions are wrapped with ^ and $ so that the expression must match the
+whole topic name. Regular expressions cannot be used to match internal topics,
+as such, specifying both -i and -r will exit with failure.
+
+Lastly, --detailed flag (-d) opts in to printing extra per-partition
+information.
+
+== Usage
+
+[,bash]
+----
+rpk topic list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --detailed` |- |Print per-partition information for topics.
+
+|`-h, --help` |- |Help for list.
+
+|`-i, --internal` |- |Print internal topics.
+
+|`-r, --regex` |- |Parse topics as regex; list any topic that matches any input topic expression.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic-produce.adoc
+++ b/tools/gen/23.3-beta/rpk-topic-produce.adoc
@@ -1,0 +1,205 @@
+= rpk topic produce
+:description: rpk topic produce
+
+Produce records to a topic.
+
+Producing records reads from STDIN, parses input according to --format, and
+produce records to Redpanda. The input formatter understands a wide variety of
+formats.
+
+Parsing input operates on either sizes or on delimiters, both of which can be
+specified in the same formatting options. If using sizes to specify something,
+the size must come before what it is specifying. Delimiters match on an exact
+text basis. This command will quit with an error if any input fails to match
+your specified format.
+
+Slashes can be used for common escapes:
+
+    \t \n \r \\ \xNN
+
+matches tabs, newlines, carriage returns, slashes, and hex encoded characters.
+
+Percent encoding reads into specific values of a record:
+
+    %t    topic
+    %T    topic length
+    %k    key
+    %K    key length
+    %v    value
+    %V    value length
+    %h    begin the header specification
+    %H    number of headers
+    %p    partition (if using the --partition flag)
+
+Three escapes exist to parse characters that are used to modify the previous
+escapes:
+
+    %%    percent sign
+    %{    left brace
+    %}    right brace
+
+MODIFIERS
+
+Text and numbers can be read in multiple formats, and the default format can be
+changed within brace modifiers. %v reads a value, while %v{hex} reads a value
+and then hex decodes it before producing. %T reads the length of a topic from
+the input, while %T{3} reads exactly three bytes for a topic from the input.
+
+All modifiers go within braces following a percent-escape.
+
+NUMBERS
+
+Reading number values can have the following modifiers:
+
+     ascii       parse numeric digits until a non-numeric (default)
+
+     hex64       sixteen hex characters
+     hex32       eight hex characters
+     hex16       four hex characters
+     hex8        two hex characters
+     hex4        one hex character
+
+     big64       eight byte big endian number
+     big32       four byte big endian number
+     big16       two byte big endian number
+     big8        alias for byte
+
+     little64    eight byte little endian number
+     little32    four byte little endian number
+     little16    two byte little endian number
+     little8     alias for byte
+
+     byte        one byte number
+     <digits>    directly specify the length as this many digits
+     bool        read "true" as 1, "false" as 0
+
+When reading number sizes, the size corresponds to the size of the encoded
+values, not the decoded values. "%T{6}%t{hex}" will read six hex bytes and
+decode into three.
+
+TEXT
+
+Reading text values can have the following modifiers:
+
+    hex       read text then hex decode it
+    base64    read text then std-encoding base64 decode it
+    re        read text matching a regular expression
+    json      read text as json then compact it
+
+HEADERS
+
+Headers are parsed with an internal key / value specifier format. For example,
+the following will read three headers that begin and end with a space and are
+separated by an equal:
+
+    %H{3}%h{ %k=%v }
+
+SCHEMA-REGISTRY
+
+Records can be encoded using a specified schema from our schema registry. Use
+the '--schema-id' or '--schema-key-id' flags to define the schema ID, rpk will
+retrieve the schemas and encode the record accordingly.
+
+Additionally, utilizing 'topic' in the mentioned flags allows for the use of the
+Topic Name Strategy. This strategy identifies a schema subject name based on the
+topic itself. For example:
+
+Produce to 'foo', encode using the latest schema in the subject 'foo-value':
+    rpk topic produce foo --schema-id=topic
+
+For protobuf schemas, you can specify the fully qualified name of the message
+you want the record to be encoded with. Use the 'schema-type' flag or
+'schema-key-type'. If the schema contains only one message, specifying the
+message name is unnecessary. For example:
+
+Produce to 'foo', using schema ID 1, message FQN Person.Name
+    rpk topic produce foo --schema-id 1 --schema-type Person.Name
+
+EXAMPLES
+
+In the below examples, we can parse many records at once. The produce command
+reads input and tokenizes based on your specified format. Every time the format
+is completely matched, a record is produced and parsing begins anew.
+
+A key and value, separated by a space and ending in newline:
+    -f '%k %v\n'
+A four byte topic, four byte key, and four byte value:
+    -f '%T{4}%K{4}%V{4}%t%k%v'
+A value to a specific partition, if using a non-negative --partition flag:
+    -f '%p %v\n'
+A big-endian uint16 key size, the text " foo ", and then that key:
+    -f '%K{big16} foo %k'
+A value that can be two or three characters followed by a newline:
+    -f '%v{re#...?#}\n'
+A key and a json value, separated by a space:
+    -f '%k %v{json}'
+
+MISC
+
+Producing requires a topic to produce to. The topic can be specified either
+directly on as an argument, or in the input text through %t. A parsed topic
+takes precedence over the default passed in topic. If no topic is specified
+directly and no topic is parsed, this command will quit with an error.
+
+The input format can parse partitions to produce directly to with %p. Doing so
+requires specifying a non-negative --partition flag. Any parsed partition
+takes precedence over the --partition flag; specifying the flag is the main
+requirement for being able to directly control which partition to produce to.
+
+You can also specify an output format to write when a record is produced
+successfully. The output format follows the same formatting rules as the topic
+consume command. See that command's help text for a detailed description.
+
+== Usage
+
+[,bash]
+----
+rpk topic produce [TOPIC] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`--acks` |int |Number of acks required for producing (-1=all, 0=none, 1=leader) (default -1).
+
+|`--allow-auto-topic-creation` |- |Auto-create non-existent topics; requires auto_create_topics_enabled on the broker.
+
+|`-z, --compression` |string |Compression to use for producing batches (none, gzip, snappy, lz4, zstd) (default "snappy").
+
+|`--delivery-timeout` |duration |Per-record delivery timeout, if non-zero, min 1s.
+
+|`-f, --format` |string |Input record format (default "%v\n").
+
+|`-H, --header` |stringArray |Headers in format key:value to add to each record (repeatable).
+
+|`-h, --help` |- |Help for produce.
+
+|`-k, --key` |string |A fixed key to use for each record (parsed input keys take precedence).
+
+|`--max-message-bytes` |int32 |If non-negative, maximum size of a record batch before compression (default -1).
+
+|`-o, --output-format` |string |what to write to stdout when a record is successfully produced (default "Produced to partition %p at offset %o with timestamp %d.\n").
+
+|`-p, --partition` |int32 |Partition to directly produce to, if non-negative (also allows %p parsing to set partitions) (default -1).
+
+|`--schema-id` |string |Schema ID to encode the record value with, use 'topic' for TopicName strategy.
+
+|`--schema-key-id` |string |Schema ID to encode the record key with, use 'topic' for TopicName strategy.
+
+|`--schema-key-type` |string |Name of the protobuf message type to be used to encode the record key using schema registry.
+
+|`--schema-type` |string |Name of the protobuf message type to be used to encode the record value using schema registry.
+
+|`-Z, --tombstone` |- |Produce empty values as tombstones.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic-trim-prefix.adoc
+++ b/tools/gen/23.3-beta/rpk-topic-trim-prefix.adoc
@@ -1,0 +1,72 @@
+= rpk topic trim-prefix
+:description: rpk topic trim-prefix
+
+Trim records from topics
+
+This command allows you to trim records from topics, to trim the topics Redpanda
+sets the LogStartOffset for partitions to the requested offset. All segments
+whose base offset is less then the requested offset are deleted, and any records
+within the segment before the requested offset can no longer be read.
+
+The --offset/-o flag allows you to indicate which index you want to set the
+partition's low watermark (start offset) to. It can be a single integer value
+denoting the offset or a timestamp if you prefix the offset with an '@'. You may
+select which partition you want to trim the offset from with the --partition/-p
+flag.
+
+The --from-file option allows to trim the offsets specified in a text file with
+the following format:
+    [TOPIC] [PARTITION] [OFFSET]
+    [TOPIC] [PARTITION] [OFFSET]
+    ...
+or the equivalent keyed JSON/YAML file.
+
+EXAMPLES
+
+Trim records in 'foo' topic to offset 120 in partition 1
+    rpk topic trim-prefix foo --offset 120 --partition 1
+
+Trim records in all partitions of topic foo previous to an specific timestamp
+    rpk topic trim-prefix foo -o "@1622505600"
+
+Trim records from a JSON file
+    rpk topic trim-prefix --from-file /tmp/to_trim.json
+
+== Usage
+
+[,bash]
+----
+rpk topic trim-prefix [TOPIC] [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+trim-prefix, trim
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-f, --from-file` |string |File of topic/partition/offset for which to trim offsets for.
+
+|`-h, --help` |- |Help for trim-prefix.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`-o, --offset` |string |Offset to set the partition's start offset to (end, 47, @<timestamp>).
+
+|`-p, --partitions` |int32 |int32Slice   Comma-separated list of partitions to trim records from (default to all) (default []).
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-topic.adoc
+++ b/tools/gen/23.3-beta/rpk-topic.adoc
@@ -1,0 +1,29 @@
+= rpk topic
+:description: rpk topic
+
+Create, delete, produce to and consume from Redpanda topics
+
+== Usage
+
+[,bash]
+----
+rpk topic [flags]
+  rpk topic [command]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for topic.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-transform-build.adoc
+++ b/tools/gen/23.3-beta/rpk-transform-build.adoc
@@ -1,0 +1,41 @@
+= rpk transform build
+:description: rpk transform build
+
+Build a transform.
+
+This command looks in the current working directory for a transform.yaml file.
+It installs the appropriate build plugin, then builds a .wasm file.
+
+When invoked, it passes extra arguments directly to the underlying toolchain.
+
+For example to add debug symbols for tinygo:
+
+  rpk transform build -- -no-debug=false
+
+LANGUAGES
+
+Tinygo - By default tinygo are release builds (-opt=2) for maximum performance.
+
+== Usage
+
+[,bash]
+----
+rpk transform build [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for build.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-transform-delete.adoc
+++ b/tools/gen/23.3-beta/rpk-transform-delete.adoc
@@ -1,0 +1,30 @@
+= rpk transform delete
+:description: rpk transform delete
+
+Delete a data transform
+
+== Usage
+
+[,bash]
+----
+rpk transform delete [NAME] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for delete.
+
+|`--no-confirm` |- |Disable confirmation prompt.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-transform-deploy.adoc
+++ b/tools/gen/23.3-beta/rpk-transform-deploy.adoc
@@ -1,0 +1,55 @@
+= rpk transform deploy
+:description: rpk transform deploy
+
+Deploy a transform.
+
+When run in the same directory as a transform.yaml, this reads the configuration
+file, then looks for a .wasm file with the same name as your project. If the
+input and output topics are specified in the configuration file, those are used.
+Otherwise, the topics can be specified on the command line using the 
+--input-topic and --output-topic flags.
+
+To deploy Wasm files directly without a transform.yaml file:
+
+  rpk transform deploy transform.wasm --name myTransform \
+    --input-topic my-topic-1 \
+    --output-topic my-topic-2
+
+Environment variables can be specified for the transform using the --var flag, these
+are separated by an equals for example: --var=KEY=VALUE
+
+The --var flag can be repeated to specify multiple variables like so:
+
+  rpk transform deploy --var FOO=BAR --var FIZZ=BUZZ
+
+== Usage
+
+[,bash]
+----
+rpk transform deploy [WASM] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for deploy.
+
+|`-i, --input-topic` |string |The input topic to apply the transform to.
+
+|`--name` |string |The name of the transform.
+
+|`-o, --output-topic` |string |The output topic to write the transform results to.
+
+|`--var` |- |environmentVariable   Specify an environment variable in the form of KEY=VALUE.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-transform-init.adoc
+++ b/tools/gen/23.3-beta/rpk-transform-init.adoc
@@ -1,0 +1,42 @@
+= rpk transform init
+:description: rpk transform init
+
+Initialize a transform.
+
+Create a new transform using a template in the current directory.
+
+A new directory to create by specifying it in the command:
+
+  rpk transform init foobar
+
+This initializes a transform project in the foobar directory.
+
+== Usage
+
+[,bash]
+----
+rpk transform init [DIRECTORY] [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for init.
+
+|`--install-deps` |- |If dependencies should be installed for the project (default prompt).
+
+|`-l, --language` |string |The language used to develop the transform.
+
+|`--name` |string |The name of the transform.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-transform-list.adoc
+++ b/tools/gen/23.3-beta/rpk-transform-list.adoc
@@ -1,0 +1,48 @@
+= rpk transform list
+:description: rpk transform list
+
+List data transforms.
+
+This command lists all data transforms in a cluster, as well as showing the
+state of a individual transform processor, such as if it's errored or how many
+records are pending to be processed (lag).
+
+There is a processor assigned to each partition on the input topic, and each
+processor is a separate entity that can make progress or fail independently.
+
+The --detailed flag (-d) opts in to printing extra per-processor information.
+
+== Usage
+
+[,bash]
+----
+rpk transform list [flags]
+----
+
+== Aliases
+
+[,bash]
+----
+list, ls
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-d, --detailed` |- |Print per-partition information for data transforms.
+
+|`--format` |string |Output format (json,yaml,text,wide,help) (default "text").
+
+|`-h, --help` |- |Help for list.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-transform.adoc
+++ b/tools/gen/23.3-beta/rpk-transform.adoc
@@ -1,0 +1,36 @@
+= rpk transform
+:description: rpk transform
+
+Develop, deploy and manage Redpanda data transforms
+
+== Usage
+
+[,bash]
+----
+rpk transform [flags]
+  rpk transform [command]
+----
+
+== Aliases
+
+[,bash]
+----
+transform, wasm, transfrom
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for transform.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===

--- a/tools/gen/23.3-beta/rpk-version.adoc
+++ b/tools/gen/23.3-beta/rpk-version.adoc
@@ -1,0 +1,34 @@
+= rpk version
+:description: rpk version
+
+Prints the current rpk and Redpanda version.
+
+This command prints the current rpk version and allows you to list the Redpanda 
+version running on each node in your cluster.
+
+To list the Redpanda version of each node in your cluster you may pass the
+Admin API hosts via flags, profile, or environment variables.
+
+== Usage
+
+[,bash]
+----
+rpk version [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a]
+|===
+|*Value* |*Type* |*Description*
+
+|`-h, --help` |- |Help for version.
+
+|`--config` |string |Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/`redpanda.yaml`.
+
+|`-X, --config-opt` |stringArray |Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail.
+
+|`--profile` |string |rpk profile to use.
+
+|`-v, --verbose` |- |Enable verbose logging.
+|===


### PR DESCRIPTION
This PR adds the rpk commands extracted  for every available of Redpanda. This makes them easy to compare between versions. 

Those files are the RAW versions, meaning that they're not ready to be published without some special edits.

They should only be used for comparisons between versions 