### PR TITLE
fix typo in legacy_permit_unsafe_log_operations

### DIFF
--- a/modules/reference/pages/cluster-properties.adoc
+++ b/modules/reference/pages/cluster-properties.adoc
@@ -1544,7 +1544,7 @@ To figure out whether to set `storage_ignore_timestamps_in_future_sec` for your 
 
 == Support properties
 
-=== legacy_permit_unsafe_log_operations
+=== legacy_permit_unsafe_log_operation
 
 Flag enabling a Redpanda cluster operator to use unsafe control characters within strings such as consumer group names or user names.
 
@@ -1564,7 +1564,7 @@ This flag applies only for Redpanda clusters v23.1 or earlier that have upgraded
 
 Period at which to log a warning about using unsafe strings containing control characters.
 
-If unsafe strings are permitted by <<legacy_permit_unsafe_log_operations,`legacy_permit_unsafe_log_operations`>>, a warning will be logged at an interval specified by this property.
+If unsafe strings are permitted by <<legacy_permit_unsafe_log_operation,`legacy_permit_unsafe_log_operation`>>, a warning will be logged at an interval specified by this property.
 
 *Units*: seconds
 
@@ -1572,7 +1572,7 @@ If unsafe strings are permitted by <<legacy_permit_unsafe_log_operations,`legacy
 
 *Restart required*: no
 
-*Related properties*: <<legacy_permit_unsafe_log_operations,legacy_permit_unsafe_log_operations>>
+*Related properties*: <<legacy_permit_unsafe_log_operation,legacy_permit_unsafe_log_operation>>
 
 ---
 


### PR DESCRIPTION
Removes the superfluous "s"
Fixes https://github.com/redpanda-data/documentation-private/issues/1841
[Preview](https://deploy-preview-264--redpanda-docs-preview.netlify.app/current/reference/cluster-properties/#legacy_permit_unsafe_log_operation)