### PR TITLE
Minor edit to auth instructions in cloud API doc

### DIFF
--- a/modules/ROOT/pages/cloud/auth/auth.adoc
+++ b/modules/ROOT/pages/cloud/auth/auth.adoc
@@ -1,6 +1,6 @@
 :page-layout: api-partial
 
-. If <<try-the-cloud-api,issuing requests to the Cloud API from this page>> using the *Try* option, *Get Token*.
+. To <<try-the-cloud-api,issue requests to the Cloud API from this page>>, click *Get Token*.
 . If successful, the text “1 API key applied” displays under the *Authentication* header. The token is valid for one hour.
 . Make sure to choose the correct <<servers,API server>> before making requests.
 

--- a/modules/ROOT/pages/cloud/auth/auth.adoc
+++ b/modules/ROOT/pages/cloud/auth/auth.adoc
@@ -1,6 +1,6 @@
 :page-layout: api-partial
 
-. If <<try-the-cloud-api,issuing requests to the Cloud API from this page>> using the *Try* option, *Get Token*. Do not edit the input field next to the button.
+. If <<try-the-cloud-api,issuing requests to the Cloud API from this page>> using the *Try* option, *Get Token*.
 . If successful, the text “1 API key applied” displays under the *Authentication* header. The token is valid for one hour.
 . Make sure to choose the correct <<servers,API server>> before making requests.
 

--- a/modules/ROOT/pages/cloud/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud/overview/overview.adoc
@@ -48,7 +48,7 @@ See also:
 Before you can issue requests against the API from your browser, you must complete the following steps:
 
 . Go to *Authentication* in the sidebar.
-. Click *Get Token*. Do not edit the input field next to the button.
+. Click *Get Token*.
 . If successful, the text “1 API key applied” displays under the *Authentication* section of this page. The token is valid for an hour.
 . Choose the correct API server for your request.
 


### PR DESCRIPTION
## Description

https://docs.redpanda.com/api/cloud-api/#auth We have removed the text field next to Get Token (see https://docs.api.redpanda.com/#auth), so the instructions no longer need to mention it.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->
[Preview](https://deploy-preview-506--redpanda-docs-preview.netlify.app/api/cloud-api.html)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)