### PR TITLE
Update from write_caching on/off to write_caching_default true/false

### DIFF
--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -95,7 +95,7 @@ rpk topic alter-config [TOPICS…] —-set cleanup.policy=compact
 
 Write caching is a relaxed mode of xref:develop:produce-data/configure-producers.adoc#acksall[`acks=all`] that provides better performance at the expense of durability. It acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to be written to disk. This provides lower latency while still ensuring that a majority of brokers acknowledge the write.
 
-Write caching applies to user topics. It does not apply to transactions or consumer offsets: data written in the context of a transaction and consumer offset commits are always fsynced.
+Write caching applies to user topics. It does not apply to transactions or consumer offsets: data written in the context of a transaction and consumer offset commits is always written to disk and fsynced before being acknowledged to the client.
 
 NOTE: For clusters in xref:reference:rpk/rpk-redpanda/rpk-redpanda-mode.adoc#development-mode[development mode], write caching is enabled by default. For clusters in production mode, it is disabled by default. 
 

--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -93,9 +93,9 @@ rpk topic alter-config [TOPICS…] —-set cleanup.policy=compact
 
 === Configure write caching
 
-Write caching is a relaxed mode of xref:develop:produce-data/configure-producers.adoc#acksall[`acks=all`] that provides better performance at the expense of durability. It acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to fsync to disk. This provides lower latency while still ensuring that a majority of brokers acknowledge the write. 
+Write caching is a relaxed mode of xref:develop:produce-data/configure-producers.adoc#acksall[`acks=all`] that provides better performance at the expense of durability. It acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to be written to disk. This provides lower latency while still ensuring that a majority of brokers acknowledge the write.
 
-Write caching applies to user topics. It does not apply to transactions or consumer offsets:  transactions and offset commits are always fsynced. 
+Write caching applies to user topics. It does not apply to transactions or consumer offsets: data written in the context of a transaction and consumer offset commits are always fsynced.
 
 NOTE: For clusters in xref:reference:rpk/rpk-redpanda/rpk-redpanda-mode.adoc#development-mode[development mode], write caching is enabled by default. For clusters in production mode, it is disabled by default. 
 
@@ -103,17 +103,17 @@ Only enable write caching on workloads that can tolerate some data loss in the c
 
 ==== Configure at cluster level
 
-To enable write caching by default in all user topics, set the cluster-level property xref:reference:cluster-properties.adoc#write_caching[`write_caching`]:
+To enable write caching by default in all user topics, set the cluster-level property xref:reference:cluster-properties.adoc#write_caching_default[`write_caching_default`]:
 
-`rpk cluster config set write_caching=on`
+`rpk cluster config set write_caching_default=true`
 
-With `write_caching` enabled at the cluster level, Redpanda fsyncs to disk according to xref:reference:cluster-properties.adoc#raftreplicamaxpendingflushbytes[`raft_replica_max_pending_flush_bytes`] and xref:reference:cluster-properties.adoc#raftreplicamaxflushdelayms[`raft_replica_max_flush_delay_ms`], whichever is reached first.
+With `write_caching_default` set to true at the cluster level, Redpanda fsyncs to disk according to xref:reference:cluster-properties.adoc#raftreplicamaxpendingflushbytes[`raft_replica_max_pending_flush_bytes`] and xref:reference:cluster-properties.adoc#raftreplicamaxflushdelayms[`raft_replica_max_flush_delay_ms`], whichever is reached first.
 
 ==== Configure at topic level
 
 To override the cluster-level setting at the topic level, set the topic-level property xref:reference:topic-properties.adoc#writecaching[`write.caching`]:
 
-`rpk topic alter-config my_topic --set write.caching=on`
+`rpk topic alter-config my_topic --set write.caching=true`
 
 With `write.caching` enabled at the topic level, Redpanda fsyncs to disk according to xref:reference:topic-properties.adoc#flushms[`flush.ms`] and xref:reference:topic-properties.adoc#flushbytes[`flush.bytes`], whichever is reached first. 
 

--- a/modules/develop/pages/produce-data/configure-producers.adoc
+++ b/modules/develop/pages/produce-data/configure-producers.adoc
@@ -20,7 +20,7 @@ The `acks` property sets the number of acknowledgments the producer requires the
 Redpanda guarantees data safety with fsync, which means flushing to disk.
 
 * With `acks=all`, every write is fsynced by default. 
-* With other `acks` settings, or with `write_caching` enabled at the cluster level, Redpanda fsyncs to disk according to `raft_replica_max_pending_flush_bytes` and `raft_replica_max_flush_delay_ms`, whichever is reached first. 
+* With other `acks` settings, or with `write_caching_default=true` at the cluster level, Redpanda fsyncs to disk according to `raft_replica_max_pending_flush_bytes` and `raft_replica_max_flush_delay_ms`, whichever is reached first.
 * With `write.caching` enabled at the topic level, Redpanda fsyncs to disk according to `flush.ms` and `flush.bytes`, whichever is reached first.
 
 === `acks=0`

--- a/modules/develop/partials/topic-defaults.adoc
+++ b/modules/develop/partials/topic-defaults.adoc
@@ -44,8 +44,8 @@ The following table shows the default cluster-level properties and their equival
 | 1048576 bytes (1 MiB)
 | `max.message.bytes`
 
-| `write_caching`
-| off
+| `write_caching_default`
+| false
 | `write.caching`
 |===
 

--- a/modules/reference/pages/cluster-properties.adoc
+++ b/modules/reference/pages/cluster-properties.adoc
@@ -489,19 +489,19 @@ When the disk usage of a node exceeds this threshold, it triggers Redpanda to mo
 
 ---
 
-=== write_caching
+=== write_caching_default
 
-The write caching mode to apply to a cluster. Write caching acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to fsync to disk. With `acks=all`, this provides lower latency while still ensuring that a majority of brokers acknowledge the write. Fsyncs follow <<raftreplicamaxpendingflushbytes, `raft_replica_max_pending_flush_bytes`>> and <<raftreplicamaxflushdelayms, `raft_replica_max_flush_delay_ms`>>, whichever is reached first. 
+The default write caching mode to apply to user topics. Write caching acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to be written to disk. With `acks=all`, this provides lower latency while still ensuring that a majority of brokers acknowledge the write. Fsyncs follow <<raftreplicamaxpendingflushbytes, `raft_replica_max_pending_flush_bytes`>> and <<raftreplicamaxflushdelayms, `raft_replica_max_flush_delay_ms`>>, whichever is reached first.
 
 Valid modes:
 
-* `off`
-* `on`
+* `true`
+* `false`
 * `disabled`: This takes precedence over topic overrides and disables write caching for the entire cluster.
 
-The `write_caching` cluster property can be overridden with the xref:topic-properties.adoc#writecaching[`write.caching`] topic property.
+The `write_caching_default` cluster property can be overridden with the xref:topic-properties.adoc#writecaching[`write.caching`] topic property.
 
-*Default*: For clusters in production mode, the default is `off`. For clusters in development mode, the default is `on`.
+*Default*: For clusters in production mode, the default is `false`. For clusters in development mode, the default is `true`.
 
 *Type*: boolean
 

--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
@@ -28,7 +28,7 @@ Bundled flags:
 
 Bundled cluster properties:
 
-* `write_caching: on`
+* `write_caching_default: true`
 * `auto_create_topics_enabled: true`
 * `group_topic_partitions: 3`
 * `storage_min_free_bytes: 10485760 (10MiB)`

--- a/modules/reference/pages/topic-properties.adoc
+++ b/modules/reference/pages/topic-properties.adoc
@@ -45,7 +45,7 @@ Many topic-level properties have corresponding xref:manage:cluster-maintenance/c
 | xref:./cluster-properties.adoc#default_topic_replications[`default_topic_replications`]
 
 | <<writecaching,`write.caching`>>
-| xref:./cluster-properties.adoc#write_caching[`write_caching`]
+| xref:./cluster-properties.adoc#write_caching_default[`write_caching_default`]
 |===
 
 [NOTE]
@@ -157,7 +157,7 @@ Configure properties to manage the disk space used by a topic:
 - Retain logs for a maximum duration before cleanup (<<retentionms, `retention.ms`>>).
 - Periodically close an active log segment (<<segmentms, `segment.ms`>>).
 - Limit the maximum size of an active log segment (<<segmentbytes, `segment.bytes`>>).
-- Cache batches until the segment appender chunk is full, instead of fsyncing for every `acks=all` write (<<writecaching,`write.caching`>>). With `write.caching` enabled, fsyncs follow <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>, whichever is reached first. 
+- Cache batches until the segment appender chunk is full, instead of fsyncing for every `acks=all` write (<<writecaching,`write.caching`>>). With `write.caching` enabled, fsyncs follow <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>, whichever is reached first.
 
 ---
 
@@ -280,14 +280,14 @@ When `segment.bytes` is set to a positive value, it overrides the cluster proper
 
 The write caching mode to apply to a topic. 
 
-When `write.caching` is set, it overrides the cluster property xref:cluster-properties.adoc#write_caching[`write_caching`]. Write caching acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to fsync to disk. With `acks=all`, this provides lower latency while still ensuring that a majority of brokers acknowledge the write. Fsyncs follow <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>, whichever is reached first. 
+When `write.caching` is set, it overrides the cluster property xref:cluster-properties.adoc#write_caching_default[`write_caching_default`]. Write caching acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to be written to disk. With `acks=all`, this provides lower latency while still ensuring that a majority of brokers acknowledge the write. Fsyncs follow <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>, whichever is reached first.
 
-**Default**: `off`
+**Default**: `false`
 
 **Values**:
 
-- `on` - Turns on write caching for a topic, according to <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>.
-- `off` - Turns off write caching for a topic, according to <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>.
+- `true` - Enables write caching for a topic, according to <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>.
+- `false` - Disables write caching for a topic, according to <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>.
 
 **Related topics**:
 


### PR DESCRIPTION
* Cluster level `write_caching` was renamed to `write_caching_default`
* Cluster level write caching values {off, on} were renamed to {false, true}
* Topic level `write.caching` values {off, on} were renamed to {false, true}
