### PR TITLE
Update node-properties.adoc

### DIFF
--- a/modules/reference/pages/node-properties.adoc
+++ b/modules/reference/pages/node-properties.adoc
@@ -206,9 +206,18 @@ List of seed servers used to join an existing cluster.
 
 If a cluster does not already exist:
 
-* A broker with an <<empty_seed_starts_cluster,empty_seed_starts_cluster>> set to `true` and an empty `seed_servers` list becomes the cluster root to form a new cluster for other brokers to join. Set `seed_servers` to empty for exactly one broker when first bootstrapping a cluster. 
-* Otherwise, when <<empty_seed_starts_cluster,empty_seed_starts_cluster>> is `false`, `seed_servers` is the list of brokers that initially bootstrap the cluster. In this case, `seed_servers` cannot be empty and must be identical for all brokers in that list. 
+* When `empty_seed_starts_cluster` is `true`, Redpanda enables one broker with an empty `seed_servers` list to initiate a new cluster. The broker with an empty `seed_servers` becomes the cluster root, to which other brokers must connect to join the cluster.  Brokers looking to join the cluster should have their `seed_servers` populated with the cluster root's address, facilitating their connection to the cluster.
++
+[IMPORTANT]
+====
+Only one broker, the designated cluster root, should have an empty `seed_servers` list during the initial cluster bootstrapping. This ensures a single initiation point for cluster formation.
+====
 
-For brokers that are not the root broker or are not in the `seed_servers` list, `seed_servers` is the list of brokers used to join the cluster.
+* When `empty_seed_starts_cluster` is `false`, Redpanda requires all brokers to start with a known set of brokers listed in `seed_servers`. The `seed_servers` list must not be empty and should be identical across these initial seed brokers, containing the addresses of all seed brokers. Brokers not included in the `seed_servers` list use it to discover and join the cluster, allowing for expansion beyond the foundational members.
++
+[NOTE]
+====
+The `seed_servers` list must be consistent across all seed brokers to prevent cluster fragmentation and ensure stable cluster formation.
+====
 
 *Default*: null

--- a/modules/reference/pages/node-properties.adoc
+++ b/modules/reference/pages/node-properties.adoc
@@ -118,7 +118,7 @@ Flag to enable developer mode, which skips most of the checks performed at start
 
 Controls how a new cluster is formed. All brokers in a cluster must have the same value.
 
-<<seed_servers,See how the empty_seed_starts_cluster setting works with the seed_servers setting>> to form a cluster.
+<<seed_servers,See how the `empty_seed_starts_cluster` setting works with the `seed_servers` setting>> to form a cluster.
 
 *Default*: true
 

--- a/modules/reference/pages/node-properties.adoc
+++ b/modules/reference/pages/node-properties.adoc
@@ -116,13 +116,13 @@ Flag to enable developer mode, which skips most of the checks performed at start
 
 === empty_seed_starts_cluster
 
-Controls how a new cluster is formed. This property must have the same value in all brokers in a cluster.
+Controls how a new cluster is formed. All brokers in a cluster must have the same value.
 
-If `true`, an empty <<seed_servers,seed_servers>> list denotes that this broker should form a cluster. At most, one broker in the cluster should be configured with an empty seed_servers list. If no such configured broker exists, or if configured to be `false`, then all brokers denoted by the seed_servers list must be identical in their configurations, and those brokers form the initial cluster.
-
-TIP: This is set to `true` by default for backward compatibility, but Redpanda recommends setting `empty_seed_starts_cluster` to `false`.
+<<seed_servers,See how the empty_seed_starts_cluster setting works with the seed_servers setting>> to form a cluster.
 
 *Default*: true
+
+TIP: For backward compatibility, `true` is the default. Redpanda recommends using `false`.
 
 ---
 
@@ -206,7 +206,9 @@ List of seed servers used to join an existing cluster.
 
 If a cluster does not already exist:
 
-* When <<empty_seed_starts_cluster,empty_seed_starts_cluster>> is `true`, if the seed_servers list is empty, this broker will be the cluster root to form a new cluster that other brokers subsequently join. Exactly one broker in the cluster should set seed_servers to be empty when first bootstrapping a cluster. For brokers that are not the root broker, this is the list of brokers used to join the cluster.
-* Otherwise, when <<empty_seed_starts_cluster,empty_seed_starts_cluster>> is `false`, this refers to the list of brokers that initially bootstrap the cluster. In this case, seed_servers cannot be empty, and seed_servers must be identical for all brokers in that list. For brokers not in the seed_servers list, this is the list of brokers used to join the cluster.
+* A broker with an <<empty_seed_starts_cluster,empty_seed_starts_cluster>> set to `true` and an empty `seed_servers` list becomes the cluster root to form a new cluster for other brokers to join. Set `seed_servers` to empty for exactly one broker when first bootstrapping a cluster. 
+* Otherwise, when <<empty_seed_starts_cluster,empty_seed_starts_cluster>> is `false`, `seed_servers` is the list of brokers that initially bootstrap the cluster. In this case, `seed_servers` cannot be empty and must be identical for all brokers in that list. 
+
+For brokers that are not the root broker or are not in the `seed_servers` list, `seed_servers` is the list of brokers used to join the cluster.
 
 *Default*: null

--- a/modules/reference/pages/node-properties.adoc
+++ b/modules/reference/pages/node-properties.adoc
@@ -122,7 +122,7 @@ Controls how a new cluster is formed. All brokers in a cluster must have the sam
 
 *Default*: true
 
-TIP: For backward compatibility, `true` is the default. Redpanda recommends using `false`.
+TIP: For backward compatibility, `true` is the default. Redpanda recommends using `false` in production environments to prevent accidental cluster formation.
 
 ---
 


### PR DESCRIPTION
Clarify the relationship between seed_servers and empty_seed_starts_cluster in one place in the doc instead of spreading the information across both settings. Also, eliminate redundant details.