### PR TITLE
Remove tls.passphrase option

### DIFF
--- a/modules/shared/attachments/redpanda-console-config.yaml
+++ b/modules/shared/attachments/redpanda-console-config.yaml
@@ -56,12 +56,10 @@ kafka:
   # certificates, enable TLS and do not provide a certificate
   # authority in the caFilepath. In this case,
   # the system's certificate pool is used.
-  #  enabled: false
+    #enabled: false
     #caFilepath:
     #certFilepath:
     #keyFilepath:
-    # Passphrase also be set using the --kafka.tls.passphrase flag.
-    #passphrase:
     #insecureSkipTlsVerify: false
   #schemaRegistry:
     #enabled: false


### PR DESCRIPTION
TLS passphrases were proved to be insecure by design, hence we removed the support for it in Console quite a while ago. This change reflects the removal of the config in Console's reference config.