### PR TITLE
Fix Helm controller flag usage

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -85,7 +85,7 @@ helm upgrade --install redpanda-controller redpanda/operator \
   --values redpanda-operator-values.yaml
 ----
 +
-NOTE: If you already have Flux installed and you want it to continue managing resources across the entire cluster, use the `--set enableHelmControllers=false` flag.  This flag prevents the Redpanda Operator from deploying its own set of Helm controllers that may conflict with those installed with Flux.
+NOTE: If you already have Flux installed and you want it to continue managing resources across the entire cluster, use the `--set additionalCmdFlags="{--enable-helm-controllers=false}"` flag.  This flag prevents the Redpanda Operator from deploying its own set of Helm controllers that may conflict with those installed with Flux.
 
 . Ensure that the Deployment is successfully rolled out:
 +

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
@@ -161,7 +161,7 @@ helm upgrade --install redpanda-controller redpanda/operator \
   --create-namespace
 ----
 +
-NOTE: If you already have Flux installed and you want it to continue managing resources across the entire cluster, use the `--set enableHelmControllers=false` flag. This flag prevents the Redpanda Operator from deploying its own set of Helm controllers that may conflict with those installed with Flux.
+NOTE: If you already have Flux installed and you want it to continue managing resources across the entire cluster, use the `--set additionalCmdFlags="{--enable-helm-controllers=false}"` flag. This flag prevents the Redpanda Operator from deploying its own set of Helm controllers that may conflict with those installed with Flux.
 
 . Ensure that the Deployment is successfully rolled out:
 +

--- a/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
+++ b/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
@@ -47,7 +47,7 @@ helm upgrade --install redpanda-controller redpanda/operator \
   --timeout 1h
 ----
 +
-NOTE: If you already have Flux installed and you want it to continue managing resources across the entire cluster, use the `--set enableHelmControllers=false` flag. This flag prevents the Redpanda Operator from deploying its own set of Helm controllers that may conflict with those installed with Flux.
+NOTE: If you already have Flux installed and you want it to continue managing resources across the entire cluster, use the `--set additionalCmdFlags="{--enable-helm-controllers=false}"` flag. This flag prevents the Redpanda Operator from deploying its own set of Helm controllers that may conflict with those installed with Flux.
 
 . Ensure that the Deployment is successfully rolled out:
 +


### PR DESCRIPTION
The `enableHelmControllers` chart key currently in the docs does not exist. The operator should be passed the additional `--enable-helm-controllers` argument explicitly using the `additionalCmdFlags` key instead.

Closes #362.

Previews: 
https://deploy-preview-363--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/kubernetes/k-production-deployment/

https://deploy-preview-363--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/kubernetes/local-guide/

https://deploy-preview-363--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/kubernetes/aks-guide/#deploy-redpanda-and-redpanda-console

https://deploy-preview-363--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/kubernetes/eks-guide/#deploy-redpanda-and-redpanda-console

https://deploy-preview-363--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/kubernetes/gke-guide/#deploy-redpanda-and-redpanda-console

