### PR TITLE
Single-source command to install CRDs

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,6 +8,7 @@ asciidoc:
   attributes:
     full-version: 23.3.1
     latest-release-commit: '9eefb907c'
+    latest-operator-version: 'v2.1.11-23.3.1'
     supported-kubernetes-version: 1.21
     supported-helm-version: 3.6.0
     supported-rhel-required: '8'

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -59,9 +59,7 @@ The Redpanda Helm chart enables TLS by default and uses cert-manager to manage T
 
 . Install the Redpanda Operator CRDs:
 +
-```bash
-kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd | kubectl apply -f -
-```
+include::deploy:partial$kubernetes/install-crds.adoc[]
 
 . Deploy the Redpanda Operator.
 +
@@ -70,7 +68,7 @@ kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s
 helm repo add redpanda https://charts.redpanda.com
 helm upgrade --install redpanda-controller redpanda/operator \
   --namespace <namespace> \
-  --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
+  --set image.tag={latest-operator-version} \
   --create-namespace
 ----
 +
@@ -233,7 +231,7 @@ Helm + Operator::
 helm repo add redpanda https://charts.redpanda.com
 helm upgrade --install redpanda-controller redpanda/operator \
   --namespace <another-namespace> \
-  --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
+  --set image.tag={latest-operator-version} \
   --create-namespace
 ----
 

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
@@ -146,9 +146,7 @@ TLS is enabled by default. The Redpanda Helm chart uses cert-manager to manage T
 
 . Install the Redpanda Operator custom resource definitions (CRDs):
 +
-```bash
-kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd | kubectl apply -f -
-```
+include::deploy:partial$kubernetes/install-crds.adoc[]
 
 . Deploy the Redpanda Operator:
 +
@@ -157,7 +155,7 @@ kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s
 helm repo add redpanda https://charts.redpanda.com
 helm upgrade --install redpanda-controller redpanda/operator \
   --namespace <namespace> \
-  --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
+  --set image.tag={latest-operator-version} \
   --create-namespace
 ----
 +

--- a/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
+++ b/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
@@ -33,9 +33,7 @@ The Redpanda Helm chart uses cert-manager to enable TLS and manage TLS certifica
 
 . Install the Redpanda Operator custom resource definitions (CRDs):
 +
-```bash
-kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd | kubectl apply -f -
-```
+include::deploy:partial$kubernetes/install-crds.adoc[]
 
 . Deploy the Redpanda Operator:
 +
@@ -44,7 +42,7 @@ kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s
 helm repo add redpanda https://charts.redpanda.com
 helm upgrade --install redpanda-controller redpanda/operator \
   --namespace <namespace> \
-  --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
+  --set image.tag={latest-operator-version} \
   --create-namespace \
   --timeout 1h
 ----

--- a/modules/deploy/partials/kubernetes/install-crds.adoc
+++ b/modules/deploy/partials/kubernetes/install-crds.adoc
@@ -1,0 +1,14 @@
+ifdef::latest-operator-version[]
+[,bash,subs="attributes+"]
+----
+kubectl kustomize "https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref={latest-operator-version}" \
+    | kubectl apply -f -
+----
+endif::[]
+ifndef::latest-operator-version[]
+[,bash]
+----
+kubectl kustomize "https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd" \
+    | kubectl apply -f -
+----
+endif::[]

--- a/modules/deploy/partials/kubernetes/install-crds.adoc
+++ b/modules/deploy/partials/kubernetes/install-crds.adoc
@@ -8,7 +8,7 @@ endif::[]
 ifndef::latest-operator-version[]
 [,bash]
 ----
-kubectl kustomize "https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd" \
+kubectl kustomize "https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref=<operator-version>" \
     | kubectl apply -f -
 ----
 endif::[]

--- a/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
+++ b/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
@@ -268,12 +268,12 @@ To install the Decommission controller as part of the Redpanda Operator:
 
 .. Deploy the Redpanda Operator with the Decommission controller:
 +
-[,bash,lines=7+8]
+[,bash,subs="attributes+"lines=7+8]
 ----
 helm repo add redpanda https://charts.redpanda.com
 helm upgrade --install redpanda-controller redpanda/operator \
   --namespace <namespace> \
-  --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
+  --set image.tag={latest-operator-version} \
   --create-namespace \
   --set additionalCmdFlags={--additional-controllers="decommission"} \
   --set rbac.createAdditionalControllerCRs=true

--- a/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
+++ b/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
@@ -138,12 +138,12 @@ To install the Nodewatcher controller as part of the Redpanda Operator:
 
 .. Deploy the Redpanda Operator with the Nodewatcher controller:
 +
-[,bash,lines=7+8]
+[,bash,subs="attributes+",lines=7+8]
 ----
 helm repo add redpanda https://charts.redpanda.com
 helm upgrade --install redpanda-controller redpanda/operator \
   --namespace <namespace> \
-  --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
+  --set image.tag={latest-operator-version} \
   --create-namespace \
   --set additionalCmdFlags={--additional-controllers="nodeWatcher"} \
   --set rbac.createAdditionalControllerCRs=true

--- a/modules/upgrade/pages/k-rolling-upgrade.adoc
+++ b/modules/upgrade/pages/k-rolling-upgrade.adoc
@@ -94,10 +94,7 @@ If the new Redpanda Helm chart version introduces significant changes that affec
 
 * Upgrade the CRDs to match the latest version of the Redpanda Operator.
 +
-[,bash]
-----
-kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd | kubectl apply -f -
-----
+include::deploy:partial$kubernetes/install-crds.adoc[]
 +
 This step ensures that the Redpanda Operator can correctly interpret and manage the configurations defined in the Redpanda resource.
 
@@ -107,7 +104,8 @@ This step ensures that the Redpanda Operator can correctly interpret and manage 
 ----
 helm repo add redpanda https://charts.redpanda.com
 helm upgrade --install redpanda-controller redpanda/operator \
-  --namespace <namespace>
+  --namespace <namespace> \
+  --set image.tag={latest-operator-version}
 ----
 +
 CAUTION: Make sure to include all existing overrides, otherwise the upgrade may fail.

--- a/modules/upgrade/pages/migrate/kubernetes/helm-to-operator.adoc
+++ b/modules/upgrade/pages/migrate/kubernetes/helm-to-operator.adoc
@@ -71,9 +71,7 @@ You need these cluster-level permissions to install the Redpanda Operator CRDs i
 
 . Install the Redpanda Operator custom resource definitions (CRDs):
 +
-```bash
-kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd | kubectl apply -f -
-```
+include::deploy:partial$kubernetes/install-crds.adoc[]
 
 . Install the Redpanda Operator *in the same namespace as your Redpanda Helm chart*:
 +
@@ -82,7 +80,7 @@ kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s
 helm repo add redpanda https://charts.redpanda.com
 helm upgrade --install redpanda-controller redpanda/operator \
   --namespace <namespace> \
-  --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
+  --set image.tag={latest-operator-version} \
   --create-namespace
 ----
 

--- a/modules/upgrade/pages/migrate/kubernetes/operator.adoc
+++ b/modules/upgrade/pages/migrate/kubernetes/operator.adoc
@@ -51,9 +51,7 @@ You need cluster-level permissions to install the Redpanda Operator CRDs in the 
 
 . Install the Redpanda Operator custom resource definitions (CRDs):
 +
-```bash
-kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd | kubectl apply -f -
-```
+include::deploy:partial$kubernetes/install-crds.adoc[]
 
 . Install the Redpanda Operator *in the same namespace as your Cluster custom resource*:
 +
@@ -62,7 +60,7 @@ kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s
 helm repo add redpanda https://charts.redpanda.com
 helm upgrade --install redpanda-controller redpanda/operator \
   --namespace <namespace> \
-  --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
+  --set image.tag={latest-operator-version} \
   --create-namespace
 ----
 


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/documentation-private/issues/2190

Uses the [release version fetched from GitHub](https://github.com/redpanda-data/docs-extensions-and-macros/pull/28) in all install commands for the RP Operator chart and CRDs.

[See an example in the live preview](https://deploy-preview-258--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/kubernetes/k-production-deployment/#deploy-a-redpanda-cluster:~:text=Install%20the%20Redpanda%20Operator%20CRDs%3A).