### PR TITLE
Explain CPU utilization metrics 

### DIFF
--- a/modules/manage/partials/monitor-redpanda.adoc
+++ b/modules/manage/partials/monitor-redpanda.adoc
@@ -287,9 +287,7 @@ While CPU utilization at the host-level might appear high (for example, 99-100% 
 
 This high host-level CPU utilization happens because Redpanda uses Seastar, which runs event loops on every core (also referred to as a _reactor_), constantly polling for the next task. This process never blocks and will increment clock ticks. It doesn't necessarily mean that Redpanda is busy.
 
-Use xref:reference:public-metrics-reference.adoc#redpanda_cpu_busy_seconds_total[`redpanda_cpu_busy_seconds_total`] (public metrics) or xref:reference:internal-metrics-reference.adoc#vectorized_reactor_utilization[`vectorized_reactor_utilization`] (internal metrics) to monitor the actual Redpanda CPU utilization. When these particular metrics indicate close to 100% utilization over a given period of time, you will then also start to see higher produce and consume <<latency,latency>>.
-
-If achieving very low latency consume is not a priority, consider tuning the xref:reference:tunable-properties.adoc#fetch_reads_debounce_timeout[`fetch_reads_debounce_timeout`] property. The default setting at 1ms means that Redpanda pings the partition once per millisecond of the given client poll cycle. Setting the duration at a higher value, for example up to 10ms, can help reduce CPU utilization.
+Use xref:reference:public-metrics-reference.adoc#redpanda_cpu_busy_seconds_total[`redpanda_cpu_busy_seconds_total`] (public metrics) or xref:reference:internal-metrics-reference.adoc#vectorized_reactor_utilization[`vectorized_reactor_utilization`] (internal metrics) to monitor the actual Redpanda CPU utilization. When these particular metrics indicate close to 100% utilization over a given period of time, make sure to also monitor produce and consume <<latency,latency>> as they may then start to increase as a result of resources becoming overburdened.
 ====
 
 ==== Memory allocated

--- a/modules/manage/partials/monitor-redpanda.adoc
+++ b/modules/manage/partials/monitor-redpanda.adoc
@@ -283,11 +283,11 @@ rate(redpanda_cpu_busy_seconds_total[5m])
 
 [TIP]
 ====
-While CPU utilization at the host-level can typically appear high (for example, 99-100% utilization) when I/O events like message arrival occur, the actual Redpanda process utilization is likely low, in contrast to what system-level metrics might indicate such as those provided by the `top` command. 
+While CPU utilization at the host-level might appear high (for example, 99-100% utilization) when I/O events like message arrival occur, the actual Redpanda process utilization is likely low. System-level metrics such as those provided by the `top` command can be misleading.  
 
 This high host-level CPU utilization happens because Redpanda uses Seastar, which runs event loops on every core (also referred to as a _reactor_), constantly polling for the next task. This process never blocks and will increment clock ticks. It doesn't necessarily mean that Redpanda is busy.
 
-Use `redpanda_cpu_busy_seconds_total` (public metrics) or xref:reference:internal-metrics-reference.adoc#vectorized_reactor_utilization[`vectorized_reactor_utilization`] (internal metrics) to monitor the actual Redpanda CPU utilization. When these particular metrics approach 100% utilization, you will then also start to see higher produce and consume <<latency,latency>>.
+Use xref:reference:public-metrics-reference.adoc#redpanda_cpu_busy_seconds_total[`redpanda_cpu_busy_seconds_total`] (public metrics) or xref:reference:internal-metrics-reference.adoc#vectorized_reactor_utilization[`vectorized_reactor_utilization`] (internal metrics) to monitor the actual Redpanda CPU utilization. When these particular metrics indicate close to 100% utilization over a given period of time, you will then also start to see higher produce and consume <<latency,latency>>.
 
 If achieving very low latency consume is not a priority, consider tuning the xref:reference:tunable-properties.adoc#fetch_reads_debounce_timeout[`fetch_reads_debounce_timeout`] property. The default setting at 1ms means that Redpanda pings the partition once per millisecond of the given client poll cycle. Setting the duration at a higher value, for example up to 10ms, can help reduce CPU utilization.
 ====

--- a/modules/manage/partials/monitor-redpanda.adoc
+++ b/modules/manage/partials/monitor-redpanda.adoc
@@ -281,11 +281,15 @@ To detect unexpected idling, you can query the rate of change as a percentage of
 rate(redpanda_cpu_busy_seconds_total[5m])
 ----
 
-[NOTE]
+[TIP]
 ====
-While CPU utilization at the host-level can typically appear high (for example, 99-100% utilization) when I/O events like message arrival occur, the actual Redpanda process utilization is likely low and can be monitored with `redpanda_cpu_busy_seconds_total`.
+While CPU utilization at the host-level can typically appear high (for example, 99-100% utilization) when I/O events like message arrival occur, the actual Redpanda process utilization is likely low, in contrast to what system-level metrics might indicate such as those provided by the `top` command. 
 
-This high host-level CPU utilization happens because Redpanda uses Seastar and constantly polls and increments clock ticks, and it doesn't necessarily mean that Redpanda is busy.
+This high host-level CPU utilization happens because Redpanda uses Seastar, which runs event loops on every core (also referred to as a _reactor_), constantly polling for the next task. This process never blocks and will increment clock ticks. It doesn't necessarily mean that Redpanda is busy.
+
+Use `redpanda_cpu_busy_seconds_total` (public metrics) or xref:reference:internal-metrics-reference.adoc#vectorized_reactor_utilization[`vectorized_reactor_utilization`] (internal metrics) to monitor the actual Redpanda CPU utilization. When these particular metrics approach 100% utilization, you will then also start to see higher produce and consume <<latency,latency>>.
+
+If achieving very low latency consume is not a priority, consider tuning the xref:reference:tunable-properties.adoc#fetch_reads_debounce_timeout[`fetch_reads_debounce_timeout`] property. The default setting at 1ms means that Redpanda pings the partition once per millisecond of the given client poll cycle. Setting the duration at a higher value, for example up to 10ms, can help reduce CPU utilization.
 ====
 
 ==== Memory allocated


### PR DESCRIPTION
### Preview
https://deploy-preview-179--redpanda-docs-preview.netlify.app/current/manage/monitoring/#cpu-usage

Adds more information to [CPU utilization](https://docs.redpanda.com/current/manage/monitoring/#cpu-usage) section regarding why cores may always look busy and which metrics should be monitored to determine actual Redpanda process utilization.

The section currently contains a NOTE admonition, but the community member who opened the [thread](https://redpandacommunity.slack.com/archives/C01AJDUT88N/p1699851597910539) in Slack may not have seen the admonition right away nor realized that it answers their question albeit partially. I've added the additional info to the same block but changed it to a TIP. With that said the block is now rather long so I am also open to going a different direction in terms of the format.

Closes https://github.com/redpanda-data/documentation-private/issues/2108