### PR TITLE
Add `health_monitor_tick_interval` to deprecations

### DIFF
--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -24,6 +24,10 @@ This index helps you to identify deprecated features in Redpanda releases and pl
 | 23.2.1
 | Use the xref:23.2@upgrade:deprecated/cluster-resource.adoc[Redpanda resource] instead.
 
+| xref:reference:tunable-properties.adoc#health_monitor_tick_interval[`health_monitor_tick_interval`]
+| 22.2.1
+| No longer required. Previously, health refreshes were triggered based on this interval, potentially leading to scenarios where stale health metadata was accessed after a leadership change. The revised mechanism triggers a health refresh only when the controller leader's health metadata becomes stale. Now, whenever a health report is requested, Redpanda checks the age of the metadata. If stale, a refresh request is dispatched to contact the leader directly or to gather fresh information from the cluster. This change ensures that health metadata remains accurate, eliminating unnecessary periodic checks.
+
 |===
 
 == rpk commands


### PR DESCRIPTION
## Description

This property was deprecated in 22.3 and backported to 22.2.

I also updated the order of deprecations to display the latest version at the top. @Deflaimun are the `rpk` deprecations automated? If so, we should update the script to display them in order and use Asciidoc syntax for the headings.

@BenPope do you remember the reason for the deprecation/if we have an alternative property? i couldn't see anything in the codebase.

Review deadline: 20 May

## Page previews

https://deploy-preview-502--redpanda-docs-preview.netlify.app/current/upgrade/deprecated/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)