### PR TITLE
Add secretmanager.secrets.get to console permissions

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/vpc-byo-gcp.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/vpc-byo-gcp.adoc
@@ -259,6 +259,7 @@ cat << EOT > redpanda-console.role
   "title": "Redpanda Console Secret Manager Writer",
   "description": "Redpanda Console Secret Manager Writer",
   "includedPermissions": [
+    "secretmanager.secrets.get",
     "secretmanager.secrets.create",
     "secretmanager.secrets.delete",
     "secretmanager.secrets.list",


### PR DESCRIPTION
As part of Dataplane API work, Console will also need `secretmanager.secrets.get` GCP Secrets Manager API permission.
This documents the change.