### PR TITLE
Add ap-south-1 support for Dedicated AWS

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -7,6 +7,10 @@ This page lists new features added in Redpanda Cloud.
 
 == May 2024
 
+=== Additional AWS region for Dedicated
+
+Redpanda added support for the ap-south-1 (Mumbai) xref:deploy:deployment-option/cloud/dedicated/dedicated-tiers.adoc#tab=tabs-1-amazon-web-services-aws[region for Dedicted clusters].
+
 === Simplified navigation and namespaces renamed resource groups
 
 Redpanda Cloud has a simplified navigation, with clusters and networks available at the top level. It now has a global view of all the resources in your organization. Namespaces are now called glossterm:resource group[,resource groups], although the functionality remains the same.
@@ -15,7 +19,7 @@ Redpanda Cloud has a simplified navigation, with clusters and networks available
 
 === Additional cloud tiers for BYOC
 
-When you create a BYOC or Dedicated cluster, you select a xref:deploy:deployment-option/cloud/cloud-overview.adoc#cluster-tiers[cloud tier] with the expected usage for your cluster, including the maximum ingress, egress, logical partitions, and connections. Redpanda has added tiers 8 and 9 for BYOC clusters, which provide higher supported configurations.
+When you create a BYOC or Dedicated cluster, you select a xref:deploy:deployment-option/cloud/byoc-tiers.adoc[cloud tier] with the expected usage for your cluster, including the maximum ingress, egress, logical partitions, and connections. Redpanda has added tiers 8 and 9 for BYOC clusters, which provide higher supported configurations.
 
 == March 2024
 
@@ -35,7 +39,7 @@ xref:deploy:deployment-option/cloud/aws-privatelink.adoc[AWS PrivateLink] is now
 
 === Additional cloud tiers
 
-When you create a cluster, you select a xref:deploy:deployment-option/cloud/cloud-overview.adoc#cluster-tiers[cloud tier] with the expected throughput for your cluster, including the maximum ingress, egress, partitions, and connections. On February 5, Redpanda added tiers 6 and 7 for BYOC clusters, which provide higher throughput limits.
+When you create a cluster, you select a xref:deploy:deployment-option/cloud/byoc-tiers.adoc[cloud tier] with the expected throughput for your cluster, including the maximum ingress, egress, partitions, and connections. On February 5, Redpanda added tiers 6 and 7 for BYOC clusters, which provide higher throughput limits.
 
 == January 2024
 

--- a/modules/deploy/partials/cloud/tiers.adoc
+++ b/modules/deploy/partials/cloud/tiers.adoc
@@ -110,6 +110,7 @@ Amazon Web Services (AWS)::
 |=== 
 | Region 
 
+| ap-south-1
 | ap-southeast-1
 | ap-southeast-2
 | ca-central-1


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2458

Review deadline: May 23

## Page previews
[What's New in Cloud](https://deploy-preview-513--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/whats-new-cloud/)
[Dedicated supported regions (AWS)](https://deploy-preview-513--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/dedicated/dedicated-tiers/#tab=tabs-1-amazon-web-services-aws)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)