### PR TITLE
Update serverless - retention size limit

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/serverless.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/serverless.adoc
@@ -24,7 +24,7 @@ Each Serverless cluster has the following limits:
 * Egress: up to 30 MBps, 1.5 MBps guaranteed
 * Partitions: 100 logical partitions
 * Message size: 20 MB
-* Retention: unlimited time, 10 GiB size per partition
+* Retention: unlimited time
 * Storage: unlimited
 * Users: 30
 * ACLs: 120


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-428--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/serverless/#limits)

Remove 10GiB retention limit, per [this discussion](https://redpandadata.slack.com/archives/C02DKEQE50S/p1713298680985229) 