### PR TITLE
Correct recovery commands

### DIFF
--- a/modules/manage/partials/recovery-mode.adoc
+++ b/modules/manage/partials/recovery-mode.adoc
@@ -264,7 +264,7 @@ rpk::
 +
 --
 ```bash
-rpk cluster partitions disable --topic <topic-name> --partition <partition-id>
+rpk cluster partitions disable <topic-name> --partitions <comma-delimited-partition-id>
 ```
 --
 Curl::
@@ -284,7 +284,7 @@ rpk::
 +
 --
 ```bash
-rpk cluster partitions enable --topic <topic-name> --partition <partition-id>
+rpk cluster partitions enable <topic-name> --partitions <comma-delimited-partition-id>
 ```
 --
 Curl::
@@ -304,7 +304,7 @@ rpk::
 +
 --
 ```bash
-rpk cluster partitions disable --topic <topic-name>
+rpk cluster partitions disable <topic-name> --all
 ```
 --
 Curl::
@@ -324,7 +324,7 @@ rpk::
 +
 --
 ```bash
-rpk cluster partitions enable --topic <topic-name>
+rpk cluster partitions enable <topic-name> --all
 ```
 --
 Curl::
@@ -344,7 +344,7 @@ rpk::
 +
 --
 ```bash
-rpk cluster partitions list --disabled
+rpk cluster partitions list --all --disabled-only
 ```
 --
 Curl::
@@ -364,7 +364,7 @@ rpk::
 +
 --
 ```bash
-rpk cluster partitions list --topic <topic-name> --disabled
+rpk cluster partitions list <topic-names> --disabled-only
 ```
 --
 Curl::


### PR DESCRIPTION
Some of the `rpk` instructions in https://docs.redpanda.com/beta/manage/recovery-mode are not correct. This commit corrects the wrong ones. 
Adding @r-vasquez as a SME reviewer.