### PR TITLE
Document the enableHelmControllers flag

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc
@@ -27,11 +27,9 @@ Helm + Operator::
 +
 --
 
-The Redpanda Operator handles the deployment and management of the Redpanda Helm chart for you using https://fluxcd.io/flux/concepts/[Flux^].
-
 The Redpanda Operator extends Kubernetes with custom resource definitions (CRDs), allowing you to define Redpanda clusters as native Kubernetes resources. The resource that the Redpanda Operator uses to represent a Redpanda cluster is the Redpanda resource.
 
-When you deploy a Redpanda resource, the Redpanda Operator takes that configuration and passes it to Flux. Flux, in turn, interacts with Helm, creating the necessary HelmRepository and HelmRelease resources to deploy and manage the Redpanda Helm chart.
+The Redpanda Operator handles the deployment and management of the Redpanda Helm chart for you using https://fluxcd.io/flux/concepts/[Flux^]. When you deploy a Redpanda resource, the Redpanda Operator takes that configuration and passes it to Flux. Flux, in turn, interacts with Helm, creating the necessary HelmRepository and HelmRelease resources to deploy and manage the Redpanda Helm chart.
 
 NOTE: The Redpanda Operator is namespace scoped. You must install the Redpanda Operator in the same namespace as your Redpanda resource (Redpanda cluster).
 
@@ -74,6 +72,8 @@ helm upgrade --install redpanda-controller redpanda/operator \
   --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
   --create-namespace
 ----
++
+NOTE: If you already have Flux installed on your Kubernetes cluster, use the `--set enableHelmControllers=false` flag to prevent the Redpanda Operator from deploying its own set of Helm controllers.
 
 . Ensure that the Deployment is successfully rolled out:
 +

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc
@@ -29,7 +29,7 @@ Helm + Operator::
 
 The Redpanda Operator extends Kubernetes with custom resource definitions (CRDs), allowing you to define Redpanda clusters as native Kubernetes resources. The resource that the Redpanda Operator uses to represent a Redpanda cluster is the Redpanda resource.
 
-The Redpanda Operator handles the deployment and management of the Redpanda Helm chart for you using https://fluxcd.io/flux/concepts/[Flux^]. When you deploy a Redpanda resource, the Redpanda Operator takes that configuration and passes it to Flux. Flux, in turn, interacts with Helm, creating the necessary HelmRepository and HelmRelease resources to deploy and manage the Redpanda Helm chart.
+The Redpanda Operator handles the deployment and management of the Redpanda Helm chart for you using https://fluxcd.io/flux/concepts/[Flux^]. When you deploy a Redpanda resource, the Redpanda Operator takes that configuration and passes it to Flux. Flux, in turn, interacts with Helm, by creating the necessary HelmRepository and HelmRelease resources to deploy and manage the Redpanda Helm chart.
 
 NOTE: The Redpanda Operator is namespace scoped. You must install the Redpanda Operator in the same namespace as your Redpanda resource (Redpanda cluster).
 

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc
@@ -29,7 +29,7 @@ Helm + Operator::
 
 The Redpanda Operator extends Kubernetes with custom resource definitions (CRDs), allowing you to define Redpanda clusters as native Kubernetes resources. The resource that the Redpanda Operator uses to represent a Redpanda cluster is the Redpanda resource.
 
-The Redpanda Operator handles the deployment and management of the Redpanda Helm chart for you using https://fluxcd.io/flux/concepts/[Flux^]. When you deploy a Redpanda resource, the Redpanda Operator takes that configuration and passes it to Flux. Flux, in turn, interacts with Helm, by creating the necessary HelmRepository and HelmRelease resources to deploy and manage the Redpanda Helm chart.
+The Redpanda Operator handles the deployment and management of the Redpanda Helm chart for you by using https://fluxcd.io/flux/concepts/[Flux^]. When you deploy a Redpanda resource, the Redpanda Operator takes that configuration and passes it to Flux. Flux, in turn, interacts with Helm, by creating the necessary HelmRepository and HelmRelease resources to deploy and manage the Redpanda Helm chart.
 
 NOTE: The Redpanda Operator is namespace scoped. You must install the Redpanda Operator in the same namespace as your Redpanda resource (Redpanda cluster).
 
@@ -73,7 +73,7 @@ helm upgrade --install redpanda-controller redpanda/operator \
   --create-namespace
 ----
 +
-NOTE: If you already have Flux installed on your Kubernetes cluster, use the `--set enableHelmControllers=false` flag to prevent the Redpanda Operator from deploying its own set of Helm controllers.
+NOTE: If you already have Flux installed on your Kubernetes cluster and you want it to continue managing the entire cluster, use the `--set enableHelmControllers=false` flag.  This flag prevents the Redpanda Operator from deploying its own set of Helm controllers that may conflict with those installed with https://fluxcd.io/flux/concepts/[Flux^].
 
 . Ensure that the Deployment is successfully rolled out:
 +

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
@@ -159,6 +159,8 @@ helm upgrade --install redpanda-controller redpanda/operator \
   --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
   --create-namespace
 ----
++
+NOTE: If you already have Flux installed on your Kubernetes cluster, use the `--set enableHelmControllers=false` flag to prevent the Redpanda Operator from deploying its own set of Helm controllers.
 
 . Ensure that the Deployment is successfully rolled out:
 +

--- a/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
+++ b/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
@@ -48,6 +48,8 @@ helm upgrade --install redpanda-controller redpanda/operator \
   --create-namespace \
   --timeout 1h
 ----
++
+NOTE: If you already have Flux installed on your Kubernetes cluster, use the `--set enableHelmControllers=false` flag to prevent the Redpanda Operator from deploying its own set of Helm controllers.
 
 . Ensure that the Deployment is successfully rolled out:
 +


### PR DESCRIPTION
Added a note to sections where we describe how to deploy Redpanda Operator with details on disabling our internal Helm controllers.

Related PR: https://github.com/redpanda-data/redpanda-operator/pull/47