### PR TITLE
make partition_autobalancing_movement_batch_size_bytes deprecated

### DIFF
--- a/modules/reference/pages/tunable-properties.adoc
+++ b/modules/reference/pages/tunable-properties.adoc
@@ -990,6 +990,7 @@ Tick interval of the partition auto-balancer.
 ---
 
 === partition_autobalancing_movement_batch_size_bytes
+{badge-deprecated}
 
 Total size of partitions that the partition auto-balancer moves in one batch.
 

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -1,11 +1,16 @@
 = Deprecated Features
 :description: See a list of deprecated features in Redpanda 23.2 and plan necessary upgrades or modifications.
 
-This index helps you to identify deprecated features in Redpanda 23.2 and plan necessary upgrades or modifications.
+This index helps you to identify deprecated features in Redpanda releases and plan necessary upgrades or modifications.
 
 |===
-| Feature | Deprecated in
+| Feature | Deprecated in |Details
 
-| xref:./cluster-resource.adoc[Cluster and Console custom resources]
+| xref:reference:redpanda-operator/index.adoc[Cluster and Console custom resources]
 | 23.2.1
+| Use the xref:./cluster-resource.adoc[Redpanda resource] instead.
+
+|xref:reference:tunable-properties.adoc#partition_autobalancing_movement_batch_size_bytes[`partition_autobalancing_movement_batch_size_bytes`]
+|23.2.12
+| Use xref:reference:tunable-properties.adoc#partition_autobalancing_concurrent_moves[`partition_autobalancing_concurrent_moves`] instead.
 |===


### PR DESCRIPTION
It is deprecated since v23.2.12 per https://github.com/redpanda-data/redpanda/commit/8ff2e12494927a629f24e0a4f8da9c611e380241#diff-e8306fee110be0a0c5b29616987ead39d84f451b7bd4bf8ab705e62ccc593dff.

Confirmed with SME @ztlpn in https://redpandadata.slack.com/archives/C05G315PGDR/p1702884556378539