### PR TITLE
#2159 edit beta admonition for data transforms

### DIFF
--- a/modules/develop/pages/data-transforms/how-transforms-work.adoc
+++ b/modules/develop/pages/data-transforms/how-transforms-work.adoc
@@ -1,13 +1,13 @@
 = How Data Transforms Work
 :description: Learn how Redpanda data transforms work.
 
+include::shared:partial$public-beta.adoc[] 
+
 Redpanda provides the framework to build and deploy inline transformations (data transforms) on data written to Redpanda topics, delivering processed and validated data to consumers in the format they expect. Redpanda does this directly inside the broker, eliminating the need to manage a separate stream processing environment or use 3rd-party tools.
 
 image::shared:wasm1.png[Data transforms in a broker] 
 
 Data transforms let you run common data streaming tasks, like filtering, scrubbing, and transcoding, within Redpanda. For example, you may have consumers that require you to redact credit card numbers or convert JSON to Avro. Data transforms can also interact with the Redpanda Schema Registry to work with encoded data types. To learn how to build and deploy data transforms, see xref:./run-transforms.adoc[].
-
-include::shared:partial$public-beta.adoc[] 
 
 == Data transforms with WebAssembly
 

--- a/modules/develop/pages/data-transforms/how-transforms-work.adoc
+++ b/modules/develop/pages/data-transforms/how-transforms-work.adoc
@@ -7,7 +7,7 @@ image::shared:wasm1.png[Data transforms in a broker]
 
 Data transforms let you run common data streaming tasks, like filtering, scrubbing, and transcoding, within Redpanda. For example, you may have consumers that require you to redact credit card numbers or convert JSON to Avro. Data transforms can also interact with the Redpanda Schema Registry to work with encoded data types. To learn how to build and deploy data transforms, see xref:./run-transforms.adoc[].
 
-IMPORTANT: Data transforms is a Public Beta feature. It is not supported for production deployments. Runtime behavior may change in the GA release, and you may not be able to upgrade data transforms deployed during the Beta release without changes. Public Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback]. 
+include::shared:partial$public-beta.adoc[] 
 
 == Data transforms with WebAssembly
 

--- a/modules/develop/pages/data-transforms/how-transforms-work.adoc
+++ b/modules/develop/pages/data-transforms/how-transforms-work.adoc
@@ -7,6 +7,8 @@ image::shared:wasm1.png[Data transforms in a broker]
 
 Data transforms let you run common data streaming tasks, like filtering, scrubbing, and transcoding, within Redpanda. For example, you may have consumers that require you to redact credit card numbers or convert JSON to Avro. Data transforms can also interact with the Redpanda Schema Registry to work with encoded data types. To learn how to build and deploy data transforms, see xref:./run-transforms.adoc[].
 
+IMPORTANT: Data transforms is a Public Beta feature. It is not supported for production deployments. Runtime behavior may change in the GA release, and you may not be able to upgrade data transforms deployed during the Beta release without changes. Public Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback]. 
+
 == Data transforms with WebAssembly
 
 Data transforms use https://webassembly.org/[WebAssembly^] (Wasm) engines inside a Redpanda broker, allowing Redpanda to control the entire transform lifecycle. For example, Redpanda can stop and start transforms when partitions are moved or to free up system resources for other tasks. 

--- a/modules/develop/pages/data-transforms/index.adoc
+++ b/modules/develop/pages/data-transforms/index.adoc
@@ -1,3 +1,5 @@
 = Data Transforms
 :description: Learn about WebAssembly data transforms within Redpanda.
 :page-layout: index
+
+IMPORTANT: Data transforms is a Public Beta feature. It is not supported for production deployments. Runtime behavior may change in the GA release, and you may not be able to upgrade data transforms deployed during the Beta release without changes. Public Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback]. 

--- a/modules/develop/pages/data-transforms/index.adoc
+++ b/modules/develop/pages/data-transforms/index.adoc
@@ -2,4 +2,4 @@
 :description: Learn about WebAssembly data transforms within Redpanda.
 :page-layout: index
 
-IMPORTANT: Data transforms is a Public Beta feature. It is not supported for production deployments. Runtime behavior may change in the GA release, and you may not be able to upgrade data transforms deployed during the Beta release without changes. Public Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback]. 
+include::shared:partial$public-beta.adoc[] 

--- a/modules/develop/partials/run-transforms.adoc
+++ b/modules/develop/partials/run-transforms.adoc
@@ -6,7 +6,7 @@ You should build and deploy transforms from a separate, non-production machine (
 
 See also: xref:./how-transforms-work.adoc[] and <<Limitations>>
 
-IMPORTANT: Data transforms is a Public Beta feature. It is not supported for production deployments. Runtime behavior may change in the GA release, and you may not be able to upgrade data transforms deployed during the Beta release without changes. Public Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback].
+include::shared:partial$public-beta.adoc[] 
 
 == Prerequisites
 

--- a/modules/develop/partials/run-transforms.adoc
+++ b/modules/develop/partials/run-transforms.adoc
@@ -1,3 +1,5 @@
+include::shared:partial$public-beta.adoc[] 
+
 Data transforms let you run common data streaming tasks, like filtering, scrubbing, and transcoding, within Redpanda. For example, you may have consumers that require you to redact credit card numbers or convert JSON to Avro. Data transforms can also interact with the Redpanda Schema Registry to work with encoded data types.
 
 Data transforms use a WebAssembly (Wasm) engine inside a Redpanda broker. A Wasm function acts on a single record in an input topic. You can develop and manage data transforms with xref:reference:rpk/rpk-transform/rpk-transform.adoc[`rpk transform`] commands.
@@ -5,8 +7,6 @@ Data transforms use a WebAssembly (Wasm) engine inside a Redpanda broker. A Wasm
 You should build and deploy transforms from a separate, non-production machine (host machine). Using a separate host machine avoids potential resource conflicts and stability issues on the nodes that run your brokers.
 
 See also: xref:./how-transforms-work.adoc[] and <<Limitations>>
-
-include::shared:partial$public-beta.adoc[] 
 
 == Prerequisites
 

--- a/modules/develop/partials/run-transforms.adoc
+++ b/modules/develop/partials/run-transforms.adoc
@@ -6,7 +6,7 @@ You should build and deploy transforms from a separate, non-production machine (
 
 See also: xref:./how-transforms-work.adoc[] and <<Limitations>>
 
-IMPORTANT: Data transforms is a beta feature is not supported for production deployments. Runtime behavior may change in the GA release, and you may not be able to upgrade data transforms deployed during the beta release without changes.
+IMPORTANT: Data transforms is a Public Beta feature. It is not supported for production deployments. Runtime behavior may change in the GA release, and you may not be able to upgrade data transforms deployed during the Beta release without changes. Public Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback].
 
 == Prerequisites
 

--- a/modules/shared/partials/public-beta.adoc
+++ b/modules/shared/partials/public-beta.adoc
@@ -1,0 +1,1 @@
+IMPORTANT: Data transforms is a Public Beta feature. It is not supported for production deployments. Runtime behavior may change in the GA release, and you may not be able to upgrade data transforms deployed during the Beta release without changes. Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback]. 


### PR DESCRIPTION
fixes https://github.com/redpanda-data/documentation-private/issues/2159

Data transforms will stay in a "Public Beta" state even after the 23.3 Beta release closes. This edits the existing admonition and adds a link to the Community slack for feedback. 

preview:
- https://deploy-preview-200--redpanda-docs-preview.netlify.app/23.3/develop/data-transforms/
- https://deploy-preview-200--redpanda-docs-preview.netlify.app/23.3/develop/data-transforms/how-transforms-work/
- https://deploy-preview-200--redpanda-docs-preview.netlify.app/23.3/develop/data-transforms/run-transforms/