### PR TITLE
Remove references to redpanda-examples repo

### DIFF
--- a/modules/manage/pages/console/topic-documentation.adoc
+++ b/modules/manage/pages/console/topic-documentation.adoc
@@ -1,18 +1,18 @@
 = Topic Documentation
-:description: Embed your Kafka topic-specific documentation into the Redpanda Console UI by linking a Git repository that contains the topics' documentation files.
+:description: Embed your Kafka topic documentation into the Redpanda Console UI by linking a Git repository that contains the topic documentation files.
 :page-aliases: console:features/topic-documentation.adoc
 :page-categories: Redpanda Console
 
 
-You can embed your topic's documentation into the Redpanda Console user interface by providing access to a GitHub repository that hosts your documentation files in Markdown format.
+You can embed your topic's documentation into the Redpanda Console user interface by providing access to a public or private Git repository that hosts your documentation files in Markdown format.
 
-== Integrating topic documentation into Redpanda Console
+image::shared:console-topic-documentation.png[Topic Documentation]
 
-Redpanda Console clones the provided GitHub repository, recursively iterates through all directories in the repository (up to a max depth of 5) and stores all `.md` files it finds in memory.
-The "Documentation" tab in the frontend will show the markdown of the file matching the name of the Kafka topic.
+Redpanda Console clones the provided Git repository and stores all Markdown files it finds in memory.
+The *Documentation* tab in the frontend displays the content of the Markdown file that matches the name of the Kafka topic.
 
 |===
-| Path/Filename | Kafka Topic Name | Matches
+| Path/Filename | Topic Name | Matches
 
 | ordersv2.md
 | orders-v2
@@ -31,20 +31,94 @@ The "Documentation" tab in the frontend will show the markdown of the file match
 | &#10003;
 |===
 
-=== Example
+== Configuration
 
-The following diagram shows an example of topic documentation in Redpanda Console:
-
-image::shared:console-topic-documentation.png[Topic Documentation]
-
-=== Configuration
-
-In addition to the repository URL and branch, you usually need to configure authentication credentials so that you can access private repositories.
+In addition to the repository URL and branch, you can configure authentication credentials for private repositories.
 Redpanda Console supports SSH as well as basic auth. If neither is specified you could still pull publicly accessible repositories.
 
-Following is the configuration:
+=== Repository information
 
-[,yaml]
+Start by specifying the Git repository that contains your Markdown documentation. You need to provide the repository's URL, the branch you want to use, and the base directory where your documentation is located.
+
+[source,yaml]
+----
+console:
+  topicDocumentation:
+    git:
+      enabled: true
+      repository:
+        url: https://github.com/<organization>/<repository>
+        branch: main
+        baseDirectory: <path-to-documentation-files>
+----
+
+* `url`: The complete URL of your Git repository.
+* `branch`: The branch of the repository that has the documentation files.
+* `baseDirectory`: The path within your repository from where the documentation search should begin. Redpanda Console recursively iterates through five levels of directories.
+
+=== Refresh interval
+
+Define how often Redpanda Console should refresh the documentation from the repository. This ensures your documentation is always up to date.
+
+[source,yaml]
+----
+console:
+  topicDocumentation:
+    git:
+      enabled: true
+      refreshInterval: 10m
+----
+
+* `refreshInterval`: A value such as `10m` means the documentation will be refreshed every 10 minutes. Adjust this based on how frequently your documentation is updated, or set to `0` to disable automatic refresh.
+
+=== Authentication configuration
+
+To use private repositories, you must configure authentication. Redpanda Console supports both SSH and basic authentication.
+
+==== Basic authentication
+
+To use a personal access token:
+
+[source,yaml]
+----
+console:
+  topicDocumentation:
+    git:
+      enabled: true
+      basicAuth:
+        enabled: true
+        username: token # Use "token" for GitHub personal access tokens
+        password: "your_github_token"
+----
+
+* Enable `basicAuth` and input your GitHub personal access token as the `password`. If using a personal access token, the `username` should be `token`.
+
+==== SSH authentication
+
+To use SSH-based access:
+
+[source,yaml]
+----
+console:
+  topicDocumentation:
+    git:
+      enabled: true
+      ssh:
+        enabled: true
+        username: git
+        privateKey: "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+        # OR specify a file path
+        privateKeyFilepath: "/path/to/private/key"
+        passphrase: "optional_passphrase"
+----
+
+* Enable SSH and provide your private key either directly in the configuration or in the `privateKeyFilepath` field. Include the passphrase if your key has one.
+
+== Example configuration
+
+Below is an example for a setup where documentation needs frequent updates and is stored in a private repository accessed through SSH:
+
+[source,yaml]
 ----
 console:
   topicDocumentation:
@@ -52,24 +126,15 @@ console:
     git:
       enabled: true
       repository:
-        url: https://github.com/redpanda-data/redpanda-examples
+        url: https://github.com/example/redpanda-docs
         branch: main
-        baseDirectory: console/topic-documentation
-      # How often Console shall pull the repository to look for new files.
-      # Set to 0 to disable periodic pulls
-      refreshInterval: 1m
-      # Basic Auth
-      # If you want to use GitHub's personal access tokens use `token` as username
-      # and pass the token as password
-      basicAuth:
-        enabled: false
-        username: token
-        password: ""
-      # SSH Auth
+        baseDirectory: path/to/documentation
+      refreshInterval: 10m
       ssh:
-        enabled: false
-        username: ""
-        privateKey: ""
-        privateKeyFilepath: ""
-        passphrase: ""
+        enabled: true
+        username: git
+        privateKeyFilepath: "/home/user/.ssh/redpanda_docs_key"
+        passphrase: "your_passphrase"
 ----
+
+This configuration is designed for a secure and automated integration of topic documentation into the Redpanda Console, using SSH for secure repository access and a refresh interval that keeps the documentation consistently updated without manual intervention.


### PR DESCRIPTION
fixes https://github.com/redpanda-data/documentation-private/issues/2087

Also improves the documentation for the Redpanda Console doc feature by providing more context around the configuration options.