### PR TITLE
Add Policy permissions to CloudStorage bucket documentation

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/security/authorization/cloud-iam-policies.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/authorization/cloud-iam-policies.adoc
@@ -304,10 +304,12 @@ storage.
    sid    = "RedpandaAgentS3CloudStorageBucket"
    effect = "Allow"
    actions = [
-     "s3:List__",
-     "s3:Get__",
+     "s3:List*",
+     "s3:Get*",
      "s3:CreateBucket",
      "s3:DeleteBucket",
+     "s3:PutBucketPolicy",
+     "s3:DeleteBucketPolicy",
    ]
    resources = [
      local.redpanda_cloud_storage_bucket_arn,


### PR DESCRIPTION
The `s3:PutBucketPolicy` and `s3:DeleteBucketPolicy` permissions were recently introduced in order to support remote read replicas in cloud.

Also modified the - - to a * for Get and List, as this is more correct.