### PR TITLE
Add Kubernetes steps for cluster restore

### DIFF
--- a/modules/manage/pages/audit-logging.adoc
+++ b/modules/manage/pages/audit-logging.adoc
@@ -30,7 +30,7 @@ Redpanda's audit logging mechanism supports several options to control the volum
 * `audit_exclude_topics` : List of strings in JSON style identifying the topics the audit logging system should ignore. Default: null.
 * `audit_exclude_principals` : List of strings in JSON style identifying the principals the audit logging system should ignore. Principals can be listed as `User:name` or `name`, both are accepted. Default: null.
 
-Even though audited event messages are stored to a specialized immutable topic, standard xref:develop:config-topics.adoc[topic settings] still apply. For example, you can apply the same tiered storage, retention time, and replication settings available to normal topics. These particular options are important for controlling the amount of disk space utilized by your audit topics.
+Even though audited event messages are stored to a specialized immutable topic, standard xref:develop:config-topics.adoc[topic settings] still apply. For example, you can apply the same Tiered Storage, retention time, and replication settings available to normal topics. These particular options are important for controlling the amount of disk space utilized by your audit topics.
 
 IMPORTANT: You must configure certain audit logging properties before enabling audit logging because these settings impact the creation of the `__audit_log` topic itself. These properties include: `audit_log_num_partitions` and `audit_log_replication_factor`. The Kafka API allows you to add partitions or alter the replication factor after enabling audit logging, but Redpanda prevents you from altering these two configuration values directly.
 
@@ -59,8 +59,8 @@ Follow this sequence of commands in rpk to configure audit logging:
 
 == Optimize costs for audit logging
 
-By default, audit logging is turned off. When enabled, audit logging can quickly generate a very large amount of data, especially if all event types are selected. Proper configuration of audit logging is critical for avoiding filling your disk or using excess tiered storage. The configuration options available help ensure your audit logs contain only the volume of data necessary to meeting your regulatory or legal requirements.
+By default, audit logging is turned off. When enabled, audit logging can quickly generate a very large amount of data, especially if all event types are selected. Proper configuration of audit logging is critical for avoiding filling your disk or using excess Tiered Storage. The configuration options available help ensure your audit logs contain only the volume of data necessary to meeting your regulatory or legal requirements.
 
-With audit logging, your own systems are both producer and consumer for the messages. The pattern of message generation may be very different from your typical sources of data. As a result, your retention, replication, and tiered storage requirements may differ from your other topics.
+With audit logging, your own systems are both producer and consumer for the messages. The pattern of message generation may be very different from your typical sources of data. As a result, your retention, replication, and Tiered Storage requirements may differ from your other topics.
 
 A typical scenario with audit logging is to route the messages to an analytics platform like Splunk. If your retention period is excessively long, for example, you will find yourself storing very large amounts of replicated messages in both Redpanda and in your analytics suite. Finding the right balance of retention and replication settings minimizes this duplication while retaining your data in a system and finding actionable intelligence from it.

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -74,11 +74,12 @@ spec:
   chartRef: {}
   clusterSpec:
     storage:
-      tieredConfig:
-        cloud_storage_enabled: true
-        cloud_storage_credentials_source: aws_instance_metadata
-        cloud_storage_region: <region>
-        cloud_storage_bucket: <redpanda-bucket-name>
+      tiered:
+        config:
+          cloud_storage_enabled: true
+          cloud_storage_credentials_source: aws_instance_metadata
+          cloud_storage_region: <region>
+          cloud_storage_bucket: <redpanda-bucket-name>
 ----
 
 ```bash
@@ -96,11 +97,12 @@ Helm::
 [,yaml]
 ----
 storage:
-  tieredConfig:
-    cloud_storage_enabled: true
-    cloud_storage_credentials_source: aws_instance_metadata
-    cloud_storage_region: <region>
-    cloud_storage_bucket: <redpanda-bucket-name>
+  tiered:
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: aws_instance_metadata
+      cloud_storage_region: <region>
+      cloud_storage_bucket: <redpanda-bucket-name>
 ----
 +
 ```bash
@@ -112,10 +114,10 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set storage.tieredConfig.cloud_storage_enabled=true \
-  --set storage.tieredConfig.cloud_storage_credentials_source=aws_instance_metadata \
-  --set storage.tieredConfig.cloud_storage_region=<region> \
-  --set storage.tieredConfig.cloud_storage_bucket=<redpanda-bucket-name>
+  --set storage.tiered.config.cloud_storage_enabled=true \
+  --set storage.tiered.config.cloud_storage_credentials_source=aws_instance_metadata \
+  --set storage.tiered.config.cloud_storage_region=<region> \
+  --set storage.tiered.config.cloud_storage_bucket=<redpanda-bucket-name>
 ```
 ====
 --
@@ -137,7 +139,7 @@ To configure access to an S3 bucket with access keys instead of an IAM role:
 - `PutObjectTagging`
 - `ListBucket`
 
-. Copy the access key and secret key for the `storage.tieredConfig.cloud_storage_access_key` and `storage.tieredConfig.cloud_storage_secret_key` cluster properties.
+. Copy the access key and secret key for the `storage.tiered.config.cloud_storage_access_key` and `storage.tiered.config.cloud_storage_secret_key` cluster properties.
 . Override the following required cluster properties in the Helm chart:
 +
 [tabs]
@@ -156,13 +158,14 @@ spec:
   chartRef: {}
   clusterSpec:
     storage:
-      tieredConfig:
-        cloud_storage_enabled: true
-        cloud_storage_credentials_source: config_file
-        cloud_storage_access_key: <access-key>
-        cloud_storage_secret_key: <secret-key>
-        cloud_storage_region: <region>
-        cloud_storage_bucket: <redpanda-bucket-name>
+      tiered:
+        config:
+          cloud_storage_enabled: true
+          cloud_storage_credentials_source: config_file
+          cloud_storage_access_key: <access-key>
+          cloud_storage_secret_key: <secret-key>
+          cloud_storage_region: <region>
+          cloud_storage_bucket: <redpanda-bucket-name>
 ----
 
 ```bash
@@ -180,13 +183,14 @@ Helm::
 [,yaml]
 ----
 storage:
-  tieredConfig:
-    cloud_storage_enabled: true
-    cloud_storage_credentials_source: config_file
-    cloud_storage_access_key: <access-key>
-    cloud_storage_secret_key: <secret-key>
-    cloud_storage_region: <region>
-    cloud_storage_bucket: <redpanda-bucket-name>
+  tiered:
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: config_file
+      cloud_storage_access_key: <access-key>
+      cloud_storage_secret_key: <secret-key>
+      cloud_storage_region: <region>
+      cloud_storage_bucket: <redpanda-bucket-name>
 ----
 +
 ```bash
@@ -197,12 +201,12 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set storage.tieredConfig.cloud_storage_enabled=true \
-  --set storage.tieredConfig.cloud_storage_credentials_source=config_file \
-  --set storage.tieredConfig.cloud_storage_access_key=<access-key> \
-  --set storage.tieredConfig.cloud_storage_secret_key=<secret-key> \
-  --set storage.tieredConfig.cloud_storage_region=<region> \
-  --set storage.tieredConfig.cloud_storage_bucket=<redpanda_bucket_name>
+  --set storage.tiered.config.cloud_storage_enabled=true \
+  --set storage.tiered.config.cloud_storage_credentials_source=config_file \
+  --set storage.tiered.config.cloud_storage_access_key=<access-key> \
+  --set storage.tiered.config.cloud_storage_secret_key=<secret-key> \
+  --set storage.tiered.config.cloud_storage_region=<region> \
+  --set storage.tiered.config.cloud_storage_bucket=<redpanda_bucket_name>
 ```
 ====
 --
@@ -242,11 +246,12 @@ spec:
   chartRef: {}
   clusterSpec:
     storage:
-      tieredConfig:
-        cloud_storage_enabled: true
-        cloud_storage_credentials_source: gcp_instance_metadata
-        cloud_storage_region: <region>
-        cloud_storage_bucket: <redpanda-bucket-name>
+      tiered:
+        config:
+          cloud_storage_enabled: true
+          cloud_storage_credentials_source: gcp_instance_metadata
+          cloud_storage_region: <region>
+          cloud_storage_bucket: <redpanda-bucket-name>
 ----
 
 ```bash
@@ -264,11 +269,12 @@ Helm::
 [,yaml]
 ----
 storage:
-  tieredConfig:
-    cloud_storage_enabled: true
-    cloud_storage_credentials_source: gcp_instance_metadata
-    cloud_storage_region: <region>
-    cloud_storage_bucket: <redpanda-bucket-name>
+  tiered:
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: gcp_instance_metadata
+      cloud_storage_region: <region>
+      cloud_storage_bucket: <redpanda-bucket-name>
 ----
 +
 ```bash
@@ -279,10 +285,10 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set storage.tieredConfig.cloud_storage_enabled=true \
-  --set storage.tieredConfig.cloud_storage_credentials_source=aws_instance_metadata \
-  --set storage.tieredConfig.cloud_storage_region=<region> \
-  --set storage.tieredConfig.cloud_storage_bucket=<redpanda-bucket-name>
+  --set storage.tiered.config.cloud_storage_enabled=true \
+  --set storage.tiered.config.cloud_storage_credentials_source=aws_instance_metadata \
+  --set storage.tiered.config.cloud_storage_region=<region> \
+  --set storage.tiered.config.cloud_storage_bucket=<redpanda-bucket-name>
 ```
 ====
 --
@@ -319,14 +325,15 @@ spec:
   chartRef: {}
   clusterSpec:
     storage:
-      tieredConfig:
-        cloud_storage_enabled: true
-        cloud_storage_credentials_source: config_file
-        cloud_storage_api_endpoint: storage.googleapis.com
-        cloud_storage_access_key: <access-key>
-        cloud_storage_secret_key: <secret-key>
-        cloud_storage_region: <region>
-        cloud_storage_bucket: <redpanda-bucket-name>
+      tiered:
+        config:
+          cloud_storage_enabled: true
+          cloud_storage_credentials_source: config_file
+          cloud_storage_api_endpoint: storage.googleapis.com
+          cloud_storage_access_key: <access-key>
+          cloud_storage_secret_key: <secret-key>
+          cloud_storage_region: <region>
+          cloud_storage_bucket: <redpanda-bucket-name>
 ----
 
 ```bash
@@ -344,14 +351,15 @@ Helm::
 [,yaml]
 ----
 storage:
-  tieredConfig:
-    cloud_storage_enabled: true
-    cloud_storage_credentials_source: config_file
-    cloud_storage_api_endpoint: storage.googleapis.com
-    cloud_storage_access_key: <access-key>
-    cloud_storage_secret_key: <secret-key>
-    cloud_storage_region: <region>
-    cloud_storage_bucket: <redpanda-bucket-name>
+  tiered:
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: config_file
+      cloud_storage_api_endpoint: storage.googleapis.com
+      cloud_storage_access_key: <access-key>
+      cloud_storage_secret_key: <secret-key>
+      cloud_storage_region: <region>
+      cloud_storage_bucket: <redpanda-bucket-name>
 ----
 +
 ```bash
@@ -362,13 +370,13 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set storage.tieredConfig.cloud_storage_enabled=true \
-  --set storage.tieredConfig.cloud_storage_credentials_source=config_file \
-  --set storage.tieredConfig.cloud_storage_api_endpoint=storage.googleapis.com \
-  --set storage.tieredConfig.cloud_storage_access_key=<access-key> \
-  --set storage.tieredConfig.cloud_storage_secret_key=<secret-key> \
-  --set storage.tieredConfig.cloud_storage_region=<region> \
-  --set storage.tieredConfig.cloud_storage_bucket=<redpanda_bucket_name>
+  --set storage.tiered.config.cloud_storage_enabled=true \
+  --set storage.tiered.config.cloud_storage_credentials_source=config_file \
+  --set storage.tiered.config.cloud_storage_api_endpoint=storage.googleapis.com \
+  --set storage.tiered.config.cloud_storage_access_key=<access-key> \
+  --set storage.tiered.config.cloud_storage_secret_key=<secret-key> \
+  --set storage.tiered.config.cloud_storage_region=<region> \
+  --set storage.tiered.config.cloud_storage_bucket=<redpanda_bucket_name>
 ```
 ====
 --
@@ -386,7 +394,7 @@ IMPORTANT: Do not set an object storage property to an empty string `""` or to `
 ==== Microsoft ABS/ADLS
 
 
-NOTE: Starting in release 23.2.8, Redpanda supports storage accounts configured for ADLS Gen2 with https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-namespace[hierarchical namespaces^] enabled. For hierarchical namespaces created with a custom endpoint, set the properties `cloud_storage_azure_adls_endpoint` and `cloud_storage_azure_adls_port` in the Helm chart through the command line (`--set storage.tieredConfig`) or the YAML file. If you haven't configured custom endpoints in Azure, there's no need to edit these properties.
+NOTE: Starting in release 23.2.8, Redpanda supports storage accounts configured for ADLS Gen2 with https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-namespace[hierarchical namespaces^] enabled. For hierarchical namespaces created with a custom endpoint, set the properties `cloud_storage_azure_adls_endpoint` and `cloud_storage_azure_adls_port` in the Helm chart through the command line (`--set storage.tiered.config`) or the YAML file. If you haven't configured custom endpoints in Azure, there's no need to edit these properties.
 
 To configure access to ABS/ADLS, use shared keys:
 
@@ -409,11 +417,12 @@ spec:
   chartRef: {}
   clusterSpec:
     storage:
-      tieredConfig:
-        cloud_storage_enabled: true
-        cloud_storage_azure_shared_key: <access_key>
-        cloud_storage_azure_storage_account: <account-name>
-        cloud_storage_azure_container: <container-name>
+      tiered:
+        config:
+          cloud_storage_enabled: true
+          cloud_storage_azure_shared_key: <access_key>
+          cloud_storage_azure_storage_account: <account-name>
+          cloud_storage_azure_container: <container-name>
 ----
 
 ```bash
@@ -431,11 +440,12 @@ Helm::
 [,yaml]
 ----
 storage:
-  tieredConfig:
-    cloud_storage_enabled: true
-    cloud_storage_azure_shared_key: <access_key>
-    cloud_storage_azure_storage_account: <account-name>
-    cloud_storage_azure_container: <container-name>
+  tiered:
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_azure_shared_key: <access_key>
+      cloud_storage_azure_storage_account: <account-name>
+      cloud_storage_azure_container: <container-name>
 ----
 +
 ```bash
@@ -446,10 +456,10 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set storage.tieredConfig.cloud_storage_enabled=true \
-  --set storage.tieredConfig.cloud_storage_azure_shared_key=<access_key> \
-  --set storage.tieredConfig.cloud_storage_azure_storage_account=<account-name> \
-  --set storage.tieredConfig.cloud_storage_azure_container=<container-name>
+  --set storage.tiered.config.cloud_storage_enabled=true \
+  --set storage.tiered.config.cloud_storage_azure_shared_key=<access_key> \
+  --set storage.tiered.config.cloud_storage_azure_storage_account=<account-name> \
+  --set storage.tiered.config.cloud_storage_azure_container=<container-name>
 ```
 ====
 --
@@ -970,12 +980,13 @@ spec:
   chartRef: {}
   clusterSpec:
     storage:
-      tieredStoragePersistentVolume:
-        enabled: true
-        storageClass: ""
-      tieredConfig:
-        cloud_storage_cache_size: <max-size-for-volume>
-        cloud_storage_cache_directory: <custom-cache-directory>
+      tiered:
+        mountType: persistentVolume
+        persistentVolume:
+          storageClass: ""
+        config:
+          cloud_storage_cache_size: <max-size-for-volume>
+          cloud_storage_cache_directory: <custom-cache-directory>
 ----
 
 ```bash
@@ -996,12 +1007,13 @@ Helm::
 [,yaml]
 ----
 storage:
-  tieredStoragePersistentVolume:
-    enabled: true
-    storageClass: ""
-  tieredConfig:
-    cloud_storage_cache_size: <max-size-for-volume>
-    cloud_storage_cache_directory: <custom-cache-directory>
+  tiered:
+    mountType: persistentVolume
+    persistentVolume:
+      storageClass: ""
+    config:
+      cloud_storage_cache_size: <max-size-for-volume>
+      cloud_storage_cache_directory: <custom-cache-directory>
 ----
 +
 ```bash
@@ -1013,10 +1025,10 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set storage.tieredStoragePersistentVolume.enabled=true \
-  --set storage.tieredStoragePersistentVolume.storageClass="" \
-  --set storage.tieredConfig.cloud_storage_cache_size=<max-size-for-volume> \
-  --set storage.tieredConfig.cloud_storage_cache_directory=<custom-cache-directory>
+  --set storage.tiered.mountType=persistentVolume \
+  --set storage.tiered.persistentVolume.storageClass="" \
+  --set storage.tiered.config.cloud_storage_cache_size=<max-size-for-volume> \
+  --set storage.tiered.config.cloud_storage_cache_directory=<custom-cache-directory>
 ```
 ====
 --
@@ -1039,13 +1051,21 @@ metadata:
 spec:
   chartRef: {}
   clusterSpec:
+apiVersion: cluster.redpanda.com/v1alpha1
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  chartRef: {}
+  clusterSpec:
     storage:
-      tieredStoragePersistentVolume:
-        enabled: true
-        storageClass: "<storage-class>"
-      tieredConfig:
-        cloud_storage_cache_size: <max-size-for-volume>
-        cloud_storage_cache_directory: <custom-cache-directory>
+      tiered:
+        mountType: persistentVolume
+        persistentVolume:
+          storageClass: "<storage-class>"
+        config:
+          cloud_storage_cache_size: <max-size-for-volume>
+          cloud_storage_cache_directory: <custom-cache-directory>
 ----
 
 ```bash
@@ -1063,12 +1083,13 @@ Helm::
 [,yaml]
 ----
 storage:
-  tieredStoragePersistentVolume:
-    enabled: true
-    storageClass: "<storage-class>"
-  tieredConfig:
-    cloud_storage_cache_size: <max-size-for-volume>
-    cloud_storage_cache_directory: <custom-cache-directory>
+  tiered:
+    mountType: persistentVolume
+    persistentVolume:
+      storageClass: "<storage-class>"
+    config:
+      cloud_storage_cache_size: <max-size-for-volume>
+      cloud_storage_cache_directory: <custom-cache-directory>
 ----
 +
 ```bash
@@ -1080,10 +1101,10 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set storage.tieredStoragePersistentVolume.enabled=true \
-  --set storage.tieredStoragePersistentVolume.storageClass="<storage-class>" \
-  --set storage.tieredConfig.cloud_storage_cache_size=<max-size-for-volume> \
-  --set storage.tieredConfig.cloud_storage_cache_directory=<custom-cache-directory>
+  --set storage.tiered.mountType=persistentVolume \
+  --set storage.tiered.persistentVolume.storageClass="<storage-class>" \
+  --set storage.tiered.config.cloud_storage_cache_size=<max-size-for-volume> \
+  --set storage.tiered.config.cloud_storage_cache_directory=<custom-cache-directory>
 ```
 ====
 --
@@ -1095,9 +1116,9 @@ IMPORTANT: Do not set an object storage property to an empty string `""` or to `
 
 When you use a static provisioner, an existing PersistentVolume in the cluster is selected and bound to one PersistentVolumeClaim for each Redpanda broker.
 
-. Create one PersistentVolume for each Redpanda broker. Make sure to create PersistentVolumes with a capacity of at least the value of the `storage.tieredConfig.cloud_storage_cache_size` configuration.
+. Create one PersistentVolume for each Redpanda broker. Make sure to create PersistentVolumes with a capacity of at least the value of the `storage.tiered.config.cloud_storage_cache_size` configuration.
 
-. Set the `storage.tieredStoragePersistentVolume.storageClass` to a dash (`"-"`) to use a PersistentVolume with a static provisioner:
+. Set the `storage.tiered.persistentVolume.storageClass` to a dash (`"-"`) to use a PersistentVolume with a static provisioner:
 +
 [tabs]
 ======
@@ -1115,12 +1136,13 @@ spec:
   chartRef: {}
   clusterSpec:
     storage:
-      tieredStoragePersistentVolume:
-        enabled: true
-        storageClass: "-"
-      tieredConfig:
-        cloud_storage_cache_size: <max-size-for-volume>
-        cloud_storage_cache_directory: <custom-cache-directory>
+      tiered:
+        mountType: persistentVolume
+        persistentVolume:
+          storageClass: "-"
+        config:
+          cloud_storage_cache_size: <max-size-for-volume>
+          cloud_storage_cache_directory: <custom-cache-directory>
 ----
 
 ```bash
@@ -1138,12 +1160,13 @@ Helm::
 [,yaml]
 ----
 storage:
-  tieredStoragePersistentVolume:
-    enabled: true
-    storageClass: "-"
-  tieredConfig:
-    cloud_storage_cache_size: <max-size-for-volume>
-    cloud_storage_cache_directory: <custom-cache-directory>
+  tiered:
+    mountType: persistentVolume
+    persistentVolume:
+      storageClass: "-"
+    config:
+      cloud_storage_cache_size: <max-size-for-volume>
+      cloud_storage_cache_directory: <custom-cache-directory>
 ----
 +
 ```bash
@@ -1155,10 +1178,10 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set storage.tieredStoragePersistentVolume.enabled=true \
-  --set storage.tieredStoragePersistentVolume.storageClass="-" \
-  --set storage.tieredConfig.cloud_storage_cache_size=<max-size-for-volume> \
-  --set storage.tieredConfig.cloud_storage_cache_directory=<custom-cache-directory>
+  --set storage.tiered.mountType=persistentVolume \
+  --set storage.tiered.persistentVolume.storageClass="-" \
+  --set storage.tiered.config.cloud_storage_cache_size=<max-size-for-volume> \
+  --set storage.tiered.config.cloud_storage_cache_directory=<custom-cache-directory>
 ```
 ====
 --
@@ -1173,8 +1196,8 @@ For details about hostPath volumes, see the https://kubernetes.io/docs/concepts/
 
 To use a hostPath volume for the cache directory:
 
-. Set the `storage.tieredStorageHostPath` configuration to the absolute path of a file on the local worker node.
-. Set `storage.tieredStoragePersistentVolume.enabled` to `false`.
+. Set the `storage.tiered.mountPath` configuration to `hostPath`.
+. Set the `storage.tiered.hostPath` configuration to the absolute path of a file on the local worker node.
 . Set `statefulset.initContainers.setDataDirOwnership.enabled` to `true`.
 
 include::manage:partial$kubernetes/init-container.adoc[]
@@ -1195,12 +1218,12 @@ spec:
   chartRef: {}
   clusterSpec:
     storage:
-      tieredStorageHostPath: "<absolute-path>"
-      tieredStoragePersistentVolume:
-        enabled: false
-      tieredConfig:
-        cloud_storage_cache_size: <max-size-for-volume>
-        cloud_storage_cache_directory: <custom-cache-directory>
+      tiered:
+        mountType: hostPath
+        hostPath: "<absolute-path>"
+        config:
+          cloud_storage_cache_size: <max-size-for-volume>
+          cloud_storage_cache_directory: <custom-cache-directory>
 ----
 
 ```bash
@@ -1218,12 +1241,12 @@ Helm::
 [,yaml]
 ----
 storage:
-  tieredStorageHostPath: "<absolute-path>"
-  tieredStoragePersistentVolume:
-    enabled: false
-  tieredConfig:
-    cloud_storage_cache_size: <max-size-for-volume>
-    cloud_storage_cache_directory: <custom-cache-directory>
+  tiered:
+    mountType: hostPath
+    hostPath: "<absolute-path>"
+    config:
+      cloud_storage_cache_size: <max-size-for-volume>
+      cloud_storage_cache_directory: <custom-cache-directory>
 ----
 +
 ```bash
@@ -1235,10 +1258,10 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set storage.tieredStoragePersistentVolume.enabled=false \
-  --set storage.tieredStorageHostPath=<absolute-path>
-  --set storage.tieredConfig.cloud_storage_cache_size=<max-size-for-volume> \
-  --set storage.tieredConfig.cloud_storage_cache_directory=<custom-cache-directory>
+  --set storage.tiered.mountType=hostPath \
+  --set storage.tiered.hostPath="<absolute-path>" \
+  --set storage.tiered.config.cloud_storage_cache_size=<max-size-for-volume> \
+  --set storage.tiered.config.cloud_storage_cache_directory=<custom-cache-directory>
 ```
 ====
 --
@@ -1250,51 +1273,19 @@ endif::[]
 
 == Whole cluster restore for disaster recovery
 
-With tiered storage enabled, you can restore your cluster, including its metadata, in the event of failure. This is a simpler and less expensive alternative to active-active replication (for example, using xref:upgrade:migrate/data-migration.adoc[MirrorMaker 2]).
+With Tiered Storage enabled, you can restore data from a failed cluster (source cluster), including its metadata, onto a new cluster (target cluster). This is a simpler and cheaper alternative to active-active replication, for example with xref:upgrade:migrate/data-migration.adoc[MirrorMaker 2]. Use this recovery method to restore your application to the latest functional state as quickly as possible.
 
-You can take the following steps to restore a failed cluster:
-
-. Start a new cluster. 
-. Restore data from a failed source cluster to the new cluster.
-. Perform a rolling restart.
-
-Use this recovery method to restore your application to the latest functional state as quickly as possible. 
-
-CAUTION: Whole cluster restore is not intended to be a fully-functional disaster recovery solution. It does not provide snapshot-style consistency: some partitions in some topics will be more up to date than others. Committed transactions are not guaranteed to be atomic.
-
-By default, Redpanda uploads metadata to object storage periodically. You can manage metadata uploads, or disable them entirely, with the following cluster configuration properties:
-
-* `enable_cluster_metadata_upload_loop`: Enable metadata uploads. This property is enabled by default and is required for whole cluster restore.
-* `cloud_storage_cluster_metadata_upload_interval_ms`: Set the time interval to wait between cluster metadata uploads.
-* `controller_snapshot_max_age_sec`: Maximum amount of time that can pass before Redpanda attempts to take a controller snapshot after a new controller command appears. This affects how fresh the uploaded metadata can be.
-* `cloud_storage_attempt_cluster_recovery_on_bootstrap`: Automate cluster restore in Kubernetes. Setting to `true` is recommended when using an automated method for deployment. When bootstrapping a cluster with a given bucket, make sure that any previous cluster using the bucket is fully destroyed; otherwise tiered storage subsystems may interfere with each other.
-
-=== Start a target cluster
-
-For Redpanda Enterprise, follow the steps to xref:deploy:deployment-option/index.adoc[deploy a new cluster] in a self-hosted environment.
-
-For Redpanda Cloud, follow the steps to xref:deploy:deployment-option/cloud/index.adoc[provision a new cloud cluster]. 
-Cloud account credentials (such as secrets or access keys) are not included in backed up metadata. You must manually configure these credentials for the new cluster.
-
-=== Restore to target cluster
-
-// Update xref when rpk command alias is implemented
-You can restore data from a failed cluster to a target cluster using the xref:reference:rpk/rpk-cluster/rpk-cluster-storage-recovery.adoc[`rpk cluster storage restore`] command. The wait flag `-w` tells the command to poll the status of the restore process until completed, before exiting.
-
-[,bash]
-----
-rpk cluster storage restore start -w
-----
+CAUTION: Whole cluster restore is not a fully-functional disaster recovery solution. It does not provide snapshot-style consistency. Some partitions in some topics will be more up-to-date than others. Committed transactions are not guaranteed to be atomic.
 
 NOTE: If you need to restore only a subset of topic data, consider using <<remote-recovery,remote recovery>> instead of a whole cluster restore.
 
 The following metadata is included in a whole cluster restore:
 
-* Topic definitions. If you have enabled tiered storage only for specific topics, topics without tiered storage enabled will be restored as empty 
-* Users and access control lists (ACLs)
-* xref:manage:schema-reg/schema-reg-overview.adoc[Schemas]. To ensure that your schemas are also archived and restored, you must also enable tiered storage for the `_schemas` topic
-* The xref:develop:consume-data/consumer-offsets.adoc[consumer offsets topic]
-* Transaction metadata, up to the highest committed transaction. In-flight transactions are treated as aborted and will not be included in the restore
+* Topic definitions. If you have enabled Tiered Storage only for specific topics, topics without Tiered Storage enabled will be restored empty.
+* Users and access control lists (ACLs).
+* xref:manage:schema-reg/schema-reg-overview.adoc[Schemas]. To ensure that your schemas are also archived and restored, you must also enable Tiered Storage for the `_schemas` topic.
+* The xref:develop:consume-data/consumer-offsets.adoc[consumer offsets topic].
+* Transaction metadata, up to the highest committed transaction. In-flight transactions are treated as aborted and will not be included in the restore.
 * xref:reference:cluster-properties.adoc[Cluster configurations], including your Redpanda license key, with the exception of the following properties:
 ** `cloud_storage_cache_size`
 ** `cluster_id`
@@ -1313,25 +1304,157 @@ The following metadata is included in a whole cluster restore:
 ** `cloud_storage_azure_adls_endpoint`
 ** `cloud_storage_azure_adls_port`
 
-Redpanda recommends that the destination cluster be empty before the restore; that is, the cluster should not contain user- or application-managed topic data and schemas, users, ACLs, and ongoing transactions.
+=== Restore a failed cluster
 
-If a duplicate cluster configuration is found in the destination cluster, it will be overwritten by the restore.
+To restore a failed cluster:
 
-Whole cluster restore supports only one source cluster. It is not possible to consolidate multiple clusters into the target cluster.
+ifdef::env-kubernetes[. <<Start a target cluster>> (new cluster) with cluster restore enabled.]
+ifndef::env-kubernetes[. <<Start a target cluster>> (new cluster).]
+ifndef::env-kubernetes[. <<restore-to-target-cluster, Restore data from a failed source cluster to the new cluster>>.]
+ifndef::env-kubernetes[. <<Perform a rolling restart>>.]
+ifdef::env-kubernetes[. <<Verify that the data is restored>>.]
 
-=== Perform a rolling restart
+==== Prerequisites
 
-To ensure that the cluster reflects newly-restored configuration properties, perform a xref:manage:cluster-maintenance/rolling-restart.adoc[rolling restart] after the restore process. 
+You must have the following:
 
-TIP: Run the `rpk cluster config status` command to see nodes that need to restart for updated configuration properties to take effect.
+- Tiered Storage enabled on the failed source cluster.
+- Physical or virtual machines on which to deploy a the target cluster.
 
-At this point, you may redirect your application workload to the new cluster. Make sure to update your application code to use the new cluster's addresses.
+==== Limitations
+
+- Whole cluster restore supports only one source cluster. It is not possible to consolidate multiple clusters onto the target cluster.
+
+- If a duplicate cluster configuration is found in the target cluster, it will be overwritten by the restore.
+
+- The target cluster should not contain user-managed or application-managed topic data, schemas, users, ACLs, or ongoing transactions.
+
+==== Start a target cluster
+
+ifdef::env-kubernetes[]
+
+Deploy the target Redpanda cluster.
+
+[tabs]
+======
+Helm + Operator::
++
+--
+.`redpanda-cluster.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha1
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  chartRef: {}
+  clusterSpec:
+    storage:
+      tiered:
+        <tiered-storage-settings>
+    config:
+      cluster:
+        cloud_storage_attempt_cluster_recovery_on_bootstrap: true
+----
+
+```bash
+kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
+```
+--
+Helm::
++
+--
+[tabs]
+====
+--values::
++
+.`cluster-restore.yaml`
+[,yaml]
+----
+storage:
+  tiered:
+    <tiered-storage-settings>
+config:
+  cluster:
+    cloud_storage_attempt_cluster_recovery_on_bootstrap: true
+----
++
+```bash
+helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
+--values cluster-restore.yaml
+```
+
+--set::
++
+```bash
+helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
+  --set storage.tiered.<tiered-storage-settings> \
+  --set config.cluster.cloud_storage_attempt_cluster_recovery_on_bootstrap=true
+```
+====
+--
+======
+
+- `storage.tiered`: Make sure to configure the target cluster with the same Tiered Storage settings as the failed source cluster.
+- `config.cluster.cloud_storage_attempt_cluster_recovery_on_bootstrap`: Automate cluster restore in Kubernetes. Setting to `true` is recommended when using an automated method for deployment. When bootstrapping a cluster with a given bucket, make sure that any previous cluster using the bucket is fully destroyed; otherwise Tiered Storage subsystems may interfere with each other.
+endif::[]
+
+ifndef::env-kubernetes[]
+For self-hosted, follow the steps to xref:deploy:deployment-option/self-hosted/manual/index.adoc[deploy a new cluster].
+
+For Redpanda Cloud, follow the steps to xref:deploy:deployment-option/cloud/index.adoc[provision a new cloud cluster].
+Cloud account credentials (such as secrets or access keys) are not included in backed up metadata. You must manually configure these credentials for the new cluster.
+
+NOTE: Make sure to configure the target cluster with the same Tiered Storage settings as the failed source cluster.
+endif::[]
+
+==== Manage metadata uploads
+
+By default, Redpanda uploads metadata to object storage periodically. You can manage metadata uploads, or disable them entirely, with the following cluster configuration properties:
+
+* `enable_cluster_metadata_upload_loop`: Enable metadata uploads. This property is enabled by default and is required for whole cluster restore.
+* `cloud_storage_cluster_metadata_upload_interval_ms`: Set the time interval to wait between cluster metadata uploads.
+* `controller_snapshot_max_age_sec`: Maximum amount of time that can pass before Redpanda attempts to take a controller snapshot after a new controller command appears. This affects how fresh the uploaded metadata can be.
+
+ifndef::env-kubernetes[]
+==== Restore to target cluster
+
+// Update xref when rpk command alias is implemented
+You can restore data from a failed cluster to a target cluster using the xref:reference:rpk/rpk-cluster/rpk-cluster-storage-recovery.adoc[`rpk cluster storage restore`] command. The wait flag `-w` tells the command to poll the status of the restore process until completed, before exiting.
+
+[,bash]
+----
+rpk cluster storage restore start -w
+----
+
+==== Perform a rolling restart
+
+To ensure that the cluster reflects newly-restored configuration properties, perform a xref:manage:cluster-maintenance/rolling-restart.adoc[rolling restart] after the restore process.
+
+TIP: Run the `rpk cluster config status` command to see brokers that need to restart for updated configuration properties to take effect.
+endif::[]
+
+ifdef::env-kubernetes[]
+==== Verify that the data is restored
+
+To verify that the cluster restore completed successfully,
+run the following command until it returns `inactive`:
+
+[,bash]
+----
+rpk cluster storage recovery status
+----
+
+endif::[]
+
+When the cluster restore is completed successfully, you can redirect your application workload to the new cluster. Make sure to update your application code to use the new addresses of your brokers.
 
 == Remote recovery
 
 When you create a topic, you can use remote recovery to download the topic data from object storage. This is useful when you need to restore a single topic that was accidentally deleted from a cluster.
 
-Note that remote recovery is only safe when no other clusters are still writing to the specified bucket or container. 
+Note that remote recovery is only safe when no other clusters are still writing to the specified bucket or container.
 
 To create a new topic using remote recovery:
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1318,8 +1318,8 @@ ifdef::env-kubernetes[. <<Verify that the cluster restore is complete>>.]
 
 You must have the following:
 
-- Tiered Storage enabled on the failed source cluster.
-- Physical or virtual machines on which to deploy a the target cluster.
+- Tiered Storage enabled on the source cluster.
+- Physical or virtual machines on which to deploy the target cluster.
 
 ==== Limitations
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1312,7 +1312,7 @@ ifdef::env-kubernetes[. <<Start a target cluster>> (new cluster) with cluster re
 ifndef::env-kubernetes[. <<Start a target cluster>> (new cluster).]
 ifndef::env-kubernetes[. <<restore-to-target-cluster, Restore data from a failed source cluster to the new cluster>>.]
 ifndef::env-kubernetes[. <<Perform a rolling restart>>.]
-ifdef::env-kubernetes[. <<Verify that the data is restored>>.]
+ifdef::env-kubernetes[. <<Verify that the cluster restore is complete>>.]
 
 ==== Prerequisites
 
@@ -1436,9 +1436,9 @@ TIP: Run the `rpk cluster config status` command to see brokers that need to res
 endif::[]
 
 ifdef::env-kubernetes[]
-==== Verify that the data is restored
+==== Verify that the cluster restore is complete
 
-To verify that the cluster restore completed successfully,
+To verify that the cluster restore successfully completed,
 run the following command until it returns `inactive`:
 
 [,bash]
@@ -1448,7 +1448,7 @@ rpk cluster storage recovery status
 
 endif::[]
 
-When the cluster restore is completed successfully, you can redirect your application workload to the new cluster. Make sure to update your application code to use the new addresses of your brokers.
+When the cluster restore is successfully completed successfully, you can redirect your application workload to the new cluster. Make sure to update your application code to use the new addresses of your brokers.
 
 == Remote recovery
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1421,7 +1421,7 @@ ifndef::env-kubernetes[]
 ==== Restore to target cluster
 
 // Update xref when rpk command alias is implemented
-You can restore data from a failed cluster to a target cluster using the xref:reference:rpk/rpk-cluster/rpk-cluster-storage-recovery.adoc[`rpk cluster storage restore`] command. The wait flag `-w` tells the command to poll the status of the restore process until completed, before exiting.
+You can restore data from a failed cluster to a target cluster using the xref:reference:rpk/rpk-cluster/rpk-cluster-storage-recovery.adoc[`rpk cluster storage restore`] command. The wait flag `-w` tells the command to poll the status of the restore process and then exit when completed.
 
 [,bash]
 ----
@@ -1432,7 +1432,7 @@ rpk cluster storage restore start -w
 
 To ensure that the cluster reflects newly-restored configuration properties, perform a xref:manage:cluster-maintenance/rolling-restart.adoc[rolling restart] after the restore process.
 
-TIP: Run the `rpk cluster config status` command to see brokers that need to restart for updated configuration properties to take effect.
+TIP: Run the `rpk cluster config status` command to list the brokers that need a restart for updated configuration properties to take effect.
 endif::[]
 
 ifdef::env-kubernetes[]
@@ -1454,7 +1454,7 @@ When the cluster restore is successfully completed successfully, you can redirec
 
 When you create a topic, you can use remote recovery to download the topic data from object storage. This is useful when you need to restore a single topic that was accidentally deleted from a cluster.
 
-Note that remote recovery is only safe when no other clusters are still writing to the specified bucket or container.
+IMPORTANT: Remote recovery is only safe when no other clusters are writing to the specified bucket or container.
 
 To create a new topic using remote recovery:
 


### PR DESCRIPTION
Preview: https://deploy-preview-176--redpanda-docs-preview.netlify.app/23.3/manage/kubernetes/storage/tiered-storage/#whole-cluster-restore-for-disaster-recovery

- Added steps for cluster restore in Kubernetes.
- Restructured some of the information into clearer sections.
- Fixed instances of tiered storage in lowercase.

Fixes redpanda-data/documentation-private#2025