### PR TITLE
Add details on setting log levels for subsystems

### DIFF
--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -65,7 +65,7 @@ kubectl logs --namespace <namespace> -l app.kubernetes.io/component=redpanda-sta
 ----
 ====
 
-== Change log levels
+=== Change the log level
 
 Changing the log level to `debug` can provide more detailed logs for diagnostics. This logging level increases the volume of generated logs.
 

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -143,7 +143,7 @@ After applying these changes, verify the log level by <<view-redpanda-logs, chec
 
 You can override the log levels for individual subsystems, such as `rpc` and `kafka`, for more detailed logging control. Overrides exist for the entire length of the running Redpanda process.
 
-TIP: To temporarily override the log level for individual subsystems, you can use the xref:reference:rpk/redpanda/rpk-redpanda-admin-config-log-level-set.adoc[`rpk-redpanda-admin-config-log-level-set`] command.
+TIP: To temporarily override the log level for individual subsystems, you can use the xref:reference:rpk/rpk-redpanda/rpk-redpanda-admin-config-log-level-set.adoc[`rpk-redpanda-admin-config-log-level-set`] command.
 
 . List all available subsystem loggers:
 +

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -71,7 +71,7 @@ To change the default log level for all Redpanda subsystems, use the `logging.lo
 
 Changing the default log level to `debug` can provide more detailed logs for diagnostics. This logging level increases the volume of generated logs.
 
-NOTE: To override the log level for specific subsystems, see <<Override log levels for Redpanda subsystems>>.
+NOTE: To set different log levels for individual subsystems, see <<Override the default log level for Redpanda subsystems>>.
 
 [tabs]
 ======
@@ -139,7 +139,7 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 
 After applying these changes, verify the log level by <<view-redpanda-logs, checking the initial output of the logs>> for the Redpanda Pods.
 
-=== Override log levels for Redpanda subsystems
+=== Override the default log level for Redpanda subsystems
 
 You can override the log levels for individual subsystems, such as `rpc` and `kafka`, for more detailed logging control. Overrides exist for the entire length of the running Redpanda process.
 

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -78,6 +78,7 @@ Helm + Operator::
 --
 Apply the new log level:
 
+.`redpanda-cluster.yaml`
 [source,yaml]
 ----
 apiVersion: cluster.redpanda.com/v1alpha1
@@ -109,6 +110,7 @@ Choose between using a custom values file or setting values directly:
 +
 Specify logging settings in `logging.yaml`, then upgrade:
 +
+.`logging.yaml`
 [source,yaml]
 ----
 logging:
@@ -155,6 +157,7 @@ Helm + Operator::
 --
 Apply the new log level:
 
+.`redpanda-cluster.yaml`
 [source,yaml]
 ----
 apiVersion: cluster.redpanda.com/v1alpha1
@@ -187,6 +190,7 @@ Choose between using a custom values file or setting values directly:
 +
 Specify logging settings in `logging.yaml`, then upgrade:
 +
+.`logging.yaml`
 [source,yaml]
 ----
 statefulset:

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -65,13 +65,13 @@ kubectl logs --namespace <namespace> -l app.kubernetes.io/component=redpanda-sta
 ----
 ====
 
-=== Change the log level
+=== Change the default log level
 
-Changing the log level to `debug` can provide more detailed logs for diagnostics. This logging level increases the volume of generated logs.
+Changing the default log level to `debug` can provide more detailed logs for diagnostics. This logging level increases the volume of generated logs.
 
 Valid values are `trace`, `debug`, `info`, `warn`, `error`.
 
-NOTE: Instead of setting a global log level, you can also <<Set log levels for Redpanda subsystems>>.
+NOTE: To temporarily override the log level for specific subsystems, see <<Set log levels for Redpanda subsystems>>.
 
 [tabs]
 ======
@@ -141,7 +141,9 @@ After applying these changes, verify the log level by <<view-redpanda-logs, chec
 
 === Set log levels for Redpanda subsystems
 
-You can specify log levels for individual subsystems, such as `rpc` and `kafka`, for more detailed logging control.
+You can override the log levels for individual subsystems, such as `rpc` and `kafka`, for more detailed logging control.
+
+Log-level overrides for individual subsystems are reset to the default after 300 seconds. To change this default timeout, you can use the xref:reference:rpk/redpanda/rpk-redpanda-admin-config-log-level-set.adoc[`rpk-redpanda-admin-config-log-level-set`] command.
 
 . List all available subsystem loggers:
 +
@@ -218,7 +220,7 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 --
 ======
 
-Adjusting the log levels for specific subsystems provides enhanced visibility into Redpanda's internal operations, facilitating better debugging and monitoring.
+Overriding the log levels for specific subsystems provides enhanced visibility into Redpanda's internal operations, facilitating better debugging and monitoring.
 
 == View Redpanda Operator logs
 

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -139,7 +139,7 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 
 After applying these changes, verify the log level by <<view-redpanda-logs, checking the initial output of the logs>> for the Redpanda Pods.
 
-=== Set log levels for Redpanda subsystems
+=== Override log levels for Redpanda subsystems
 
 You can override the log levels for individual subsystems, such as `rpc` and `kafka`, for more detailed logging control. Overrides exist for the entire length of the running Redpanda process.
 

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -71,6 +71,8 @@ Changing the log level to `debug` can provide more detailed logs for diagnostics
 
 Valid values are `trace`, `debug`, `info`, `warn`, `error`.
 
+NOTE: Instead of setting a global log level, you can also <<Set log levels for Redpanda subsystems>>.
+
 [tabs]
 ======
 Helm + Operator::

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -37,29 +37,48 @@ helm get values <chart-name> --namespace <namespace> --all
 
 == View Redpanda logs
 
-Logs for each Redpanda broker running inside a Pod are sent to STDOUT. Use `kubectl logs` to get logs from STDOUT.
+Logs are crucial for monitoring and troubleshooting your Redpanda clusters. Redpanda brokers output logs to STDOUT, making them accessible via `kubectl`.
 
-To view logs for a particular Pod:
+To access logs for a specific Pod:
 
-```bash
+. List all Pods to find the names of those that are running Redpanda brokers:
++
+[source,bash]
+----
+kubectl get pods --namespace <namespace>
+----
+
+. View logs for a particular Pod by replacing `<pod-name>` with the name of your Pod:
++
+[source,bash]
+----
 kubectl logs <pod-name> --namespace <namespace>
-```
+----
++
+[TIP]
+====
+For a comprehensive overview, you can view aggregated logs from all Pods in the StatefulSet:
 
-To view logs for all Pods in the StatefulSet:
-
-```bash
+[source,bash]
+----
 kubectl logs --namespace <namespace> -l app.kubernetes.io/component=redpanda-statefulset
-```
+----
+====
 
-To change the log level of the Redpanda brokers to `debug`:
+=== Change log levels
+
+Changing the log level to `debug` can provide more detailed logs for diagnostics. This logging level increases the volume of generated logs.
+
+Valid values are `trace`, `debug`, `info`, `warn`, `error`.
 
 [tabs]
 ======
 Helm + Operator::
 +
 --
-.`redpanda-cluster.yaml`
-[,yaml]
+Apply the new log level:
+
+[source,yaml]
 ----
 apiVersion: cluster.redpanda.com/v1alpha1
 kind: Redpanda
@@ -72,39 +91,128 @@ spec:
       logLevel: debug
 ----
 
-```bash
+Then, apply this configuration:
+
+[source,bash]
+----
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
-```
+----
 --
 
 Helm::
 +
 --
+Choose between using a custom values file or setting values directly:
 [tabs]
 ====
 --values::
 +
-.`logging.yaml`
-[,yaml]
+Specify logging settings in `logging.yaml`, then upgrade:
++
+[source,yaml]
 ----
 logging:
   logLevel: debug
 ----
 +
-```bash
+[source,bash]
+----
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
   --values logging.yaml --reuse-values
-```
-
+----
 --set::
 +
-```bash
+Directly set the log level during upgrade:
++
+[source,bash]
+----
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
   --set logging.logLevel=debug
-```
+----
 ====
 --
 ======
+
+After applying these changes, verify the log level by <<view-redpanda-logs, checking the initial output of the logs>> for the Redpanda Pods.
+
+== Set log levels for Redpanda subsystems
+
+You can specify log levels for individual subsystems, such as `rpc` and `kafka`, for more detailed logging control.
+
+. List all available subsystem loggers:
++
+[source,bash]
+----
+kubectl exec -it --namespace <namespace> <pod-name> -c redpanda -- rpk redpanda start --help-loggers
+----
+
+. Set the log level for one or more subsystems. In this example, the `rpc` and `kafka` subsystem loggers are set to `debug`.
++
+[tabs]
+======
+Helm + Operator::
++
+--
+Apply the new log level:
+
+[source,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha1
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  chartRef: {}
+  clusterSpec:
+    statefulset:
+      additionalRedpandaCmdFlags:
+        - '--logger-log-level=rpc=debug:kafka=debug'
+----
+
+Then, apply this configuration:
+
+[source,bash]
+----
+kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
+----
+--
+
+Helm::
++
+--
+Choose between using a custom values file or setting values directly:
+[tabs]
+====
+--values::
++
+Specify logging settings in `logging.yaml`, then upgrade:
++
+[source,yaml]
+----
+statefulset:
+  additionalRedpandaCmdFlags:
+    - '--logger-log-level=rpc=debug:kafka=debug'
+----
++
+[source,bash]
+----
+helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
+  --values logging.yaml --reuse-values
+----
+--set::
++
+Directly set the log level during upgrade:
++
+[source,bash]
+----
+helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
+  --set statefulset.additionalRedpandaCmdFlags="{--logger-log-level=rpc=debug:kafka=debug}"
+----
+====
+--
+======
+
+Adjusting the log levels for specific subsystems provides enhanced visibility into Redpanda's internal operations, facilitating better debugging and monitoring.
 
 == View Redpanda Operator logs
 

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -67,11 +67,11 @@ kubectl logs --namespace <namespace> -l app.kubernetes.io/component=redpanda-sta
 
 === Change the default log level
 
+To change the default log level for all Redpanda subsystems, use the `logging.logLevel` configuration. Valid values are `trace`, `debug`, `info`, `warn`, `error`.
+
 Changing the default log level to `debug` can provide more detailed logs for diagnostics. This logging level increases the volume of generated logs.
 
-Valid values are `trace`, `debug`, `info`, `warn`, `error`.
-
-NOTE: To temporarily override the log level for specific subsystems, see <<Set log levels for Redpanda subsystems>>.
+NOTE: To override the log level for specific subsystems, see <<Override log levels for Redpanda subsystems>>.
 
 [tabs]
 ======
@@ -141,9 +141,9 @@ After applying these changes, verify the log level by <<view-redpanda-logs, chec
 
 === Set log levels for Redpanda subsystems
 
-You can override the log levels for individual subsystems, such as `rpc` and `kafka`, for more detailed logging control.
+You can override the log levels for individual subsystems, such as `rpc` and `kafka`, for more detailed logging control. Overrides exist for the entire length of the running Redpanda process.
 
-Log-level overrides for individual subsystems are reset to the default after 300 seconds. To change this default timeout, you can use the xref:reference:rpk/redpanda/rpk-redpanda-admin-config-log-level-set.adoc[`rpk-redpanda-admin-config-log-level-set`] command.
+TIP: To temporarily override the log level for individual subsystems, you can use the xref:reference:rpk/redpanda/rpk-redpanda-admin-config-log-level-set.adoc[`rpk-redpanda-admin-config-log-level-set`] command.
 
 . List all available subsystem loggers:
 +

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -65,7 +65,7 @@ kubectl logs --namespace <namespace> -l app.kubernetes.io/component=redpanda-sta
 ----
 ====
 
-=== Change log levels
+== Change log levels
 
 Changing the log level to `debug` can provide more detailed logs for diagnostics. This logging level increases the volume of generated logs.
 
@@ -135,7 +135,7 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 
 After applying these changes, verify the log level by <<view-redpanda-logs, checking the initial output of the logs>> for the Redpanda Pods.
 
-== Set log levels for Redpanda subsystems
+=== Set log levels for Redpanda subsystems
 
 You can specify log levels for individual subsystems, such as `rpc` and `kafka`, for more detailed logging control.
 


### PR DESCRIPTION
Provides users with the flags required for setting the log level of individual subsystems. This question was asked in our internal Slack channel and is useful for users who manage Redpanda deployments.

Preview: https://deploy-preview-408--redpanda-docs-preview.netlify.app/current/manage/kubernetes/troubleshooting/k-troubleshoot/#set-log-levels-for-redpanda-subsystems

More details about the subsystem loggers will be added in https://github.com/redpanda-data/documentation-private/issues/2333