### PR TITLE
Clarify why we do not support autoscalers

### DIFF
--- a/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
+++ b/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
@@ -25,7 +25,7 @@ The <<node-pvc, Nodewatcher controller>> can automate this process.
 
 Horizontal scaling involves modifying the number of brokers in your cluster, either by adding new ones (scaling out) or removing existing ones (scaling in). In situations where the workload is variable, horizontal scaling allows for flexibility. You can scale out when demand is high and scale in when demand is low, optimizing resource usage and cost.
 
-NOTE: Redpanda does not support Kubernetes autoscalers in production.
+NOTE: Redpanda does not support Kubernetes autoscalers in production. Autoscalers primarily rely on CPU and memory metrics for scaling decisions, which do not fully capture the complexities involved in scaling Redpanda clusters. Improper scaling can lead to operational challenges. Therefore, we recommend manually scaling your Redpanda clusters as described in this topic.
 
 === Scale out
 


### PR DESCRIPTION
A community Slack user questioned our statement where we say that we don't support autoscalers.

To support this statement, this PR adds more details to clarify the reason.

https://redpandacommunity.slack.com/archives/C048589SBEZ/p1708622907627989?thread_ts=1708588868.666829&cid=C048589SBEZ