### PR TITLE
Zap whitespace in command example

### DIFF
--- a/modules/reference/pages/rpk/rpk-acl/rpk-acl.adoc
+++ b/modules/reference/pages/rpk/rpk-acl/rpk-acl.adoc
@@ -97,7 +97,7 @@ requests. In flag form to set up a general producing/consuming client, you can
 invoke `rpk acl create` three times with the following (including your
 `--allow-principal`):
 
-`rpk acl create --operation write,read,describe --topic [topics] `
+`rpk acl create --operation write,read,describe --topic [topics]`
 
 `rpk acl create --operation describe,read --group [group.id]`
 


### PR DESCRIPTION
The whitespace was causing the `rpk` command example to render incorrectly.