### PR TITLE
Fix value types for K8s Tiered Storage

### DIFF
--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -509,7 +509,7 @@ spec:
     statefulset:
       podTemplate:
         labels:
-          "azure.workload.identity/use": true
+          "azure.workload.identity/use": "true"
 ----
 
 ```bash
@@ -540,7 +540,7 @@ serviceAccount:
 statefulset:
   podTemplate:
     labels:
-      "azure.workload.identity/use": true
+      "azure.workload.identity/use": "true"
 ----
 +
 ```bash
@@ -557,7 +557,7 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
   --set storage.tiered.config.cloud_storage_azure_container=<container-name> \
   --set serviceAccount.create=true \
   --set serviceAccount.annotations."azure\.workload\.identity/client-id"="<managed-identity-client-id>" \
-  --set statefulset.podTemplate.labels."azure\.workload\.identity/use"=true
+  --set statefulset.podTemplate.labels."azure\.workload\.identity/use"="true"
 ```
 ====
 --

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -75,7 +75,7 @@ spec:
     storage:
       tiered:
         config:
-          cloud_storage_enabled: true
+          cloud_storage_enabled: "true"
           cloud_storage_credentials_source: aws_instance_metadata
           cloud_storage_region: <region>
           cloud_storage_bucket: <redpanda-bucket-name>
@@ -159,7 +159,7 @@ spec:
     storage:
       tiered:
         config:
-          cloud_storage_enabled: true
+          cloud_storage_enabled: "true"
           cloud_storage_credentials_source: config_file
           cloud_storage_access_key: <access-key>
           cloud_storage_secret_key: <secret-key>
@@ -285,7 +285,7 @@ spec:
     storage:
       tiered:
         config:
-          cloud_storage_enabled: true
+          cloud_storage_enabled: "true"
           cloud_storage_api_endpoint: storage.googleapis.com
           cloud_storage_credentials_source: gcp_instance_metadata
           cloud_storage_region: <region>
@@ -367,7 +367,7 @@ spec:
     storage:
       tiered:
         config:
-          cloud_storage_enabled: true
+          cloud_storage_enabled: "true"
           cloud_storage_credentials_source: config_file
           cloud_storage_api_endpoint: storage.googleapis.com
           cloud_storage_access_key: <access-key>
@@ -498,7 +498,7 @@ spec:
     storage:
       tiered:
         config:
-          cloud_storage_enabled: true
+          cloud_storage_enabled: "true"
           cloud_storage_credentials_source: azure_aks_oidc_federation
           cloud_storage_azure_storage_account: <account-name>
           cloud_storage_azure_container: <container-name>
@@ -598,7 +598,7 @@ spec:
     storage:
       tiered:
         config:
-          cloud_storage_enabled: true
+          cloud_storage_enabled: "true"
           cloud_storage_azure_shared_key: <access_key>
           cloud_storage_azure_storage_account: <account-name>
           cloud_storage_azure_container: <container-name>


### PR DESCRIPTION
When I tested this I saw the following errors. This PR fixes the second error.

```
* spec.clusterSpec.storage.tiered.config.cloud_storage_enabled: Invalid value: "boolean": spec.clusterSpec.storage.tiered.config.cloud_storage_enabled in body must be of type string: "boolean"
* spec.clusterSpec.statefulset.podTemplate.labels.azure.workload.identity/use: Invalid value: "boolean": spec.clusterSpec.statefulset.podTemplate.labels.azure.workload.identity/use in body must be of type string: "boolean"
```

 I'm unsure if the first error should be resolved in docs or by changing the type in the CRD:

https://github.com/redpanda-data/redpanda-operator/blob/4c8b40a9860708759ee139ffc318d07516c2d325/src/go/k8s/api/redpanda/v1alpha1/redpanda_clusterspec_types.go#L471