### PR TITLE
Revert "Remove explicit memory and smp configs"

### DIFF
--- a/modules/shared/attachments/docker/single-broker/docker-compose.yml
+++ b/modules/shared/attachments/docker/single-broker/docker-compose.yml
@@ -21,9 +21,13 @@ services:
       # Address the broker advertises to clients that connect to the HTTP Proxy.
       - --advertise-pandaproxy-addr internal://redpanda-0:8082,external://localhost:18082
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
-      # Redpanda brokers use the RPC API to communicate with each other internally.
+      # Redpanda brokers use the RPC API to communicate with eachother internally.
       - --rpc-addr redpanda-0:33145
       - --advertise-rpc-addr redpanda-0:33145
+      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
+      - --smp 1
+      # The amount of memory to make available to Redpanda.
+      - --memory 1G
       # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
       # enable logs for debugging.

--- a/modules/shared/attachments/docker/single-broker/docker-compose.yml
+++ b/modules/shared/attachments/docker/single-broker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       # Address the broker advertises to clients that connect to the HTTP Proxy.
       - --advertise-pandaproxy-addr internal://redpanda-0:8082,external://localhost:18082
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
-      # Redpanda brokers use the RPC API to communicate with eachother internally.
+      # Redpanda brokers use the RPC API to communicate with each other internally.
       - --rpc-addr redpanda-0:33145
       - --advertise-rpc-addr redpanda-0:33145
       # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.

--- a/modules/shared/attachments/docker/three-brokers/docker-compose.yml
+++ b/modules/shared/attachments/docker/three-brokers/docker-compose.yml
@@ -23,9 +23,13 @@ services:
       # Address the broker advertises to clients that connect to the HTTP Proxy.
       - --advertise-pandaproxy-addr internal://redpanda-0:8082,external://localhost:18082
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
-      # Redpanda brokers use the RPC API to communicate with each other internally.
+      # Redpanda brokers use the RPC API to communicate with eachother internally.
       - --rpc-addr redpanda-0:33145
       - --advertise-rpc-addr redpanda-0:33145
+      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
+      - --smp 1
+      # The amount of memory to make available to Redpanda.
+      - --memory 1G
       # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
       # enable logs for debugging.
@@ -52,6 +56,8 @@ services:
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:28081
       - --rpc-addr redpanda-1:33145
       - --advertise-rpc-addr redpanda-1:33145
+      - --smp 1
+      - --memory 1G
       - --mode dev-container
       - --default-log-level=debug
       - --seeds redpanda-0:33145
@@ -79,6 +85,8 @@ services:
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:38081
       - --rpc-addr redpanda-2:33145
       - --advertise-rpc-addr redpanda-2:33145
+      - --smp 1
+      - --memory 1G
       - --mode dev-container
       - --default-log-level=debug
       - --seeds redpanda-0:33145

--- a/modules/shared/attachments/docker/three-brokers/docker-compose.yml
+++ b/modules/shared/attachments/docker/three-brokers/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       # Address the broker advertises to clients that connect to the HTTP Proxy.
       - --advertise-pandaproxy-addr internal://redpanda-0:8082,external://localhost:18082
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
-      # Redpanda brokers use the RPC API to communicate with eachother internally.
+      # Redpanda brokers use the RPC API to communicate with each other internally.
       - --rpc-addr redpanda-0:33145
       - --advertise-rpc-addr redpanda-0:33145
       # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.


### PR DESCRIPTION
Reverting the change based on https://redpandadata.slack.com/archives/C01ND4SVB6Z/p1706823380154949

Currently, not setting `--smp 1` can lead to this error:

```
2024-02-01 18:35:49 WARN  2024-02-01 21:35:49,892 seastar - Requested AIO slots too large, please increase request capacity in /proc/sys/fs/aio-max-nr. configured:65536 available:4 requested:132312
2024-02-01 18:35:49 Could not initialize seastar: std::runtime_error (Could not setup Async I/O: Not enough request capacity in /proc/sys/fs/aio-max-nr. Try increasing that number or reducing the amount of logical CPUs available for your application)
```