### PR TITLE
#2057 redpanda-console-config.yaml not installed in Docker containers

### DIFF
--- a/modules/reference/pages/console/config.adoc
+++ b/modules/reference/pages/console/config.adoc
@@ -1,9 +1,12 @@
 = Redpanda Console Configuration
-:description: Redpanda Console configuration YAML template with property descriptions.
+:description: Redpanda Console configuration file with property descriptions.
 :page-aliases: console:reference/config.adoc
 :page-categories: Redpanda Console
 
-When you install Redpanda Console, a `redpanda-console-config.yaml` file is installed on each instance in `/etc/redpanda/redpanda-console-config.yaml`. This file contains configuration properties for Redpanda Console.
+The `redpanda-console-config.yaml` file contains configuration properties for Redpanda Console. 
+
+- If you install Redpanda Console on Linux, this file is installed on each instance in `/etc/redpanda/redpanda-console-config.yaml`. 
+- In you install in Docker, you must mount this file to the `/etc/redpanda/` directory in the Docker image.
 
 == Configuration sources
 

--- a/modules/reference/pages/console/config.adoc
+++ b/modules/reference/pages/console/config.adoc
@@ -6,7 +6,7 @@
 The `redpanda-console-config.yaml` file contains configuration properties for Redpanda Console. 
 
 - If you install Redpanda Console on Linux, this file is installed on each instance in `/etc/redpanda/redpanda-console-config.yaml`. 
-- If you install Redpanda Console in a containerized environment , you must mount this file to the `/etc/redpanda/` directory in the container.
+- If you install Redpanda Console in a containerized environment, you must mount this file to the `/etc/redpanda/` directory in the container.
 
 == Configuration sources
 

--- a/modules/reference/pages/console/config.adoc
+++ b/modules/reference/pages/console/config.adoc
@@ -6,7 +6,7 @@
 The `redpanda-console-config.yaml` file contains configuration properties for Redpanda Console. 
 
 - If you install Redpanda Console on Linux, this file is installed on each instance in `/etc/redpanda/redpanda-console-config.yaml`. 
-- In you install in Docker, you must mount this file to the `/etc/redpanda/` directory in the Docker image.
+- If you install Redpanda Console in a containerized environment , you must mount this file to the `/etc/redpanda/` directory in the container.
 
 == Configuration sources
 

--- a/modules/reference/pages/console/role-bindings.adoc
+++ b/modules/reference/pages/console/role-bindings.adoc
@@ -1,5 +1,5 @@
 = Redpanda Console Role-Binding Configuration
-:description: Redpanda Console role-binding configuration template with properties description.
+:description: Redpanda Console role-binding configuration file with property descriptions.
 :page-aliases: console:features/role-bindings.adoc, console:reference/role-bindings.adoc
 :page-categories: Redpanda Console, Security
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2057
Review deadline: Thursday, May 16

## Page previews

https://deploy-preview-492--redpanda-docs-preview.netlify.app/current/reference/console/config/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X ] Small fix (typos, links, copyedits, etc)