### PR TITLE
Fix typo in "Benchmark Redpanda"

### DIFF
--- a/modules/develop/pages/benchmark.adoc
+++ b/modules/develop/pages/benchmark.adoc
@@ -191,7 +191,7 @@ ssh -i ~/.ssh/redpanda_aws ubuntu@$(terraform output --raw client_ssh_host)
 cd /opt/benchmark
 ----
 
-. Create a workload configuration file. For example, create a `.yaml` file with one topic, 144 partitions, 500 MBps producer rate, four producers, and and four consumers:
+. Create a workload configuration file. For example, create a `.yaml` file with one topic, 144 partitions, 500 MBps producer rate, four producers, and four consumers:
 +
 [,bash]
 ----


### PR DESCRIPTION
Corrects the typo of "and and" in [https://docs.redpanda.com/current/develop/benchmark/#run-benchmark](https://docs.redpanda.com/current/develop/benchmark/#run-benchmark).