### PR TITLE
Add requirements label

### DIFF
--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -52,7 +52,7 @@ endif::[]
 
 - x86_64 (Westmere or newer) and AWS Graviton family processors are supported.
 
-- 2 GB or more of memory per core.
+- 4 GB or more of memory per core.
 
 - 4 MB of memory for each topic partition replica. You can enforce this requirement in the tunable xref:reference:tunable-properties.adoc#topic_memory_per_partition[`topic_memory_per_partition` property].
 

--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -48,11 +48,13 @@ endif::[]
 
 == CPU and memory
 
+*Requirements*:
+
 - Two physical, not virtual, cores for each {node}.
 
 - x86_64 (Westmere or newer) and AWS Graviton family processors are supported.
 
-- 4 GB or more of memory per core.
+- 2 GB or more of memory per core.
 
 - 4 MB of memory for each topic partition replica. You can enforce this requirement in the tunable xref:reference:tunable-properties.adoc#topic_memory_per_partition[`topic_memory_per_partition` property].
 
@@ -65,6 +67,8 @@ ifdef::env-kubernetes[]
 endif::[]
 
 == Storage
+
+*Requirements*:
 
 - An XFS or ext4 file system.
 +


### PR DESCRIPTION
~The latest guidance is 4 GB per core of memory for production deployments.~