### PR TITLE
Add breadcrumbs to API docs

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -4,3 +4,5 @@ asciidoc:
   attributes:
     page-hide-view-latest: true
     page-exclude-from-dropdown-selector: true
+nav:
+- modules/ROOT/nav.adoc

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -8,9 +8,12 @@ content:
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
     branches: [v/*, site-search, main, shared]
+  - url: https://github.com/redpanda-data/redpanda-labs
+    branches: main
+    start_paths: [docs,'*/docs']
 ui:
   bundle:
-    url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip
+    url: ../docs-ui/build/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:
@@ -23,6 +26,11 @@ antora:
   extensions:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unlisted-pages'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-global-attributes'
+  - '@redpanda-data/docs-extensions-and-macros/extensions/version-fetcher/set-latest-version'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/replace-attributes-in-attachments'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/validate-attributes'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/find-related-docs'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/find-related-labs'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/aggregate-terms'
 output:
   clean: true

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -13,7 +13,7 @@ content:
     start_paths: [docs,'*/docs']
 ui:
   bundle:
-    url: ../docs-ui/build/ui-bundle.zip
+    url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,0 +1,5 @@
+* xref:ROOT:reference:index.adoc[Reference]
+** xref:ROOT:reference:api-reference.adoc[]
+*** xref:api:ROOT:pandaproxy-rest.adoc[]
+*** xref:api:ROOT:pandaproxy-schema-registry.adoc[]
+*** xref:api:ROOT:admin-api.adoc[]

--- a/package-lock.json
+++ b/package-lock.json
@@ -895,9 +895,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.0.14.tgz",
-      "integrity": "sha512-vPdLahJDH+Dco6sAZOeuDmwrYwPRcjGoDEdwApObTzYNLiP/NdGAdHUjYpe4Crs2GULDqoTUBRwa48B3H+euRA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.2.1.tgz",
+      "integrity": "sha512-Tvlu+DFaGDHRg6UOToGuyNdpMVp/D2YU4bDBSaLL8UgNWzyEGk51AGFv305FlMsOfVHpEioJKgp00K4c8Lq6LQ==",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",
         "@octokit/rest": "^19.0.7",


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/documentation-private/issues/2260

Related PR: https://github.com/redpanda-data/docs-ui/pull/154

Adds a nav file to the API docs so that the breadcrumbs are generated and displayed at the top of the page.

Result:

![2024-02-28_16-39-42](https://github.com/redpanda-data/docs/assets/45230295/5e5f99d6-5d3a-4cb5-a8ef-71a6dc412cf5)
