### PR TITLE
Update Remote recovery section

### DIFF
--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1275,20 +1275,25 @@ endif::[]
 
 When you create a topic, you can use remote recovery to download the topic data from object storage. This is useful when you need to restore a single topic that was accidentally deleted from a cluster.
 
-IMPORTANT: Remote recovery is only safe when no other clusters are writing to the specified bucket or container.
+[IMPORTANT]
+====
+* Remote recovery is only safe when no other clusters are writing to the specified bucket or container.
+* You must enable `redpanda.remote.read` when using remote recovery.
+* If you later disable `redpanda.remote.read` on the remote recovery topic, previously hydrated (downloaded) data will not be used to serve requests.
+====
 
-To create a new topic using remote recovery:
-
-[,bash]
-----
-rpk topic create <topic_name> -c redpanda.remote.recovery=true
-----
-
-To create a new topic using remote recovery and enable Tiered Storage on the new topic with the `redpanda.remote.write` and `redpanda.remote.read` properties:
+To create a new topic using remote recovery (the recovered topic can read and write in the cloud):
 
 [,bash]
 ----
 rpk topic create <topic_name> -c redpanda.remote.recovery=true -c redpanda.remote.write=true -c redpanda.remote.read=true
+----
+
+To create a new topic using remote recovery (while also disabling the `redpanda.remote.write` property):
+
+[,bash]
+----
+rpk topic create <topic_name> -c redpanda.remote.recovery=true -c redpanda.remote.write=false -c redpanda.remote.read=true
 ----
 
 == Retries and backoff


### PR DESCRIPTION
remote.read has to be always true when using remote.recovery. Otherwise redpanda tries to hydrate all of the segments from cloud and possibly ends up with crash.

Fixes https://github.com/redpanda-data/documentation-private/issues/1953