### PR TITLE
docs: update decommission-status page

### DIFF
--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-admin-brokers-decommission-status.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-admin-brokers-decommission-status.adoc
@@ -35,7 +35,7 @@ kafka/test2      3          3          5             2752632301      140975805  
 kafka/test2      4          3          6             2975443783      181581219    2793862564
 ----
 
-If a partition cannot be moved with some reason, the command reports the problematic partition in the 'ALLOCATION FAILURES' section and decommission never succeeds. Typical scenarios the failure occurs are; there's no node that has enough space to allocate a partition or that can satisfy rack constraints, etc.
+If for some reason a partition cannot be moved, the command reports the problematic partition in the 'ALLOCATION FAILURES' section and the decommission fails. A typical failure scenario would be when no node has enough space to allocate a partition, or cannot satisfy rack constraints.
 
 [,bash]
 ----

--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-admin-brokers-decommission-status.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-admin-brokers-decommission-status.adoc
@@ -5,7 +5,7 @@ include::reference:partial$unsupported-os-rpk.adoc[]
 
 Show the progress of a broker decommissioning.
 
-When a node is being decommissioned, this command reports the decommissioning progress as follows, where PARTITION-SIZE is in bytes. Using -H, it prints the
+When a node is in the process of being decommissioned, this command reports the decommissioning progress as follows, where PARTITION-SIZE is in bytes. Using -H, it prints the
 partition size in a human-readable format.
 
 [,bash]

--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-admin-brokers-decommission-status.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-admin-brokers-decommission-status.adoc
@@ -5,6 +5,47 @@ include::reference:partial$unsupported-os-rpk.adoc[]
 
 Show the progress of a broker decommissioning.
 
+When a node is being decommissioned, this command reports the decommissioning progress as follows, where PARTITION-SIZE is in bytes. Using -H, it prints the
+partition size in a human-readable format.
+
+[,bash]
+----
+$ rpk redpanda admin brokers decommission-status 4
+DECOMMISSION PROGRESS
+=====================
+NAMESPACE-TOPIC              PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE
+kafka/test                   0          3          9             1699470920
+kafka/test                   4          3          0             1614258779
+kafka/test2                  3          3          3             2722706514
+kafka/test2                  4          3          4             2945518089
+kafka_internal/id_allocator  0          3          0             3562
+----
+
+Using --detailed / -d, it additionally prints granular reports.
+
+[,bash]
+----
+$ rpk redpanda admin brokers decommission-status 4 -d
+DECOMMISSION PROGRESS
+=====================
+NAMESPACE-TOPIC  PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE  BYTES-MOVED  BYTES-REMAINING
+kafka/test       0          3          13            1731773243      228114727    1503658516
+kafka/test       4          3          1             1645952961      18752660     1627200301
+kafka/test2      3          3          5             2752632301      140975805    2611656496
+kafka/test2      4          3          6             2975443783      181581219    2793862564
+----
+
+If a partition cannot be moved with some reason, the command reports the problematic partition in the 'ALLOCATION FAILURES' section and decommission never succeeds. Typical scenarios the failure occurs are; there's no node that has enough space to allocate a partition or that can satisfy rack constraints, etc.
+
+[,bash]
+----
+ALLOCATION FAILURES
+==================
+kafka/foo/2
+kafka/test/0
+----
+
+
 == Usage
 
 [,bash]
@@ -19,6 +60,8 @@ rpk redpanda admin brokers decommission-status [BROKER ID] [flags]
 |*Value* |*Type* |*Description*
 
 |-d, --detailed |- |Print how much data moved and remaining in bytes.
+
+|-H, --human-readable |- |Print the partition size in a human-readable form.
 
 |-h, --help |- |Help for decommission-status.
 


### PR DESCRIPTION
To align with the command's help text: https://github.com/redpanda-data/redpanda/blob/dev/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go#L27-L63

The last paragraph in the help text in dev, below, is deprecated and we're going to remove it per https://github.com/redpanda-data/redpanda/pull/16693, hence not included in the PR.

```
Note that the command reports allocation failed partitions only when
'partition_autobalancing_mode' is set to 'continuous'. See the current value
using 'rpk cluster config get partition_autobalancing_mode'.
```