### PR TITLE
Edits to cloud API reference

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -7,7 +7,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [v/*, site-search, main, shared]
+    branches: [v/*, site-search, 2461_cloud-api-errors-plus-other-docs, shared]
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -7,7 +7,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [v/*, site-search, 2461_cloud-api-errors-plus-other-docs, shared]
+    branches: [v/*, site-search, main, shared]
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/ROOT/pages/cloud/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud/overview/overview.adoc
@@ -7,7 +7,7 @@ The Redpanda Cloud API is a collection of REST APIs that allow you to interact w
 To use the Cloud API:
 
 * You must be a customer with an existing organization in Redpanda Cloud.
-* You can only use one organization for authentication. See xref:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[Cloud API Authentication] for steps to authenticate API requests.
+* You can only use one organization for authentication. See xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[Cloud API Authentication] for steps to authenticate API requests.
 
 == Cloud API architecture 
 

--- a/modules/ROOT/pages/cloud/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud/overview/overview.adoc
@@ -2,7 +2,9 @@
 
 The Redpanda Cloud API is a collection of REST APIs that allow you to interact with different parts of Redpanda Cloud. To familiarize yourself with Redpanda Cloud API basics, see the xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-overview.adoc[Redpanda Cloud API Overview]. To get started using the API, try the <<cloud-api-quickstart,Quickstart>>.
 
-== Control Plane API
+== Cloud API architecture 
+
+=== Control Plane API
 
 The Control Plane API enables you to programmatically manage your clusters, networks, and resource groups.
 
@@ -12,65 +14,11 @@ The xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-overview.adoc#control
 https://api.redpanda.com
 ```
 
-== Data Plane APIs
+=== Data Plane APIs
 
 The Data Plane APIs enable you to programmatically manage the resources within your clusters, including topics, users, access control lists (ACLs), and connectors.
 
 The xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-overview.adoc#data-plane-apis-url[*base URL*] of the Data Plane APIs is unique to every cluster. You can retrieve this value by making a xref:get-/v1beta2/clusters/-id-[Get Cluster] request to your target cluster. Use the `dataplane_api.url` from the response body as the base URL when calling the Data Plane API endpoints. 
-
-== Cloud API Quickstart
-
-. Authenticate to the API. See <<try-the-cloud-api>> if issuing requests here, or see the xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[authentication guide] for details.
-. Create a resource group by making a xref:post-/v1beta2/resource-groups[`POST /v1beta2/resource-groups`] request.
-. Create a network by making a xref:post-/v1beta2/networks[`POST /v1beta2/networks`] request. Note that this operation may be long-running.
-. Create a cluster by making a xref:post-/v1beta2/clusters[`POST /v1beta2/clusters`] request.
-. For BYOC, run `rpk cloud byoc`, passing the `metadata.cluster_id` from the Create Cluster response as a flag:
-+
-GCP:
-+
-```bash
-rpk cloud byoc gcp apply --redpanda-id=<metadata.cluster_id> --project-id=<gcp-project-id>
-```
-+
-AWS:
-+
-```bash
-rpk cloud byoc aws apply --redpanda-id=<metadata.cluster_id>
-```
-
-See also:
-
-- xref:ROOT:deploy:deployment-option/cloud/api/cloud-controlplane-api.adoc[Use the Control Plane API]
-- xref:ROOT:deploy:deployment-option/cloud/api/cloud-dataplane-api.adoc[Use the Data Plane APIs]
-
-== Try the Cloud API
-
-Before you can issue requests against the API from your browser, you must complete the following steps:
-
-. Go to *Authentication* in the sidebar.
-. Click *Get Token*.
-. If successful, the text “1 API key applied” displays under the *Authentication* section of this page. The token is valid for an hour.
-. Choose the correct API server for your request.
-
-WARNING: Your API requests are executed against your actual environment and data, not a sandbox. 
-
-=== Make a request to the Control Plane API
-
-For requests to the Control Plane API endpoints:
-
-. Click *API Servers* in the sidebar. 
-. Select “https://api.redpanda.com - Control Plane API”. 
-. From the Control Plane API endpoints, you can make a request by using the *Try* option. Make sure to enter any required parameter values, and provide the request body object if necessary.
-
-=== Make a request to the Data Plane APIs
-
-For requests to the Data Plane API endpoints: 
-
-. Make a Get Cluster request for your target cluster.
-. The Get Cluster response contains the Data Plane API URL. Copy the value of `dataplane_api.url` from the response body. 
-. Click *API Servers* in the sidebar and select “\{dataplane_api_url} - Data Plane API”.
-. Paste the URL into the `dataplane_api_url` input field.
-. From the Data Plane API endpoints, you can make a request by using the *Try* option. Make sure to enter any required parameter values, and provide the request body object if necessary.
 
 == Response codes and errors
 

--- a/modules/ROOT/pages/cloud/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud/overview/overview.adoc
@@ -11,6 +11,8 @@ To use the Cloud API:
 
 == Cloud API architecture 
 
+Redpanda Cloud uses a control plane and data plane architecture.
+
 === Control Plane API
 
 The Control Plane API enables you to programmatically manage your clusters, networks, and resource groups.
@@ -29,7 +31,7 @@ The xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-overview.adoc#data-pl
 
 == See also
 
-* xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-quickstart.adoc[]
-* xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-errors.adoc[]
+* xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-quickstart.adoc[Cloud API Quickstart]
+* xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-errors.adoc[Cloud API Error and Status Codes]
 
 

--- a/modules/ROOT/pages/cloud/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud/overview/overview.adoc
@@ -1,6 +1,13 @@
 :page-layout: api-partial
 
-The Redpanda Cloud API is a collection of REST APIs that allow you to interact with different parts of Redpanda Cloud. To familiarize yourself with Redpanda Cloud API basics, see the xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-overview.adoc[Redpanda Cloud API Overview]. To get started using the API, try the <<cloud-api-quickstart,Quickstart>>.
+The Redpanda Cloud API is a collection of REST APIs that allow you to interact with different parts of Redpanda Cloud. To familiarize yourself with Redpanda Cloud API basics, see the xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-overview.adoc[Redpanda Cloud API Overview]. To get started using the API, try the xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-quickstart.adoc[Quickstart].
+
+== Requirements
+
+To use the Cloud API:
+
+* You must be a customer with an existing organization in Redpanda Cloud.
+* You can only use one organization for authentication. See xref:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[Cloud API Authentication] for steps to authenticate API requests.
 
 == Cloud API architecture 
 
@@ -20,23 +27,9 @@ The Data Plane APIs enable you to programmatically manage the resources within y
 
 The xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-overview.adoc#data-plane-apis-url[*base URL*] of the Data Plane APIs is unique to every cluster. You can retrieve this value by making a xref:get-/v1beta2/clusters/-id-[Get Cluster] request to your target cluster. Use the `dataplane_api.url` from the response body as the base URL when calling the Data Plane API endpoints. 
 
-== Response codes and errors
+== See also
 
-A `2xx` HTTP status code indicates that a request is successful:
-
-- `200` OK. Request was successful.
-- `201` Created. The requested resource was successfully created.
-- `202` Accepted. The request is accepted and is processing, for example for a long-running operation.
-- `204` No content. Usually returned by a successful delete request.
-
-The following HTTP status codes indicate errors:
-
-- `400` Bad request. There is an error that must be fixed in the request, such as an invalid parameter value. Attempt the request again after it is fixed.
-- `401` Unauthenticated. The authentication credentials are missing or invalid.
-- `404` Not found. The specified resource was not found.
-- `409` Conflict. Usually returned when the resource to be created by the request already exists.
-- `500` Internal server error. Reach out to Redpanda support.
-
-For errors, the response also includes a gRPC error code and details. See the https://grpc.io/docs/guides/status-codes/[official gRPC status codes documentation^] for further details.
+* xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-quickstart.adoc[]
+* xref:ROOT:deploy:deployment-option/cloud/api/cloud-api-errors.adoc[]
 
 


### PR DESCRIPTION
## Description

This PR takes out some of the content that was in the cloud API reference. They will be set up as standalone docs under https://docs.redpanda.com/current/deploy/deployment-option/cloud/api/
Resolves https://github.com/redpanda-data/documentation-private/issues/2461
Review deadline: 30 May 2024

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->
[Deploy preview](https://deploy-preview-523--redpanda-docs-preview.netlify.app/api/cloud-api.html#overview)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)