### PR TITLE
Update public-metrics-reference.adoc (redpanda_rest_proxy_request_latency_seconds_bucket)

### DIFF
--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -533,7 +533,7 @@ Total number of REST proxy server errors.
 
 ---
 
-=== redpanda_rest_proxy_request_latency_seconds
+=== redpanda_rest_proxy_request_latency_seconds_bucket
 
 Internal latency of REST proxy requests.
 


### PR DESCRIPTION
`redpanda_rest_proxy_request_latency_seconds`

should be 

`redpanda_rest_proxy_request_latency_seconds_bucket`

we reference the correct metric name here
https://docs.redpanda.com/current/manage/monitoring/#rest-proxy