### PR TITLE
fix glossary links with new cloud-docs repo

### DIFF
--- a/modules/terms/partials/byoc.adoc
+++ b/modules/terms/partials/byoc.adoc
@@ -2,5 +2,3 @@
 :term-name: BYOC
 :hover-text: Bring Your Own Cloud (BYOC) is a fully-managed Redpanda Cloud deployment where clusters run in your private cloud, so all data is contained in your own environment. Redpanda handles provisioning, operations, and maintenance. 
 :category: Redpanda Cloud
-
-For more information, see xref:deploy:deployment-option/cloud/cloud-overview.adoc[].

--- a/modules/terms/partials/connector.adoc
+++ b/modules/terms/partials/connector.adoc
@@ -4,5 +4,3 @@
 :category: Redpanda Cloud
 
 Redpanda managed connectors offer a simpler way to integrate your data than manually creating a solution with the Kafka API. You can set up and manage connectors in Redpanda Console. 
-
-For more information, see xref:deploy:deployment-option/cloud/managed-connectors/index.adoc[Managed Connectors].

--- a/modules/terms/partials/resource-group.adoc
+++ b/modules/terms/partials/resource-group.adoc
@@ -2,5 +2,3 @@
 :term-name: resource group
 :hover-text: A container for Redpanda Cloud resources, including clusters and networks. You can rename your default resource group, and you can create more resource groups. For example, you may want different resource groups for production and testing. 
 :category: Redpanda Cloud
-
-For more information, see xref:deploy:deployment-option/cloud/cloud-overview.adoc[].

--- a/modules/terms/partials/serverless.adoc
+++ b/modules/terms/partials/serverless.adoc
@@ -2,5 +2,3 @@
 :term-name: Serverless
 :hover-text: Serverless is a fully-managed Redpanda Cloud deployment where you host your data in Redpanda's VPC, and Redpanda handles automatic scaling, provisioning, operations, and maintenance. A cluster is available instantly, there is no base cost, and you only pay for what you consume.
 :category: Redpanda Cloud
-
-For more information, see xref:deploy:deployment-option/cloud/cloud-overview.adoc[].


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2521
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)