### PR TITLE
Documented new public and private metrics

### DIFF
--- a/modules/manage/partials/whole-cluster-restore.adoc
+++ b/modules/manage/partials/whole-cluster-restore.adoc
@@ -51,7 +51,7 @@ By default, Redpanda uploads cluster metadata to object storage periodically. Yo
 * xref:reference:cluster-properties.adoc#cloud_storage_cluster_metadata_upload_interval_ms[`cloud_storage_cluster_metadata_upload_interval_ms`]: Set the time interval to wait between metadata uploads.
 * xref:reference:cluster-properties.adoc#controller_snapshot_max_age_sec[`controller_snapshot_max_age_sec`]: Maximum amount of time that can pass before Redpanda attempts to take a controller snapshot after a new controller command appears. This property affects how current the uploaded metadata can be.
 
-NOTE: You can monitor the xref:reference:public-metrics-reference.adoc#redpanda_latest_cluster_metadata_age[redpanda_latest_cluster_metadata_age] metric to track the timestamp of the most recent metadata upload.
+NOTE: You can monitor the xref:reference:public-metrics-reference.adoc#redpanda_cluster_latest_cluster_metadata_manifest_age[redpanda_cluster_latest_cluster_metadata_manifest_age] metric to track the age of the most recent metadata upload.
 
 == Restore data from a source cluster
 

--- a/modules/manage/partials/whole-cluster-restore.adoc
+++ b/modules/manage/partials/whole-cluster-restore.adoc
@@ -51,6 +51,8 @@ By default, Redpanda uploads cluster metadata to object storage periodically. Yo
 * xref:reference:cluster-properties.adoc#cloud_storage_cluster_metadata_upload_interval_ms[`cloud_storage_cluster_metadata_upload_interval_ms`]: Set the time interval to wait between metadata uploads.
 * xref:reference:cluster-properties.adoc#controller_snapshot_max_age_sec[`controller_snapshot_max_age_sec`]: Maximum amount of time that can pass before Redpanda attempts to take a controller snapshot after a new controller command appears. This property affects how current the uploaded metadata can be.
 
+NOTE: You can monitor the xref:reference:public-metrics-reference.adoc#redpanda_latest_cluster_metadata_age[redpanda_latest_cluster_metadata_age] metric to track the timestamp of the most recent metadata upload.
+
 == Restore data from a source cluster
 
 To restore data from a source cluster:

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -153,7 +153,7 @@ The `namespace` label supports the following options for this metric:
 
 The difference between the last committed offset and the last offset uploaded to Tiered Storage for each partition. A value of zero for this metric indicates that all data for a partition is uploaded to Tiered Storage.
 
-This metric is impacted by the xref:reference:tunable-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] tunable property. If this interval is set to 10 seconds, the archiver will upload committed segments to Tiered Storage every 10 seconds or less. If this metric continues growing for longer than the configured interval, it can indicate a potential network issue with the upload path for that partition.
+This metric is impacted by the xref:reference:tunable-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] tunable property. If this interval is set to 5 minutes, the archiver will upload committed segments to Tiered Storage every 5 minutes or less. If this metric continues growing for longer than the configured interval, it can indicate a potential network issue with the upload path for that partition.
 
 The `namespace` label supports the following options for this metric:
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -31,7 +31,7 @@ Redpanda uptime in milliseconds.
 
 === vectorized_cloud_storage_read_bytes
 
-Number of bytes Redpanda has read from cloud storage. This is tracked on a per-topic and per-partition basis. It increments each time a cloud storage read operation successfully completes.
+Number of bytes Redpanda has read from cloud storage. This is tracked on a per-topic and per-partition basis, and increments each time a cloud storage read operation successfully completes.
 
 ---
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -29,6 +29,12 @@ Redpanda uptime in milliseconds.
 
 ---
 
+=== vectorized_cloud_storage_read_bytes
+
+Number of bytes Redpanda has read from cloud storage. This is tracked on a per-topic and per-partition basis. It increments each time a cloud storage read operation successfully completes.
+
+---
+
 === vectorized_cluster_partition_last_stable_offset
 
 Last stable offset.
@@ -123,6 +129,22 @@ Number of Kafka RPC service errors.
 
 ---
 
+=== vectorized_ntp_archiver_log_compaction_bytes_removed
+
+Number of bytes removed from cloud storage by compaction operations. This is tracked on a per-topic and per-partition basis.
+
+This metric resets every time partition leadership changes. It primarily exists to track the fact that compaction is performing operations on cloud storage.
+
+---
+
+=== vectorized_ntp_archiver_pending
+
+The offset of the last committed offset uploaded to cloud storage for each partition. This metric matching the last committed offset of a partition indicates that all data for a partition has been uploaded.
+
+This metric can indicate an issue in the upload path for a partition when it lags behind the last committed offset.
+
+---
+
 === vectorized_raft_leadership_changes
 
 Number of leadership changes.
@@ -142,6 +164,14 @@ Shows the true utilization of the CPU by a Redpanda process.
 === vectorized_storage_log_compacted_segment
 
 Number of compacted segments.
+
+---
+
+=== vectorized_storage_log_compaction_bytes_removed
+
+Number of bytes removed from local storage by compaction operations. This is tracked on a per-topic and per-partition basis.
+
+This metric resets every time partition leadership changes. It primarily exists to track the fact that compaction is performing operations on local storage.
 
 ---
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -129,7 +129,7 @@ Number of Kafka RPC service errors.
 
 ---
 
-=== vectorized_ntp_archiver_log_compaction_bytes_removed
+=== vectorized_ntp_archiver_compacted_replaced_bytes
 
 Number of bytes removed from cloud storage by compaction operations. This is tracked on a per-topic and per-partition basis.
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -155,6 +155,18 @@ The offset of the last committed offset uploaded to tiered storage for each part
 
 This metric is impacted by the `cloud_storage_upload_loop_max_backoff_ms` configuration property. If this metrics lags behind the latest committed offset by more than twice this property value, it may indicate a network issue in the upload path for the partition, or it may indicate a cluster that is under too much pressure.
 
+The `namespace` label supports the following options for this metric:
+
+* `kafka` - user topics
+* `kafka_internal` - internal kafka topic such as consumer groups
+* `redpanda - redpanda-only internal data
+
+*Labels*:
+
+* `namespace=("kafka" | "kafka_internal" | "redpanda")`
+* `topic`
+* `partition`
+
 ---
 
 === vectorized_raft_leadership_changes
@@ -181,9 +193,7 @@ Number of compacted segments.
 
 === vectorized_storage_log_compaction_removed_bytes
 
-Number of bytes removed from local storage by compaction operations. This is tracked on a per-topic and per-partition basis.
-
-This metric resets every time partition leadership changes. It primarily exists to track the fact that compaction is performing operations on local storage.
+Number of bytes removed from local storage by compaction operations. This is tracked on a per-topic and per-partition basis. It primarily exists to track the fact that compaction is performing operations on local storage.
 
 The `namespace` label supports the following options for this metric:
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -133,7 +133,7 @@ Number of Kafka RPC service errors.
 
 Number of bytes removed from cloud storage by compaction operations. This is tracked on a per-topic and per-partition basis.
 
-This metric resets every time partition leadership changes. It primarily exists to track the fact that compaction is performing operations on cloud storage.
+This metric resets every time partition leadership changes. It tracks whether or not compaction is performing operations on cloud storage.
 
 The `namespace` label supports the following options for this metric:
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -151,9 +151,9 @@ The `namespace` label supports the following options for this metric:
 
 === vectorized_ntp_archiver_pending
 
-The offset of the last committed offset uploaded to tiered storage for each partition. This metric matching the last committed offset of a partition indicates that all data for a partition is uploaded to tiered storage.
+The difference between the last committed offset and the last offset uploaded to Tiered Storage for each partition. A value of zero for this metric indicates that all data for a partition is uploaded to Tiered Storage.
 
-This metric is impacted by the `cloud_storage_upload_loop_max_backoff_ms` configuration property. If this metrics lags behind the latest committed offset by more than twice this property value, it may indicate a network issue in the upload path for the partition, or it may indicate a cluster that is under too much pressure.
+This metric is impacted by the xref:reference:tunable-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] tunable property. If this interval is set to 10 seconds, the archiver will upload committed segments to Tiered Storage every 10 seconds or less. If this metric continues growing for longer than the configured interval, it can indicate a potential network issue with the upload path for that partition.
 
 The `namespace` label supports the following options for this metric:
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -135,13 +135,37 @@ Number of bytes removed from cloud storage by compaction operations. This is tra
 
 This metric resets every time partition leadership changes. It primarily exists to track the fact that compaction is performing operations on cloud storage.
 
+The `namespace` label supports the following options for this metric:
+
+* `kafka` - user topics
+* `kafka_internal` - internal kafka topic such as consumer groups
+* `redpanda - redpanda-only internal data
+
+*Labels*:
+
+* `namespace=("kafka" | "kafka_internal" | "redpanda")`
+* `topic`
+* `partition`
+
 ---
 
 === vectorized_ntp_archiver_pending
 
-The offset of the last committed offset uploaded to cloud storage for each partition. This metric matching the last committed offset of a partition indicates that all data for a partition has been uploaded.
+The offset of the last committed offset uploaded to tiered storage for each partition. This metric matching the last committed offset of a partition indicates that all data for a partition is uploaded to tiered storage.
 
-This metric can indicate an issue in the upload path for a partition when it lags behind the last committed offset.
+This metric is impacted by the `cloud_storage_upload_loop_max_backoff_ms` configuration property. If this metrics lags behind the latest committed offset by more than twice this property value, it may indicate a network issue in the upload path for the partition, or it may indicate a cluster that is under too much pressure.
+
+The `namespace` label supports the following options for this metric:
+
+* `kafka` - user topics
+* `kafka_internal` - internal kafka topic such as consumer groups
+* `redpanda - redpanda-only internal data
+
+*Labels*:
+
+* `namespace=("kafka" | "kafka_internal" | "redpanda")`
+* `topic`
+* `partition`
 
 ---
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -179,7 +179,7 @@ Number of compacted segments.
 
 ---
 
-=== vectorized_storage_log_compaction_bytes_removed
+=== vectorized_storage_log_compaction_removed_bytes
 
 Number of bytes removed from local storage by compaction operations. This is tracked on a per-topic and per-partition basis.
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -155,18 +155,6 @@ The offset of the last committed offset uploaded to tiered storage for each part
 
 This metric is impacted by the `cloud_storage_upload_loop_max_backoff_ms` configuration property. If this metrics lags behind the latest committed offset by more than twice this property value, it may indicate a network issue in the upload path for the partition, or it may indicate a cluster that is under too much pressure.
 
-The `namespace` label supports the following options for this metric:
-
-* `kafka` - user topics
-* `kafka_internal` - internal kafka topic such as consumer groups
-* `redpanda - redpanda-only internal data
-
-*Labels*:
-
-* `namespace=("kafka" | "kafka_internal" | "redpanda")`
-* `topic`
-* `partition`
-
 ---
 
 === vectorized_raft_leadership_changes
@@ -196,6 +184,18 @@ Number of compacted segments.
 Number of bytes removed from local storage by compaction operations. This is tracked on a per-topic and per-partition basis.
 
 This metric resets every time partition leadership changes. It primarily exists to track the fact that compaction is performing operations on local storage.
+
+The `namespace` label supports the following options for this metric:
+
+* `kafka` - user topics
+* `kafka_internal` - internal kafka topic such as consumer groups
+* `redpanda - redpanda-only internal data
+
+*Labels*:
+
+* `namespace=("kafka" | "kafka_internal" | "redpanda")`
+* `topic`
+* `partition`
 
 ---
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -138,8 +138,8 @@ This metric resets every time partition leadership changes. It tracks whether or
 The `namespace` label supports the following options for this metric:
 
 * `kafka` - user topics
-* `kafka_internal` - internal kafka topic such as consumer groups
-* `redpanda - redpanda-only internal data
+* `kafka_internal` - internal Kafka topic, such as consumer groups
+* `redpanda - Redpanda-only internal data
 
 *Labels*:
 
@@ -158,8 +158,8 @@ This metric is impacted by the xref:reference:tunable-properties.adoc#cloud_stor
 The `namespace` label supports the following options for this metric:
 
 * `kafka` - user topics
-* `kafka_internal` - internal kafka topic such as consumer groups
-* `redpanda - redpanda-only internal data
+* `kafka_internal` - internal Kafka topic, such as consumer groups
+* `redpanda - Redpanda-only internal data
 
 *Labels*:
 
@@ -193,13 +193,13 @@ Number of compacted segments.
 
 === vectorized_storage_log_compaction_removed_bytes
 
-Number of bytes removed from local storage by compaction operations. This is tracked on a per-topic and per-partition basis. It primarily exists to track the fact that compaction is performing operations on local storage.
+Number of bytes removed from local storage by compaction operations. This is tracked on a per-topic and per-partition basis. It tracks whether compaction is performing operations on local storage.
 
 The `namespace` label supports the following options for this metric:
 
 * `kafka` - user topics
-* `kafka_internal` - internal kafka topic such as consumer groups
-* `redpanda - redpanda-only internal data
+* `kafka_internal` - internal Kafka topic, such as consumer groups
+* `redpanda - Redpanda-only internal data
 
 *Labels*:
 

--- a/modules/reference/pages/internal-metrics-reference.adoc
+++ b/modules/reference/pages/internal-metrics-reference.adoc
@@ -137,9 +137,9 @@ This metric resets every time partition leadership changes. It tracks whether or
 
 The `namespace` label supports the following options for this metric:
 
-* `kafka` - user topics
-* `kafka_internal` - internal Kafka topic, such as consumer groups
-* `redpanda - Redpanda-only internal data
+* `kafka` - User topics
+* `kafka_internal` - Internal Kafka topic, such as consumer groups
+* `redpanda` - Redpanda-only internal data
 
 *Labels*:
 
@@ -157,9 +157,9 @@ This metric is impacted by the xref:reference:tunable-properties.adoc#cloud_stor
 
 The `namespace` label supports the following options for this metric:
 
-* `kafka` - user topics
-* `kafka_internal` - internal Kafka topic, such as consumer groups
-* `redpanda - Redpanda-only internal data
+* `kafka` - User topics
+* `kafka_internal` - Internal Kafka topic, such as consumer groups
+* `redpanda` - Redpanda-only internal data
 
 *Labels*:
 
@@ -197,9 +197,9 @@ Number of bytes removed from local storage by compaction operations. This is tra
 
 The `namespace` label supports the following options for this metric:
 
-* `kafka` - user topics
-* `kafka_internal` - internal Kafka topic, such as consumer groups
-* `redpanda - Redpanda-only internal data
+* `kafka` - User topics
+* `kafka_internal` - Internal Kafka topic, such as consumer groups
+* `redpanda` - Redpanda-only internal data
 
 *Labels*:
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -680,7 +680,7 @@ Total number of requests that uploaded an object to cloud storage.
 
 === repdanda_cloud_storage_cloud_log_size
 
-The amount of data, in bytes, existing in tiered storage that is accessible by kafka. This increases every time Redpanda offloads a segment to tiered storage, and it decreases every time compaction or retention deletes data.
+The amount of data, in bytes, that exists in Tiered Storage and is accessible by Kafka. Increases every time Redpanda offloads a segment to Tiered Storage, and decreases every time compaction or retention deletes data.
 
 The `redpanda_namespace` label supports the following options for this metric:
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -685,7 +685,7 @@ The amount of data, in bytes, that exists in Tiered Storage and is accessible by
 The `redpanda_namespace` label supports the following options for this metric:
 
 * `kafka` - user topics
-* `kafka_internal` - internal kafka topic such as consumer groups
+* `kafka_internal` - internal Kafka topic such as consumer groups
 * `redpanda - redpanda-only internal data
 
 *Type*: gauge

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -117,21 +117,9 @@ Number of unavailable partitions (the partitions that lack quorum among their re
 
 The age in seconds since the last time Redpanda uploaded metadata files to tiered storage for your cluster. A value of `0` indicates metadata has not yet been uploaded. When performing a xref:manage:whole-cluster-restore.adoc[whole cluster restore] operation, the metadata for the new cluster will not have any changes made to the source cluster which are newer than this age.
 
-The `redpanda_namespace` label supports the following options for this metric:
-
-* `kafka` - user topics
-* `kafka_internal` - internal kafka topic such as consumer groups
-* `redpanda - redpanda-only internal data
-
 *Type*: gauge
 
 *Usage*: on a healthy system, this should not exceed the value set for `cloud_storage_cluster_metadata_upload_interval_ms`. You may consider setting an alert if this remains `0` for longer than 1.5 * `cloud_storage_cluster_metadata_upload_interval_ms` as that may indicate a configuration issue.
-
-*Labels*:
-
-* `redpanda_namespace=("kafka" | "kafka_internal" | "redpanda")`
-* `redpanda_topic`
-* `redpanda_partition`
 
 == Infrastructure metrics
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -112,6 +112,15 @@ Number of unavailable partitions (the partitions that lack quorum among their re
 
 ---
 
+[[redpanda_latest_cluster_metadata_age]]
+=== redpanda_latest_cluster_metadata_age
+
+The unix-style timestamp of the last time Redpanda uploaded metadata files to tiered storage for your cluster. When performing a xref:manage:whole-cluster-restore.adoc[whole cluster restore] operation, the metadata for the new cluster will not have any changes made to the source cluster after this timestamp.
+
+*Type*: gauge
+
+*Usage*: monitoring this is important when considering whole cluster recovery as it indicates the potential metadata changes your new cluster will not mirror. as well which transactions may have been in flight and therefore considered aborted in the new cluster
+
 == Infrastructure metrics
 
 === redpanda_cpu_busy_seconds_total
@@ -576,11 +585,11 @@ Total number of requests that backed off.
 *Labels*:
 
 * S3
- ** `redpanda_endpoint`
- ** `redpanda_region`
+** `redpanda_endpoint`
+** `redpanda_region`
 * Azure Blob Storage (ABS)
- ** `redpanda_endpoint`
- ** `redpanda_storage_account`
+** `redpanda_endpoint`
+** `redpanda_storage_account`
 
 ---
 
@@ -610,11 +619,11 @@ Total number of requests that downloaded an object from cloud storage.
 *Labels*:
 
 * S3
- ** `redpanda_endpoint`
- ** `redpanda_region`
+** `redpanda_endpoint`
+** `redpanda_region`
 * Azure Blob Storage (ABS)
- ** `redpanda_endpoint`
- ** `redpanda_storage_account`
+** `redpanda_endpoint`
+** `redpanda_storage_account`
 
 ---
 
@@ -668,6 +677,14 @@ Total number of requests that uploaded an object to cloud storage.
 ** `redpanda_storage_account`
 
 ---
+
+=== repdanda_cloud_storage_cloud_log_size
+
+The amount of data, in bytes, existing in tiered storage that is accessible by kafka. This increases every time Redpanda offloads a segment to tiered storage, and it decreases every time compaction or retention deletes data.
+
+*Type*: gauge
+
+*Usage*: this metric reports the log size for each topic and partition in your cluster
 
 [[tls_metrics]]
 == TLS metrics

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -119,7 +119,7 @@ The amount of time in seconds since the last time Redpanda uploaded metadata fil
 
 *Type*: gauge
 
-*Usage*: on a healthy system, this should not exceed the value set for `cloud_storage_cluster_metadata_upload_interval_ms`. You may consider setting an alert if this remains `0` for longer than 1.5 * `cloud_storage_cluster_metadata_upload_interval_ms` as that may indicate a configuration issue.
+*Usage*: On a healthy system, this should not exceed the value set for `cloud_storage_cluster_metadata_upload_interval_ms`. You may consider setting an alert if this remains `0` for longer than 1.5 * `cloud_storage_cluster_metadata_upload_interval_ms` as that may indicate a configuration issue.
 
 == Infrastructure metrics
 
@@ -684,13 +684,13 @@ The amount of data, in bytes, that exists in Tiered Storage and is accessible by
 
 The `redpanda_namespace` label supports the following options for this metric:
 
-* `kafka` - user topics
-* `kafka_internal` - internal Kafka topic, such as consumer groups
-* `redpanda - Redpanda-only internal data
+* `kafka` - User topics
+* `kafka_internal` - Internal Kafka topic, such as consumer groups
+* `redpanda` - Redpanda-only internal data
 
 *Type*: gauge
 
-*Usage*: this metric reports the log size for each topic and partition in your cluster
+*Usage*: This metric reports the log size for each topic and partition in your cluster
 
 *Labels*:
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -26,7 +26,7 @@ Number of configured, fully commissioned brokers in a cluster.
 
 *Type*: gauge
 
-*How to monitor*: create an alert for when this gauge dips below a steady-state threshold, as a node(s) has become unresponsive.
+*How to monitor*: Create an alert for when this gauge dips below a steady-state threshold, as a node(s) has become unresponsive.
 
 ---
 
@@ -52,7 +52,7 @@ Number of requests dropped by a cluster controller log due to exceeding <<redpan
 
 * `redpanda_cmd_group=("move_operations" | "topic_operations" | "configuration_operations" | "node_management_operations" | "acls_and_users_operations")`
 
-*Usage*: when this counter increases, it indicates that the controller is dropping requests.
+*Usage*: When this counter increases, it indicates that the controller is dropping requests.
 
 ---
 
@@ -62,7 +62,7 @@ Number of partition replicas in the cluster that are currently being removed fro
 
 *Type*: gauge
 
-*Usage*: when this gauge is non-zero, determine whether there is an expected or unexpected reassignment of partitions that is causing movement of partition replicas.
+*Usage*: When this gauge is non-zero, determine whether there is an expected or unexpected reassignment of partitions that is causing movement of partition replicas.
 
 ---
 
@@ -72,7 +72,7 @@ Number of partition replicas in the cluster that are currently being added or mo
 
 *Type*: gauge
 
-*Usage*: when this gauge is non-zero, determine whether there is an expected or unexpected reassignment of partitions that is causing movement of partition replicas.
+*Usage*: When this gauge is non-zero, determine whether there is an expected or unexpected reassignment of partitions that is causing movement of partition replicas.
 
 ---
 
@@ -82,7 +82,7 @@ During a partition movement cancellation operation, the number of partition repl
 
 *Type*: gauge
 
-*How to monitor*: when this gauge is non-zero, determine whether there is an expected or unexpected reassignment of partitions that is causing movement of partition replicas.
+*How to monitor*: When this gauge is non-zero, determine whether there is an expected or unexpected reassignment of partitions that is causing movement of partition replicas.
 
 ---
 
@@ -108,7 +108,7 @@ Number of unavailable partitions (the partitions that lack quorum among their re
 
 *Type*: gauge
 
-*Usage*: when this gauge is non-zero, it indicates that a partition(s) doesn't have quorum and thus doesn't have an active leader. To mitigate, consider increasing the number of brokers and the partition replication factor.
+*Usage*: When this gauge is non-zero, it indicates that a partition(s) doesn't have quorum and thus doesn't have an active leader. To mitigate, consider increasing the number of brokers and the partition replication factor.
 
 ---
 
@@ -231,7 +231,7 @@ Number of RPC errors.
 
 * `redpanda_server=("kafka" | "internal")`
 
-*Usage*: when this counter increases, analyze the logged errors.
+*Usage*: When this counter increases, analyze the logged errors.
 
 ---
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -115,7 +115,7 @@ Number of unavailable partitions (the partitions that lack quorum among their re
 [[redpanda_cluster_latest_cluster_metadata_manifest_age]]
 === redpanda_cluster_latest_cluster_metadata_manifest_age
 
-The age in seconds since the last time Redpanda uploaded metadata files to tiered storage for your cluster. A value of `0` indicates metadata has not yet been uploaded. When performing a xref:manage:whole-cluster-restore.adoc[whole cluster restore] operation, the metadata for the new cluster will not have any changes made to the source cluster which are newer than this age.
+The amount of time in seconds since the last time Redpanda uploaded metadata files to Tiered Storage for your cluster. A value of `0` indicates metadata has not yet been uploaded. When performing a xref:manage:whole-cluster-restore.adoc[whole cluster restore] operation, the metadata for the new cluster will not have any changes made to a source cluster that is newer than this age.
 
 *Type*: gauge
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -112,14 +112,26 @@ Number of unavailable partitions (the partitions that lack quorum among their re
 
 ---
 
-[[redpanda_latest_cluster_metadata_age]]
-=== redpanda_latest_cluster_metadata_age
+[[redpanda_cluster_latest_cluster_metadata_manifest_age]]
+=== redpanda_cluster_latest_cluster_metadata_manifest_age
 
-The unix-style timestamp of the last time Redpanda uploaded metadata files to tiered storage for your cluster. When performing a xref:manage:whole-cluster-restore.adoc[whole cluster restore] operation, the metadata for the new cluster will not have any changes made to the source cluster after this timestamp.
+The age in seconds since the last time Redpanda uploaded metadata files to tiered storage for your cluster. A value of `0` indicates metadata has not yet been uploaded. When performing a xref:manage:whole-cluster-restore.adoc[whole cluster restore] operation, the metadata for the new cluster will not have any changes made to the source cluster which are newer than this age.
+
+The `redpanda_namespace` label supports the following options for this metric:
+
+* `kafka` - user topics
+* `kafka_internal` - internal kafka topic such as consumer groups
+* `redpanda - redpanda-only internal data
 
 *Type*: gauge
 
-*Usage*: monitoring this is important when considering whole cluster recovery as it indicates the potential metadata changes your new cluster will not mirror. as well which transactions may have been in flight and therefore considered aborted in the new cluster
+*Usage*: on a healthy system, this should not exceed the value set for `cloud_storage_cluster_metadata_upload_interval_ms`. You may consider setting an alert if this remains `0` for longer than 1.5 * `cloud_storage_cluster_metadata_upload_interval_ms` as that may indicate a configuration issue.
+
+*Labels*:
+
+* `redpanda_namespace=("kafka" | "kafka_internal" | "redpanda")`
+* `redpanda_topic`
+* `redpanda_partition`
 
 == Infrastructure metrics
 
@@ -682,9 +694,21 @@ Total number of requests that uploaded an object to cloud storage.
 
 The amount of data, in bytes, existing in tiered storage that is accessible by kafka. This increases every time Redpanda offloads a segment to tiered storage, and it decreases every time compaction or retention deletes data.
 
+The `redpanda_namespace` label supports the following options for this metric:
+
+* `kafka` - user topics
+* `kafka_internal` - internal kafka topic such as consumer groups
+* `redpanda - redpanda-only internal data
+
 *Type*: gauge
 
 *Usage*: this metric reports the log size for each topic and partition in your cluster
+
+*Labels*:
+
+* `redpanda_namespace=("kafka" | "kafka_internal" | "redpanda")`
+* `redpanda_topic`
+* `redpanda_partition`
 
 [[tls_metrics]]
 == TLS metrics

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -685,8 +685,8 @@ The amount of data, in bytes, that exists in Tiered Storage and is accessible by
 The `redpanda_namespace` label supports the following options for this metric:
 
 * `kafka` - user topics
-* `kafka_internal` - internal Kafka topic such as consumer groups
-* `redpanda - redpanda-only internal data
+* `kafka_internal` - internal Kafka topic, such as consumer groups
+* `redpanda - Redpanda-only internal data
 
 *Type*: gauge
 

--- a/modules/reference/pages/tunable-properties.adoc
+++ b/modules/reference/pages/tunable-properties.adoc
@@ -469,6 +469,7 @@ Timeout for IAM role related operations. While connecting to object storage, fai
 
 ---
 
+[[cloud_storage_segment_max_upload_interval_sec]]
 === cloud_storage_segment_max_upload_interval_sec
 
 Duration that a segment can be kept in local storage without uploading it to object storage. If `null`, defaults to infinite duration.


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/documentation-private/issues/2229

This adds two new public metrics and two new private metrics, plus a blurb in whole cluster restore about one of the public metrics.

Public metrics:
[redpanda_cluster_latest_cluster_metadata_manifest_age](https://deploy-preview-418--redpanda-docs-preview.netlify.app/24.1/reference/public-metrics-reference/#redpanda_cluster_latest_cluster_metadata_manifest_age)
[Note in Whole Cluster Restore about the above metric](https://deploy-preview-418--redpanda-docs-preview.netlify.app/24.1/manage/whole-cluster-restore/#manage-source-metadata-uploads)
[repdanda_cloud_storage_cloud_log_size](https://deploy-preview-418--redpanda-docs-preview.netlify.app/24.1/reference/public-metrics-reference/#repdanda_cloud_storage_cloud_log_size)

Internal metrics:
[vectorized_ntp_archiver_log_compaction_bytes_removed](https://deploy-preview-418--redpanda-docs-preview.netlify.app/24.1/reference/internal-metrics-reference/#vectorized_ntp_archiver_log_compaction_bytes_removed)
[vectorized_storage_log_compaction_bytes_removed](https://deploy-preview-418--redpanda-docs-preview.netlify.app/24.1/reference/internal-metrics-reference/#vectorized_storage_log_compaction_bytes_removed)

Additional internal metrics that Andrea noticed were not documented:
[vectorized_cloud_storage_read_bytes](https://deploy-preview-418--redpanda-docs-preview.netlify.app/24.1/reference/internal-metrics-reference/#vectorized_cloud_storage_read_bytes)
[vectorized_ntp_archiver_pending](https://deploy-preview-418--redpanda-docs-preview.netlify.app/24.1/reference/internal-metrics-reference/#vectorized_ntp_archiver_pending)