### PR TITLE
Update disk-utilization.adoc

### DIFF
--- a/modules/manage/pages/cluster-maintenance/disk-utilization.adoc
+++ b/modules/manage/pages/cluster-maintenance/disk-utilization.adoc
@@ -158,7 +158,7 @@ For periodic offset expiration, set the retention duration of consumer group off
 | Retention duration of consumer group offsets.
 
 | xref:reference:tunable-properties.adoc#legacy_group_offset_retention_enabled[`legacy_group_offset_retention_enabled`]
-| Enable group offset retention for Redpanda versions earlier than v23.1.
+| Enable group offset retention for Clusters that have been upgraded from Redpanda versions earlier than v23.1.
 |===
 
 Redpanda supports group offset deletion with the Kafka OffsetDelete API through rpk with the xref:reference:rpk/rpk-group/rpk-group-offset-delete.adoc[`rpk group offset-delete`] command. The offset delete API provides finer control over culling consumer offsets. For example, it enables the manual removal of offsets that are tracked by Redpanda within the `__consumer_groups` topic. The offsets requested to be removed will be removed only if either the group in question is in a dead state, or the partitions being deleted have no active subscriptions.

--- a/modules/manage/pages/cluster-maintenance/disk-utilization.adoc
+++ b/modules/manage/pages/cluster-maintenance/disk-utilization.adoc
@@ -158,7 +158,7 @@ For periodic offset expiration, set the retention duration of consumer group off
 | Retention duration of consumer group offsets.
 
 | xref:reference:tunable-properties.adoc#legacy_group_offset_retention_enabled[`legacy_group_offset_retention_enabled`]
-| Enable group offset retention for Clusters that have been upgraded from Redpanda versions earlier than v23.1.
+| Enable group offset retention for Redpanda clusters upgraded from versions prior to v23.1.
 |===
 
 Redpanda supports group offset deletion with the Kafka OffsetDelete API through rpk with the xref:reference:rpk/rpk-group/rpk-group-offset-delete.adoc[`rpk group offset-delete`] command. The offset delete API provides finer control over culling consumer offsets. For example, it enables the manual removal of offsets that are tracked by Redpanda within the `__consumer_groups` topic. The offsets requested to be removed will be removed only if either the group in question is in a dead state, or the partitions being deleted have no active subscriptions.


### PR DESCRIPTION
It reads currently like this param is needed if you are on 22.2.27 for example

that is not the case...

this feature is only in 23.1 and higher 

this param is needed on any cluster that has been upgraded to 23.1* or higher from an earlier version than 23.1