### PR TITLE
Raft terms

### DIFF
--- a/modules/terms/partials/controller-broker.adoc
+++ b/modules/terms/partials/controller-broker.adoc
@@ -1,5 +1,5 @@
-=== controller
-:term-name: controller
+=== controller broker
+:term-name: controller broker
 :hover-text: A broker that’s responsible for managing operational metadata for a Redpanda cluster. At any given time, one active controller exists in a cluster. 
 :category: Redpanda core
 

--- a/modules/terms/partials/learner.adoc
+++ b/modules/terms/partials/learner.adoc
@@ -1,0 +1,8 @@
+=== learner
+:term-name: learner
+:hover-text: A broker that is a follower in a Raft group but is not part of quorum.
+:category: Redpanda core
+
+In a Raft group, a broker can be in learner status. Learners are followers that cannot vote and so do not count towards quorum (the majority). They cannot be elected to leader nor can they trigger leader elections. Brokers can be promoted or demoted between learner and voter. New Raft group members start as learners. 
+
+For more information, see xref:manage:raft-group-reconfiguration.adoc[].


### PR DESCRIPTION
- Add new glossary term for "learner"
- Update "controller" to "controller broker". This helps clarify that the term refers to an individual broker, as there can be other contexts where "controller" has a more nuanced meaning, for example a "controller" Raft group. (See [this thread](https://github.com/redpanda-data/docs/pull/262#discussion_r1462036903) and [this thread](https://github.com/redpanda-data/docs/pull/262#discussion_r1476474383) for context) 

Since the glossary entry has a reference to a page that isn't published yet, this PR should not be merged before #262 