### PR TITLE
Clarify when controller snapshots are enabled

### DIFF
--- a/modules/get-started/pages/architecture.adoc
+++ b/modules/get-started/pages/architecture.adoc
@@ -47,7 +47,7 @@ If a follower triggers an election, but the incumbent leader subsequently spring
 
 Redpanda stores metadata update commands (such as creating and deleting topics or users) in a system partition called the controller partition. A new snapshot is created after each controller command is added, or, with rapid updates, after a set period of time (default is 60 seconds). Controller snapshots save the current cluster metadata state to disk, so startup is fast. For example, with a partition that has moved several times, a snapshot can restore the latest state without replaying every move command.
 
-Each broker has a snapshot file stored in the controller log directory, such as `/var/lib/redpanda/data/redpanda/controller/0_0/snapshot`. The controller partition is replicated by a Raft group that includes all cluster brokers, and the controller snapshot is the Raft snapshot for this group. Snapshots are hydrated when a broker joins the cluster or restarts. Controller snapshots are enabled by default only in new clusters. To enable controller snapshots in existing or upgraded clusters, contact https://support.redpanda.com/hc/en-us[Redpanda Support^].
+Each broker has a snapshot file stored in the controller log directory, such as `/var/lib/redpanda/data/redpanda/controller/0_0/snapshot`. The controller partition is replicated by a Raft group that includes all cluster brokers, and the controller snapshot is the Raft snapshot for this group. Snapshots are hydrated when a broker joins the cluster or restarts. Snapshots are enabled by default for all clusters, both new and upgraded.
 
 == Optimized platform performance
 

--- a/modules/upgrade/partials/rolling-upgrades/upgrade-limitations.adoc
+++ b/modules/upgrade/partials/rolling-upgrades/upgrade-limitations.adoc
@@ -20,6 +20,3 @@ CAUTION: In a mixed-version state, the cluster could run out of disk space. If y
 * *Remote Read Replicas*:
 Upgrade the Remote Read Replica cluster first, ensuring it's on the same version as the origin cluster or one feature release ahead of the origin cluster.
 When upgrading to Redpanda 23.2, metadata from object storage is not synchronized until all brokers in the cluster are upgraded. If you need to force a mixed-version cluster to sync read replicas, transfer partition leadership to brokers running the original version.
-
-* *Controller snapshots*:
-Starting in Redpanda version 23.3, controller snapshots are enabled by default, and persist across cluster restarts and future upgrades. 

--- a/modules/upgrade/partials/rolling-upgrades/upgrade-limitations.adoc
+++ b/modules/upgrade/partials/rolling-upgrades/upgrade-limitations.adoc
@@ -22,4 +22,4 @@ Upgrade the Remote Read Replica cluster first, ensuring it's on the same version
 When upgrading to Redpanda 23.2, metadata from object storage is not synchronized until all brokers in the cluster are upgraded. If you need to force a mixed-version cluster to sync read replicas, transfer partition leadership to brokers running the original version.
 
 * *Controller snapshots*:
-xref:get-started:architecture.adoc#controller-partition-and-snapshots[Controller snapshots] are disabled in upgraded clusters. To re-enable them, contact link:https://support.redpanda.com/hc/en-us[Redpanda Support^].
+Starting in Redpanda version 23.3, controller snapshots are enabled by default, and persist across cluster restarts and future upgrades. 


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/documentation-private/issues/2189

Preview:
[Controller partition and snapshots](https://deploy-preview-486--redpanda-docs-preview.netlify.app/current/get-started/architecture/#controller-partition-and-snapshots)

[Upgrades - Limitations](https://deploy-preview-486--redpanda-docs-preview.netlify.app/current/upgrade/rolling-upgrade/#limitations)
