### PR TITLE
Fix out of order results for the Console chart

### DIFF
--- a/scripts/generate-k8s-compatibility-matrix/generate-rp-matrix.js
+++ b/scripts/generate-k8s-compatibility-matrix/generate-rp-matrix.js
@@ -69,7 +69,7 @@ async function generateTable() {
 
       } else if (chartDetails && chartDetails.consoleChartVersions && MATRIX_TO_GENERATE === 'console') {
 
-        fetchLatestConsoleChartVersion(chartDetails.consoleChartVersions, allConsoleChartVersions)
+        await fetchLatestConsoleChartVersion(chartDetails.consoleChartVersions, allConsoleChartVersions)
           .then(({ latestVersion, appVersion }) => {
             table += `| link:https://github.com/redpanda-data/helm-charts/releases/redpanda-${chartDetails.chartVersion}[${chartMajorMinor}]\n`;
             table += `| link:https://github.com/redpanda-data/helm-charts/releases/console-${latestVersion}[${latestVersion}]\n`;


### PR DESCRIPTION
We weren't awaiting the results of the `fetchLatestConsoleChartVersion` function, which led to results in the table being out of order.