### PR TITLE
Documented new public and private metrics

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,8 @@
 name: ROOT
 title: Redpanda
-version: 23.3
+version: 24.1
+prerelease: true
+display_version: '24.1 Beta'
 start_page: get-started:intro-to-events.adoc
 nav:
 - modules/ROOT/nav.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -2,7 +2,7 @@ name: ROOT
 title: Redpanda
 version: 24.1
 prerelease: true
-display_version: '24.1 Beta'
+display_version: '24.1 beta'
 start_page: get-started:intro-to-events.adoc
 nav:
 - modules/ROOT/nav.adoc

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [v/*, api, shared, site-search]
+    branches: [v/*, api, shared, site-search,main]
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/develop/pages/data-transforms/how-transforms-work.adoc
+++ b/modules/develop/pages/data-transforms/how-transforms-work.adoc
@@ -14,7 +14,7 @@ Data transforms let you run common data streaming tasks, like filtering, scrubbi
 
 Data transforms use https://webassembly.org/[WebAssembly^] (Wasm) engines inside a Redpanda broker, allowing Redpanda to control the entire transform lifecycle. For example, Redpanda can stop and start transforms when partitions are moved or to free up system resources for other tasks.
 
-Data transforms take data from an input topic and map it to an output topic. For each topic partition, a leader is responsible for handling the data. Redpanda runs a virtual machine (VM) on the same CPU core (shard) as these partition leaders to execute the transforms function.
+Data transforms take data from an input topic and map it to one or more output topics. For each topic partition, a leader is responsible for handling the data. Redpanda runs a Web Assembly virtual machine (VM) on the same CPU core (shard) as these partition leaders to execute the transforms function.
 
 To execute a transforms function, Redpanda uses just-in-time (JIT) compilation to compile the bytecode in memory, write it to an executable space, then run the directly translated machine code. This JIT compilation ensures efficient execution of the machine code, as it is tailored to the specific hardware it runs on.
 

--- a/modules/develop/partials/run-transforms.adoc
+++ b/modules/develop/partials/run-transforms.adoc
@@ -246,7 +246,8 @@ func filterValidJson(e transform.WriteEvent, w transform.RecordWriter) error {
 	if json.Valid(e.Record().Value) {
 		return w.Write(e.Record())
 	}
-	return nil
+	// Send invalid records to separate topic
+	return w.Write(e.Record(), transform.ToTopic("invalid-json"))
 }
 ```
 ====
@@ -354,6 +355,9 @@ fn filter_valid_json(event: WriteEvent, writer: &mut RecordWriter) -> Result<()>
     let value = event.record.value().unwrap_or_default();
     if serde_json::from_slice::<serde_json::Value>(value).is_ok() {
         writer.write(event.record)?;
+    } else {
+        // Send invalid records to separate topic
+        write.write_with_options(event.record, WriteOptions::to_topic("invalid-json"))?;
     }
     Ok(())
 }
@@ -443,7 +447,7 @@ See xref:reference:public-metrics-reference.adoc[]
 
 - Transforms have no external access to disk or network resources.
 - Only single record transforms is supported, but multiple output records from a single input record is supported. For aggregations, joins, or complex transformations, use Apache Flink.
-- Only a single output topic is supported.
+- Up to 8 output topics are supported.
 - Transforms have at-least-once delivery.
 - When clients use the Kafka Transactions API on partitions of an input topic, transforms process only committed records.
 - Because data transforms are powered by Wasm, transform functions can be authored in any language. However, a data transforms SDK currently is only available in xref:reference:data-transform-api.adoc[Golang] and xref:reference:data-transform-rust-sdk.adoc[Rust].

--- a/modules/manage/partials/whole-cluster-restore.adoc
+++ b/modules/manage/partials/whole-cluster-restore.adoc
@@ -51,6 +51,8 @@ By default, Redpanda uploads cluster metadata to object storage periodically. Yo
 * xref:reference:cluster-properties.adoc#cloud_storage_cluster_metadata_upload_interval_ms[`cloud_storage_cluster_metadata_upload_interval_ms`]: Set the time interval to wait between metadata uploads.
 * xref:reference:cluster-properties.adoc#controller_snapshot_max_age_sec[`controller_snapshot_max_age_sec`]: Maximum amount of time that can pass before Redpanda attempts to take a controller snapshot after a new controller command appears. This property affects how current the uploaded metadata can be.
 
+The xref:reference:public-metrics-reference.adoc#redpanda_latest_cluster_metadata_age[redpanda_latest_cluster_metadata_age] metric tracks the timestamp of the last metadata upload.
+
 == Restore data from a source cluster
 
 To restore data from a source cluster:

--- a/modules/manage/partials/whole-cluster-restore.adoc
+++ b/modules/manage/partials/whole-cluster-restore.adoc
@@ -51,7 +51,7 @@ By default, Redpanda uploads cluster metadata to object storage periodically. Yo
 * xref:reference:cluster-properties.adoc#cloud_storage_cluster_metadata_upload_interval_ms[`cloud_storage_cluster_metadata_upload_interval_ms`]: Set the time interval to wait between metadata uploads.
 * xref:reference:cluster-properties.adoc#controller_snapshot_max_age_sec[`controller_snapshot_max_age_sec`]: Maximum amount of time that can pass before Redpanda attempts to take a controller snapshot after a new controller command appears. This property affects how current the uploaded metadata can be.
 
-The xref:reference:public-metrics-reference.adoc#redpanda_latest_cluster_metadata_age[redpanda_latest_cluster_metadata_age] metric tracks the timestamp of the last metadata upload.
+NOTE: You can monitor the xref:reference:public-metrics-reference.adoc#redpanda_latest_cluster_metadata_age[redpanda_latest_cluster_metadata_age] metric to track the timestamp of the most recent metadata upload.
 
 == Restore data from a source cluster
 

--- a/modules/reference/pages/data-transform-golang-sdk.adoc
+++ b/modules/reference/pages/data-transform-golang-sdk.adoc
@@ -1,6 +1,7 @@
 = Golang SDK for Data Transforms
 :description: Work with data transform APIs in Redpanda using Go.
 :page-aliases: labs:data-transform/data-transform-api.adoc, reference:data-transform-api.adoc
+:page-categories: Development, Stream Processing, Data Transforms
 
 API reference documentation for Redpanda data transforms.
 
@@ -19,6 +20,14 @@ func OnRecordWritten(fn OnRecordWrittenCallback)
 The `OnRecordWritten` function registers a callback of type <<onrecordwrittencallback, `OnRecordWrittenCallback`>>, which is invoked when a record is written to the input topic.
 
 The function should be called in a package's `main` function to register the transform function that will be applied.
+
+==== ToTopic
+
+```go
+func ToTopic(topic string) WriteOpt
+```
+
+The `ToTopic` function is of type <<writeopt,`WriteOpt`>> and allows you to specify the output topic to write to.
 
 ---
 
@@ -93,6 +102,14 @@ type WriteEvent interface {
 
 The `WriteEvent` type contains information about a record that was written.
 
+==== WriteOpt
+
+```go
+type WriteOpt = func(c *writeOpts)
+```
+
+The `WriteOpt` type provides options to customize a write, for example, specify an output topic to write to.
+
 ==== RecordWriter
 
 ```go
@@ -102,7 +119,7 @@ type RecordWriter interface {
       // When writing a record, only the key, value and headers are
       // used other information like the timestamp will be overridden
       // by the broker.
-      Write(Record) error
+      Write(Record, ...WriteOpt) error
 }
 ```
 

--- a/modules/reference/pages/data-transform-rust-sdk.adoc
+++ b/modules/reference/pages/data-transform-rust-sdk.adoc
@@ -191,8 +191,17 @@ impl<'a> RecordWriter<'a> {
     // Creates a new [`RecordWriter`] using the specified `sink`.
     pub fn new(sink: &'a mut dyn RecordSink) -> Self;
 
-    /// Write a record to the output topic returning any errors.
+    /// Write a record to the default output topic, returning any errors.
+    // The default output topic is the 0th output topic in the transform's configuration,
+    // or as specified in the --output-topic flag when running rpk transform deploy
     pub fn write<'b>(&mut self, r: impl Into<BorrowedRecord<'b>>) -> Result<(), WriteError>;
+
+    /// Write a record with the given options, returning any errors.
+    pub fn write_with_options<'b>(
+        &mut self,
+        r: impl Into<BorrowedRecord<'b>>,
+        opts: WriteOptions<'b>,
+    ) -> Result<(), WriteError>;
 }
 ----
 
@@ -203,6 +212,26 @@ impl<'a> RecordWriter<'a> {
 [,rust]
 ----
 pub struct WriteEvent<'a> { /* private fields */ }
+----
+
+=== WriteOptions
+
+`WriteOptions` allows you to customize a <<recordwriter,`RecordWriter`>>'s write.
+
+[,rust]
+----
+pub struct WriteOptions<'a> { /* private fields */ }
+
+impl<'a> WriteOptions<'a> {
+    /// Create a new options struct with the [`Record`]'s destination to an optional `topic`.
+    ///
+    /// If `topic` is `None`, the record will be written to the first
+    /// output topic listed in the configuration.
+    pub fn new(topic: Option<&'a str>) -> Self;
+
+    /// Create a new options struct with the [`Record`]'s destination to `topic`.
+    pub fn to_topic(topic: &'a str) -> Self;
+}
 ----
 
 === WrittenRecord
@@ -278,7 +307,7 @@ A https://doc.rust-lang.org/rust-by-example/trait.html[trait] defines behavior t
 ----
 pub trait RecordSink {
     // Required method
-    fn write(&mut self, r: BorrowedRecord<'_>) -> Result<(), WriteError>;
+    fn write(&mut self, r: BorrowedRecord<'_>, opts: WriteOptions<'_>) -> Result<(), WriteError>;
 }
 ----
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -29,6 +29,12 @@ Redpanda uptime in milliseconds.
 
 ---
 
+=== vectorized_cloud_storage_read_bytes
+
+Number of bytes Redpanda has read from cloud storage. This is tracked on a per-topic and per-partition basis. It increments each time a cloud storage read operation successfully completes.
+
+---
+
 === vectorized_cluster_partition_last_stable_offset
 
 Last stable offset.
@@ -123,6 +129,22 @@ Number of Kafka RPC service errors.
 
 ---
 
+=== vectorized_ntp_archiver_log_compaction_bytes_removed
+
+Number of bytes removed from cloud storage by compaction operations. This is tracked on a per-topic and per-partition basis.
+
+This metric resets every time partition leadership changes. It primarily exists to track the fact that compaction is performing operations on cloud storage.
+
+---
+
+=== vectorized_ntp_archiver_pending
+
+The offset of the last committed offset uploaded to cloud storage for each partition. This metric matching the last committed offset of a partition indicates that all data for a partition has been uploaded.
+
+This metric can indicate an issue in the upload path for a partition when it lags behind the last committed offset.
+
+---
+
 === vectorized_raft_leadership_changes
 
 Number of leadership changes.
@@ -142,6 +164,14 @@ Shows the true utilization of the CPU by a Redpanda process.
 === vectorized_storage_log_compacted_segment
 
 Number of compacted segments.
+
+---
+
+=== vectorized_storage_log_compaction_bytes_removed
+
+Number of bytes removed from local storage by compaction operations. This is tracked on a per-topic and per-partition basis.
+
+This metric resets every time partition leadership changes. It primarily exists to track the fact that compaction is performing operations on local storage.
 
 ---
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -121,14 +121,6 @@ The unix-style timestamp of the last time Redpanda uploaded metadata files to ti
 
 *Usage*: monitoring this is important when considering whole cluster recovery as it indicates the potential metadata changes your new cluster will not mirror. as well which transactions may have been in flight and therefore considered aborted in the new cluster
 
-=== repdanda_cloud_storage_cloud_log_size
-
-The amount of data, in bytes, existing in tiered storage that is accessible by kafka. This increases every time Redpanda offloads a segment to tiered storage, and it decreases every time compaction or retention deletes data.
-
-*Type*: gauge
-
-*Usage*: this metric reports the log size for all topics and partitions in your cluster
-
 == Infrastructure metrics
 
 === redpanda_cpu_busy_seconds_total
@@ -685,6 +677,14 @@ Total number of requests that uploaded an object to cloud storage.
 ** `redpanda_storage_account`
 
 ---
+
+=== repdanda_cloud_storage_cloud_log_size
+
+The amount of data, in bytes, existing in tiered storage that is accessible by kafka. This increases every time Redpanda offloads a segment to tiered storage, and it decreases every time compaction or retention deletes data.
+
+*Type*: gauge
+
+*Usage*: this metric reports the log size for each topic and partition in your cluster
 
 [[tls_metrics]]
 == TLS metrics

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -112,6 +112,14 @@ Number of unavailable partitions (the partitions that lack quorum among their re
 
 ---
 
+=== redpanda_latest_cluster_metadata_age
+
+The unix-style timestamp of the last time Redpanda uploaded metadata files related to whole cluster recovery to tiered storage.
+
+*Type*: gauge
+
+*Usage*: this is an important indicator of how far tiered storage is lagging behind local storage; monitoring this is important when considering whole cluster recovery using tiered storage
+
 == Infrastructure metrics
 
 === redpanda_cpu_busy_seconds_total

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -112,13 +112,22 @@ Number of unavailable partitions (the partitions that lack quorum among their re
 
 ---
 
+[[redpanda_latest_cluster_metadata_age]]
 === redpanda_latest_cluster_metadata_age
 
-The unix-style timestamp of the last time Redpanda uploaded metadata files related to whole cluster recovery to tiered storage.
+The unix-style timestamp of the last time Redpanda uploaded metadata files to tiered storage for your cluster. When performing a xref:manage:whole-cluster-restore.adoc[whole cluster restore] operation, the metadata for the new cluster will not have any changes made to the source cluster after this timestamp.
 
 *Type*: gauge
 
-*Usage*: this is an important indicator of how far tiered storage is lagging behind local storage; monitoring this is important when considering whole cluster recovery using tiered storage
+*Usage*: monitoring this is important when considering whole cluster recovery as it indicates the potential metadata changes your new cluster will not mirror. as well which transactions may have been in flight and therefore considered aborted in the new cluster
+
+=== repdanda_cloud_storage_cloud_log_size
+
+The amount of data, in bytes, existing in tiered storage that is accessible by kafka. This increases every time Redpanda offloads a segment to tiered storage, and it decreases every time compaction or retention deletes data.
+
+*Type*: gauge
+
+*Usage*: this metric reports the log size for all topics and partitions in your cluster
 
 == Infrastructure metrics
 


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/documentation-private/issues/2229

This adds two new public metrics and two new private metrics, plus a blurb in whole cluster restore about one of the public metrics.

Public metrics:
[redpanda_latest_cluster_metadata_age](https://deploy-preview-412--redpanda-docs-preview.netlify.app/24.1/reference/public-metrics-reference/#redpanda_latest_cluster_metadata_age)
[Note in Whole Cluster Restore about the above metric](https://deploy-preview-412--redpanda-docs-preview.netlify.app/24.1/manage/whole-cluster-restore/#manage-source-metadata-uploads)
[repdanda_cloud_storage_cloud_log_size](https://deploy-preview-412--redpanda-docs-preview.netlify.app/24.1/reference/public-metrics-reference/#repdanda_cloud_storage_cloud_log_size)

Internal metrics:
[vectorized_ntp_archiver_log_compaction_bytes_removed](https://deploy-preview-412--redpanda-docs-preview.netlify.app/24.1/reference/internal-metrics-reference/#vectorized_ntp_archiver_log_compaction_bytes_removed)
[vectorized_storage_log_compaction_bytes_removed](https://deploy-preview-412--redpanda-docs-preview.netlify.app/24.1/reference/internal-metrics-reference/#vectorized_storage_log_compaction_bytes_removed)

Additional internal metrics that Andrea noticed were not documented:
[vectorized_cloud_storage_read_bytes](https://deploy-preview-412--redpanda-docs-preview.netlify.app/24.1/reference/internal-metrics-reference/#vectorized_cloud_storage_read_bytes)
[vectorized_ntp_archiver_pending](https://deploy-preview-412--redpanda-docs-preview.netlify.app/24.1/reference/internal-metrics-reference/#vectorized_ntp_archiver_pending)