### PR TITLE
#2303 remove labs from cloud pages

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/cidr-ranges.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cidr-ranges.adoc
@@ -1,7 +1,6 @@
 = Choose CIDR Ranges
 :description: Guidelines for choosing CIDR ranges when VPC peering.
 :page-cloud: true
-:page-categories: Management, Networking
 
 Choosing Classless Inter-Domain Routing (CIDR) ranges is an essential part of the VPC peering process, required to ensure that data transfers successfully between Redpanda and your cloud provider.
 

--- a/modules/deploy/pages/deployment-option/cloud/create-byoc-cluster-aws.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/create-byoc-cluster-aws.adoc
@@ -2,7 +2,6 @@
 :description: Use the Redpanda Cloud UI to create a BYOC cluster on AWS.
 :page-aliases: cloud:create-byoc-cluster-aws.adoc
 :page-cloud: true
-:page-categories: Deployment
 
 To create a Redpanda cluster in your virtual private cloud (VPC), log in to the Redpanda Cloud UI
 and create a namespace, then follow the steps to create a Bring Your Own Cloud

--- a/modules/deploy/pages/deployment-option/cloud/create-byoc-cluster-gcp.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/create-byoc-cluster-gcp.adoc
@@ -2,7 +2,6 @@
 :description: Use the Redpanda Cloud UI to create a BYOC cluster on GCP.
 :page-aliases: cloud:create-byoc-cluster-gcp.adoc
 :page-cloud: true
-:page-categories: Deployment
 
 To create a Redpanda cluster in your virtual private cloud (VPC), log in to the Redpanda Cloud UI
 and create a namespace, then follow the steps to create a Bring Your Own Cloud

--- a/modules/deploy/pages/deployment-option/cloud/create-dedicated-cloud-cluster-aws.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/create-dedicated-cloud-cluster-aws.adoc
@@ -2,7 +2,6 @@
 :description: Learn how to create a Dedicated cluster.
 :page-aliases: cloud:create-dedicated-cloud-cluster-aws.adoc, deploy:deployment-option/cloud/provision-a-dedicated-cluster/index.adoc
 :page-cloud: true
-:page-categories: Deployment
 
 To create a Dedicated Cloud cluster, log in to Redpanda Cloud, add a namespace, then follow the steps for creating a Dedicated cluster.
 

--- a/modules/deploy/pages/deployment-option/cloud/create-topic.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/create-topic.adoc
@@ -2,7 +2,6 @@
 :description: Learn how to create a topic for a Redpanda Cloud cluster.
 :page-aliases: cloud:create-topic.adoc
 :page-cloud: true
-:page-categories: Development
 
 After you create a cluster, you can create a topic for that cluster.
 

--- a/modules/deploy/pages/deployment-option/cloud/index.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/index.adoc
@@ -3,4 +3,3 @@
 :page-layout: index
 :page-aliases: cloud:index.adoc
 :page-cloud: true
-:page-categories: Deployment

--- a/modules/deploy/pages/deployment-option/cloud/manage-billing/aws-commit.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/manage-billing/aws-commit.adoc
@@ -1,5 +1,6 @@
 = Use AWS Commitments
 :description: Subscribe to Redpanda in AWS Marketplace with committed use.
+:page-cloud: true
 
 You can subscribe to Redpanda Cloud through AWS Marketplace and use your existing marketplace billing and credits to quickly provision Redpanda Dedicated Cloud clusters. View your bills and manage your subscription directly in the marketplace.
 

--- a/modules/deploy/pages/deployment-option/cloud/manage-billing/billing.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/manage-billing/billing.adoc
@@ -1,5 +1,6 @@
 = Usage Metrics
 :description: Learn about the metrics Redpanda uses to measure consumption in Redpanda Cloud.
+:page-cloud: true
 
 Redpanda Cloud billing is mapped to the consumption of resources. When you create a cluster, you select a xref:deploy:deployment-option/cloud/cloud-overview.adoc#cluster-tiers[cluster tier] that specifies the expected throughput for your cluster, including the maximum ingress, egress, partitions, and connections. Billing is based on the resources consumed, multiplied by the cost of that resource.
 

--- a/modules/deploy/pages/deployment-option/cloud/manage-billing/gcp-commit.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/manage-billing/gcp-commit.adoc
@@ -1,5 +1,6 @@
 = Use GCP Commitments
 :description: Subscribe to Redpanda in Google Cloud Marketplace with committed use.
+:page-cloud: true
 
 You can subscribe to Redpanda Cloud through Google Cloud Marketplace and use your existing marketplace billing and credits to quickly provision Redpanda Dedicated Cloud clusters. View your bills and manage your subscription directly in the marketplace.
 

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/converters-and-serialization.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/converters-and-serialization.adoc
@@ -1,7 +1,6 @@
 = Converters and Serialization
 :description: Use converters to handle the serialization and deserialization of data between a Redpanda topic and a managed connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 Connectors are a translation layer working between Redpanda and the remote system. 
 

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-gcp-bigquery-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-gcp-bigquery-connector.adoc
@@ -1,7 +1,6 @@
 = Create a Google BigQuery Sink Connector
 :description: Use the Redpanda Cloud UI to create a Google BigQuery Sink Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 The Google BigQuery Sink connector enables you to stream any structured data from
 Redpanda to BigQuery for advanced analytics.

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-gcs-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-gcs-connector.adoc
@@ -1,7 +1,6 @@
 = Create a GCS Sink Connector
 :description: Use the Redpanda Cloud UI to create a GCS Sink Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 The Google Cloud Storage (GCS) Sink connector stores Redpanda messages in a Google Cloud Storage bucket.
 

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-http-source-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-http-source-connector.adoc
@@ -1,7 +1,6 @@
 = Create an HTTP Source Connector
 :description: Use the Redpanda Cloud UI to create a HTTP Source Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 You can use an HTTP Source connector to enable change data capture (CDC) from
 JSON/HTTP APIs into Redpanda. The HTTP Source connector imports data from HTTP

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-iceberg-sink-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-iceberg-sink-connector.adoc
@@ -2,7 +2,6 @@
 :description: Use the Redpanda Cloud UI to create an Iceberg Sink Connector.
 :page-aliases: cloud:managed-connectors/create-iceberg-sink-connector.adoc
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 You can use the Iceberg Sink connector to accomplish the following: 
 

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-sink-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-sink-connector.adoc
@@ -1,7 +1,6 @@
 = Create a JDBC Sink Connector
 :description: Use the Redpanda Cloud UI to create a JDBC Sink Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 You can use a JDBC Sink connector to export structured data from Redpanda to
 a relational database.

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-source-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-source-connector.adoc
@@ -1,7 +1,6 @@
 = Create a JDBC Source Connector
 :description: Use the Redpanda Cloud UI to create a JDBC Source Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 You can use a JDBC Source connector to import batches of rows from MySQL,
 PostgreSQL, SQLite, and SQL Server relational databases into Redpanda topics.

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-mmaker-checkpoint-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-mmaker-checkpoint-connector.adoc
@@ -1,7 +1,6 @@
 = Create a MirrorMaker2 Checkpoint Connector
 :description: Use the Redpanda Cloud UI to create a MirrorMaker2 Checkpoint Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 You can use the MirrorMaker2 Checkpoint connector to import consumer group offsets
 from other Kafka clusters.

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-mmaker-heartbeat-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-mmaker-heartbeat-connector.adoc
@@ -1,7 +1,6 @@
 = Create a MirrorMaker2 Heartbeat Connector
 :description: Use the Redpanda Cloud UI to create a MirrorMaker2 Heartbeat Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 You can use a MirrorMaker2 Heartbeat connector to generate heartbeat messages
 to a local cluster's `heartbeat` topic.

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-mmaker-source-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-mmaker-source-connector.adoc
@@ -1,7 +1,6 @@
 = Create a MirrorMaker2 Source Connector
 :description: Use the Redpanda Cloud UI to create a MirrorMaker2 Source Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 You can use a MirrorMaker2 Source connector to import messages from another Kafka cluster.
 You can also use it to:

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-mongodb-sink-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-mongodb-sink-connector.adoc
@@ -1,7 +1,6 @@
 = Create a MongoDB Sink Connector
 :description: Use the Redpanda Cloud UI to create a MongoDB Sink Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 The MongoDB Sink managed connector exports Redpanda structured data to a MongoDB
 database.

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-mongodb-source-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-mongodb-source-connector.adoc
@@ -1,7 +1,6 @@
 = Create a MongoDB Source Connector
 :description: Use the Redpanda Cloud UI to create a MongoDB Source Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 The MongoDB Source managed connector imports collections from a MongoDB database
 into Redpanda topics.

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-s3-sink-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-s3-sink-connector.adoc
@@ -2,7 +2,6 @@
 :description: Use the Redpanda Cloud UI to create an AWS S3 Sink Connector.
 :page-aliases: cloud:managed-connectors/create-s3-sink-connector.adoc
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 The Amazon S3 Sink connector exports Apache Kafka messages to files in AWS S3 buckets.
 

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-snowflake-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-snowflake-connector.adoc
@@ -1,7 +1,6 @@
 = Create a Snowflake Sink Connector
 :description: Use the Redpanda Cloud UI to create a Snowflake Sink Connector.
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 You can use the Snowflake Sink connector to ingest and store Redpanda structured data into a
 Snowflake database for analytics and decision-making.

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/monitor-connectors.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/monitor-connectors.adoc
@@ -2,6 +2,5 @@
 :description: Use metrics to monitor the health of your Redpanda managed connectors.
 :page-context-links: [{"name": "Cloud", "to": "deploy:deployment-option/cloud/managed-connectors/monitor-connectors.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/monitoring/k-monitor-connectors.adoc" } ]
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 include::manage:partial$monitor-connectors.adoc[]

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/sizing-connectors.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/sizing-connectors.adoc
@@ -2,7 +2,6 @@
 :description: How to choose number of tasks to set for a connector.
 :page-aliases: cloud:managed-connectors/task-count.adoc
 :page-cloud: true
-:page-categories: Deployment, Integration
 
 == Connector tasks
 When you set up a connector, its main responsibility is to validate the configuration and spawn _connector tasks_, which perform the work.

--- a/modules/deploy/pages/deployment-option/cloud/security/authorization/cloud-authorization.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/authorization/cloud-authorization.adoc
@@ -1,7 +1,6 @@
 = Authorization
 :description: Learn how Redpanda Cloud uses IAM roles for authorization.
 :page-cloud: true
-:page-categories: Management, Security
 
 There are two types of authorization in Redpanda Cloud:
 

--- a/modules/deploy/pages/deployment-option/cloud/security/authorization/cloud-iam-policies.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/authorization/cloud-iam-policies.adoc
@@ -1,7 +1,6 @@
 = IAM Policies
 :description: Learn how Redpanda Cloud uses IAM policies for authorization.
 :page-cloud: true
-:page-categories: Management, Security
 
 Redpanda automatically assigns IAM policies to xref:deploy:deployment-option/cloud/cloud-overview.adoc#agent[agents]
 at the time they are deployed. The permissions grant that agent access to BYOC clusters in AWS and GCP. IAM policies

--- a/modules/deploy/pages/deployment-option/cloud/security/cloud-authentication.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/cloud-authentication.adoc
@@ -1,7 +1,6 @@
 = Authentication
 :description: Learn about Redpanda Cloud authentication and authentication services.
 :page-cloud: true
-:page-categories: Management, Security
 
 Redpanda Cloud ensures the highest level of authentication for both users and services.
 

--- a/modules/deploy/pages/deployment-option/cloud/security/cloud-availability.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/cloud-availability.adoc
@@ -1,7 +1,6 @@
 = Availability
 :description: Learn how Redpanda Cloud supports deploying Redpanda clusters in single or multiple availability zones (AZs).
 :page-cloud: true
-:page-categories: Management, Security
 
 Redpanda Cloud supports the deployment of Redpanda clusters in single or multiple
 availability zones (AZs), spanning at most three AZs. Nodes are evenly distributed

--- a/modules/deploy/pages/deployment-option/cloud/security/cloud-encryption.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/cloud-encryption.adoc
@@ -1,7 +1,6 @@
 = Encryption
 :description: Learn how Redpanda Cloud provides data encryption in transit and at rest.
 :page-cloud: true
-:page-categories: Management, Security
 
 Redpanda Cloud provides data at rest and data in transit encryption.
 

--- a/modules/deploy/pages/deployment-option/cloud/security/cloud-safety-reliability.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/cloud-safety-reliability.adoc
@@ -1,7 +1,6 @@
 = Safety and Reliability
 :description: Learn how Redpanda Cloud tests for data inconsistency, liveness, and availability during adverse events.
 :page-cloud: true
-:page-categories: Management, Security
 
 Safety, reliability, and security are a top priority at Redpanda and an important
 part of the product development lifecycle. Redpanda continuously performs

--- a/modules/deploy/pages/deployment-option/cloud/security/cloud-security-network.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/cloud-security-network.adoc
@@ -1,7 +1,6 @@
 = Network Design, Ports, and Flows
 :description: Learn about Redpanda Cloud network design, including ports, and flows.
 :page-cloud: true
-:page-categories: Management, Security
 
 Redpanda Cloud deploys two different types of networks: one for private Redpanda
 clusters and another for public Redpanda clusters. By default, networks are always

--- a/modules/deploy/pages/deployment-option/cloud/security/secrets.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/secrets.adoc
@@ -1,7 +1,6 @@
 = Secrets
 :description: Learn how Redpanda Cloud manages secrets.
 :page-cloud: true
-:page-categories: Management, Security
 
 Redpanda Cloud uses _dynamic secrets_ through IAM roles. These
 have policies defined by the actions and resources that a user (also

--- a/modules/deploy/pages/deployment-option/cloud/serverless.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/serverless.adoc
@@ -2,7 +2,6 @@
 :description: Learn how to create a Serverless cluster.
 :page-cloud: true
 :page-beta: true
-:page-categories: Deployment
 
 Redpanda Serverless is the fastest and easiest way to start event streaming in the cloud. 
 

--- a/modules/deploy/pages/deployment-option/cloud/vpc-byo-gcp.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/vpc-byo-gcp.adoc
@@ -1,7 +1,6 @@
 = Configure a Customer-Managed VPC on GCP
 :description: Connect Redpanda Cloud to your existing VPC for additional security.
 :page-cloud: true
-:page-categories: Deployment
 
 include::shared:partial$feature-flag.adoc[]
 

--- a/modules/deploy/pages/deployment-option/cloud/vpc-peering-aws.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/vpc-peering-aws.adoc
@@ -1,7 +1,6 @@
 = Add a BYOC VPC Peering Connection on AWS
 :description: Use the Redpanda UI and AWS CLI to create a VPC peering connection for a BYOC cluster.
 :page-cloud: true
-:page-categories: Management, Networking
 
 To start sending data to the Redpanda cluster, you must configure the VPC network connection by connecting your Redpanda VPC to your existing AWS VPC.
 

--- a/modules/deploy/pages/deployment-option/cloud/vpc-peering-gcp.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/vpc-peering-gcp.adoc
@@ -1,7 +1,6 @@
 = Add a BYOC VPC Peering Connection on GCP
 :description: Use the Redpanda and GCP UIs to create a VPC peering connection for a BYOC cluster.
 :page-cloud: true
-:page-categories: Management, Networking
 
 To start sending data to the Redpanda cluster, you must configure the VPC network connection by connecting your Redpanda VPC to your existing GCP VPC.
 

--- a/modules/deploy/pages/deployment-option/cloud/vpc-peering.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/vpc-peering.adoc
@@ -2,7 +2,6 @@
 :description: Use the Redpanda Cloud UI to set up VPC peering.
 :page-aliases: cloud:vpc-peering.adoc
 :page-cloud: true
-:page-categories: Management, Networking
 
 A VPC peering connection is a networking connection between two VPCs. This connection allows the VPCs to communicate with each other as if they were within the same network. A route table routes traffic between the two VPCs using private IPv4 addresses.
 


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/documentation-private/issues/2303

removes `page-categories` from cloud pages and adds `page-cloud` to 3 pages that were missing it

preview: https://deploy-preview-343--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/