### PR TITLE
Update rpk-group-offset-delete.adoc

### DIFF
--- a/modules/reference/pages/rpk/rpk-group/rpk-group-offset-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-group/rpk-group-offset-delete.adoc
@@ -2,7 +2,7 @@
 
 Forcefully delete offsets for a Kafka group.
 
-The broker will only allow the request to succeed if the group is in a dead
+The broker will only allow the request to succeed if the group is in a Empty
 state (no subscriptions) or there are no subscriptions for offsets for
 topic/partitions requested to be deleted.
 


### PR DESCRIPTION
The group needs to be in empty state . 


./rpk group describe  jason-test --tls-enabled
GROUP        jason-test
COORDINATOR  1
STATE        Empty
BALANCER     
MEMBERS      0
TOTAL-LAG    3039412080

TOPIC   PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG         MEMBER-ID  CLIENT-ID  HOST
topic3  0          2987674728      3006357709      18682981                          
topic3  1          -               3001606123      3001606123                        
topic3  2          2982766838      3001889814      19122976                          
[root@ip-172-31-10-71 ~]# ./rpk group offset-delete jason-test  --topic topic3:0,1,2  --tls-enabled
topic3  2     OK
topic3  0     OK
topic3  1     OK


[root@ip-172-31-10-71 ~]# ./rpk group describe  jason-test --tls-enabled
GROUP        jason-test
COORDINATOR  1
STATE        Dead
BALANCER     
MEMBERS      0
TOTAL-LAG    0

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)