### PR TITLE
#2182 add GCP tier limits

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -107,7 +107,9 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 == Cluster tiers
 
-When you create a cluster, you select your throughput tier. For example, the following table lists the current tier limits. Legacy tiers may have different limits. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[support^]. 
+When you create a cluster, you select your throughput tier. 
+
+The following table lists current tier limits. Legacy tiers may have different limits. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[support^]. 
 
 |=== 
 | | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -107,15 +107,15 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 == Cluster tiers
 
-When you create a cluster, you select your throughput tier. For example, the following table lists the current AWS tier limits. Legacy tiers may have different limits. For more information, or for the current GCP limits, contact https://support.redpanda.com/hc/en-us/requests/new[support^]. 
+When you create a cluster, you select your throughput tier. For example, the following table lists the current tier limits. Legacy tiers may have different limits. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[support^]. 
 
-|===
+|=== 
 | | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
 
 | *Tier 1* | 20 MBps | 60 MBps | 1,000 | 1,500
 | *Tier 2* | 50 MBps | 150 MBps | 2,800 | 3,750
 | *Tier 3* | 100 MBps | 200 MBps | 5,600 | 7,500
-| *Tier 4* | 200 MBps | 400 MBps | 11,200 | 15,000
+| *Tier 4* | 200 MBps | 400 MBps | 11,300 | 15,000
 | *Tier 5* | 400 MBps | 800 MBps | 22,800 | 30,000
 |===
 

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -114,11 +114,11 @@ The following table lists current AWS and GCP tier limits. Legacy tiers may have
 |=== 
 | Tier | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
 
-| *Tier 1* | 20 MBps | 60 MBps | 1,000 | 1,500
-| *Tier 2* | 50 MBps | 150 MBps | 2,800 | 3,750
-| *Tier 3* | 100 MBps | 200 MBps | 5,600 | 7,500
-| *Tier 4* | 200 MBps | 400 MBps | 11,300 | 15,000
-| *Tier 5* | 400 MBps | 800 MBps | 22,800 | 30,000
+| Tier 1 | 20 MBps | 60 MBps | 1,000 | 1,500
+| Tier 2 | 50 MBps | 150 MBps | 2,800 | 3,750
+| Tier 3 | 100 MBps | 200 MBps | 5,600 | 7,500
+| Tier 4 | 200 MBps | 400 MBps | 11,300 | 15,000
+| Tier 5 | 400 MBps | 800 MBps | 22,800 | 30,000
 |===
 
 == Redpanda Cloud vs self-hosted feature compatibility

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -109,10 +109,10 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 When you create a cluster, you select your throughput tier. 
 
-The following table lists current tier limits. Legacy tiers may have different limits. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[support^]. 
+The following table lists current AWS and GCP tier limits. Legacy tiers may have different limits. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[support^]. 
 
 |=== 
-| | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
+| Tier | Maximum ingress | Maximum egress | Maximum partitions | Maximum connections
 
 | *Tier 1* | 20 MBps | 60 MBps | 1,000 | 1,500
 | *Tier 2* | 50 MBps | 150 MBps | 2,800 | 3,750


### PR DESCRIPTION
fixes https://github.com/redpanda-data/documentation-private/issues/2182

Previously we only showed tier limits for AWS. This updates the table to include GCP (which look like the same limits). Updates tier 4 partition limits to 11,300.  

Preview: https://deploy-preview-240--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/cloud-overview/#cluster-tiers