### PR TITLE
Add link to deprecation badge

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -14,6 +14,7 @@ asciidoc:
     supported-rhel-recommended: '9+'
     supported-ubuntu-required: '20.04 LTS'
     supported-ubuntu-recommended: '22.04+'
+    badge-deprecated: 'image:https://img.shields.io/badge/-Deprecated-red.svg[xref=upgrade:deprecated/index.adoc]'
     # Data for the home page
     page-feature-list:
       - title: 'Redpanda Quickstart'


### PR DESCRIPTION
Relies on https://github.com/redpanda-data/docs-site/pull/39 and https://github.com/redpanda-data/docs-extensions-and-macros/pull/26 being merged.

fixes redpanda-data/documentation-private#2137