### PR TITLE
Explain why we use Docker Compose in the quickstart

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -5,7 +5,7 @@
 ** xref:get-started:architecture.adoc[How Redpanda Works]
 ** xref:get-started:quickstarts/index.adoc[Quickstarts]
 *** xref:get-started:quick-start-cloud.adoc[Cloud Quickstart]
-*** xref:get-started:quick-start.adoc[Self-hosted Quickstart]
+*** xref:get-started:quick-start.adoc[Self-Hosted Quickstart]
 ** xref:get-started:licenses.adoc[Redpanda Licensing]
 ** xref:get-started:rpk/index.adoc[Redpanda CLI]
 *** xref:get-started:intro-to-rpk.adoc[Introduction to rpk]

--- a/modules/develop/pages/consume-data/follower-fetching.adoc
+++ b/modules/develop/pages/consume-data/follower-fetching.adoc
@@ -23,7 +23,7 @@ To enable follower fetching in Redpanda, configure properties for the consumer a
 
 [tabs]
 ====
-Self-hosted::
+Self-Hosted::
 +
 --
 - For a Redpanda cluster, set the xref:reference:cluster-properties.adoc#enable_rack_awareness[`enable_rack_awareness`] property to `true`.

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -17,6 +17,8 @@ To deploy self-hosted Redpanda in production, use one of the following environme
 - xref:deploy:deployment-option/self-hosted/manual/index.adoc[Linux]
 - xref:deploy:deployment-option/self-hosted/kubernetes/index.adoc[Kubernetes]
 
+To download the Redpanda binary, see https://github.com/redpanda-data/redpanda/releases/latest[GitHub].
+
 ====
 
 == Prerequisites

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -1,4 +1,4 @@
-= Redpanda Self-hosted Quickstart
+= Redpanda Self-Hosted Quickstart
 :description: Learn how to quickly start working with a cluster in self-hosted Redpanda.
 :page-context-links: [{"name": "Cloud", "to": "quick-start-cloud.adoc" },{"name": "Docker", "to": "quick-start.adoc" }]
 :page-aliases: install-upgrade:index.adoc, install-upgrade:index/index.adoc, install-upgrade:start-streaming.adoc, quickstart:console-installation, quickstart:quick-start-docker.adoc, quickstart:quick-start-linux.adoc, quickstart:quick-start-macos.adoc, quickstart:quick-start-windows.adoc, getting-started:quick-start-docker.adoc, getting-started:quick-start-linux.adoc, getting-started:quick-start-windows.adoc, getting-started:quick-start-macos.adoc, console:installation.adoc, get-started:quick-start/quick-start-console.adoc, get-started:quick-start/quick-start-macos.adoc, get-started:quick-start/quick-start-linux.adoc, get-started:quick-start/quick-start-docker.adoc

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -7,6 +7,8 @@
 
 {description}
 
+This quickstart introduces you to Redpanda in a self-hosted environment with a minimal setup. Docker Compose provides a straightforward and reproducible setup process, whether you're exploring Redpanda for the first time or testing new configurations. The option between a single broker and a three-broker setup helps you test Redpanda for simplicity and resilience.
+
 [NOTE]
 ====
 Redpanda in Docker is supported only for development and testing.
@@ -33,8 +35,10 @@ You should see the version of Docker Compose that's installed on your local mach
 
 For lightweight testing, you can start a single Redpanda broker,
 or you can use a more robust example with three Redpanda brokers.
-With three brokers, you can configure your topics with a replication factor of three
-so that the cluster can recover from a single-broker failure.
+
+A single broker setup is the simplest way to get Redpanda up and running. It's ideal for initial exploration, learning, or development environments where high availability and fault tolerance are not critical concerns.
+
+For production environments where you need more resilience, a three-broker setup is recommended. This configuration allows you to leverage Redpanda's replication capabilities, enhancing the durability and availability of your data.
 
 [tabs]
 ======
@@ -133,6 +137,15 @@ Output:
 TOPIC       STATUS
 chat-room  OK
 ```
++
+[TIP]
+====
+If you deployed three brokers, you can configure your topics with a replication factor of three. This replication factor provides high availability and data durability. For more details, see xref:develop:config-topics.adoc#choose-the-replication-factor[Choose the replication factor].
+
+```bash
+docker exec -it redpanda-0 rpk topic create chat-room --replicas 3
+```
+====
 
 . Produce a message to the topic:
 +

--- a/modules/manage/partials/remote-read-replicas.adoc
+++ b/modules/manage/partials/remote-read-replicas.adoc
@@ -361,7 +361,7 @@ A topic's object store thus lags behind the local copy by the xref:reference:tun
 if set, by the topic's `segment.bytes` value. To reduce this lag in the data availability for the Remote Read Replica:
 
 * You can lower the value of `segment.bytes`. This lets Redpanda archive smaller log segments more frequently, at the cost of increasing I/O and file count.
-* Self-hosted implementations can set an idle timeout with config_ref:{config-ref},true,tunable-properties[]
+* Self-Hosted implementations can set an idle timeout with config_ref:{config-ref},true,tunable-properties[]
 to force Redpanda to periodically archive the contents of open log segments to object storage.
 This is useful if a topic's write rate is low and log segments are kept open for long periods of time.
 The appropriate interval may depend on your total partition count: a system with less partitions can handle a higher number of segments per partition.


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/documentation-private/issues/2141

Also provides the command for setting replication factor to three for the three-broker deployment.