### PR TITLE
Remove DOMAIN environment variable

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc
@@ -551,8 +551,8 @@ For smooth and uninterrupted updates, use the default `RollingUpdate` strategy. 
 statefulset:
   updateStrategy:
     type: "RollingUpdate"
-    budget:
-      maxUnavailable: 1
+  budget:
+    maxUnavailable: 1
 ----
 
 For all available settings, see the xref:reference:redpanda-helm-spec.adoc#statefulset[Helm specification].

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
@@ -234,13 +234,12 @@ The Redpanda Helm chart uses cert-manager to manage TLS certificates.
 . Install Redpanda using Helm:
 +
 ```bash
-export DOMAIN=customredpandadomain.local && \
 helm repo add redpanda https://charts.redpanda.com/
 helm repo update
 helm install redpanda redpanda/redpanda \
   --namespace <namespace> \
   --create-namespace \
-  --set external.domain=${DOMAIN} \
+  --set external.domain=customredpandadomain.local \
   --set statefulset.initContainers.setDataDirOwnership.enabled=true
 ```
 +
@@ -472,7 +471,7 @@ NOTE: These steps work only on Linux operating systems.
 . Add mappings in your `/etc/hosts` file between your worker nodes' IP addresses and their custom domain names:
 +
 ```bash
-sudo true && kubectl --namespace <namespace> get endpoints,node -A -o go-template='{{ range $_ := .items }}{{ if and (eq .kind "Endpoints") (eq .metadata.name "redpanda-external") }}{{ range $_ := (index .subsets 0).addresses }}{{ $nodeName := .nodeName }}{{ $podName := .targetRef.name }}{{ range $node := $.items }}{{ if and (eq .kind "Node") (eq .metadata.name $nodeName) }}{{ range $_ := .status.addresses }}{{ if eq .type "InternalIP" }}{{ .address }} {{ $podName }}.${DOMAIN}{{ "\n" }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}' | envsubst | sudo tee -a /etc/hosts
+sudo true && kubectl --namespace <namespace> get endpoints,node -A -o go-template='{{ range $_ := .items }}{{ if and (eq .kind "Endpoints") (eq .metadata.name "redpanda-external") }}{{ range $_ := (index .subsets 0).addresses }}{{ $nodeName := .nodeName }}{{ $podName := .targetRef.name }}{{ range $node := $.items }}{{ if and (eq .kind "Node") (eq .metadata.name $nodeName) }}{{ range $_ := .status.addresses }}{{ if eq .type "InternalIP" }}{{ .address }} {{ $podName }}.customredpandadomain.local{{ "\n" }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}' | envsubst | sudo tee -a /etc/hosts
 ```
 +
 .`/etc/hosts`

--- a/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
+++ b/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
@@ -137,14 +137,13 @@ TLS is enabled by default. The Redpanda Helm chart uses cert-manager to manage T
 +
 [,bash,lines=6+8+9]
 ----
-helm repo add redpanda https://charts.redpanda.com
-export DOMAIN=customredpandadomain.local && \
+helm repo add redpanda https://charts.redpanda.com \
 helm install redpanda redpanda/redpanda \
   --namespace <namespace> --create-namespace \
   --set auth.sasl.enabled=true \
   --set "auth.sasl.users[0].name=superuser" \
   --set "auth.sasl.users[0].password=secretpassword" \
-  --set external.domain=${DOMAIN} \
+  --set external.domain=customredpandadomain.local \
   --set "storage.persistentVolume.storageClass=csi-driver-lvm-striped-xfs" \
   --wait \
   --timeout 1h

--- a/modules/deploy/partials/kubernetes/guides/external-access-steps.adoc
+++ b/modules/deploy/partials/kubernetes/guides/external-access-steps.adoc
@@ -2,7 +2,7 @@
 +
 [,bash]
 ----
-sudo true && kubectl --namespace <namespace> get endpoints,node -A -o go-template='{{ range $_ := .items }}{{ if and (eq .kind "Endpoints") (eq .metadata.name "redpanda-external") }}{{ range $_ := (index .subsets 0).addresses }}{{ $nodeName := .nodeName }}{{ $podName := .targetRef.name }}{{ range $node := $.items }}{{ if and (eq .kind "Node") (eq .metadata.name $nodeName) }}{{ range $_ := .status.addresses }}{{ if eq .type "ExternalIP" }}{{ .address }} {{ $podName }}.${DOMAIN}{{ "\n" }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}' | envsubst | sudo tee -a /etc/hosts
+sudo true && kubectl --namespace <namespace> get endpoints,node -A -o go-template='{{ range $_ := .items }}{{ if and (eq .kind "Endpoints") (eq .metadata.name "redpanda-external") }}{{ range $_ := (index .subsets 0).addresses }}{{ $nodeName := .nodeName }}{{ $podName := .targetRef.name }}{{ range $node := $.items }}{{ if and (eq .kind "Node") (eq .metadata.name $nodeName) }}{{ range $_ := .status.addresses }}{{ if eq .type "ExternalIP" }}{{ .address }} {{ $podName }}.customredpandadomain.local{{ "\n" }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}' | envsubst | sudo tee -a /etc/hosts
 ----
 +
 .`/etc/hosts`

--- a/modules/manage/pages/kubernetes/decommission-brokers.adoc
+++ b/modules/manage/pages/kubernetes/decommission-brokers.adoc
@@ -331,6 +331,8 @@ spec:
 Helm::
 +
 --
+NOTE: If you deploy the Redpanda Helm chart with https://argo-cd.readthedocs.io/en/stable/[Argo CD], you cannot use the Decommission controller.
+
 [tabs]
 ====
 --values::


### PR DESCRIPTION
- The Helm + Operator steps were missing the DOMAIN environment variable, resulting in incorrect domains being appended to the `/etc/hosts` file. To simplify the tutorial, this PR removes the environment variable in favor of hard-coding the domain.
- The Decommission controller does not currently work if you deploy the Helm chart with Argo CD: https://github.com/redpanda-data/helm-charts/issues/932
- The indentation of `statefulset.budget` was incorrect in the deployment doc.