### PR TITLE
Bump supported Helm version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     latest-release-commit: '9eefb907c'
     latest-operator-version: 'v2.1.11-23.3.1'
     supported-kubernetes-version: 1.21
-    supported-helm-version: 3.6.0
+    supported-helm-version: 3.10.0
     supported-rhel-required: '8'
     supported-rhel-recommended: '9+'
     supported-ubuntu-required: '20.04 LTS'


### PR DESCRIPTION
In https://github.com/redpanda-data/helm-charts/pull/1199 the minimum supported Helm version was changed. This commit sync that version