### PR TITLE
Add server-side apply flag to kubectl apply

### DIFF
--- a/modules/deploy/partials/kubernetes/install-crds.adoc
+++ b/modules/deploy/partials/kubernetes/install-crds.adoc
@@ -2,13 +2,13 @@ ifdef::latest-operator-version[]
 [,bash,subs="attributes+"]
 ----
 kubectl kustomize "https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref={latest-operator-version}" \
-    | kubectl apply -f -
+    | kubectl apply --server-side -f -
 ----
 endif::[]
 ifndef::latest-operator-version[]
 [,bash]
 ----
 kubectl kustomize "https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref=<operator-version>" \
-    | kubectl apply -f -
+    | kubectl apply --server-side -f -
 ----
 endif::[]


### PR DESCRIPTION
## Description

Due to a repetition for Redpanda in version v1alpha1 and v1alpha2 the kubectl apply fails with

```
The CustomResourceDefinition "redpandas.cluster.redpanda.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
```

With server-side flag the annotation is not added to each resource.

## Reference

https://github.com/kubernetes/kubectl/blob/514f46729f82412dd9cc41f206058bc4ae9b62b0/pkg/cmd/apply/apply.go#L762-L784 https://github.com/redpanda-data/redpanda-operator/commit/62a11afb2727a3ea551dab3127c1c05de77661f8

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)