### PR TITLE
Escape all closing square brackets in link text apart from the last

### DIFF
--- a/.github/workflows/generate-helm-spec.yml
+++ b/.github/workflows/generate-helm-spec.yml
@@ -58,9 +58,9 @@ jobs:
 
       - name: Modify third-level headings format
         run: |
-          sed -i 's/\(\[.*\)\]\(.*\]\)/\1\\]\2/' ./redpanda-docs/modules/reference/pages/redpanda-helm-spec.adoc
-          sed -i 's/\(\[.*\)\]\(.*\]\)/\1\\]\2/' ./redpanda-docs/modules/reference/pages/console-helm-spec.adoc
-          sed -i 's/\(\[.*\)\]\(.*\]\)/\1\\]\2/' ./redpanda-docs/modules/reference/pages/connector-helm-spec.adoc
+          sed -i ':a; s/\(\[[^]]*\)\]\([^]]*\)\]/\1\\]\2]/; ta' ./redpanda-docs/modules/reference/pages/redpanda-helm-spec.adoc
+          sed -i ':a; s/\(\[[^]]*\)\]\([^]]*\)\]/\1\\]\2]/; ta' ./redpanda-docs/modules/reference/pages/console-helm-spec.adoc
+          sed -i ':a; s/\(\[[^]]*\)\]\([^]]*\)\]/\1\\]\2]/; ta' ./redpanda-docs/modules/reference/pages/connector-helm-spec.adoc
           sed -i 's/=== \(http\([^[]\|\%5[BbDd]\)*\)\[\([^]]*\)\]/=== link:++\1++\[\3\]/' ./redpanda-docs/modules/reference/pages/redpanda-helm-spec.adoc
           sed -i 's/=== \(http\([^[]\|\%5[BbDd]\)*\)\[\([^]]*\)\]/=== link:++\1++\[\3\]/' ./redpanda-docs/modules/reference/pages/console-helm-spec.adoc
           sed -i 's/=== \(http\([^[]\|\%5[BbDd]\)*\)\[\([^]]*\)\]/=== link:++\1++\[\3\]/' ./redpanda-docs/modules/reference/pages/connector-helm-spec.adoc


### PR DESCRIPTION
I noticed that we are only currently escaping the first closing `]`, which results in broken formatting.

We need examples such as `[ingress.hosts[0].paths[0].path]` to become `[ingress.hosts[0\].paths[0\].path]`.