### PR TITLE
docs: update public api docs to v1beta2

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/aws-privatelink.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/aws-privatelink.adoc
@@ -1,5 +1,5 @@
 = Configure AWS PrivateLink for Redpanda Cloud
-:description: Set up AWS PrivateLink to securely access Redpanda Cloud. 
+:description: Set up AWS PrivateLink to securely access Redpanda Cloud.
 :page-cloud: true
 
 include::shared:partial$feature-flag.adoc[]
@@ -19,10 +19,10 @@ TIP: Make sure to replace the variable values in the code examples on this page 
 
 * Install `rpk`.
 * Your Redpanda cluster and <<create-client-vpc,VPC>> must be in the same region.
-* You must use the Redpanda Cloud API to enable the Redpanda endpoint service for your clusters. Follow the steps below to <<get-an-access-token,get an access token>>.  
+* You must use the Redpanda Cloud API to enable the Redpanda endpoint service for your clusters. Follow the steps below to <<get-an-access-token,get an access token>>.
 * Use the https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[AWS CLI] to create a new client VPC or modify an existing one to use the PrivateLink endpoint.
 
-== Get a Cloud API access token 
+== Get a Cloud API access token
 
 . Specify the base URL of the Redpanda Cloud API:
 +
@@ -67,7 +67,7 @@ You must send the API token in the `Authorization` header when making requests t
 
 == Create new cluster with PrivateLink endpoint service enabled
 
-. Call https://docs.api.redpanda.com/#post-/v1beta1/networks[`POST /v1beta1/networks`] to create a network.
+. Call https://docs.api.redpanda.com/#post-/v1beta2/networks[`POST /v1beta2/networks`] to create a network.
 +
 Make sure to supply your own values in the example request below. Store the network ID (`network_id`) after the network is created in order to check whether you can proceed to cluster creation.
 +
@@ -95,14 +95,14 @@ EOF`
 NETWORK_ID=`curl -vv -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-    -d "$NETWORK_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta1/networks | jq .metadata.network_id`
+    -d "$NETWORK_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta2/networks | jq .metadata.network_id`
 
 echo $NETWORK_ID
 ----
 +
-Wait for the network to be ready before creating the cluster in the next step. You can check the state of the network creation by calling https://docs.api.redpanda.com/#get-/v1beta1/networks/-id-[`GET /v1beta1/networks/\{id}`]. You can create the cluster when the state is `STATE_READY`.
+Wait for the network to be ready before creating the cluster in the next step. You can check the state of the network creation by calling https://docs.api.redpanda.com/#get-/v1beta2/networks/-id-[`GET /v1beta2/networks/\{id}`]. You can create the cluster when the state is `STATE_READY`.
 
-. Create a new cluster with the endpoint service enabled by calling https://docs.api.redpanda.com/#post-/v1beta1/clusters[`POST /v1beta1/clusters`].
+. Create a new cluster with the endpoint service enabled by calling https://docs.api.redpanda.com/#post-/v1beta2/clusters[`POST /v1beta2/clusters`].
 +
 In the example below, make sure to set your own values for the following fields:
 +
@@ -127,11 +127,9 @@ CLUSTER_POST_BODY=`cat << EOF
     "zones": [ <zones> ],
     "throughput_tier": "<tier>",
     "type": "<type>",
-    "private_link": {
+    "aws_private_link": {
         "enabled": true,
-        "aws": {
         "allowed_principals": ["<principal_1>","<principal_2>"]
-        }
     }
 }
 EOF`
@@ -139,12 +137,12 @@ EOF`
 CLUSTER_ID=`curl -vv -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-    -d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta1/clusters | jq .metadata.cluster_id | sed 's/"//g'`
+    -d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters | jq .operation.metadata.cluster_id | sed 's/"//g'`
 
 echo $CLUSTER_ID
 ----
 +
-**BYOC clusters:** Check that the cluster operation is completed by calling https://docs.api.redpanda.com/#get-/v1beta1/operations/-id-[`GET /v1beta1/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
+**BYOC clusters:** Check that the cluster operation is completed by calling https://docs.api.redpanda.com/#get-/v1beta2/operations/-id-[`GET /v1beta2/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
 +
 When the Create Cluster operation is completed (`STATE_COMPLETED`), run the following `rpk cloud` command to finish setting up your BYOC cluster:
 +
@@ -162,7 +160,7 @@ rpk cloud byoc aws apply --redpanda-id=$CLUSTER_ID
 CLUSTER_ID=<cluster_id>
 ----
 
-. Make a https://docs.api.redpanda.com/#patch-/v1beta1/clusters/-cluster.id-[`PATCH /v1beta1/clusters/{cluster.id}`] request to update the cluster with the Redpanda Private Link Endpoint Service enabled.
+. Make a https://docs.api.redpanda.com/#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request to update the cluster with the Redpanda Private Link Endpoint Service enabled.
 +
 In the example below, make sure to set your own value for the following field:
 +
@@ -174,11 +172,9 @@ In the example below, make sure to set your own value for the following field:
 ----
 CLUSTER_PATCH_BODY=`cat << EOF
 {
-  "private_link": {
-     "enabled": true,
-     "aws": {
-        "allowed_principals": ["<principal_1>","<principal_2>"]
-     }
+  "aws_private_link": {
+    "enabled": true,
+    "allowed_principals": ["<principal_1>","<principal_2>"]
   }
 }
 EOF`
@@ -186,19 +182,19 @@ EOF`
 curl -vv -X PATCH \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $AUTH_TOKEN" \
-  -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta1/clusters/$CLUSTER_ID
+  -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
 ----
 
-. Before proceeding, check the state of the Update Cluster operation by calling https://docs.api.redpanda.com/#get-/v1beta1/operations/-id-[`GET /v1beta1/operations/\{id}`], and passing the operation ID returned from Update Cluster call. When the state is `STATE_READY`, proceed to the next step.
+. Before proceeding, check the state of the Update Cluster operation by calling https://docs.api.redpanda.com/#get-/v1beta2/operations/-id-[`GET /v1beta2/operations/\{id}`], and passing the operation ID returned from Update Cluster call. When the state is `STATE_READY`, proceed to the next step.
 
-. Check the service state by calling https://docs.api.redpanda.com/#get-/v1beta1/clusters/-id-[`GET /v1beta1/clusters/\{id}`]. The `service_state` in the `private_link.status` response object must be `Available` for you to <<connect-to-privatelink-endpoint-service,connect to the service>>.
+. Check the service state by calling https://docs.api.redpanda.com/#get-/v1beta2/clusters/-id-[`GET /v1beta2/clusters/\{id}`]. The `service_state` in the `aws_private_link.status` response object must be `Available` for you to <<connect-to-privatelink-endpoint-service,connect to the service>>.
 +
 [,bash]
 ----
 curl -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-    $PUBLIC_API_ENDPOINT/v1beta1/clusters/$CLUSTER_ID | jq '.private_link.status.aws | {service_name, service_state}'
+    $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID | jq '.cluster.aws_private_link.status | {service_name, service_state}'
 ----
 
 == Configure PrivateLink connection to Redpanda Cloud
@@ -225,12 +221,12 @@ The service name is required to <<create-vpc-endpoint,create VPC private endpoin
 PL_SERVICE_NAME=`curl -X GET \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $AUTH_TOKEN" \
-  $PUBLIC_API_ENDPOINT/v1beta1/clusters/$CLUSTER_ID | jq -r .private_link.status.aws.service_name`
+  $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID | jq -r .cluster.aws_private_link.status.service_name`
 ----
 
 === Create client VPC
 
-If you are not using an existing VPC, you must create a new one. 
+If you are not using an existing VPC, you must create a new one.
 
 [CAUTION]
 ====
@@ -243,7 +239,7 @@ The VPC region must be the same region where the Redpanda cluster is deployed. R
 
 [,bash]
 ----
-# See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html for 
+# See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html for
 # information on profiles and credential files
 PROFILE=<specific-profile-from-credential-file>
 
@@ -320,7 +316,7 @@ aws ec2 authorize-security-group-ingress --region $REGION --profile $PROFILE \
 
 === Create VPC subnet
 
-You need the subnet ID `subnet_id` from the command output to <<create-vpc-endpoint,create a VPC endpoint>>. Run the following command, specifying the subnet availability zone (for example, `usw2-az1`): 
+You need the subnet ID `subnet_id` from the command output to <<create-vpc-endpoint,create a VPC endpoint>>. Run the following command, specifying the subnet availability zone (for example, `usw2-az1`):
 
 [,bash]
 ----
@@ -347,7 +343,7 @@ aws ec2 create-vpc-endpoint \
 
 == Access Redpanda services through VPC endpoint
 
-After you have enabled PrivateLink for your cluster, your connection URLs are available in the *How to Connect* section of the cluster overview in the Redpanda Cloud UI. 
+After you have enabled PrivateLink for your cluster, your connection URLs are available in the *How to Connect* section of the cluster overview in the Redpanda Cloud UI.
 
 include::deploy:partial$cloud/private-links-access-rp-services-through-vpc.adoc[]
 

--- a/modules/deploy/pages/deployment-option/cloud/gcp-private-service-connect.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/gcp-private-service-connect.adoc
@@ -1,5 +1,5 @@
 = Configure GCP Private Service Connect for BYOC
-:description: Set up GCP Private Service Connect to securely access Redpanda Cloud. 
+:description: Set up GCP Private Service Connect to securely access Redpanda Cloud.
 :page-cloud: true
 
 include::shared:partial$feature-flag.adoc[]
@@ -15,10 +15,10 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 
 == Requirements
 
-* You must use the Redpanda Cloud API to enable the Redpanda endpoint service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>. 
+* You must use the Redpanda Cloud API to enable the Redpanda endpoint service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
 * Use https://cloud.google.com/sdk/docs/install[gcloud^] to create the consumer-side resources, such as a VPC and forwarding rule, or modify an existing one to use the Private Service Connect service attachment created for your cluster.
 
-== Get a Cloud API access token 
+== Get a Cloud API access token
 
 . Save the base URL of the Redpanda Cloud API in an environment variable:
 +
@@ -85,7 +85,7 @@ Provide your values for the following placeholders:
 
 See the official GCP documentation for https://cloud.google.com/vpc/docs/configure-private-service-connect-producer#add-subnet-psc[creating a subnet for Private Service Connect^].
 
-== Create new BYOC cluster with Private Service Connect enabled 
+== Create new BYOC cluster with Private Service Connect enabled
 
 . Update the Redpanda Cloud Agent IAM role.
 +
@@ -102,7 +102,7 @@ compute.serviceAttachments.update
 compute.subnetworks.use
 ```
 
-. Make a request to the https://docs.api.redpanda.com/#post-/v1beta1/networks[`POST /v1beta1/networks`] endpoint to create a network
+. Make a request to the https://docs.api.redpanda.com/#post-/v1beta2/networks[`POST /v1beta2/networks`] endpoint to create a network
 +
 [,bash]
 ----
@@ -126,7 +126,7 @@ EOF`
 curl -vv -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$network_post_body" $PUBLIC_API_ENDPOINT/v1beta1/networks
+-d "$network_post_body" $PUBLIC_API_ENDPOINT/v1beta2/networks
 ----
 +
 Replace the following placeholder variables for the request body:
@@ -147,7 +147,7 @@ Replace the following placeholder variables for the request body:
 export NETWORK_ID=<metadata.network_id>
 ----
 
-. Make a request to the https://docs.api.redpanda.com/#post-/v1beta1/clusters[`POST /v1beta1/clusters`] endpoint to create a Redpanda Cloud cluster with Private Service Connect enabled:
+. Make a request to the https://docs.api.redpanda.com/#post-/v1beta2/clusters[`POST /v1beta2/clusters`] endpoint to create a Redpanda Cloud cluster with Private Service Connect enabled:
 +
 [,bash]
 ----
@@ -163,11 +163,9 @@ export CLUSTER_POST_BODY=`cat << EOF
     "zones": <zones>,
     "throughput_tier": "<throughput-tier>",
     "redpanda_version": "<redpanda-version>",
-    "private_link": {
+    "gcp_private_service_connect": {
         "enabled": true,
-        "gcp": {
-            "consumer_accept_list": <consumer-accept-list>
-        }
+        "consumer_accept_list": <consumer-accept-list>
     },
     "customer_managed_resources": {
         "gcp": {
@@ -192,7 +190,7 @@ EOF`
 curl -vv -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta1/clusters
+-d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters
 ----
 +
 Replace the following placeholders for the request body. Variables with a `byovpc_` prefix represent xref:./vpc-byo-gcp.adoc[customer-managed resources] that should have been created previously:
@@ -242,7 +240,7 @@ compute.serviceAttachments.update
 compute.subnetworks.use
 ----
 
-. Make a request to the https://docs.api.redpanda.com/#patch-/v1beta1/clusters/-cluster.id-[`PATCH /v1beta1/clusters/{cluster.id}`] endpoint to update the cluster to include the newly-created Private Service Connect NAT subnet.
+. Make a request to the https://docs.api.redpanda.com/#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] endpoint to update the cluster to include the newly-created Private Service Connect NAT subnet.
 +
 [,bash]
 ----
@@ -260,31 +258,29 @@ EOF`
 curl -v -X PATCH \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta1/clusters/$CLUSTER_ID
+-d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
 ----
 +
 Replace the following placeholder:
 +
 `<psc-nat-subnet-name>`: The name of the Private Service Connect NAT subnet. Use the fully-qualified name, for example `"projects/<project>/regions/<region>/subnetworks/<subnet-name>"`.
 
-. Make a https://docs.api.redpanda.com/#patch-/v1beta1/clusters/-cluster.id-[`PATCH /v1beta1/clusters/{cluster.id}`] request to update the cluster to enable Private Service Connect.
+. Make a https://docs.api.redpanda.com/#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request to update the cluster to enable Private Service Connect.
 +
 [,bash]
 ----
 CLUSTER_PATCH_BODY=`cat << EOF
 {
-    "private_link": {
+    "gcp_private_service_connect": {
         "enabled": true,
-        "gcp": {
-            "consumer_accept_list": <accept-list>
-        }
+         "consumer_accept_list": <accept-list>
     }
 }
 EOF`
 curl -v -X PATCH \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta1/clusters/$CLUSTER_ID
+-d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
 ----
 +
 Replace the following placeholder:
@@ -300,7 +296,7 @@ gcloud compute service-attachments list --project '<service-project-id>'
 
 == Access Redpanda services through VPC endpoint
 
-After you have enabled Private Service Connect for your cluster, your connection URLs are available in the *How to Connect* section of the cluster overview in the Redpanda Cloud UI. 
+After you have enabled Private Service Connect for your cluster, your connection URLs are available in the *How to Connect* section of the cluster overview in the Redpanda Cloud UI.
 
 include::deploy:partial$cloud/private-links-access-rp-services-through-vpc.adoc[]
 


### PR DESCRIPTION
Update references to the public api v1beta1 in the gcp private service connect and aws private link documentation.

ref https://github.com/redpanda-data/documentation-private/issues/2415