### PR TITLE
Fix incorrect network id used in vpc-peering-aws.adoc

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/vpc-peering-aws.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/vpc-peering-aws.adoc
@@ -23,7 +23,7 @@ The following command routes traffic from Redpanda to AWS by finding the route t
 
 [,bash]
 ----
-aws ec2 describe-route-tables --filter "Name=tag:Name,Values=network-<redpanda-cluster-id>" "Name=tag:purpose,Values=private" | jq -r '.RouteTables[].RouteTableId' | \
+aws ec2 describe-route-tables --filter "Name=tag:Name,Values=network-<redpanda-network-id>" "Name=tag:purpose,Values=private" | jq -r '.RouteTables[].RouteTableId' | \
 while read -r route_table_id; do \
 aws ec2 create-route --route-table-id $route_table_id --destination-cidr-block <aws-vpc-cidr-block> --vpc-peering-connection-id <peering-connection-id>; \
 done;
@@ -31,7 +31,7 @@ done;
 
 Replace the following placeholder values:
 
-* Redpanda cluster ID: This is listed in the *Overview* page of your cluster.
+* Redpanda network ID: This ID appears after clicking on the name of the *Redpanda network* in the *Details* section of the *Overview* page of your cluster. Note: This network ID may look similar, however, it is distinct from your cluster ID.
 * AWS CIDR block: This is listed in the AWS UI *Details* for your VPC.
 * Peering connection ID: This is the ID of the peering connection noted in step one.
 

--- a/modules/deploy/pages/deployment-option/cloud/vpc-peering-aws.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/vpc-peering-aws.adoc
@@ -31,7 +31,7 @@ done;
 
 Replace the following placeholder values:
 
-* Redpanda network ID: This ID appears after clicking on the name of the *Redpanda network* in the *Details* section of the *Overview* page of your cluster. Note: This network ID may look similar, however, it is distinct from your cluster ID.
+* Redpanda network ID: This ID appears after clicking on the name of the *Redpanda network* in the *Details* section of the *Overview* page of your cluster. This network ID may look similar, however, it is distinct from your cluster ID.
 * AWS CIDR block: This is listed in the AWS UI *Details* for your VPC.
 * Peering connection ID: This is the ID of the peering connection noted in step one.
 


### PR DESCRIPTION
Redpanda VPC uses Redpanda network ID in the Name tag, not the Redpanda cluster ID. This addresses the issue when BYOC customers were not able to create correct routes from Redpanda network to their peered VPC.