### PR TITLE
Add intentionally missing pages

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -38,7 +38,11 @@ asciidoc:
         reason: Page moved to Redpanda Labs.
       - page: develop/code-samples/
         reason: Page moved to Redpanda Labs.
+      - page: develop/code-examples/
+        reason: Page moved to Redpanda Labs.
       - page: console/reference/docker-compose/
+        reason: Page moved to Redpanda Labs.
+      - page: reference/docker-compose/
         reason: Page moved to Redpanda Labs.
       - page: reference/console/docker-compose/
         reason: Page moved to Redpanda Labs.

--- a/antora.yml
+++ b/antora.yml
@@ -30,6 +30,34 @@ asciidoc:
         reason: Page moved to Redpanda Labs.
       - page: develop/chat-room-cloud/
         reason: Page moved to Redpanda Labs.
+      - page: get-started/code-samples/
+        reason: Page moved to Redpanda Labs.
+      - page: development/code-samples/
+        reason: Page moved to Redpanda Labs.
+      - page: introduction/code-samples/
+        reason: Page moved to Redpanda Labs.
+      - page: develop/code-samples/
+        reason: Page moved to Redpanda Labs.
+      - page: console/reference/docker-compose/
+        reason: Page moved to Redpanda Labs.
+      - page: reference/console/docker-compose/
+        reason: Page moved to Redpanda Labs.
+      - page: develop/guide-go-cloud/
+        reason: Page moved to Redpanda Labs.
+      - page: develop/guide-python-cloud/
+        reason: Page moved to Redpanda Labs.
+      - page: develop/guide-java-cloud/
+        reason: Page moved to Redpanda Labs.
+      - page: develop/guide-nodejs-cloud/
+        reason: Page moved to Redpanda Labs.
+      - page: develop/guide-go/
+        reason: Page moved to Redpanda Labs.
+      - page: develop/guide-python/
+        reason: Page moved to Redpanda Labs.
+      - page: develop/guide-java/
+        reason: Page moved to Redpanda Labs.
+      - page: develop/guide-nodejs/
+        reason: Page moved to Redpanda Labs.
     # Data for the home page
     page-feature-list:
       - title: 'Serverless'


### PR DESCRIPTION
## Description

Resolves the build logs that warn us about missing pages in the latest version:

```
6:00:21 PM: /23.2/develop/code-examples/ does not exist in 24.1
6:00:21 PM: /23.2/develop/guide-go-cloud/ does not exist in 24.1
6:00:21 PM: /23.2/develop/guide-go/ does not exist in 24.1
6:00:21 PM: /23.2/develop/guide-java-cloud/ does not exist in 24.1
6:00:21 PM: /23.2/develop/guide-java/ does not exist in 24.1
6:00:21 PM: /23.2/develop/guide-nodejs-cloud/ does not exist in 24.1
6:00:21 PM: /23.2/develop/guide-nodejs/ does not exist in 24.1
6:00:21 PM: /23.2/develop/guide-python-cloud/ does not exist in 24.1
6:00:21 PM: /23.2/develop/guide-python/ does not exist in 24.1
6:00:21 PM: /23.2/reference/docker-compose/ does not exist in 24.1
```

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)