### PR TITLE
Exactly-once processing requirements

### DIFF
--- a/modules/develop/pages/transactions.adoc
+++ b/modules/develop/pages/transactions.adoc
@@ -255,6 +255,14 @@ Different transactions require different approaches to handling failures within 
 * Publishing of multiple messages: The request came from outside the system, and it is the application's responsibility to discover the true status of a timed-out transaction. (This example doesn't use consumer groups to distribute partitions between consumers.)
 * Exactly-once streaming (consume-transform-loop): This is a closed system. Upon re-initialization of the consumer and producer, the system automatically discovers the moment it was interrupted and continues from that place. Additionally, this automatically scales by the number of partitions. Run another instance of the application, and it starts processing its share of partitions in the source topic.
 
+== Enabling exactly-once processing
+
+The default configuration of Redpanda supports exactly-once processing. Preserving this capability requires maintaining the following settings:
+
+* `enable_idempotence = true`
+* `enable_transactions = true`
+* `transaction_coordinator_delete_retention_ms >= transactional_id_expiration_ms`
+
 == Transactions with compacted segments
 
 Transactions are supported on topics with compaction configured. When xref:reference:cluster-properties.adoc#log_cleanup_policy[`log_cleanup_policy`] or xref:reference:topic-properties.adoc#cleanuppolicy[`cleanup.policy`] are set to either `compact` or `compact,delete`, the compaction process removes the aborted transaction's data and all transactional control markers from the log. The resulting compacted segment contains only committed data batches (and potentially harmless gaps in the offsets due to skipped batches).


### PR DESCRIPTION
Resolves [Issue #1923](https://github.com/redpanda-data/documentation-private/issues/1923)

I added an explicit section for what's required to have Exactly-once processing functional. Everything else seemed accurate as best I could tell after review.

[Preview](https://deploy-preview-294--redpanda-docs-preview.netlify.app/current/develop/transactions/#enabling-exactly-once-processing)
