### PR TITLE
#2431 change serverless trial link

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -23,7 +23,7 @@ Available on AWS.
 
 ==== Sign up for Serverless
 
-To start using Serverless, https://redpanda.com/try-redpanda/cloud-trial#serverless-trial[sign up for a free trial^]. New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required for a trial. To continue using Serverless, add a credit card and pay as you go. You can edit payment methods on the Redpanda Cloud *Billing* page. 
+To start using Serverless, https://redpanda.com/try-redpanda/cloud-trial#serverless[sign up for a free trial^]. New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required for a trial. To continue using Serverless, add a credit card and pay as you go. You can edit payment methods on the Redpanda Cloud *Billing* page. 
 
 NOTE: Serverless is currently in a limited availability (LA) release with xref:deploy:deployment-option/cloud/serverless.adoc#limits[usage limits] and no public SLA. During LA, existing clusters can scale to the usage limits, but new clusters may need to wait for availability.
 

--- a/modules/deploy/pages/deployment-option/cloud/serverless.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/serverless.adoc
@@ -12,7 +12,7 @@ NOTE: Serverless is currently in a limited availability (LA) release with xref:d
 
 == Prerequisites
 
-. https://redpanda.com/try-redpanda/cloud-trial#serverless-trial[Sign up for a trial^] of Redpanda Serverless. 
+. https://redpanda.com/try-redpanda/cloud-trial#serverless[Sign up for a trial^] of Redpanda Serverless. 
 
 . Make sure you have the latest version of `rpk`. See xref:get-started:rpk-install.adoc[].
 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -9,7 +9,7 @@ This topic lists new features added in Redpanda Cloud.
 
 === Serverless: limited availability
 
-xref:deploy:deployment-option/cloud/serverless.adoc[Redpanda Serverless] moved out of beta and into limited availability (LA). This means that it has usage limits and no public SLA. During LA, existing clusters can scale to the usage limits, but new clusters may need to wait for availability. Serverless is the fastest and easiest way to start data streaming. It is a production-ready deployment option with automatically-scaling clusters available instantly. To start using Serverless, https://redpanda.com/try-redpanda/cloud-trial#serverless-trial[sign up for a free trial^]. This is no base cost, and with pay-as-you-go billing after the trial, you only pay for what you consume. 
+xref:deploy:deployment-option/cloud/serverless.adoc[Redpanda Serverless] moved out of beta and into limited availability (LA). This means that it has usage limits and no public SLA. During LA, existing clusters can scale to the usage limits, but new clusters may need to wait for availability. Serverless is the fastest and easiest way to start data streaming. It is a production-ready deployment option with automatically-scaling clusters available instantly. To start using Serverless, https://redpanda.com/try-redpanda/cloud-trial#serverless[sign up for a free trial^]. This is no base cost, and with pay-as-you-go billing after the trial, you only pay for what you consume. 
 
 === Authentication with SSO
 


### PR DESCRIPTION
fixes https://github.com/redpanda-data/documentation-private/issues/2310

preview:

- https://deploy-preview-358--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/cloud-overview/#sign-up-for-serverless
- https://deploy-preview-358--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/whats-new-cloud/#march-2024
- https://deploy-preview-358--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/serverless/#prerequisites
