### PR TITLE
Follower fetching configuration for cloud vs self-hosted

### DIFF
--- a/modules/develop/pages/consume-data/follower-fetching.adoc
+++ b/modules/develop/pages/consume-data/follower-fetching.adoc
@@ -8,7 +8,7 @@ Learn about follower fetching and how to configure a Redpanda consumer to fetch 
 
 **Follower fetching** enables a consumer to fetch records from the closest replica of a topic partition, regardless of whether it's a leader or a follower.
 
-For a Redpanda cluster deployed across different datacenters and availability zones (AZs), restricting a consumer to fetch only from the leader of a partition can incur more costs and have higher latency than fetching from a follower that is geographically closer to the consumer.
+For a Redpanda cluster deployed across different datacenters and availability zones (AZs), restricting a consumer to fetch only from the leader of a partition can incur greater costs and have higher latency than fetching from a follower that is geographically closer to the consumer.
 
 With follower fetching (proposed in {url-kip392}[KIP-392^]), the fetch protocol is extended to support a consumer fetching from any replica.
 

--- a/modules/develop/pages/consume-data/follower-fetching.adoc
+++ b/modules/develop/pages/consume-data/follower-fetching.adoc
@@ -8,7 +8,7 @@ Learn about follower fetching and how to configure a Redpanda consumer to fetch 
 
 **Follower fetching** enables a consumer to fetch records from the closest replica of a topic partition, regardless of whether it's a leader or a follower.
 
-For a Redpanda cluster deployed across different datacenters and availability zones, restricting a consumer to fetch only from the leader of a partition can incur more costs and have higher latency than fetching from a follower that is geographically closer to the consumer.
+For a Redpanda cluster deployed across different datacenters and availability zones (AZs), restricting a consumer to fetch only from the leader of a partition can incur more costs and have higher latency than fetching from a follower that is geographically closer to the consumer.
 
 With follower fetching (proposed in {url-kip392}[KIP-392^]), the fetch protocol is extended to support a consumer fetching from any replica.
 
@@ -20,9 +20,21 @@ Redpanda decides which replica a consumer fetches from. If the consumer configur
 
 To enable follower fetching in Redpanda, configure properties for the consumer and the Redpanda cluster and node:
 
+[tabs]
+====
+Self-hosted::
++
+--
 - For a Redpanda cluster, set the xref:reference:cluster-properties.adoc#enable_rack_awareness[`enable_rack_awareness`] property to `true`.
 - For each Redpanda node, set the xref:reference:node-properties.adoc#rack[`rack`] property to a rack ID.
 - For each consumer, set the `client.rack` property to a rack ID.
+--
+Cloud::
++
+--
+For each consumer, set the `client.rack` property to a rack ID. xref:manage:rack-awareness.adoc[Rack awareness] is pre-enabled for cloud-based clusters in multi-AZ environments.
+--
+====
 
 include::shared:partial$suggested-video.adoc[]
 


### PR DESCRIPTION
Organize cloud vs self hosted instructions using tabs. [Preview](https://deploy-preview-183--redpanda-docs-preview.netlify.app/current/develop/consume-data/follower-fetching/#configure-follower-fetching)

Closes https://github.com/redpanda-data/documentation-private/issues/2033