### PR TITLE
Add new cluster config option minimum_topic_replications #2161

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/create-topic.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/create-topic.adoc
@@ -19,7 +19,7 @@ After you create a cluster, you can create a topic for that cluster.
 | The number of partitions for the topic.
 
 | *Replication factor*
-| The number of partition replicas for the topic. Three replicas are recommended. The cluster property `minimum_topic_replication`, if set, provides a lower bound for this property.
+| The number of partition replicas for the topic. Three replicas are recommended. The value for this property must meet or exceed the cluster's xref:reference:cluster-properties.adoc#minimum_topic_replication[`minimum_topic_replication`] setting.
 
 | *Cleanup policy*
 | The policy that determines how to clean up old log segments. The default is *delete*.

--- a/modules/deploy/pages/deployment-option/cloud/create-topic.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/create-topic.adoc
@@ -19,7 +19,7 @@ After you create a cluster, you can create a topic for that cluster.
 | The number of partitions for the topic.
 
 | *Replication factor*
-| The number of partition replicas for the topic. Three replicas are recommended.
+| The number of partition replicas for the topic. Three replicas are recommended. The cluster property `minimum_topic_replicas`, if set, provides a lower bound for this property.
 
 | *Cleanup policy*
 | The policy that determines how to clean up old log segments. The default is *delete*.

--- a/modules/deploy/pages/deployment-option/cloud/create-topic.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/create-topic.adoc
@@ -19,7 +19,7 @@ After you create a cluster, you can create a topic for that cluster.
 | The number of partitions for the topic.
 
 | *Replication factor*
-| The number of partition replicas for the topic. Three replicas are recommended. The cluster property `minimum_topic_replicas`, if set, provides a lower bound for this property.
+| The number of partition replicas for the topic. Three replicas are recommended. The cluster property `minimum_topic_replication`, if set, provides a lower bound for this property.
 
 | *Cleanup policy*
 | The policy that determines how to clean up old log segments. The default is *delete*.

--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -45,7 +45,7 @@ To specify a replication factor of 3 for topic "`xyz`":
 rpk topic create xyz -r 3
 ----
 
-NOTE: The replication factor must be an odd number. Redpanda Data recommends a replication factor of 3 for most use cases. Administrators may set a lower boundary for replication factor through the cluster level `minimum_topic_replications` property.
+NOTE: The replication factor must be an odd number. Redpanda Data recommends a replication factor of 3 for most use cases. Administrators may set a lower boundary for replication factor through the cluster level `minimum_topic_replication` property.
 
 == Update topic configurations
 

--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -45,7 +45,7 @@ To specify a replication factor of 3 for topic "`xyz`":
 rpk topic create xyz -r 3
 ----
 
-NOTE: The replication factor must be an odd number. Redpanda Data recommends a replication factor of 3 for most use cases.
+NOTE: The replication factor must be an odd number. Redpanda Data recommends a replication factor of 3 for most use cases. Administrators may set a lower boundary for replication factor through the cluster level `minimum_topic_replications` property.
 
 == Update topic configurations
 

--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -45,7 +45,7 @@ To specify a replication factor of 3 for topic "`xyz`":
 rpk topic create xyz -r 3
 ----
 
-NOTE: The replication factor must be an odd number. Redpanda Data recommends a replication factor of 3 for most use cases. Administrators may set a lower boundary for replication factor through the cluster level `minimum_topic_replication` property.
+NOTE: The replication factor must be an odd number. Redpanda Data recommends a replication factor of 3 for most use cases. Administrators may set a minimum required replication factor for any new topic in the cluster through the cluster-level xref:reference:cluster-properties.adoc#minimum_topic_replication[`minimum_topic_replication`] property.
 
 == Update topic configurations
 

--- a/modules/reference/pages/cluster-properties.adoc
+++ b/modules/reference/pages/cluster-properties.adoc
@@ -1642,7 +1642,7 @@ Target replication factor for internal topics.
 
 Minimum permitted replication factor value for newly-created topics. Redpanda returns an `INVALID_REPLICATION_FACTOR` error on any attempt to create a topic with a replication factor less than this property.
 
-When changing the `minimum_topic_replications` parameter, any previously existing topics having a replication factor less than the new value will continue to work as normal. Redpanda will, however, issue a warning level log message at start up indicating the existence of topics with a replication factor less than the cluster's `minimum_topic_replications`. That error message will read, `Topic X has a replication factor less than specified minimum: {} < {}`.
+When changing the `minimum_topic_replication` parameter, any previously existing topics having a replication factor less than the new value will continue to work as normal. Redpanda will, however, issue a warning level log message at start up indicating the existence of topics with a replication factor less than the cluster's `minimum_topic_replication`. That error message will read, for example, `Topic X has a replication factor less than specified minimum: 1 < 3`.
 
 *Units*: minimum number of replicas per topic
 

--- a/modules/reference/pages/cluster-properties.adoc
+++ b/modules/reference/pages/cluster-properties.adoc
@@ -1638,7 +1638,7 @@ Target replication factor for internal topics.
 
 ---
 
-=== minimum_topic_replications
+=== minimum_topic_replication
 
 Minimum permitted replication factor value for newly-created topics. Redpanda returns an `INVALID_REPLICATION_FACTOR` error on any attempt to create a topic with a replication factor less than this property.
 

--- a/modules/reference/pages/cluster-properties.adoc
+++ b/modules/reference/pages/cluster-properties.adoc
@@ -1638,11 +1638,12 @@ Target replication factor for internal topics.
 
 ---
 
+[[minimum_topic_replication]]
 === minimum_topic_replication
 
-Minimum permitted replication factor value for newly-created topics. Redpanda returns an `INVALID_REPLICATION_FACTOR` error on any attempt to create a topic with a replication factor less than this property.
+Minimum allowable replication factor for topics in this cluster. The set value must be positive, odd, and equal to or less than the number of available brokers. Changing this parameter only restricts newly-created topics. Redpanda returns an `INVALID_REPLICATION_FACTOR` error on any attempt to create a topic with a replication factor less than this property.
 
-When changing the `minimum_topic_replication` parameter, any previously existing topics having a replication factor less than the new value will continue to work as normal. Redpanda will, however, issue a warning level log message at start up indicating the existence of topics with a replication factor less than the cluster's `minimum_topic_replication`. That error message will read, for example, `Topic X has a replication factor less than specified minimum: 1 < 3`.
+If you change the `minimum_topic_replication` setting, the replication factor of existing topics remains unchanged. However, Redpanda will log a warning on start-up with a list of any topics that have fewer replicas than this minimum. For example, you might see a message such as `Topic X has a replication factor less than specified minimum: 1 < 3`.
 
 *Units*: minimum number of replicas per topic
 

--- a/modules/reference/pages/cluster-properties.adoc
+++ b/modules/reference/pages/cluster-properties.adoc
@@ -1640,7 +1640,7 @@ Target replication factor for internal topics.
 
 === minimum_topic_replications
 
-Minimum permitted replication factor value for newly created topics. Redpanda issues an error for any attempt to create a topic with a replication factor less than the specified value. Any existing topics found to have a replication factor less than the specified value will still continue to work as normal. Redpanda will issue a warning level log message at start up indicating the topic's replication factor is less than the specified minimum.
+Minimum permitted replication factor value for newly-created topics. Redpanda returns an error for any attempt to create a topic with a replication factor less than the specified value. Any existing topics found to have a replication factor less than the specified value will continue to work as normal. Redpanda will issue a warning level log message at start up indicating the topic's replication factor is less than the specified minimum.
 
 *Units*: number of replicas per topic
 

--- a/modules/reference/pages/cluster-properties.adoc
+++ b/modules/reference/pages/cluster-properties.adoc
@@ -1640,13 +1640,17 @@ Target replication factor for internal topics.
 
 === minimum_topic_replications
 
-Minimum permitted replication factor value for newly-created topics. Redpanda returns an error on any attempt to create a topic with a replication factor less than this property. When changing the `minimum_topic_replications` parameter, any previously existing topics having a replication factor less than the new value will continue to work as normal. Redpanda will, however, issue a warning level log message at start up indicating the existence of a topic with a replication factor less than the cluster's `minimum_topic_replications`.
+Minimum permitted replication factor value for newly-created topics. Redpanda returns an `INVALID_REPLICATION_FACTOR` error on any attempt to create a topic with a replication factor less than this property.
+
+When changing the `minimum_topic_replications` parameter, any previously existing topics having a replication factor less than the new value will continue to work as normal. Redpanda will, however, issue a warning level log message at start up indicating the existence of topics with a replication factor less than the cluster's `minimum_topic_replications`. That error message will read, `Topic X has a replication factor less than specified minimum: {} < {}`.
 
 *Units*: minimum number of replicas per topic
 
 *Default*: 1
 
 *Minimum*: 1
+
+*Range*: [1, ...], must be odd
 
 *Restart required*: no
 

--- a/modules/reference/pages/cluster-properties.adoc
+++ b/modules/reference/pages/cluster-properties.adoc
@@ -1638,6 +1638,20 @@ Target replication factor for internal topics.
 
 ---
 
+=== minimum_topic_replications
+
+Minimum permitted replication factor value for newly created topics. Redpanda issues an error for any attempt to create a topic with a replication factor less than the specified value. Any existing topics found to have a replication factor less than the specified value will still continue to work as normal. Redpanda will issue a warning level log message at start up indicating the topic's replication factor is less than the specified minimum.
+
+*Units*: number of replicas per topic
+
+*Default*: 1
+
+*Minimum*: 1
+
+*Restart required*: no
+
+---
+
 === retention_bytes
 
 Default maximum number of bytes per partition on disk before triggering deletion of the oldest messages. If `null` (the default value), no limit is applied.

--- a/modules/reference/pages/cluster-properties.adoc
+++ b/modules/reference/pages/cluster-properties.adoc
@@ -1640,9 +1640,9 @@ Target replication factor for internal topics.
 
 === minimum_topic_replications
 
-Minimum permitted replication factor value for newly-created topics. Redpanda returns an error for any attempt to create a topic with a replication factor less than the specified value. Any existing topics found to have a replication factor less than the specified value will continue to work as normal. Redpanda will issue a warning level log message at start up indicating the topic's replication factor is less than the specified minimum.
+Minimum permitted replication factor value for newly-created topics. Redpanda returns an error on any attempt to create a topic with a replication factor less than this property. When changing the `minimum_topic_replications` parameter, any previously existing topics having a replication factor less than the new value will continue to work as normal. Redpanda will, however, issue a warning level log message at start up indicating the existence of a topic with a replication factor less than the cluster's `minimum_topic_replications`.
 
-*Units*: number of replicas per topic
+*Units*: minimum number of replicas per topic
 
 *Default*: 1
 


### PR DESCRIPTION
Resolves issue: https://github.com/redpanda-data/documentation-private/issues/2161

Added the property and references to it in several places.

[Property listing in cluster properties.](https://deploy-preview-261--redpanda-docs-preview.netlify.app/current/reference/cluster-properties/#minimum_topic_replications)

Cloud [create topic](https://deploy-preview-261--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/create-topic/)

Develop -> [config topics](https://deploy-preview-261--redpanda-docs-preview.netlify.app/current/develop/config-topics/#choose-the-replication-factor)