### PR TITLE
#2145 Doc max partitions per tier

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -107,18 +107,17 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 == Cluster tiers
 
-When you create a cluster, you select a throughput tier. You can scale up from one tier to another with minimal downtime. 
+When you create a cluster, you select your throughput tier. For example, the following table lists the current AWS tier limits. Legacy tiers may have different limits. For more information, or for the current GCP limits, contact https://support.redpanda.com/hc/en-us/requests/new[support^]. 
 
 |===
 | | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
 
-| *AWS tier 1* | 20 MBps | 60 MBps | 1,000 | 1,500
-| *AWS tier 2* | 50 MBps | 150 MBps | 2,800 |	3,750
-| *AWS tier 3* | 100 MBps | 200 MBps | 5,600 | 7,500
-| *AWS tier 4* | 200 MBps | 400 MBps | 11,200 | 15,000
-| *AWS tier 5* | 400 MBps | 800 MBps | 22,800 | 30,000
+| *Tier 1* | 20 MBps | 60 MBps | 1,000 | 1,500
+| *Tier 2* | 50 MBps | 150 MBps | 2,800 | 3,750
+| *Tier 3* | 100 MBps | 200 MBps | 5,600 | 7,500
+| *Tier 4* | 200 MBps | 400 MBps | 11,200 | 15,000
+| *Tier 5* | 400 MBps | 800 MBps | 22,800 | 30,000
 |===
-
 
 == Redpanda Cloud vs self-hosted feature compatibility
 

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -113,7 +113,7 @@ When you create a cluster, you select a throughput tier for your expected ingres
 | | Max partitions | Max connections
 
 | Tier 1 ARM64 or x86 | 1,000 | 1,500
-| Tier 2 ARM64 or x86 | 2,800 |	3750 
+| Tier 2 ARM64 or x86 | 2,800 |	3,750 
 | Tier 3 ARM64 or x86 | 5,600 |	7,500
 | Tier 4 ARM64 or x86 | 11,200 | 15,000
 | Tier 5 ARM64 or x86 | 22,800 | 22,500

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -109,35 +109,16 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 When you create a cluster, you select a throughput tier. You can scale up from one tier to another with minimal downtime. 
 
-[tabs]
-====
-AWS::
-+
---
 |===
 | | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
 
-| *Tier 1* | 20 MBps | 60 MBps | 1,000 | 1,500
-| *Tier 2* | 50 MBps | 150 MBps | 2,800 |	3,750
-| *Tier 3* | 100 MBps | 200 MBps | 5,600 | 7,500
-| *Tier 4* | 200 MBps | 400 MBps | 11,200 | 15,000
-| *Tier 5* | 400 MBps | 800 MBps | 22,800 | 30,000
+| *AWS tier 1* | 20 MBps | 60 MBps | 1,000 | 1,500
+| *AWS tier 2* | 50 MBps | 150 MBps | 2,800 |	3,750
+| *AWS tier 3* | 100 MBps | 200 MBps | 5,600 | 7,500
+| *AWS tier 4* | 200 MBps | 400 MBps | 11,200 | 15,000
+| *AWS tier 5* | 400 MBps | 800 MBps | 22,800 | 30,000
 |===
---
-GCP::
-+
---
-|===
-| | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
 
-| *Tier 1* | 20 MBps | 60 MBps | 500 | 1,500
-| *Tier 2* | 50 MBps | 150 MBps | 1,000 | 3,750
-| *Tier 3* | 100 MBps | 200 MBps | 3,000 | 7,500
-| *Tier 4* | 200 MBps | 400 MBps | 5,000 | 15,000
-| *Tier 5* | 400 MBps | 800 MBps | 7,500 | 22,500
-|===
---
-====
 
 == Redpanda Cloud vs self-hosted feature compatibility
 

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -118,15 +118,10 @@ AWS::
 | | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
 
 | *Tier 1* | 20 MBps | 60 MBps | 1,000 | 1,500
-| *Tier 1 ARM64 or x86* | 20 MBps | 60 MBps | 1,000 | 1,500
 | *Tier 2* | 50 MBps | 150 MBps | 2,000 |	3,750
-| *Tier 2 ARM64 or x86* | 50 MBps | 150 MBps | 2,800 | 3,750 
 | *Tier 3* | 100 MBps | 200 MBps | 5,000 | 7,500
-| *Tier 3 ARM64 or x86* | 100 MBps | 200 MBps | 5,600 | 7,500
 | *Tier 4* | 200 MBps | 400 MBps | 5,000 | 15,000
-| *Tier 4 ARM64 or x86* | 200 MBps | 400 MBps | 11,200 | 15,000
 | *Tier 5* | 400 MBps | 800 MBps | 7,500 | 30,000
-| *Tier 5 ARM64 or x86* | 400 MBps | 800 MBps | 22,800 | 22,500
 |===
 --
 GCP::

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -107,17 +107,42 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 == Cluster tiers
 
-When you create a cluster, you select a throughput tier for your expected ingress and egress. You can scale up and down from one tier to another with minimal downtime. The maximum number of partitions and connections also increases with each tier. For example:
+When you create a cluster, you select a throughput tier for your expected ingress and egress. You can scale up from one tier to another with minimal downtime. The maximum number of partitions and connections also increases with each tier:
 
+[tabs]
+====
+AWS::
++
+--
 |===
 | | Max partitions | Max connections
 
+| Tier 1 | 1,000 | 1,500
 | Tier 1 ARM64 or x86 | 1,000 | 1,500
+| Tier 2 | 2,000 |	3,750
 | Tier 2 ARM64 or x86 | 2,800 |	3,750 
+| Tier 3 | 5,000 |	7,500
 | Tier 3 ARM64 or x86 | 5,600 |	7,500
+| Tier 4 | 5,000 | 15,000
 | Tier 4 ARM64 or x86 | 11,200 | 15,000
+| Tier 5 | 7,500 | 30,000
 | Tier 5 ARM64 or x86 | 22,800 | 22,500
 |===
+--
+GCP::
++
+--
+|===
+| | Max partitions | Max connections
+
+| Tier 1 | 500 | 1,500
+| Tier 2 | 1,000 |	3,750
+| Tier 3 | 3,000 |	7,500
+| Tier 4 | 5,000 | 15,000
+| Tier 5 | 7,500 | 22,500
+|===
+--
+====
 
 == Redpanda Cloud vs self-hosted feature compatibility
 

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -105,6 +105,20 @@ necessary IAM policies required to run the agent.
 
 NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, IAM roles, firewall rules, and storage buckets. For the most security, you can manage these resources yourself with a xref:./vpc-byo-gcp.adoc[customer-managed VPC].
 
+== Cluster tiers
+
+When you create a cluster, you select a throughput tier for your expected ingress and egress. You can scale up and down from one tier to another with minimal downtime. The maximum number of partitions and connections also increases with each tier. For example:
+
+|===
+| | Max partitions | Max connections
+
+| Tier 1 ARM64 or x86 | 1,000 | 1,500
+| Tier 2 ARM64 or x86 | 2,800 |	3750 
+| Tier 3 ARM64 or x86 | 5,600 |	7500
+| Tier 4 ARM64 or x86 | 11,200 | 15,000
+| Tier 5 ARM64 or x86 | 22,800 | 22,500
+|===
+
 == Redpanda Cloud vs self-hosted feature compatibility
 
 Redpanda Cloud does not support the following self-hosted functionality:

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -118,10 +118,10 @@ AWS::
 | | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
 
 | *Tier 1* | 20 MBps | 60 MBps | 1,000 | 1,500
-| *Tier 2* | 50 MBps | 150 MBps | 2,000 |	3,750
-| *Tier 3* | 100 MBps | 200 MBps | 5,000 | 7,500
-| *Tier 4* | 200 MBps | 400 MBps | 5,000 | 15,000
-| *Tier 5* | 400 MBps | 800 MBps | 7,500 | 30,000
+| *Tier 2* | 50 MBps | 150 MBps | 2,800 |	3,750
+| *Tier 3* | 100 MBps | 200 MBps | 5,600 | 7,500
+| *Tier 4* | 200 MBps | 400 MBps | 11,200 | 15,000
+| *Tier 5* | 400 MBps | 800 MBps | 22,800 | 30,000
 |===
 --
 GCP::

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -114,7 +114,7 @@ When you create a cluster, you select a throughput tier for your expected ingres
 
 | Tier 1 ARM64 or x86 | 1,000 | 1,500
 | Tier 2 ARM64 or x86 | 2,800 |	3750 
-| Tier 3 ARM64 or x86 | 5,600 |	7500
+| Tier 3 ARM64 or x86 | 5,600 |	7,500
 | Tier 4 ARM64 or x86 | 11,200 | 15,000
 | Tier 5 ARM64 or x86 | 22,800 | 22,500
 |===

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -107,7 +107,7 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 == Cluster tiers
 
-When you create a cluster, you select a throughput tier for your expected ingress and egress. You can scale up from one tier to another with minimal downtime. The maximum number of partitions and connections also increases with each tier:
+When you create a cluster, you select a throughput tier. You can scale up from one tier to another with minimal downtime. 
 
 [tabs]
 ====
@@ -115,31 +115,31 @@ AWS::
 +
 --
 |===
-| | Max partitions | Max connections
+| | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
 
-| Tier 1 | 1,000 | 1,500
-| Tier 1 ARM64 or x86 | 1,000 | 1,500
-| Tier 2 | 2,000 |	3,750
-| Tier 2 ARM64 or x86 | 2,800 |	3,750 
-| Tier 3 | 5,000 |	7,500
-| Tier 3 ARM64 or x86 | 5,600 |	7,500
-| Tier 4 | 5,000 | 15,000
-| Tier 4 ARM64 or x86 | 11,200 | 15,000
-| Tier 5 | 7,500 | 30,000
-| Tier 5 ARM64 or x86 | 22,800 | 22,500
+| *Tier 1* | 20 MBps | 60 MBps | 1,000 | 1,500
+| *Tier 1 ARM64 or x86* | 20 MBps | 60 MBps | 1,000 | 1,500
+| *Tier 2* | 50 MBps | 150 MBps | 2,000 |	3,750
+| *Tier 2 ARM64 or x86* | 50 MBps | 150 MBps | 2,800 | 3,750 
+| *Tier 3* | 100 MBps | 200 MBps | 5,000 | 7,500
+| *Tier 3 ARM64 or x86* | 100 MBps | 200 MBps | 5,600 | 7,500
+| *Tier 4* | 200 MBps | 400 MBps | 5,000 | 15,000
+| *Tier 4 ARM64 or x86* | 200 MBps | 400 MBps | 11,200 | 15,000
+| *Tier 5* | 400 MBps | 800 MBps | 7,500 | 30,000
+| *Tier 5 ARM64 or x86* | 400 MBps | 800 MBps | 22,800 | 22,500
 |===
 --
 GCP::
 +
 --
 |===
-| | Max partitions | Max connections
+| | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
 
-| Tier 1 | 500 | 1,500
-| Tier 2 | 1,000 |	3,750
-| Tier 3 | 3,000 |	7,500
-| Tier 4 | 5,000 | 15,000
-| Tier 5 | 7,500 | 22,500
+| *Tier 1* | 20 MBps | 60 MBps | 500 | 1,500
+| *Tier 2* | 50 MBps | 150 MBps | 1,000 | 3,750
+| *Tier 3* | 100 MBps | 200 MBps | 3,000 | 7,500
+| *Tier 4* | 200 MBps | 400 MBps | 5,000 | 15,000
+| *Tier 5* | 400 MBps | 800 MBps | 7,500 | 22,500
 |===
 --
 ====


### PR DESCRIPTION
fixes https://github.com/redpanda-data/documentation-private/issues/2145

This adds a new sections in the Cloud Overview about cluster tiers, including max partitions allowed in the new optimized tiers.

preview: https://deploy-preview-182--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/cloud-overview/#cluster-tiers