### PR TITLE
Remove explicit memory and smp configs

### DIFF
--- a/modules/shared/attachments/docker/single-broker/docker-compose.yml
+++ b/modules/shared/attachments/docker/single-broker/docker-compose.yml
@@ -21,13 +21,9 @@ services:
       # Address the broker advertises to clients that connect to the HTTP Proxy.
       - --advertise-pandaproxy-addr internal://redpanda-0:8082,external://localhost:18082
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
-      # Redpanda brokers use the RPC API to communicate with eachother internally.
+      # Redpanda brokers use the RPC API to communicate with each other internally.
       - --rpc-addr redpanda-0:33145
       - --advertise-rpc-addr redpanda-0:33145
-      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
-      - --smp 1
-      # The amount of memory to make available to Redpanda.
-      - --memory 1G
       # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
       # enable logs for debugging.

--- a/modules/shared/attachments/docker/three-brokers/docker-compose.yml
+++ b/modules/shared/attachments/docker/three-brokers/docker-compose.yml
@@ -23,13 +23,9 @@ services:
       # Address the broker advertises to clients that connect to the HTTP Proxy.
       - --advertise-pandaproxy-addr internal://redpanda-0:8082,external://localhost:18082
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
-      # Redpanda brokers use the RPC API to communicate with eachother internally.
+      # Redpanda brokers use the RPC API to communicate with each other internally.
       - --rpc-addr redpanda-0:33145
       - --advertise-rpc-addr redpanda-0:33145
-      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
-      - --smp 1
-      # The amount of memory to make available to Redpanda.
-      - --memory 1G
       # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
       # enable logs for debugging.
@@ -56,8 +52,6 @@ services:
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:28081
       - --rpc-addr redpanda-1:33145
       - --advertise-rpc-addr redpanda-1:33145
-      - --smp 1
-      - --memory 1G
       - --mode dev-container
       - --default-log-level=debug
       - --seeds redpanda-0:33145
@@ -85,8 +79,6 @@ services:
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:38081
       - --rpc-addr redpanda-2:33145
       - --advertise-rpc-addr redpanda-2:33145
-      - --smp 1
-      - --memory 1G
       - --mode dev-container
       - --default-log-level=debug
       - --seeds redpanda-0:33145


### PR DESCRIPTION
Reported in community Slack. The `dev-container` config already sets memory and cores.