### PR TITLE
Update cloud_storage_attempt_cluster_recovery_on_bootstrap to cloud_storage_attempt_cluster_restore_on_bootstrap

### DIFF
--- a/modules/manage/partials/whole-cluster-restore.adoc
+++ b/modules/manage/partials/whole-cluster-restore.adoc
@@ -101,7 +101,7 @@ spec:
         <tiered-storage-settings>
     config:
       cluster:
-        cloud_storage_attempt_cluster_recovery_on_bootstrap: true
+        cloud_storage_attempt_cluster_restore_on_bootstrap: true
 ----
 
 ```bash
@@ -123,7 +123,7 @@ storage:
     <tiered-storage-settings>
 config:
   cluster:
-    cloud_storage_attempt_cluster_recovery_on_bootstrap: true
+    cloud_storage_attempt_cluster_restore_on_bootstrap: true
 ----
 +
 ```bash
@@ -136,14 +136,14 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
   --set storage.tiered.<tiered-storage-settings> \
-  --set config.cluster.cloud_storage_attempt_cluster_recovery_on_bootstrap=true
+  --set config.cluster.cloud_storage_attempt_cluster_restore_on_bootstrap=true
 ```
 ====
 --
 ======
 
 - `storage.tiered`: Make sure to configure the target cluster with the same Tiered Storage settings as the failed source cluster.
-- `config.cluster.cloud_storage_attempt_cluster_recovery_on_bootstrap`: Automate cluster restore in Kubernetes. Setting to `true` is recommended when using an automated method for deployment. When bootstrapping a cluster with a given bucket, make sure that any previous cluster using the bucket is fully destroyed, otherwise Tiered Storage subsystems may interfere with each other.
+- `config.cluster.cloud_storage_attempt_cluster_restore_on_bootstrap`: Automate cluster restore in Kubernetes. Setting to `true` is recommended when using an automated method for deployment. When bootstrapping a cluster with a given bucket, make sure that any previous cluster using the bucket is fully destroyed, otherwise Tiered Storage subsystems may interfere with each other.
 endif::[]
 
 ifndef::env-kubernetes[]


### PR DESCRIPTION
The name of this cluster parameter was changed in [this PR](https://github.com/redpanda-data/redpanda/pull/15399/files)