### PR TITLE
escape link on mtls page

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/security/cloud-authentication.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/cloud-authentication.adoc
@@ -80,7 +80,7 @@ Redpanda Cloud supports mTLS authentication for the Kafka API.
 
 . Create a service account in your organization, if you have not already done so. Go to the https://cloud.redpanda.com/clients[Clients^] page in the Redpanda Cloud UI and click *Add client* to create a service account. Enter a name and description.
 . Retrieve the client ID and secret by clicking *Copy ID* and *Copy Secret*. 
-. Obtain an access token by making a `POST` request to `https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
+. Obtain an access token by making a `POST` request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
 . Make a xref:api:ROOT:cloud-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request to enable mTLS for the Kafka API on a cluster.
 
 The following code block shows a request for an access token, followed by a request to enable mTLS:


### PR DESCRIPTION
## Description

Upon testing the new mtls page https://docs.redpanda.com/current/deploy/deployment-option/cloud/security/cloud-authentication/ we identified a clickeable link in the guide that shouldn't be. 

This PR fixes it. 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)