### PR TITLE
Fix auth.sasl.users set command

### DIFF
--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -164,7 +164,7 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
   --set auth.sasl.enabled=true \
   --set auth.sasl.secretRef=redpanda-superusers \
-  --set "auth.sasl.users=[]"
+  --set "auth.sasl.users=null"
 ----
 ====
 --


### PR DESCRIPTION
We had a fix to correct the way we set `auth.sasl.users` to an empty list in the Redpanda resource, but it appears that we still need to use `null` when using the `--set` flag: https://github.com/redpanda-data/docs/pull/32