### PR TITLE
fix navtree link

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -240,7 +240,6 @@
 *** xref:reference:properties/cluster-properties.adoc[]
 *** xref:reference:properties/object-storage-properties.adoc[]
 *** xref:reference:properties/topic-properties.adoc[]
-** xref:reference:partner-integration.adoc[]
 ** xref:reference:releases/index.adoc[Release Notes]
 *** link:https://github.com/redpanda-data/redpanda/releases[Redpanda^]
 *** link:https://github.com/redpanda-data/console/releases[Redpanda Console^]


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)