### PR TITLE
Mount io-config.yaml in new location outside of /etc/redpanda

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -203,7 +203,9 @@ statefulset:
         name: redpanda-io-config
   extraVolumeMounts: |-
     - name: redpanda-io-config
-      mountPath: /etc/redpanda/io-config.yaml
+      mountPath: /etc/redpanda-io-config
+  additionalRedpandaCmdFlags:
+    - "--io-properties-file=/etc/redpanda-io-config/io-config.yaml"
 ----
 +
 Redpanda reads from this file at startup to optimize itself for the given I/O parameters.

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -117,7 +117,9 @@ spec:
             name: redpanda-io-config
       extraVolumeMounts: |-
         - name: redpanda-io-config
-          mountPath: /etc/redpanda/io-config.yaml
+          mountPath: /etc/redpanda-io-config
+      additionalRedpandaCmdFlags:
+        - "--io-properties-file=/etc/redpanda-io-config/io-config.yaml"
 ----
 +
 - `metadata.name`: Name to assign the Redpanda cluster. This name is also assigned to the Helm release.


### PR DESCRIPTION
StatefulSet mountPaths must be unique. so the io-config ConfigMap and the config EmptyDir cannot both have `/etc/redpanda` (or the last of the identical mountPaths will fail). This PR changes config in docs to mount io-config to a new unique directory, and then modifies the redpanda start command to reference the file in this new location.