### PR TITLE
fix smt search

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/transforms.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/transforms.adoc
@@ -1,5 +1,5 @@
 = Single Message Transforms
-:description: Modify the data and its characteristics as it passes through a connector.
+:description: Single Message Transforms (SMTs) let you modify the data and its characteristics as it passes through a connector.
 :page-cloud: true
 
 Single Message Transforms (SMTs) help you modify data and its characteristics as it passes through a connector, without needing additional stream processors.
@@ -713,6 +713,6 @@ Sample configuration:
 "transforms.valueToKey.fields": "txn-id"
 ----
 
-== SMTs Error handling
+== Error handling
 
 By default, `Error tolerance` is set to `NONE`, so the connector fails for any exception (notably, data parsing or data processing errors). To avoid the connector crashing for data issues, set `Error tolerance` to `ALL`, and specify `Dead Letter Queue Topic Name` as a place where failed messages are redirected.

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/transforms.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/transforms.adoc
@@ -715,4 +715,4 @@ Sample configuration:
 
 == Error handling
 
-By default, `Error tolerance` is set to `NONE`, so the connector fails for any exception (notably, data parsing or data processing errors). To avoid the connector crashing for data issues, set `Error tolerance` to `ALL`, and specify `Dead Letter Queue Topic Name` as a place where failed messages are redirected.
+By default, `Error tolerance` is set to `NONE`, so SMTs fail for any exception (notably, data parsing or data processing errors). To avoid the connector crashing for data issues, set `Error tolerance` to `ALL`, and specify `Dead Letter Queue Topic Name` as a place where failed messages are redirected.


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2449
Review deadline:

## Page previews
Search SMT: https://deploy-preview-501--redpanda-docs-preview.netlify.app/current/home/
<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)