### PR TITLE
Add oauth receiver file for cloud API doc

### DIFF
--- a/modules/ROOT/pages/oauth-receiver.adoc
+++ b/modules/ROOT/pages/oauth-receiver.adoc
@@ -1,0 +1,2 @@
+= OAuth Receiver
+:page-layout: oauth

--- a/modules/ROOT/pages/oauth-receiver.html
+++ b/modules/ROOT/pages/oauth-receiver.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+  <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+</head>
+
+<body>
+  <oauth-receiver> </oauth-receiver>
+</body>

--- a/modules/ROOT/pages/oauth-receiver.html
+++ b/modules/ROOT/pages/oauth-receiver.html
@@ -1,8 +1,0 @@
-<!doctype html>
-<head>
-  <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
-</head>
-
-<body>
-  <oauth-receiver> </oauth-receiver>
-</body>


### PR DESCRIPTION
## Description

The Get Token button on the Cloud API page does not work. This PR adds an oauth receiver HTML file that requests authorization from the auth server and then passes it to Rapidoc.

See https://rapidocweb.com/oauth_instructions.html

Review deadline: ASAP

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)