### PR TITLE
Add back the data transforms content

### DIFF
--- a/modules/develop/pages/data-transforms/k-run-transforms.adoc
+++ b/modules/develop/pages/data-transforms/k-run-transforms.adoc
@@ -3,3 +3,5 @@
 :env-kubernetes:
 :page-context-links: [{"name": "Linux", "to": "develop:data-transforms/run-transforms.adoc" },{"name": "Kubernetes", "to": "develop:data-transforms/k-run-transforms.adoc" } ]
 :page-categories: Development, Stream Processing, Data Transforms
+
+include::develop:partial$run-transforms.adoc[]

--- a/modules/develop/pages/data-transforms/run-transforms.adoc
+++ b/modules/develop/pages/data-transforms/run-transforms.adoc
@@ -3,3 +3,4 @@
 :page-context-links: [{"name": "Linux", "to": "develop:data-transforms/run-transforms.adoc" },{"name": "Kubernetes", "to": "develop:data-transforms/k-run-transforms.adoc" } ]
 :page-categories: Development, Stream Processing, Data Transforms
 
+include::develop:partial$run-transforms.adoc[]

--- a/modules/develop/partials/run-transforms.adoc
+++ b/modules/develop/partials/run-transforms.adoc
@@ -1,5 +1,3 @@
-include::shared:partial$public-beta.adoc[] 
-
 Data transforms let you run common data streaming tasks, like filtering, scrubbing, and transcoding, within Redpanda. For example, you may have consumers that require you to redact credit card numbers or convert JSON to Avro. Data transforms can also interact with the Redpanda Schema Registry to work with encoded data types.
 
 Data transforms use a WebAssembly (Wasm) engine inside a Redpanda broker. A Wasm function acts on a single record in an input topic. You can develop and manage data transforms with xref:reference:rpk/rpk-transform/rpk-transform.adoc[`rpk transform`] commands.


### PR DESCRIPTION
As part of the 24.1 release, it appears that the `include` that adds the single-sourced data transforms content was removed, leading to an empty page in 24.1 docs: https://github.com/redpanda-data/docs/commit/0126835e665ddd6e6c0231feb7bb3a9105a21a56#diff-7ead89bc384c2f975eaa0dabac7a5ba27b5f3dfd7500806c896f2afeac06709b

Also, this PR removed the note about data transforms being in beta because they are now GA as of 24.1.