### PR TITLE
RP does not support auto_create_topics_enabled in cloud

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -129,6 +129,7 @@ Redpanda Cloud does not support the following self-hosted functionality:
 - Data transforms
 - Remote Read Replicas
 - Redpanda Console topic documentation
+- Setting `auto_create_topics_enabled=true` for BYOC and dedicated clusters
 - Admin API
 - The following `rpk` commands (which use the Admin API):
 

--- a/modules/reference/pages/cluster-properties.adoc
+++ b/modules/reference/pages/cluster-properties.adoc
@@ -1564,7 +1564,7 @@ URL of the cluster metrics reporter.
 
 === auto_create_topics_enabled
 
-Allow automatic topic creation.
+Allow automatic topic creation. To prevent runaway topic creation, this property is not supported for Redpanda Cloud BYOC and dedicated clusters. You should explicitly manage topic creation for these Redpanda Cloud clusters.
 
 *Type*: boolean
 


### PR DESCRIPTION
Fixes [Issue 2168](https://github.com/redpanda-data/documentation-private/issues/2168)

Preview in [Cloud Overview](https://deploy-preview-228--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/cloud-overview/#redpanda-cloud-vs-self-hosted-feature-compatibility)

Preview in [auto_create_topics_enabled](https://deploy-preview-228--redpanda-docs-preview.netlify.app/current/reference/cluster-properties/#auto_create_topics_enabled) property description