### PR TITLE
Update spec for new path for restart service endpoint

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -1476,11 +1476,9 @@ paths:
           required: true
           schema:
             type: string
-          examples:
-            schema-registry:
-              value: 'schema-registry'
-            http-proxy:
-              value: 'http-proxy'
+            enum: 
+            - http-proxy
+            - schema-registry
       responses:
         200:
           description: Restart successful

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -1476,7 +1476,11 @@ paths:
           required: true
           schema:
             type: string
-          example: 'schema-registry'
+          examples:
+            schema-registry:
+              value: 'schema-registry'
+            http-proxy:
+              value: 'http-proxy'
       responses:
         200:
           description: Restart successful

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -1463,6 +1463,29 @@ paths:
         schema:
           type: integer
           format: int64
+  /debug/restart_service:
+    put:
+      tags: 
+        -  Debugging
+      summary: Restart service
+      description: Restart a Redpanda service.
+      operationId: restart_service
+      parameters:
+        - name: service
+          in: query
+          required: true
+          schema:
+            type: string
+          example: 'schema-registry'
+      responses:
+        200:
+          description: Restart successful
+        400:
+          description: Service name is required
+        404:
+          description: Service not found
+        500:
+          description: Internal Server Error 
   /cloud_storage/initiate_topic_scan_and_recovery:
     get:
       tags:
@@ -1597,29 +1620,7 @@ paths:
       responses:
         200:
           description: Partition metadata is up to date
-          content: {}
-  /redpanda-services/restart:
-    put:
-      tags:
-      - Services
-      summary: Restart service
-      description: Restart a Redpanda service.
-      operationId: redpanda_services_restart
-      parameters:
-      - name: service
-        in: query
-        required: true
-        schema:
-          type: string
-      responses:
-        200:
-          description: Restart successful
-        400:
-          description: Service name is required
-        404:
-          description: Service not found
-        500:
-          description: Internal server error          
+          content: {}       
 components:
   schemas:
     broker_endpoint:


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-432--redpanda-docs-preview.netlify.app/api/admin-api.html#put-/debug/restart_service)

- Changes path from `/redpanda-services/restart` to `/debug/restart_service`
- Also adds endpoint under "Debugging" tag
- Add accepted values for parameter

Fixes https://github.com/redpanda-data/documentation-private/issues/2283