### PR TITLE
Fix Okta sample url in config example

### DIFF
--- a/modules/manage/pages/security/console/okta.adoc
+++ b/modules/manage/pages/security/console/okta.adoc
@@ -54,7 +54,7 @@ login:
 
   okta:
     enabled: true
-    # URL to the OIDC endpoint; for example, "s://<your-company>.com.okta.com"
+    # URL to the OIDC endpoint; for example, "https://<your-company>.okta.com"
     url: ""
     clientId: ""
     # ClientSecret is sensitive. You can also provide this config by setting


### PR DESCRIPTION
The example url is borked. This makes it look like what someone would actually need to use.