### PR TITLE
Add SASL config to the Topic resource

### DIFF
--- a/modules/deploy/partials/kubernetes/guides/start-streaming.adoc
+++ b/modules/deploy/partials/kubernetes/guides/start-streaming.adoc
@@ -17,6 +17,13 @@ Helm + Operator::
 +
 --
 
+.. Create a Secret in which to store your user's password:
++
+[source,bash]
+----
+kubectl create secret generic redpanda-secret --from-literal=password='changethispassword' --namespace <namespace>
+----
+
 .. Create a xref:manage:kubernetes/k-manage-topics.adoc[Topic resource]:
 +
 .`topic.yaml`
@@ -36,6 +43,12 @@ spec:
       caCertSecretRef:
         name: "redpanda-default-cert"
         key: "ca.crt"
+    sasl:
+      username: redpanda-twitch-account
+      mechanism: SCRAM-SHA-256
+      passwordSecretRef:
+        name: redpanda-secret
+        key: password
 ----
 
 .. Apply the Topic resource in the same namespace as your Redpanda cluster:

--- a/modules/deploy/partials/kubernetes/guides/uninstall.adoc
+++ b/modules/deploy/partials/kubernetes/guides/uninstall.adoc
@@ -30,3 +30,8 @@ kubectl delete secret --all --namespace <namespace>
 --
 ======
 
+To remove the `internal-rpk` alias:
+
+```bash
+unalias internal-rpk
+```


### PR DESCRIPTION
A community member reported that our Managed Cloud tutorials don't work when using the Redpanda Operator. This issue was due to the Topic resource not having the required SASL configuration settings. This PR fixes that issue and also adds a step to the uninstallation section to remove the alias.