### PR TITLE
Single partition recovery

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -183,6 +183,7 @@
 *** xref:manage:cluster-maintenance/compaction-settings.adoc[Compaction Settings]
 *** xref:manage:cluster-maintenance/configure-availability.adoc[Configure Availability]
 *** xref:manage:cluster-maintenance/cluster-diagnostics.adoc[Cluster Diagnostics]
+*** xref:manage:cluster-maintenance/partition-recovery.adoc[Partition Recovery]
 *** xref:manage:cluster-maintenance/nodewise-partition-recovery.adoc[Node-wise Partition Recovery]
 ** xref:manage:security/index.adoc[Security]
 *** xref:manage:security/authentication.adoc[Configure Authentication]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -183,7 +183,7 @@
 *** xref:manage:cluster-maintenance/compaction-settings.adoc[Compaction Settings]
 *** xref:manage:cluster-maintenance/configure-availability.adoc[Configure Availability]
 *** xref:manage:cluster-maintenance/cluster-diagnostics.adoc[Cluster Diagnostics]
-*** xref:manage:cluster-maintenance/partition-recovery.adoc[Partition Recovery]
+*** xref:manage:cluster-maintenance/partition-recovery.adoc[Forced Partition Recovery]
 *** xref:manage:cluster-maintenance/nodewise-partition-recovery.adoc[Node-wise Partition Recovery]
 ** xref:manage:security/index.adoc[Security]
 *** xref:manage:security/authentication.adoc[Configure Authentication]

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -1,0 +1,30 @@
+= Partition recovery
+:description: Recover a single partition using the Admin API.
+
+You can use the Redpanda Admin API to recover a partition that appears to be stuck (for example, does not accept writes). This can arise when the partition replicas have lost glossterm:Raft[] consensus, for instance if brokers in a Raft group fail, preventing the group from reaching a majority and electing a new leader. 
+
+Partition recovery is carried out by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. However, this allows some potential data loss on the partition if the best available replica is out of sync, resulting in an unclean leader election. Partition recovery should only be used when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
+
+If you want to instead permanently remove failed brokers from a cluster, especially in situations where no surviving partition replicas remain, use nodewise recovery.  
+
+== Use the Admin API to recover a partition
+
+Make a POST request to the `/force_replicas` endpoint:
+
+[,bash]
+----
+curl -X POST http://localhost:9644/v1/debug/partitions/<namespace>/<topic>/<partition>/force_replicas \
+  -d '{
+    [
+        { "core": 0, "node_id": 0 } 
+    ]
+  }'
+----
+
+See xref:api:admin-api/#tag/Partitions/operation/force_update_partition_replicas[Redpanda Admin API] for a full reference.
+
+include::shared:partial$suggested-reading.adoc[]
+
+- https://redpanda.com/blog/raft-protocol-reconfiguration-solution/[Engineering a more robust Raft group reconfiguration^]
+
+

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -5,7 +5,7 @@ You can use the Redpanda Admin API to recover a partition that appears to be stu
 
 Partition recovery is carried out by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. However, this allows some potential data loss on the partition if the best available replica is out of sync, resulting in an unclean leader election. Partition recovery should only be used when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
 
-If you want to instead permanently remove failed brokers from a cluster, especially in situations where no surviving partition replicas remain, use nodewise recovery.  
+If you want to instead force recover partitions in bulk on a failed broker, use nodewise recovery.  
 
 == Use the Admin API to recover a partition
 
@@ -21,7 +21,8 @@ curl -X POST http://localhost:9644/v1/debug/partitions/<namespace>/<topic>/<part
   }'
 ----
 
-See xref:api:ROOT:admin-api.adoc#tag/Partitions/operation/force_update_partition_replicas[Redpanda Admin API] for a full reference.
+The request body must include the ID of the broker and the CPU core (shard ID). If there are `n` CPU cores on the machine, the value of `core` can be within the range `[0, n-1]`. You may use a random value within the range, or the least loaded shard.
+See the xref:reference:public-metrics-reference.adoc[public metrics reference] for metrics regarding CPU usage, and xref:api:ROOT:admin-api.adoc#tag/Partitions/operation/force_update_partition_replicas[Redpanda Admin API] for a full reference.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -1,9 +1,9 @@
-= Partition recovery
+= Forced partition recovery
 :description: Recover a single partition using the Admin API.
 
 You can use the Redpanda Admin API to recover a partition that appears to be stuck (for example, does not accept writes). This can arise when the partition replicas have lost glossterm:Raft[] consensus, for instance if brokers in a Raft group fail, preventing the group from reaching a majority and electing a new leader. 
 
-Partition recovery is carried out by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. However, this allows some potential data loss on the partition if the best available replica is out of sync, resulting in an unclean leader election. Partition recovery should only be used when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
+Forced partition recovery is carried out by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. However, this allows some potential data loss on the partition if the best available replica is out of sync, resulting in an unclean leader election. Forced partition recovery should only be used when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
 
 If you want to instead force recover partitions in bulk on a failed broker, use nodewise recovery.  
 

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -1,7 +1,7 @@
 = Forced partition recovery
 :description: Recover a single partition using the Admin API.
 
-You can use the Redpanda Admin API to recover a partition that appears to be stuck (for example, does not accept writes). This can arise when the partition replicas have lost glossterm:Raft[] consensus, for instance if brokers in a Raft group fail, preventing the group from reaching a majority and electing a new leader. 
+You can use the Redpanda Admin API to recover a partition that appears to be stuck (for example, does not accept writes). This can occur when the partition replicas have lost glossterm:Raft[] consensus, for instance if brokers in a Raft group fail, preventing the group from reaching a majority and electing a new leader. 
 
 Forced partition recovery is carried out by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. However, this allows some potential data loss on the partition if the best available replica is out of sync, resulting in an unclean leader election. Forced partition recovery should only be used when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
 

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -21,7 +21,7 @@ curl -X POST http://localhost:9644/v1/debug/partitions/<namespace>/<topic>/<part
   }'
 ----
 
-See xref:api:admin-api/#tag/Partitions/operation/force_update_partition_replicas[Redpanda Admin API] for a full reference.
+See xref:api:ROOT:admin-api.adoc#tag/Partitions/operation/force_update_partition_replicas[Redpanda Admin API] for a full reference.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -22,7 +22,7 @@ curl -X POST http://localhost:9644/v1/debug/partitions/<namespace>/<topic>/<part
 ----
 
 The request body must include the ID of the broker and the CPU core (shard ID). If there are `n` CPU cores on the machine, the value of `core` can be within the range `[0, n-1]`. You may use a random value within the range, or the least loaded shard.
-See the xref:reference:public-metrics-reference.adoc[public metrics reference] for metrics regarding CPU usage, and xref:api:ROOT:admin-api.adoc#tag/Partitions/operation/force_update_partition_replicas[Redpanda Admin API] for a full reference.
+See the xref:reference:public-metrics-reference.adoc[public metrics reference] for metrics regarding CPU usage, and xref:api:ROOT:admin-api.adoc#tag/Partitions/operation/force_update_partition_replicas[Redpanda Admin API] for additional detail.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -3,7 +3,7 @@
 
 You can use the Redpanda Admin API to recover a partition that is unavailable and has lost a majority of its replicas. This can occur when the partition replicas have lost glossterm:Raft[] consensus, for instance if brokers in a Raft group fail, preventing the group from reaching a majority and electing a new leader. 
 
-Redpanda carries out forced partition recovery by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. 
+Redpanda performs forced partition recovery by promoting the best available replica to leader, making the partition available for produce and consume. Typically, Redpanda chooses the replica with the highest offset.  
 
 CAUTION: Forced partition recovery allows some potential data loss on the partition if the best available replica is out of sync, ending up in an unclean leader election. Use this operation with caution, and only when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
 
@@ -17,7 +17,7 @@ The following examples assume that partition 0 in topic `test` is unavailable an
 +
 [,bash]
 ----
-curl http://localhost:9644/v1/partitions/kafka/test | jq
+curl http://localhost:9644/v1/partitions/kafka/test
 ----
 +
 [,bash,role=no-copy]
@@ -49,7 +49,7 @@ curl http://localhost:9644/v1/partitions/kafka/test | jq
 ]
 ----
 
-. Suppose brokers 2 and 3 have failed and we want to replace them with brokers 4 and 5.
+. In this scenario, brokers 2 and 3 have failed and you want to move the replicas from those brokers to brokers 4 and 5, which are healthy.
 +
 Make a POST request to the `/debug/partitions/kafka/<topic>/<partition>/force_replicas` endpoint:
 +

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -65,6 +65,6 @@ See the xref:reference:public-metrics-reference.adoc[public metrics reference] f
 
 include::shared:partial$suggested-reading.adoc[]
 
-- https://redpanda.com/blog/raft-protocol-reconfiguration-solution/[Engineering a more robust Raft group reconfiguration^]
+- xref:get-started:architecture.adoc#partition-leadership-elections[Partition leadership elections]
 
 

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -1,19 +1,21 @@
 = Forced partition recovery
 :description: Recover a single partition using the Admin API.
 
-You can use the Redpanda Admin API to recover a partition that appears to be stuck (for example, does not accept writes). This can occur when the partition replicas have lost glossterm:Raft[] consensus, for instance if brokers in a Raft group fail, preventing the group from reaching a majority and electing a new leader. 
+You can use the Redpanda Admin API to recover a partition that is unavailable and has lost a majority of its replicas. This can occur when the partition replicas have lost glossterm:Raft[] consensus, for instance if brokers in a Raft group fail, preventing the group from reaching a majority and electing a new leader. 
 
-Redpanda performs forced partition recovery by promoting the best available replica to leader, making the partition available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. 
+Redpanda carries out forced partition recovery by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. However, this allows some potential data loss on the partition if the best available replica is out of sync, ending up in an unclean leader election. Only use forced partition recovery when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
 
-If you want to instead force recover partitions in bulk on a failed broker, use nodewise recovery.  
+If you want to instead force recover all partitions in bulk from a set of failed brokers, use nodewise recovery.
 
 == Use the Admin API to recover a partition
 
-The following examples are based on the assumption that partition 0 in topic `test` is unavailable and its replicas cannot form a majority to elect a leader.
+The following examples assume that partition 0 for topic `test` is unavailable and its replicas cannot form a majority to elect a leader.
 
+. Call the xref:api:ROOT:admin-api.adoc#tag/Partitions/operation/get_topic_partitions[`/partitions/kafka/<topic>`] endpoint to determine the current broker and shard assignments of the partition replicas.
++
 [,bash]
 ----
-curl http://localhost:9644/v1/partitions/kafka/test
+curl http://localhost:9644/v1/partitions/kafka/test | jq
 ----
 +
 [,bash,role=no-copy]
@@ -45,7 +47,7 @@ curl http://localhost:9644/v1/partitions/kafka/test
 ]
 ----
 
-. In this scenario, brokers 2 and 3 have failed and you want to move the replicas from those brokers to brokers 4 and 5, which are healthy.
+. Suppose brokers 2 and 3 have failed and we want to replace them with brokers 4 and 5.
 +
 Make a POST request to the `/debug/partitions/kafka/<topic>/<partition>/force_replicas` endpoint:
 +
@@ -55,13 +57,25 @@ curl -X POST http://localhost:9644/v1/debug/partitions/kafka/test/0/force_replic
   -H 'Content-Type: application/json'
   -d '{
     [
-        { "core": 0, "node_id": 0 } 
+      { 
+        "node_id": 1, 
+        "core": 1 
+      },
+      { 
+        "node_id": 4, 
+        "core": 1 
+      },
+      { 
+        "node_id": 5, 
+        "core": 0 
+      }    
     ]
   }'
 ----
-
-The request body must include the ID of the broker and the CPU core (shard ID). If there are `n` CPU cores on the machine, the value of `core` can be within the range `[0, n-1]`. You may use a random value within the range, or the least loaded shard.
-See the xref:reference:public-metrics-reference.adoc[public metrics reference] for metrics regarding CPU usage, and xref:api:ROOT:admin-api.adoc#tag/Partitions/operation/force_update_partition_replicas[Redpanda Admin API] for additional detail.
++
+The request body includes the broker ID and the CPU core (shard ID) for the replica on broker 1, to hydrate the new replicas assigned to brokers 4 and 5 on cores 1 and 0 respectively. 
++
+If there are `n` CPU cores on the machine, the value of `core` can be within the range `[0, n-1]`. You may use a random value within the range, or the least loaded shard. See the xref:reference:public-metrics-reference.adoc[public metrics reference] for metrics regarding CPU usage, and xref:api:ROOT:admin-api.adoc#tag/Partitions/operation/force_update_partition_replicas[Redpanda Admin API] for additional detail.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -3,7 +3,7 @@
 
 You can use the Redpanda Admin API to recover a partition that appears to be stuck (for example, does not accept writes). This can occur when the partition replicas have lost glossterm:Raft[] consensus, for instance if brokers in a Raft group fail, preventing the group from reaching a majority and electing a new leader. 
 
-Forced partition recovery is carried out by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. However, this allows some potential data loss on the partition if the best available replica is out of sync, resulting in an unclean leader election. Forced partition recovery should only be used when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
+Redpanda performs forced partition recovery by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. 
 
 If you want to instead force recover partitions in bulk on a failed broker, use nodewise recovery.  
 
@@ -13,7 +13,46 @@ Make a POST request to the `/force_replicas` endpoint:
 
 [,bash]
 ----
-curl -X POST http://localhost:9644/v1/debug/partitions/<namespace>/<topic>/<partition>/force_replicas \
+curl http://localhost:9644/v1/partitions/kafka/test
+----
++
+[,bash,role=no-copy]
+----
+
+[
+  {
+    "ns": "kafka",
+    "topic": "test",
+    "partition_id": 0,
+    "status": "done",
+    "leader_id": 1,
+    "raft_group_id": 1,
+    "replicas": [
+      {
+        "node_id": 1,
+        "core": 1
+      },
+      {
+        "node_id": 2,
+        "core": 1
+      },
+      {
+        "node_id": 3,
+        "core": 1
+      }
+    ]
+  }
+]
+----
+
+. Suppose brokers 2 and 3 have failed and we want to replace them with brokers 4 and 5.
++
+Make a POST request to the `/debug/partitions/kafka/<topic>/<partition>/force_replicas` endpoint:
++
+[,bash]
+----
+curl -X POST http://localhost:9644/v1/debug/partitions/kafka/test/0/force_replicas \
+  -H 'Content-Type: application/json'
   -d '{
     [
         { "core": 0, "node_id": 0 } 

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -3,7 +3,7 @@
 
 You can use the Redpanda Admin API to recover a partition that appears to be stuck (for example, does not accept writes). This can occur when the partition replicas have lost glossterm:Raft[] consensus, for instance if brokers in a Raft group fail, preventing the group from reaching a majority and electing a new leader. 
 
-Redpanda performs forced partition recovery by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. 
+Redpanda performs forced partition recovery by promoting the best available replica to leader, making the partition available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. 
 
 If you want to instead force recover partitions in bulk on a failed broker, use nodewise recovery.  
 

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -9,7 +9,7 @@ If you want to instead force recover partitions in bulk on a failed broker, use 
 
 == Use the Admin API to recover a partition
 
-Make a POST request to the `/force_replicas` endpoint:
+The following examples are based on the assumption that partition 0 in topic `test` is unavailable and its replicas cannot form a majority to elect a leader.
 
 [,bash]
 ----
@@ -45,7 +45,7 @@ curl http://localhost:9644/v1/partitions/kafka/test
 ]
 ----
 
-. Suppose brokers 2 and 3 have failed and we want to replace them with brokers 4 and 5.
+. In this scenario, brokers 2 and 3 have failed and you want to replace them with brokers 4 and 5.
 +
 Make a POST request to the `/debug/partitions/kafka/<topic>/<partition>/force_replicas` endpoint:
 +

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -5,7 +5,7 @@ You can use the Redpanda Admin API to recover a partition that is unavailable an
 
 Redpanda carries out forced partition recovery by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. However, this allows some potential data loss on the partition if the best available replica is out of sync, ending up in an unclean leader election. Only use forced partition recovery when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
 
-If you want to instead force recover all partitions in bulk from a set of failed brokers, use nodewise recovery.
+If you want to instead force recover all partitions in bulk from a set of failed brokers, use xref:./nodewise-partition-recovery.adoc[nodewise recovery].
 
 == Use the Admin API to recover a partition
 

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -3,13 +3,15 @@
 
 You can use the Redpanda Admin API to recover a partition that is unavailable and has lost a majority of its replicas. This can occur when the partition replicas have lost glossterm:Raft[] consensus, for instance if brokers in a Raft group fail, preventing the group from reaching a majority and electing a new leader. 
 
-Redpanda carries out forced partition recovery by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. However, this allows some potential data loss on the partition if the best available replica is out of sync, ending up in an unclean leader election. Only use forced partition recovery when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
+Redpanda carries out forced partition recovery by promoting the best available replica to leader, allowing the partition to become available for produce and consume. Typically, Redpanda chooses the replica with the highest offset. 
 
-If you want to instead force recover all partitions in bulk from a set of failed brokers, use xref:./nodewise-partition-recovery.adoc[nodewise recovery].
+CAUTION: Forced partition recovery allows some potential data loss on the partition if the best available replica is out of sync, ending up in an unclean leader election. Use this operation with caution, and only when brokers have failed beyond recovery to the point that the remaining replicas cannot form a majority. 
+
+NOTE: If you want to instead force recover all partitions in bulk from a set of failed brokers, use xref:./nodewise-partition-recovery.adoc[nodewise recovery].
 
 == Use the Admin API to recover a partition
 
-The following examples assume that partition 0 for topic `test` is unavailable and its replicas cannot form a majority to elect a leader.
+The following examples assume that partition 0 in topic `test` is unavailable and its replicas cannot form a majority to elect a leader.
 
 . Call the xref:api:ROOT:admin-api.adoc#tag/Partitions/operation/get_topic_partitions[`/partitions/kafka/<topic>`] endpoint to determine the current broker and shard assignments of the partition replicas.
 +

--- a/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
+++ b/modules/manage/pages/cluster-maintenance/partition-recovery.adoc
@@ -45,7 +45,7 @@ curl http://localhost:9644/v1/partitions/kafka/test
 ]
 ----
 
-. In this scenario, brokers 2 and 3 have failed and you want to replace them with brokers 4 and 5.
+. In this scenario, brokers 2 and 3 have failed and you want to move the replicas from those brokers to brokers 4 and 5, which are healthy.
 +
 Make a POST request to the `/debug/partitions/kafka/<topic>/<partition>/force_replicas` endpoint:
 +


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-236--redpanda-docs-preview.netlify.app/current/manage/cluster-maintenance/partition-recovery/)

- Explain when and how to carry out partition recovery with the Admin API. (API doc updates were done in #153 ).
- This is also an accompanying doc to the nodewise recovery updates (separate PR) - an update will be needed to cross link the two docs.
- 
Questions for SME are added as comments in this PR

Closes https://github.com/redpanda-data/documentation-private/issues/2105