### PR TITLE
New reference for using Redpanda tuning capabilities

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -63,6 +63,7 @@
 **** xref:deploy:deployment-option/self-hosted/manual/high-availability.adoc[High Availability]
 **** xref:deploy:deployment-option/self-hosted/manual/sizing-use-cases.adoc[Sizing Use Cases]
 **** xref:deploy:deployment-option/self-hosted/manual/sizing.adoc[Sizing Guidelines]
+**** xref:deploy:deployment-option/self-hosted/manual/linux-system-tuning.adoc[System Tuning]
 *** xref:deploy:deployment-option/self-hosted/docker-image.adoc[Connectors]
 ** xref:deploy:deployment-option/cloud/index.adoc[Cloud]
 *** xref:deploy:deployment-option/cloud/cloud-overview.adoc[Redpanda Cloud Overview]

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -19,9 +19,9 @@ For the full list of available tuners, refer to xref:reference:rpk/rpk-redpanda/
 
 Redpanda makes use of systemd to manage operating system and software-based limits, such as memlocks, file handle limits, core limits, and certain distribution-specific configurations. These help ensure the system executes stably and efficiently. Some key examples of automated configurations include:
 
-* Using systemd also offers some support to detect hung services and infinite looping scenarios. This helps ensure you don't have blocking services or processes that may interfere with Redpanda's stream processing.
-* Redpanda configures asynchronus input/output interfaces and scheduler affinity. This is particularly critical when you rely on real-time processing of data streams for your applications.
-* Using systemd slices (see https://www.scylladb.com/2019/09/25/isolating-workloads-with-systemd-slices/[this blog post] for more details), which allows Redpanda to efficiently use system resources while isolating tasks for scalability and performance reasons.
+* Detection of hung services and infinite looping scenarios. This helps ensure you don't have blocking services or processes that may interfere with Redpanda's stream processing.
+* Configuration of asynchronus input/output interfaces and scheduler affinity. This is particularly critical when you rely on real-time processing of data streams for your applications.
+* Use of systemd slices (see https://www.scylladb.com/2019/09/25/isolating-workloads-with-systemd-slices/[this blog post] for more details), which allows Redpanda to efficiently use system resources while isolating tasks for scalability and performance reasons.
 
 == Monitoring configurations
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -22,3 +22,7 @@ Redpanda makes use of systemd to manage operating system and software-based limi
 * Using systemd also allows some support to detect hung services and infinite looping scenarios. This helps ensure you don't have blocking services or processes that may interfere with Redpanda's stream processing.
 * Redpanda configures asynchronus input/output interfaces and scheduler affinity. This is particular critical when you rely on real-time processing of data streams for your applications.
 * Using systemd slices (see https://www.scylladb.com/2019/09/25/isolating-workloads-with-systemd-slices/[this blog post] for more details) allows Redpanda to most efficiently use system resources while isolating tasks for scalability and performance reasons.
+
+== Monitoring configurations
+
+While Redpanda provides numerous metrics, the configurations applied via the autotuner and systemd are not exposed internally. Users should continue monitoring their system health through standard means. For example, the systemd configuration sets the file handle limit to 800,000 references. If you are concerned about approaching this limit, you will need to monitor this through standard system monitoring, such as the use of the `lsof` utility.

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -19,7 +19,7 @@ For the full list of available tuners, refer to the xref:reference:rpk/rpk-redpa
 
 Redpanda makes use of systemd to manage operating system and software-based limits, such as memlocks, file handle limits, core limits, and certain distribution-specific configurations. These help ensure the system executes stably and efficiently. Some key examples of automated configurations include:
 
-* Using systemd also allows some support to detect hung services and infinite looping scenarios. This helps ensure you don't have blocking services or processes that may interfere with Redpanda's stream processing.
+* Using systemd also offers some support to detect hung services and infinite looping scenarios. This helps ensure you don't have blocking services or processes that may interfere with Redpanda's stream processing.
 * Redpanda configures asynchronus input/output interfaces and scheduler affinity. This is particular critical when you rely on real-time processing of data streams for your applications.
 * Using systemd slices (see https://www.scylladb.com/2019/09/25/isolating-workloads-with-systemd-slices/[this blog post] for more details) allows Redpanda to most efficiently use system resources while isolating tasks for scalability and performance reasons.
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -5,7 +5,7 @@ Redpanda includes numerous features to tune your Linux systems for optimal perfo
 
 == User-triggered hardware tuning
 
-Users invoke the Redpanda autotuner using the `rpk redpanda tune` command. This command may optimize both native Linux and Kubernetes nodes. It analyzes the hardware configuration of the worker node and sets appropriate kernel options. Users may still set some hardware parameters using `ulimit` or other system tools while using the autotuner to manage others.
+Users invoke the Redpanda autotuner using the `rpk redpanda tune` command. This command may optimize both native Linux and Kubernetes nodes. It analyzes the hardware configuration of the worker node and sets appropriate kernel options. You can choose to set certain hardware parameters using `ulimit` or other system tools while using the autotuner to manage others.
 
 === Using the autotuner
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -20,7 +20,7 @@ For the full list of available tuners, refer to the xref:reference:rpk/rpk-redpa
 Redpanda makes use of systemd to manage operating system and software-based limits, such as memlocks, file handle limits, core limits, and certain distribution-specific configurations. These help ensure the system executes stably and efficiently. Some key examples of automated configurations include:
 
 * Using systemd also offers some support to detect hung services and infinite looping scenarios. This helps ensure you don't have blocking services or processes that may interfere with Redpanda's stream processing.
-* Redpanda configures asynchronus input/output interfaces and scheduler affinity. This is particular critical when you rely on real-time processing of data streams for your applications.
+* Redpanda configures asynchronus input/output interfaces and scheduler affinity. This is particularly critical when you rely on real-time processing of data streams for your applications.
 * Using systemd slices (see https://www.scylladb.com/2019/09/25/isolating-workloads-with-systemd-slices/[this blog post] for more details) allows Redpanda to most efficiently use system resources while isolating tasks for scalability and performance reasons.
 
 == Monitoring configurations

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -1,7 +1,7 @@
 = Linux System Tuning
 :description: Learn how Redpanda applies automatic tunic to your Linux system.
 
-Redpanda includes numerous features to tune your Linux systems for optimal performance. Users may trigger hardware-based optimizations through the `rpk redpanda tune` command, also called the autotuner. Software-based configurations are managed automatically through the `systemd` suite of tools.
+Redpanda includes numerous features to tune your Linux systems for optimal performance. You can trigger hardware-based optimizations through the `rpk redpanda tune` command, also called the autotuner. Software-based configurations are managed automatically through the `systemd` suite of tools.
 
 == User-triggered hardware tuning
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -5,7 +5,7 @@ Redpanda includes numerous features to tune your Linux systems for optimal perfo
 
 == User-triggered hardware tuning
 
-Users invoke the Redpanda autotuner using the `rpk redpanda tune` command. This command may optimize both native Linux and Kubernetes nodes. It analyzes the hardware configuration of the worker node and sets appropriate kernel options. You can choose to set certain hardware parameters using `ulimit` or other system tools while using the autotuner to manage others.
+Users invoke the Redpanda autotuner using the `rpk redpanda tune` command to optimize native Linux nodes. It analyzes the hardware configuration of the worker node and sets appropriate kernel options. You can choose to set certain hardware parameters using `ulimit` or other system tools while using the autotuner to manage others.
 
 === Using the autotuner
 
@@ -13,7 +13,7 @@ The Redpanda autotuner has a large array of hardware tuners to choose from. You 
 
 Redpanda recommends running the autotuner as part of your production deployment workflows. This ensures any hardware configurations or updates to the autotuner itself are incorporated quickly and efficiently into your system.
 
-For the full list of available tuners, refer to the xref:reference:rpk/rpk-redpanda/rpk-redpanda-tune.adoc[`rpk redpanda tune` guide]. The autotuner is also available for managing Kubernetes nodes, but note that changes to the Linux kernel for running Kubernetes images are not persisted. For more information on Kubernetes configuration and execution, refer to xref:deploy:deployment-option/self-hosted/kubernetes/k-tune-workers.adoc[Kubernetes worker node tuning].
+For the full list of available tuners, refer to the xref:reference:rpk/rpk-redpanda/rpk-redpanda-tune.adoc[`rpk redpanda tune` guide]. When using Kubernetes, you should tune your system at the host node level. For more information on Kubernetes configuration and execution, refer to xref:deploy:deployment-option/self-hosted/kubernetes/k-tune-workers.adoc[Kubernetes worker node tuning].
 
 == Automated software configurations
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -1,0 +1,13 @@
+= Automated Linux System Tuning
+:description: Learn how Redpanda applies automatic tunic to your Linux system.
+
+Redpanda includes numerous features for tuning your Linux systems for optimal performance. Users may trigger hardware-based optimizations through the `rpk redpanda tune` command, known as the autotuner. Software-based configurations are managed automatically through the `systemd` suite of tools. These features and their respective areas of concern are described here.
+
+== User-triggered tuning
+=== Uses rpk redpanda tune
+=== Optimizes the linux kernel for Redpanda
+== Redpanda uses systemd for configurations
+=== Among other things, configures memlocks, file handle limit, process limit, core limits, and certain distro-specific configurations
+=== Also ensures AIO and scheduler affinity are applied properly
+=== Monitors for infinite looping scenarios
+=== Employs systemd cgroups slices to isolate workloads and ensure stability and  protect resources

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -25,4 +25,4 @@ Redpanda makes use of systemd to manage operating system and software-based limi
 
 == Monitoring configurations
 
-While Redpanda provides numerous metrics, the configurations applied via the autotuner and systemd are not exposed internally. Users should continue monitoring their system health through standard means. For example, the systemd configuration sets the file handle limit to 800,000 references. If you are concerned about approaching this limit, you will need to monitor this through standard system monitoring, such as the use of the `lsof` utility.
+While Redpanda provides numerous metrics, the configurations applied using the autotuner and systemd are not exposed internally. You should continue monitoring your system health through standard means. For example, the systemd configuration sets the file handle limit to 800,000 references. If you are concerned about approaching this limit, you should monitor it through standard system monitoring, such as the use of the `lsof` utility.

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -1,7 +1,7 @@
 = Linux System Tuning
 :description: Learn how Redpanda applies automatic tunic to your Linux system.
 
-Redpanda includes numerous features to tune your Linux systems for optimal performance. You can trigger hardware-based optimizations through the `rpk redpanda tune` command, also called the autotuner. Software-based configurations are managed automatically through the `systemd` suite of tools.
+Redpanda includes several features to tune your Linux systems for optimal performance. You can trigger hardware-based optimizations through the `rpk redpanda tune` command, also called the autotuner. Software-based configurations are managed automatically through the `systemd` suite of tools.
 
 == User-triggered hardware tuning
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -21,7 +21,7 @@ Redpanda makes use of systemd to manage operating system and software-based limi
 
 * Using systemd also offers some support to detect hung services and infinite looping scenarios. This helps ensure you don't have blocking services or processes that may interfere with Redpanda's stream processing.
 * Redpanda configures asynchronus input/output interfaces and scheduler affinity. This is particularly critical when you rely on real-time processing of data streams for your applications.
-* Using systemd slices (see https://www.scylladb.com/2019/09/25/isolating-workloads-with-systemd-slices/[this blog post] for more details) allows Redpanda to most efficiently use system resources while isolating tasks for scalability and performance reasons.
+* Using systemd slices (see https://www.scylladb.com/2019/09/25/isolating-workloads-with-systemd-slices/[this blog post] for more details), which allows Redpanda to efficiently use system resources while isolating tasks for scalability and performance reasons.
 
 == Monitoring configurations
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -13,7 +13,7 @@ The Redpanda autotuner has a large array of hardware tuners to choose from. You 
 
 Redpanda recommends running the autotuner as part of your production deployment workflows. This ensures any hardware configurations or updates to the autotuner itself are incorporated quickly and efficiently into your system.
 
-For the full list of available tuners, refer to the xref:reference:rpk/rpk-redpanda/rpk-redpanda-tune.adoc[`rpk redpanda tune` guide]. When using Kubernetes, you should tune your system at the host node level. For more information on Kubernetes configuration and execution, refer to xref:deploy:deployment-option/self-hosted/kubernetes/k-tune-workers.adoc[Kubernetes worker node tuning].
+For the full list of available tuners, refer to xref:reference:rpk/rpk-redpanda/rpk-redpanda-tune.adoc[`rpk redpanda tune`]. When using Kubernetes, you should tune your system at the host node level. For more information on Kubernetes configuration and execution, refer to xref:deploy:deployment-option/self-hosted/kubernetes/k-tune-workers.adoc[Kubernetes worker node tuning].
 
 == Automated software configurations
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -13,7 +13,7 @@ The Redpanda autotuner has a large array of hardware tuners to choose from. You 
 
 Redpanda recommends running the autotuner as part of your production deployment workflows. This ensures any hardware configurations or updates to the autotuner itself are incorporated quickly and efficiently into your system.
 
-For the full list of available tuners, refer to the xref:reference:rpk/rpk-redpanda/rpk-redpanda-tune.adoc[`rpk redpanda tune` guide]. The autotuner is also available for managing Kubernetes nodes, but note that changes to the Linux kernel for running Kubernetes images are not persisted. For more information on kubernetes configuration and execution, please refer to the xref:deploy:deployment-option/self-hosted/kubernetes/k-tune-workers.adoc[kubernetes worker node tuning] guide.
+For the full list of available tuners, refer to the xref:reference:rpk/rpk-redpanda/rpk-redpanda-tune.adoc[`rpk redpanda tune` guide]. The autotuner is also available for managing Kubernetes nodes, but note that changes to the Linux kernel for running Kubernetes images are not persisted. For more information on Kubernetes configuration and execution, refer to xref:deploy:deployment-option/self-hosted/kubernetes/k-tune-workers.adoc[Kubernetes worker node tuning].
 
 == Automated software configurations
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -5,7 +5,7 @@ Redpanda includes several features to tune your Linux systems for optimal perfor
 
 == User-triggered hardware tuning
 
-Users invoke the Redpanda autotuner using the `rpk redpanda tune` command to optimize native Linux nodes. It analyzes the hardware configuration of the worker node and sets appropriate kernel options. You can choose to set certain hardware parameters using `ulimit` or other system tools while using the autotuner to manage others.
+You can invoke the Redpanda autotuner using the `rpk redpanda tune` command to optimize native Linux nodes. It analyzes the hardware configuration of the worker node and sets appropriate kernel options. You can choose to set certain hardware parameters using `ulimit` or other system tools while using the autotuner to manage others.
 
 === Using the autotuner
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -1,13 +1,24 @@
-= Automated Linux System Tuning
+= Linux System Tuning
 :description: Learn how Redpanda applies automatic tunic to your Linux system.
 
-Redpanda includes numerous features for tuning your Linux systems for optimal performance. Users may trigger hardware-based optimizations through the `rpk redpanda tune` command, known as the autotuner. Software-based configurations are managed automatically through the `systemd` suite of tools. These features and their respective areas of concern are described here.
+Redpanda includes numerous features to tune your Linux systems for optimal performance. Users may trigger hardware-based optimizations through the `rpk redpanda tune` command, also called the autotuner. Software-based configurations are managed automatically through the `systemd` suite of tools.
 
-== User-triggered tuning
-=== Uses rpk redpanda tune
-=== Optimizes the linux kernel for Redpanda
-== Redpanda uses systemd for configurations
-=== Among other things, configures memlocks, file handle limit, process limit, core limits, and certain distro-specific configurations
-=== Also ensures AIO and scheduler affinity are applied properly
-=== Monitors for infinite looping scenarios
-=== Employs systemd cgroups slices to isolate workloads and ensure stability and  protect resources
+== User-triggered hardware tuning
+
+Users invoke the Redpanda autotuner using the `rpk redpanda tune` command. This command may optimize both native Linux and Kubernetes nodes. It analyzes the hardware configuration of the worker node and sets appropriate kernel options. Users may still set some hardware parameters using `ulimit` or other system tools while using the autotuner to manage others.
+
+=== Using the autotuner
+
+The Redpanda autotuner has a large array of hardware tuners to choose from. Users may choose to either execute all available tuners, or to apply only a subset of them. This is particularly important when users wish to maintain some configurations themselves and prevent Redpanda from altering those settings.
+
+Redpanda recommends running the autotuner as part of your production deployment workflows. This ensures any hardware configurations or updates to the autotuner itself are incorporated quickly and efficiently into your system.
+
+For the full list of available tuners, refer to the xref:reference:rpk/rpk-redpanda/rpk-redpanda-tune.adoc[`rpk redpanda tune` guide]. The autotuner is also available for managing Kubernetes nodes, but note that changes to the Linux kernel for running Kubernetes images are not persisted. For more information on kubernetes configuration and execution, please refer to the xref:deploy:deployment-option/self-hosted/kubernetes/k-tune-workers.adoc[kubernetes worker node tuning] guide.
+
+== Automated software configurations
+
+Redpanda makes use of systemd to manage operating system and software-based limits, such as memlocks, file handle limits, core limits, and certain distribution-specific configurations. These help ensure the system executes stably and efficiently. Some key examples of automated configurations include:
+
+* Using systemd also allows some support to detect hung services and infinite looping scenarios. This helps ensure you don't have blocking services or processes that may interfere with Redpanda's stream processing.
+* Redpanda configures asynchronus input/output interfaces and scheduler affinity. This is particular critical when you rely on real-time processing of data streams for your applications.
+* Using systemd slices (see https://www.scylladb.com/2019/09/25/isolating-workloads-with-systemd-slices/[this blog post] for more details) allows Redpanda to most efficiently use system resources while isolating tasks for scalability and performance reasons.

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/linux-system-tuning.adoc
@@ -9,7 +9,7 @@ Users invoke the Redpanda autotuner using the `rpk redpanda tune` command. This 
 
 === Using the autotuner
 
-The Redpanda autotuner has a large array of hardware tuners to choose from. Users may choose to either execute all available tuners, or to apply only a subset of them. This is particularly important when users wish to maintain some configurations themselves and prevent Redpanda from altering those settings.
+The Redpanda autotuner has a large array of hardware tuners to choose from. You may choose to either execute all available tuners, or to apply only a subset of them. This is particularly important when you wish to maintain specific configurations and prevent Redpanda from altering these settings.
 
 Redpanda recommends running the autotuner as part of your production deployment workflows. This ensures any hardware configurations or updates to the autotuner itself are incorporated quickly and efficiently into your system.
 


### PR DESCRIPTION
Resolves [Issue #2012](https://app.zenhub.com/workspaces/documentation-628ba1cf6f2f640015ffe494/issues/gh/redpanda-data/documentation-private/2012)

This guide discusses the autotuner and lists the categories of software configurations managed by Redpanda.

[Preview](https://deploy-preview-305--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/manual/linux-system-tuning/).