### PR TITLE
Replace deprecated `license_key` and `license_secret_ref` with `enterprise`

### DIFF
--- a/modules/get-started/pages/licenses.adoc
+++ b/modules/get-started/pages/licenses.adoc
@@ -55,7 +55,7 @@ To apply the license key to your cluster, run:
 
 `rpk cluster license set`
 
-Either provide a path to a file containing the license, or provide the license string inline. For example, assuming you use the default admin host/port of `10.0.0.1:9644`, run:
+Either provide a path to a file containing the license or the license string inline. For example, assuming you use the default admin host/port of `10.0.0.1:9644`, run:
 
 ```bash
 rpk cluster license set --path <path-to-license-file> -X admin.hosts=10.0.0.1:9644
@@ -75,7 +75,7 @@ Kubernetes::
 --
 
 To apply the license key to your cluster using the Helm chart,
-either provide a secret that contains the license, or provide the license string inline:
+either provide a secret that contains the license or provide the license string inline:
 
 - Use a secret:
 +
@@ -86,9 +86,10 @@ either provide a secret that contains the license, or provide the license string
 .`license-key.yaml`
 [,yaml]
 ----
-license_secret_ref:
-  secret_name: <name-of-the-secret>
-  secret_key: <key-where-license-is-stored>
+enterprise
+  licenseSecretRef:
+    name: <name-of-the-secret>
+    key: <key-where-license-is-stored>
 ----
 +
 ```bash
@@ -100,12 +101,12 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set license_secret_ref.secret_name=<name-of-the-secret> \
-  --set license_secret_ref.secret_key=<key-where-license-is-stored>
+  --set enterprise.licenseSecretRef.name=<name-of-the-secret> \
+  --set enterprise.licenseSecretRef.key=<key-where-license-is-stored>
 ```
 ====
 +
-helm_ref:license_secret_ref[]
+helm_ref:enterprise.licenseSecretRef[]
 
 - Use an inline string:
 +
@@ -116,7 +117,8 @@ helm_ref:license_secret_ref[]
 .`license-key.yaml`
 [,yaml]
 ----
-license_key: <license-string>
+enterprise
+  license: <license-string>
 ----
 +
 ```bash
@@ -128,11 +130,11 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 +
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
-  --set license_key=<license-string>
+  --set enterprise.license=<license-string>
 ```
 ====
 +
-helm_ref:license_key[]
+helm_ref:enterprise.license[]
 
 If neither the path nor the license string are provided, Redpanda looks for the license in `/etc/redpanda/redpanda.license`.
 
@@ -149,11 +151,11 @@ Redpanda sends warning messages in the cluster logs if you enable enterprise fea
 
 === Apply a license key to Redpanda Console
 
-To use an Enterprise feature with Redpanda Console, you must provide Redpanda Console with its own copy of your license key.
+To use an Enterprise feature with Redpanda Console, you must provide Redpanda Console with a copy of your license key.
 You have two options for providing the license:
 
 . Specify the path to the license key file either in the `redpanda.licenseFilepath` property of the `/etc/redpanda/redpanda-console-config.yaml` file, or in the `REDPANDA_LICENSE_FILEPATH` environment variable.
-. Specify the license key file contents directly either in the `redpanda.license` property of the YAML file, or in the `REDPANDA_LICENSE` environment variable.
+. Specify the license key file contents directly either in the `redpanda.license` property of the YAML file or in the `REDPANDA_LICENSE` environment variable.
 
 Redpanda Console checks the license key status on startup and warns you 30 days before the license expires. You can view the license key's expiration date in the startup logs.
 If the license key expires at runtime, Redpanda Console shuts down. If the license has already


### PR DESCRIPTION
See https://redpandadata.slack.com/archives/C01H6JRQX1S/p1715631770730369

These fields were deprecated in favor of `enterprise` in https://github.com/redpanda-data/helm-charts/pull/723