### PR TITLE
adds TOC display attribute + note about Serverless limits

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/serverless.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/serverless.adoc
@@ -37,6 +37,11 @@ Your applications talk to Serverless over the public internet using encrypted co
 
 === Limitations
 
+[NOTE]
+====
+Subject to change after the Serverless Beta release.
+====
+
 Each Serverless cluster has the following limits:
 
 * Ingress: up to 10 MBps, 0.5 MBps guaranteed

--- a/modules/deploy/pages/deployment-option/cloud/serverless.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/serverless.adoc
@@ -7,7 +7,7 @@ Redpanda Serverless is the fastest and easiest way to start event streaming in t
 
 == What is Redpanda Serverless?
 
-Serverless is a managed streaming service (Kafka API) that completely abstracts users from scaling and operational concerns, and you only pay for what you use. It provides data isolation and data residency:
+Redpanda Serverless is a multi-tenant, globally-distributed managed streaming service (Kafka API) that abstracts users from scaling and operational concerns. It applies usage-based billing, so you only pay for what you consume. Serverless clusters provide data isolation and data residency:
 
 * Your data is hosted on Redpanda Cloud clusters shared among multiple tenants. Other tenants never access your data.
 * Your data is stored in the Redpanda Cloud account, in the region you select. Data never leaves that region.
@@ -39,7 +39,7 @@ Your applications talk to Serverless over the public internet using encrypted co
 
 [NOTE]
 ====
-Subject to change after the Serverless Beta release.
+These baseline limits are subject to change after the Serverless Beta release.
 ====
 
 Each Serverless cluster has the following limits:
@@ -114,48 +114,13 @@ The Redpanda Cloud *Overview* page lists your bootstrap server URL and security 
 
 Serverless clusters work with all Kafka clients. For more information, see xref:develop:kafka-clients.adoc[].
 
-Serverless clusters support all major Apache Kafka messages for managing topics, producing/consuming data (including transactions), managing groups, managing offsets, and managing ACLs. (User management is available in the Redpanda Cloud UI or with `rpk acl`.) The following Kafka messages are supported:
+Serverless clusters support all major Apache Kafka messages for managing topics, producing/consuming data (including transactions), managing groups, managing offsets, and managing ACLs. (User management is available in the Redpanda Cloud UI or with `rpk acl`.) 
 
-* `Produce`                     
-* `Fetch`                     
-* `ListOffsets`                 
-* `Metadata`                    
-* `OffsetCommit`                
-* `OffsetFetch`                 
-* `FindCoordinator`             
-* `JoinGroup`                   
-* `Heartbeat`                   
-* `LeaveGroup`                  
-* `SyncGroup`                   
-* `DescribeGroups`              
-* `ListGroups`                  
-* `SASLHandshake`               
-* `ApiVersions`                 
-* `CreateTopics`                
-* `DeleteTopics`                
-* `DeleteRecords`               
-* `InitProducerID`              
-* `OffsetForLeaderEpoch`        
-* `AddPartitionsToTxn`          
-* `AddOffsetsToTxn`             
-* `EndTxn`                      
-* `TxnOffsetCommit`             
-* `DescribeACLs`                
-* `CreateACLs`                  
-* `DeleteACLs`                  
-* `DescribeConfigs`             
-* `AlterConfigs`                
-* `AlterReplicaLogDirs`         
-* `DescribeLogDirs`             
-* `SASLAuthenticate`            
-* `CreatePartitions`            
-* `DeleteGroups`                
-* `IncrementalAlterConfigs`
+==== Unsupported features
 
-=== Unsupported features
+Redpanda Serverless currently only supports the Kafka API. The Redpanda Admin, HTTP Proxy, and Schema Registry APIs are not exposed. You can use an external schema registry. 
 
-The following features are supported in Redpanda Dedicated and BYOC clusters, but they are not yet supported in Serverless clusters: 
+The following features are not yet supported in Serverless clusters: 
 
-* Redpanda Admin, HTTP Proxy, and Schema Registry APIs (You can use an external schema registry.)
 * Managed connectors
 * Data transforms

--- a/modules/deploy/pages/deployment-option/cloud/serverless.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/serverless.adoc
@@ -118,7 +118,7 @@ Serverless clusters support all major Apache Kafka messages for managing topics,
 
 ==== Unsupported features
 
-Redpanda Serverless currently only supports the Kafka API. The Redpanda Admin, HTTP Proxy, and Schema Registry APIs are not exposed. You can use an external schema registry. 
+Redpanda Serverless supports the Kafka API. The Redpanda Admin, HTTP Proxy, and Schema Registry APIs are not exposed. You can use an external schema registry. 
 
 The following features are not yet supported in Serverless clusters: 
 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -1,12 +1,13 @@
 = What's New in Redpanda Cloud
 :description: Summary of new features in Redpanada Cloud releases.
 :page-cloud: true
+:page-toclevels: 1
 
 This topic lists new features added in Redpanda Cloud.
 
 == December 2023: Beta
 
-==== Serverless clusters
+=== Serverless clusters
 
 xref:deploy:deployment-option/cloud/serverless.adoc[Redpanda Serverless] is a managed streaming service (Kafka API) that completely abstracts users from scaling and operational concerns, and you only pay for what you consume. It's the fastest and easiest way to start event streaming in the cloud. You can try the Beta release of Redpanda Serverless with a free trial. 
 


### PR DESCRIPTION
fixes https://github.com/redpanda-data/documentation-private/issues/2142

This adds :page-toclevels: 1 to change the TOC headings to display on the What's New in Cloud page. It also adds some edits per https://redpandadata.slack.com/archives/C02DKEQE50S/p1702332380604179

Preview: 
- https://deploy-preview-172--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/serverless/
- https://deploy-preview-172--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/whats-new-cloud/