### PR TITLE
Restart is not required for cloud_storage_segment_upload_timeout_ms

### DIFF
--- a/modules/reference/pages/tunable-properties.adoc
+++ b/modules/reference/pages/tunable-properties.adoc
@@ -535,7 +535,7 @@ Log segment upload timeout.
 
 *Default*: 30000 (30 seconds)
 
-*Restart required*: yes
+*Restart required*: no
 
 ---
 


### PR DESCRIPTION
This may not be the only parameter that improperly says a restart is required, but I know this one does not take a restart to be applied. Maybe we could figure out a way to automate syncing this list with Redpanda core.