### PR TITLE
Replace kafka-python with kafka-python-ng

### DIFF
--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -27,7 +27,7 @@ The following clients have been validated with Redpanda.
 | https://github.com/twmb/franz-go[franz-go^]
 
 | Python
-| https://pypi.org/project/kafka-python[kafka-python^]
+| https://pypi.org/project/kafka-python-ng[kafka-python-ng^]
 
 | Node.js
 | https://kafka.js.org[KafkaJS^]


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/documentation-private/issues/2364

Redpanda Labs changes here: https://github.com/redpanda-data/redpanda-labs/pull/32