### PR TITLE
fix link

### DIFF
--- a/modules/get-started/pages/licenses.adoc
+++ b/modules/get-started/pages/licenses.adoc
@@ -1,13 +1,16 @@
 = Redpanda Licensing
-:description: Redpanda is free and source-available at the Redpanda GitHub repo. Additional features are included with an enterprise license.
+:description: Self-hosted Redpanda is free and source-available at the Redpanda GitHub repo. Additional features are included with an enterprise license.
 :page-aliases: introduction:licenses.adoc
 
-You can deploy Redpanda in a self-hosted environment (Redpanda platform) or as a fully-managed cloud service (Redpanda Cloud). For more information about Redpanda Cloud deployments, see xref:deploy:deployment-option/cloud/cloud-overview.adoc[Dedicated Cloud vs BYOC].
-
-To self-host Redpanda platform, select either the Community Edition or the Enterprise Edition:
+You can deploy Redpanda as a fully-managed cloud service (Redpanda Cloud) or in a self-hosted environment (Redpanda platform). To self-host Redpanda platform, select either the Community Edition or the Enterprise Edition:
 
 * Redpanda Community Edition is free and source-available at the https://github.com/redpanda-data/redpanda[Redpanda GitHub repository^].
 * Redpanda Enterprise Edition requires a license key and includes additional features.
+
+[NOTE]
+====
+To learn about Redpanda Cloud deployments, see the xref:deploy:deployment-option/cloud/cloud-overview.adoc[].
+====
 
 == Redpanda Community Edition
 
@@ -24,16 +27,16 @@ Redpanda Community Edition is licensed with the Redpanda https://github.com/redp
 Redpanda Enterprise Edition is licensed with the https://github.com/redpanda-data/redpanda/blob/dev/licenses/rcl.md[Redpanda Community License^] (RCL). It includes the free features licensed under the Redpanda BSL, as well as the following features:
 
 * xref:manage:tiered-storage.adoc[Tiered Storage], including xref:manage:data-archiving.adoc[Data Archiving]
-* xref:manage:remote-read-replicas.adoc[Remote Read Replicas]
 * xref:manage:cluster-maintenance/continuous-data-balancing.adoc[Continuous Data Balancing]
-* xref:manage:security/authentication.adoc#enable-kerberos[Kerberos Authentication]
-* xref:manage:security/console/authentication.adoc[Redpanda Console Authentication]
-* xref:manage:security/console/authorization.adoc[Redpanda Console Authorization (RBAC)]
-* xref:manage:schema-id-validation.adoc[Server-side Schema ID Validation]
+* xref:manage:remote-read-replicas.adoc[Remote Read Replicas]
 * xref:manage:audit-logging.adoc[Audit Logging]
+* xref:manage:schema-id-validation.adoc[Server-side Schema ID Validation]
+* xref:manage:security/authentication.adoc#enable-kerberos[Kerberos Authentication]
 * xref:manage:security/authorization/rbac.adoc[Redpanda Role-Based Access Control (RBAC)]
+* xref:manage:security/console/authorization.adoc[Redpanda Console Authorization (RBAC)]
+* xref:manage:security/console/authentication.adoc[Redpanda Console Authentication]
 
-Enterprise features require a license key. You can evaluate enterprise features with a free 30-day trial. Contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda Sales^] to request a trial license, to extend your trial period, or to purchase an Enterprise Edition license. If you access a Redpanda Enterprise feature without a valid license, you get the following message:
+Enterprise features require a license key. You can evaluate enterprise features with a free 30-day trial. Contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda Sales^] to request a trial license, to extend your trial period, or to purchase an Enterprise Edition license. If you access an enterprise feature without a valid license, you get the following message:
 
 ----
 Looks like you've enabled a Redpanda Enterprise feature without a valid license.
@@ -55,7 +58,7 @@ To apply the license key to your cluster, run:
 
 `rpk cluster license set`
 
-Either provide a path to a file containing the license or the license string inline. For example, assuming you use the default admin host/port of `10.0.0.1:9644`, run:
+Either provide a path to a file containing the license or provide the license string inline. For example, assuming you use the default admin host/port of `10.0.0.1:9644`, run:
 
 ```bash
 rpk cluster license set --path <path-to-license-file> -X admin.hosts=10.0.0.1:9644
@@ -151,10 +154,10 @@ Redpanda sends warning messages in the cluster logs if you enable enterprise fea
 
 === Apply a license key to Redpanda Console
 
-To use an Enterprise feature with Redpanda Console, you must provide Redpanda Console with a copy of your license key.
+To use an enterprise feature with Redpanda Console, you must provide Redpanda Console with a copy of your license key.
 You have two options for providing the license:
 
-. Specify the path to the license key file either in the `redpanda.licenseFilepath` property of the `/etc/redpanda/redpanda-console-config.yaml` file, or in the `REDPANDA_LICENSE_FILEPATH` environment variable.
+. Specify the path to the license key file either in the `redpanda.licenseFilepath` property of the `/etc/redpanda/redpanda-console-config.yaml` file or in the `REDPANDA_LICENSE_FILEPATH` environment variable.
 . Specify the license key file contents directly either in the `redpanda.license` property of the YAML file or in the `REDPANDA_LICENSE` environment variable.
 
 Redpanda Console checks the license key status on startup and warns you 30 days before the license expires. You can view the license key's expiration date in the startup logs.


### PR DESCRIPTION
## Description

No issue, this just fixes the text around a link to []. But while I was in there, I made some minor updates for consistency/readability.  

## Page previews
https://deploy-preview-503--redpanda-docs-preview.netlify.app/current/get-started/licenses/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)