### PR TITLE
Delete vs compact cleanup policy

### DIFF
--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -78,7 +78,7 @@ NOTE: The replication factor can't exceed the number of Redpanda brokers. If you
 The cleanup policy determines how to clean up the partition log files when they reach a certain size:
 
 * `delete` deletes data based on age or log size.
-* `compact` compacts the data by only keeping the latest values for each KEY.
+* `compact` compacts the data by only keeping the latest values for each KEY. For details on compaction in Redpanda, see xref:manage:cluster-maintenance/compaction-settings.adoc[Compaction settings].
 * `compact,delete` combines both methods.
 
 Suppose you configure a topic using the default cleanup policy `delete`, and you want to change the policy to `compact`. Run the `rpk topic alter-config` command as shown:

--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -77,9 +77,11 @@ NOTE: The replication factor can't exceed the number of Redpanda brokers. If you
 
 The cleanup policy determines how to clean up the partition log files when they reach a certain size:
 
-* `delete` deletes data based on age or log size.
+* `delete` deletes data based on age or log size. Topics retain all records until then.
 * `compact` compacts the data by only keeping the latest values for each KEY. For details on compaction in Redpanda, see xref:manage:cluster-maintenance/compaction-settings.adoc[Compaction settings].
 * `compact,delete` combines both methods.
+
+Unlike compacted topics which keep only the most recent message for a given key, topics configured with a delete cleanup policy provide a running history of all changes for those topics. 
 
 Suppose you configure a topic using the default cleanup policy `delete`, and you want to change the policy to `compact`. Run the `rpk topic alter-config` command as shown:
 

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -23,6 +23,13 @@ Compaction policy may be applied to a cluster or to an individual topic. If both
 * `compact`: This triggers only cleanup of messages with multiple versions. A message that represents the only version for a given key is not deleted.
 * `compact,delete`: This combines both policies, deleting messages exceeding the retention period while compacting multiple versions of messages.
 
+=== Track history of compacted topic
+
+Unlike compacted topics which keep only the most recent message for a given key, topics configured with a delete cleanup policy provide a running history of all changes for those topics. To track the history of a compacted topic, you can subscribe a consumer to the topic and do one, or both, of the following:
+
+* Sink the data to a database or another storage location.
+* Produce the data to a new topic set with `delete` cleanup.
+
 == Compaction policy settings
 
 The various cleanup policy settings rely on proper tuning of a cluster's compaction and retention policy options. The applicable settings are:

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -11,6 +11,8 @@ image::shared:compaction-example.png[Example of topic compaction]
 
 This diagram provides an illustration of a compacted topic. Imagine a remote sensor network that uses image recognition to track appearances of red pandas in a geographic area. The sensor network employs special devices that send messages to a topic when they detect one. You might enable compaction to reduce topic storage while still maintaining a record in the topic of the last time each device saw a red panda, perhaps to see if they stop frequenting a given area. The left side of the diagram shows all messages sent across the topic. The right side illustrates the results of compaction; older messages for certain keys are deleted from the message log.
 
+NOTE: If your application requires consuming every message for a given key, consider using the `delete` xref:develop:config-topics#change-the-cleanup-policy.adoc[cleanup policy] instead.
+
 IMPORTANT:  When using Tiered Storage, compaction functions at the local storage level. As long as a segment remains in local storage, its messages are eligible for compaction. Once a segment is uploaded to tiered storage and removed from local storage it is not retrieved for further compaction operations. A key may therefore appear in multiple segments between Tiered Storage and local storage.
 
 While compaction reduces storage needs, Redpanda's compaction (just like Kafka's) does not guarantee perfect de-duplication of a topic. It represents a best effort mechanism to reduce storage needs but duplicates of a key may still exist within a topic. Compaction is not a complete topic operation, either, since it operates on subsets of each partition within the topic.
@@ -22,13 +24,6 @@ Compaction policy may be applied to a cluster or to an individual topic. If both
 * `delete`: Messages are deleted from the topic once the specified retention period (time and/or size allocations) is exceeded. This is the default mechanism and is analogous to disabling compaction.
 * `compact`: This triggers only cleanup of messages with multiple versions. A message that represents the only version for a given key is not deleted.
 * `compact,delete`: This combines both policies, deleting messages exceeding the retention period while compacting multiple versions of messages.
-
-=== Track history of compacted topic
-
-Unlike compacted topics which keep only the most recent message for a given key, topics configured with a delete cleanup policy provide a running history of all changes for those topics. To track the history of a compacted topic, you can subscribe a consumer to the topic and do one, or both, of the following:
-
-* Sink the data to a database or another storage location.
-* Produce the data to a new topic set with `delete` cleanup.
 
 == Compaction policy settings
 


### PR DESCRIPTION
Closes https://github.com/redpanda-data/documentation-private/issues/707. Since the time this issue was opened we have published a new [Compaction](https://docs.redpanda.com/current/manage/cluster-maintenance/compaction-settings/) doc which should further clarify the difference between `delete` vs `compact` (original question from the community). This PR:

- adds a link to the Compaction doc from the Manage Topics doc ([preview link](https://deploy-preview-220--redpanda-docs-preview.netlify.app/current/develop/config-topics/#change-the-cleanup-policy))
- adds a note in the Compaction doc for when users might want to use the `delete` policy instead ([preview link](https://deploy-preview-220--redpanda-docs-preview.netlify.app/current/manage/cluster-maintenance/compaction-settings/#redpanda-compaction-overview))