### PR TITLE
Update requirements.adoc to move the term 'property' outside the actual property name/link

### DIFF
--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -56,7 +56,7 @@ endif::[]
 
 - 2 GB or more of memory per core.
 
-- 4 MB of memory for each topic partition replica. You can enforce this requirement in the tunable xref:reference:tunable-properties.adoc#topic_memory_per_partition[`topic_memory_per_partition` property].
+- 4 MB of memory for each topic partition replica. You can enforce this requirement in the tunable xref:reference:tunable-properties.adoc#topic_memory_per_partition[`topic_memory_per_partition`] property.
 
 *Recommendations*:
 


### PR DESCRIPTION
removed "property" from link text