### PR TITLE
update Cloud vs SH compatibility

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -212,12 +212,12 @@ Redpanda Cloud does not support the following self-hosted functionality:
 
 - Data transforms (currently in beta for Redpanda Cloud)
 - Remote Read Replicas (currently in beta for Redpanda Cloud)
-- OIDC authentication
+- Kafka API OIDC authentication (however, you can leverage IdPs for  xref:deploy:deployment-option/cloud/security/cloud-authentication.adoc#single-sign-on[user authentication to an organization with SSO])
 - Kerberos authentication
 - Redpanda Console topic documentation
-- Setting `auto_create_topics_enabled=true` for BYOC and dedicated clusters
+- Setting `auto_create_topics_enabled=true`
 - Admin API
-- The following `rpk` commands (which use the Admin API):
+- The following `rpk` commands, which use the Admin API:
 
 ** `rpk security user`
 ** `rpk cluster health`

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -212,7 +212,7 @@ Redpanda Cloud does not support the following self-hosted functionality:
 
 - Data transforms (currently in beta for Redpanda Cloud)
 - Remote Read Replicas (currently in beta for Redpanda Cloud)
-- Kafka API OIDC authentication (however, you can leverage IdPs for  xref:deploy:deployment-option/cloud/security/cloud-authentication.adoc#single-sign-on[user authentication to an organization with SSO])
+- Kafka API OIDC authentication (however, Redpanda Cloud does support xref:deploy:deployment-option/cloud/security/cloud-authentication.adoc#single-sign-on[user authentication to an organization with SSO])
 - Kerberos authentication
 - Redpanda Console topic documentation
 - Setting `auto_create_topics_enabled=true`

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -211,9 +211,9 @@ image::shared:byoc_apply.png[cloud_byoc_apply]
 Redpanda Cloud does not support the following self-hosted functionality:
 
 - Data transforms (currently in beta for Redpanda Cloud)
+- Remote Read Replicas (currently in beta for Redpanda Cloud)
 - OIDC authentication
 - Kerberos authentication
-- Remote Read Replicas
 - Redpanda Console topic documentation
 - Setting `auto_create_topics_enabled=true` for BYOC and dedicated clusters
 - Admin API

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -210,9 +210,9 @@ image::shared:byoc_apply.png[cloud_byoc_apply]
 
 Redpanda Cloud does not support the following self-hosted functionality:
 
-- OpenID Connect (OIDC) authentication
+- Data transforms (currently in beta for Redpanda Cloud)
+- OIDC authentication
 - Kerberos authentication
-- Data transforms
 - Remote Read Replicas
 - Redpanda Console topic documentation
 - Setting `auto_create_topics_enabled=true` for BYOC and dedicated clusters

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -19,7 +19,7 @@ xref:redpanda-connect:ROOT:about.adoc[Redpanda Connect] includes over 200 connec
 
 mTLS authentication is now available for Kafka API clients. You can xref:deploy:deployment-option/cloud/security/cloud-authentication.adoc#mtls[enable mTLS] for your cluster using the Cloud API.
 
-=== Manage private connectivitiy in the UI
+=== Manage private connectivity in the UI
 
 You can now manage GCP Private Service Connect and AWS PrivateLink connections to your BYOC or dedicated cluster on the *Cluster settings* page in Redpanda Cloud. See the steps for xref:deploy:deployment-option/cloud/configure-privatelink-in-cloud-ui.adoc[PrivateLink] and xref:deploy:deployment-option/cloud/configure-private-service-connect-in-cloud-ui.adoc[Private Service Connect].
 
@@ -27,7 +27,7 @@ To add private connectivity as part of cluster creation, use the Cloud API.
 
 === Additional AWS region for Dedicated
 
-Redpanda added support for the ap-south-1 (Mumbai) xref:deploy:deployment-option/cloud/dedicated/dedicated-tiers.adoc#tab=tabs-1-amazon-web-services-aws[region for Dedicted clusters].
+Redpanda added support for the ap-south-1 (Mumbai) xref:deploy:deployment-option/cloud/dedicated/dedicated-tiers.adoc#tab=tabs-1-amazon-web-services-aws[region for Dedicated clusters].
 
 === Simplified navigation and namespaces renamed resource groups
 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -7,6 +7,24 @@ This page lists new features added in Redpanda Cloud.
 
 == May 2024
 
+=== Cloud API: beta
+
+The Cloud API allows you to programmatically manage clusters and resources in your Redpanda Cloud organization. For more information, see the xref:deploy:deployment-option/cloud/api/cloud-api-quickstart.adoc[Cloud API Quickstart], the xref:deploy:deployment-option/cloud/api/cloud-api-overview.adoc[Cloud API Overview], and the full xref:api:ROOT:cloud-api.adoc[Cloud API reference].
+
+=== Redpanda Connect 
+
+Redpanda Connect (link https://docs.redpanda.com/redpanda-connect/guides/getting_started) includes over 200 connectors, with a large collection of sources, sinks, and processors. The interface provides a lightweight and easy way to set up, debug, and manage connectors. 
+
+=== mTLS authentication for Kafka API clients
+
+mTLS authentication is now available for Kafka API clients. You can xref:deploy:deployment-option/cloud/security/cloud-authentication.adoc#mtls[enable mTLS] for your cluster using the Cloud API.
+
+=== Manage private connectivitiy in the UI
+
+You can now manage GCP Private Service Connect and AWS PrivateLink connections to your BYOC or dedicated cluster on the *Cluster settings* page in Redpanda Cloud. See the steps for xref:deploy:deployment-option/cloud/configure-privatelink-in-cloud-ui.adoc[PrivateLink] and xref:deploy:deployment-option/cloud/configure-private-service-connect-in-cloud-ui.adoc[Private Service Connect].
+
+To add private connectivity as part of cluster creation, use the Cloud API. 
+
 === Additional AWS region for Dedicated
 
 Redpanda added support for the ap-south-1 (Mumbai) xref:deploy:deployment-option/cloud/dedicated/dedicated-tiers.adoc#tab=tabs-1-amazon-web-services-aws[region for Dedicted clusters].
@@ -47,9 +65,9 @@ When you create a cluster, you select a xref:deploy:deployment-option/cloud/byoc
 
 Redpanda Cloud now supports xref:deploy:deployment-option/cloud/manage-billing/index.adoc[usage-based billing] for Dedicated Cloud clusters. Contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda sales^] to request a private offer for monthly or annual committed use. You can then use existing Google Cloud Marketplace or AWS Marketplace credits to quickly provision Dedicated Cloud clusters, and you can view your bills and manage your subscription directly in the marketplace.
 
-== December 2023: beta
+== December 2023
 
-=== Serverless clusters
+=== Serverless clusters: beta
 
 xref:deploy:deployment-option/cloud/serverless.adoc[Redpanda Serverless] is a managed streaming service (Kafka API) that completely abstracts users from scaling and operational concerns, and you only pay for what you consume. It's the fastest and easiest way to start event streaming in the cloud. You can try the beta release of Redpanda Serverless with a free trial. 
 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -19,13 +19,17 @@ mTLS authentication is now available for Kafka API clients. You can xref:deploy:
 
 You can now manage GCP Private Service Connect and AWS PrivateLink connections to your BYOC or Dedicated cluster on the *Cluster settings* page in Redpanda Cloud. See the steps for xref:deploy:deployment-option/cloud/configure-privatelink-in-cloud-ui.adoc[PrivateLink] and xref:deploy:deployment-option/cloud/configure-private-service-connect-in-cloud-ui.adoc[Private Service Connect].
 
+=== Single message transforms
+
+Redpanda now provides xref:deploy:deployment-option/cloud/managed-connectors/transforms.adoc[single message transforms (SMTs)] to help you modify data as it passes through a connector, without needing additional stream processors.
+
 === Additional AWS region for Dedicated
 
 Redpanda added support for the ap-south-1 (Mumbai) xref:deploy:deployment-option/cloud/dedicated/dedicated-tiers.adoc#tab=tabs-1-amazon-web-services-aws[region for Dedicated clusters].
 
 === Simplified navigation and namespaces renamed resource groups
 
-Redpanda Cloud has a simplified navigation, with clusters and networks available at the top level. It now has a global view of all the resources in your organization. Namespaces are now called glossterm:resource group[,resource groups], although the functionality remains the same.
+Redpanda Cloud has a simplified navigation, with clusters and networks available at the top level. It now has a global view of all resources in your organization. Namespaces are now called glossterm:resource group[,resource groups], although the functionality remains the same.
 
 == April 2024
 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -13,7 +13,7 @@ The Cloud API allows you to programmatically manage clusters and resources in yo
 
 === Redpanda Connect 
 
-Redpanda Connect (link https://docs.redpanda.com/redpanda-connect/guides/getting_started) includes over 200 connectors, with a large collection of sources, sinks, and processors. The interface provides a lightweight and easy way to set up, debug, and manage connectors. 
+xref:redpanda-connect:ROOT:about.adoc[Redpanda Connect] includes over 200 connectors, with a large collection of sources, sinks, and processors. The interface provides a lightweight and easy way to set up, debug, and manage connectors. 
 
 === mTLS authentication for Kafka API clients
 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -11,10 +11,6 @@ This page lists new features added in Redpanda Cloud.
 
 The Cloud API allows you to programmatically manage clusters and resources in your Redpanda Cloud organization. For more information, see the xref:deploy:deployment-option/cloud/api/cloud-api-quickstart.adoc[Cloud API Quickstart], the xref:deploy:deployment-option/cloud/api/cloud-api-overview.adoc[Cloud API Overview], and the full xref:api:ROOT:cloud-api.adoc[Cloud API reference].
 
-=== Redpanda Connect 
-
-xref:redpanda-connect:ROOT:about.adoc[Redpanda Connect] includes over 200 connectors, with a large collection of sources, sinks, and processors. The interface provides a lightweight and easy way to set up, debug, and manage connectors. 
-
 === mTLS authentication for Kafka API clients
 
 mTLS authentication is now available for Kafka API clients. You can xref:deploy:deployment-option/cloud/security/cloud-authentication.adoc#mtls[enable mTLS] for your cluster using the Cloud API.

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -23,9 +23,11 @@ You can now manage GCP Private Service Connect and AWS PrivateLink connections t
 
 Redpanda now provides xref:deploy:deployment-option/cloud/managed-connectors/transforms.adoc[single message transforms (SMTs)] to help you modify data as it passes through a connector, without needing additional stream processors.
 
-=== Additional AWS region for Dedicated
+=== Support for additional regions
 
-Redpanda added support for the ap-south-1 (Mumbai) xref:deploy:deployment-option/cloud/dedicated/dedicated-tiers.adoc#tab=tabs-1-amazon-web-services-aws[region for Dedicated clusters].
+* For xref:deploy:deployment-option/cloud/byoc-tiers.adoc#byoc-supported-regions[BYOC clusters], Redpanda added support for the GPC us-west1 region (Oregon) and the AWS ap-south-1 region (Mumbai).
+
+* For xref:deploy:deployment-option/cloud/dedicated/dedicated-tiers.adoc#dedicated-supported-regions[Dedicated clusters], Redpanda added support for the AWS ap-south-1 region. 
 
 === Simplified navigation and namespaces renamed resource groups
 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -17,9 +17,7 @@ mTLS authentication is now available for Kafka API clients. You can xref:deploy:
 
 === Manage private connectivity in the UI
 
-You can now manage GCP Private Service Connect and AWS PrivateLink connections to your BYOC or dedicated cluster on the *Cluster settings* page in Redpanda Cloud. See the steps for xref:deploy:deployment-option/cloud/configure-privatelink-in-cloud-ui.adoc[PrivateLink] and xref:deploy:deployment-option/cloud/configure-private-service-connect-in-cloud-ui.adoc[Private Service Connect].
-
-To add private connectivity as part of cluster creation, use the Cloud API. 
+You can now manage GCP Private Service Connect and AWS PrivateLink connections to your BYOC or Dedicated cluster on the *Cluster settings* page in Redpanda Cloud. See the steps for xref:deploy:deployment-option/cloud/configure-privatelink-in-cloud-ui.adoc[PrivateLink] and xref:deploy:deployment-option/cloud/configure-private-service-connect-in-cloud-ui.adoc[Private Service Connect].
 
 === Additional AWS region for Dedicated
 

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -71,7 +71,8 @@ Additionally, to bundle security commands together, the existing `rpk acl` comma
 
 == Documentation enhancements
 
-* https://docs.redpanda.com/redpanda-labs/[Redpanda Labs] provide examples, guidance, best practices, and ideas for how to use Redpanda in your own project.
+* https://docs.redpanda.com/redpanda-labs/[Redpanda Labs] provides examples, guidance, best practices, and ideas for how to use Redpanda in your own project.
+* xref:redpanda-connect:ROOT:about.adoc[Redpanda Connect] documentation is added as a new dropdown option, similar to Redpanda Labs.
 * Improved search lets you filter for blogs, videos, labs, and documentation for all supported versions.  
 * New xref:upgrade:migrate/kubernetes/strimzi.adoc#migrate-kafka[side-by-side codeblocks] let you easily compare code examples.
 * Improved listing of changes to `rpk` commands in xref:upgrade:deprecated/index.adoc[deprecated features].

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -55,20 +55,13 @@ Before topic recovery or cluster restore, the properties xref:reference:cluster-
 
 The following `rpk` commands are new in this release:
 
-- xref:reference:rpk/rpk-connect/rpk-connect.adoc[`rpk connect`]
 - xref:reference:rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc[`rpk cluster partitions transfer-leadership`]
 - xref:reference:rpk/rpk-redpanda/rpk-redpanda-tune-help.adoc[`rpk redpanda tune help`]
 - xref:reference:rpk/rpk-transform/rpk-transform-logs.adoc[`rpk transform logs`]
-- xref:reference:rpk/rpk-security/rpk-security.adoc[`rpk security`]
-- xref:reference:rpk/rpk-security/rpk-security-role.adoc[`rpk security role`]
-- xref:reference:rpk/rpk-security/rpk-security-role-assign.adoc[`rpk security role assign`]
-- xref:reference:rpk/rpk-security/rpk-security-role-create.adoc[`rpk security role create`]
-- xref:reference:rpk/rpk-security/rpk-security-role-delete.adoc[`rpk security role delete`]
-- xref:reference:rpk/rpk-security/rpk-security-role-describe.adoc[`rpk security role describe`]
-- xref:reference:rpk/rpk-security/rpk-security-role-list.adoc[`rpk security role list`]
-- xref:reference:rpk/rpk-security/rpk-security-role-unassign.adoc[`rpk security role unassign`]
-
-Additionally, to bundle security commands together, the existing `rpk acl` commands have moved into this new section as xref:reference:rpk/rpk-security/rpk-security-acl.adoc[`rpk security acl`]. The existing `rpk acl` commands still work as an alias.
+- xref:reference:rpk/rpk-connect/rpk-connect.adoc[`rpk connect` commands]
+- xref:reference:rpk/rpk-security/rpk-security.adoc[`rpk security` commands]
++
+Additionally, to bundle security commands together, the existing `rpk acl` commands have moved into the new `rpk security` section as xref:reference:rpk/rpk-security/rpk-security-acl.adoc[`rpk security acl`]. The existing `rpk acl` commands still work as an alias.
 
 == Documentation enhancements
 

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -9,7 +9,7 @@ This topic includes new content added in version 24.1. For a complete list of al
 
 == Redpanda Connect 
 
-In release 24.1.5, Redpanda announced xref:redpanda-connect:ROOT:about.adoc[Redpanda Connect]. This includes over 200 connectors, with a large collection of sources, sinks, and processors. The interface provides a lightweight and easy way to set up, debug, and manage connectors. 
+In release 24.1.5, Redpanda announced xref:redpanda-connect:ROOT:about.adoc[Redpanda Connect]. This includes over 220 connectors, with a large collection of sources, sinks, and processors. The interface provides a lightweight and easy way to set up, debug, and manage connectors. 
 
 == Write caching
 

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -2,9 +2,10 @@
 :description: Summary of new features and updates in the release.
 :page-aliases: get-started:whats-new-233.adoc, get-started:whats-new-241.adoc
 
-This topic includes new content added in version 24.1. For a complete list of all product updates, see the https://github.com/redpanda-data/redpanda/releases/[Redpanda release notes^]. 
+This topic includes new content added in version 24.1. For a complete list of all product updates, see the https://github.com/redpanda-data/redpanda/releases/[Redpanda release notes^]. See also: 
 
-See also: xref:deploy:deployment-option/cloud/whats-new-cloud.adoc[]
+* xref:deploy:deployment-option/cloud/whats-new-cloud.adoc[] 
+* xref:deploy:deployment-option/cloud/cloud-overview.adoc#redpanda-cloud-vs-self-hosted-feature-compatibility[Redpanda Cloud vs self-hosted feature compatibility]
 
 == Write caching
 

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -55,6 +55,7 @@ Before topic recovery or cluster restore, the properties xref:reference:cluster-
 
 The following `rpk` commands are new in this release:
 
+- xref:reference:rpk/rpk-connect/rpk-connect.adoc[`rpk connect`]
 - xref:reference:rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc[`rpk cluster partitions transfer-leadership`]
 - xref:reference:rpk/rpk-redpanda/rpk-redpanda-tune-help.adoc[`rpk redpanda tune help`]
 - xref:reference:rpk/rpk-transform/rpk-transform-logs.adoc[`rpk transform logs`]

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -9,7 +9,7 @@ This topic includes new content added in version 24.1. For a complete list of al
 
 == Redpanda Connect 
 
-In release 24.1.5, Redpanda announced xref:redpanda-connect:ROOT:about.adoc[Redpanda Connect]. This includes over 220 connectors, with a large collection of sources, sinks, and processors. The interface provides a lightweight and easy way to set up, debug, and manage connectors. 
+In release 24.1.5, Redpanda announced xref:redpanda-connect:ROOT:about.adoc[Redpanda Connect]. This includes over 220 open source connectors, with a large collection of sources, sinks, and processors. The interface provides a lightweight and easy way to set up, debug, and manage connectors. 
 
 == Write caching
 
@@ -55,6 +55,7 @@ Before topic recovery or cluster restore, the properties xref:reference:cluster-
 
 The following `rpk` commands are new in this release:
 
+- xref:reference:rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc[`rpk cluster partitions transfer-leadership`]
 - xref:reference:rpk/rpk-redpanda/rpk-redpanda-tune-help.adoc[`rpk redpanda tune help`]
 - xref:reference:rpk/rpk-transform/rpk-transform-logs.adoc[`rpk transform logs`]
 - xref:reference:rpk/rpk-security/rpk-security.adoc[`rpk security`]

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -7,6 +7,10 @@ This topic includes new content added in version 24.1. For a complete list of al
 * xref:deploy:deployment-option/cloud/whats-new-cloud.adoc[] 
 * xref:deploy:deployment-option/cloud/cloud-overview.adoc#redpanda-cloud-vs-self-hosted-feature-compatibility[Redpanda Cloud vs self-hosted feature compatibility]
 
+== Redpanda Connect 
+
+In release 24.1.5, Redpanda announced xref:redpanda-connect:ROOT:about.adoc[Redpanda Connect]. This includes over 200 connectors, with a large collection of sources, sinks, and processors. The interface provides a lightweight and easy way to set up, debug, and manage connectors. 
+
 == Write caching
 
 xref:develop:config-topics.adoc#configure-write-caching[Write caching] is a relaxed mode of `acks=all` that provides better performance at the expense of durability. It acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to fsync to disk. This provides lower latency while still ensuring that a majority of brokers acknowledge the write. For clusters in development mode, write caching is enabled by default. For clusters in production mode, it is disabled by default.


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2464
Review deadline: Friday, May 31
Fixes: DOC-250

## Page previews

- [What's New in Redpanda Cloud](https://deploy-preview-526--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/whats-new-cloud/): Please review!
- [Cloud vs SH feature compatibility](https://deploy-preview-526--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/cloud-overview/#redpanda-cloud-vs-self-hosted-feature-compatibility): Please confirm if this needs any updates. mTLS is now removed from list, and beta added next to data transforms & RRR. 
- [What's New](https://deploy-preview-526--redpanda-docs-preview.netlify.app/current/get-started/whats-new/):  This adds RP Connect with 24.1.5, `rpk cluster partitions transfer-leadership`, `rpk connect`, and a link to Cloud vs SH feature compatibility, for extra visibility.

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)