### PR TITLE
Add variables to be replaced by the latest RC

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -3,6 +3,7 @@
 ** xref:get-started:whats-new.adoc[]
 ** xref:get-started:intro-to-events.adoc[Introduction to Redpanda]
 ** xref:get-started:architecture.adoc[How Redpanda Works]
+** xref:get-started:install-beta.adoc[Install Beta]
 ** xref:get-started:quickstarts/index.adoc[Quickstarts]
 *** xref:get-started:quick-start-cloud.adoc[Cloud Quickstart]
 *** xref:get-started:quick-start.adoc[Self-Hosted Quickstart]

--- a/modules/get-started/pages/install-beta.adoc
+++ b/modules/get-started/pages/install-beta.adoc
@@ -1,7 +1,8 @@
-= Install 24.1 beta
-:description: Learn how to install the beta version. 
+= Install {page-version} beta
+:description: Learn how to install the beta version.
+:publish-only-during-beta: true
 
-Redpanda beta versions provide users the opportunity to test and share feedback on new features before they're finalized in general availability. Beta versions, like `v24.1.1-rc4`, are published to `redpanda-unstable` as release candidate (RC) builds. RC builds are not recommended for production use.
+Redpanda beta versions provide users the opportunity to test and share feedback on new features before they're finalized in general availability. Beta versions, like `{redpanda-beta-version}`, are published to `redpanda-unstable` as release candidate (RC) builds. RC builds are not recommended for production use.
 
 To install the beta version, select your environment.
 
@@ -13,22 +14,17 @@ Docker::
 
 . Pull the latest RC build from https://hub.docker.com/r/redpandadata/redpanda-unstable/tags[dockerhub^]:
 +
-```
-docker pull docker.redpanda.com/redpandadata/redpanda-unstable:v24.1.1-rc4
-```
+[source,bash,subs="attributes+"]
+----
+docker pull docker.redpanda.com/redpandadata/redpanda-unstable:{redpanda-beta-version}
+----
 
-. Change your image repository to:
-+
-```
-image: docker.redpanda.com/redpandadata/redpanda-unstable
-```
-
-. Create a Docker Compose file with the beta version: 
+. Create a Docker Compose file with the beta version:
 +
 .Reveal the YAML content
 [%collapsible]
 ====
-[,yaml,lines=35]
+[source,yaml,subs="attributes+",lines=35]
 ----
 version: "3.7"
 name: redpanda-quickstart
@@ -53,7 +49,7 @@ services:
       # Address the broker advertises to clients that connect to the HTTP Proxy.
       - --advertise-pandaproxy-addr internal://redpanda-0:8082,external://localhost:18082
       - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
-      # Redpanda brokers use the RPC API to communicate with eachother internally.
+      # Redpanda brokers use the RPC API to communicate with each other internally.
       - --rpc-addr redpanda-0:33145
       - --advertise-rpc-addr redpanda-0:33145
       # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
@@ -64,7 +60,7 @@ services:
       - --mode dev-container
       # enable logs for debugging.
       - --default-log-level=debug
-	image: docker.redpanda.com/redpandadata/redpanda-unstable:v24.1.1-rc4
+	image: docker.redpanda.com/redpandadata/redpanda-unstable:{redpanda-beta-version}
     container_name: redpanda-0
     volumes:
       - redpanda-0:/var/lib/redpanda/data
@@ -77,7 +73,7 @@ services:
       - 19644:9644
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:v2.4.5
+    image: docker.redpanda.com/redpandadata/console:{latest-console-version}
     networks:
       - redpanda_network
     entrypoint: /bin/sh
@@ -107,7 +103,7 @@ services:
 docker compose up -d
 ```
 
-For more information on the quickstart, see xref:./quick-start.adoc[Redpanda Quickstart].
+For more information on getting started, see xref:get-started:quick-start.adoc[Redpanda Quickstart].
 
 --
 Linux::
@@ -119,14 +115,14 @@ Fedora/RedHat/Amazon Linux::
 +
 . Add the `redpanda-unstable` repository to your package manager:
 +
-```
+```bash
 curl -1sLf \
-  'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.rpm.sh' 
+  'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.rpm.sh'
 ```
 +
 . Install Redpanda:
 +
-```
+```bash
 sudo yum install redpanda
 ```
 
@@ -134,19 +130,19 @@ Debian/Ubuntu::
 +
 . Add the `redpanda-unstable` repository to your package manager:
 +
-```
+```bash
 curl -1sLf \
-  'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.deb.sh' 
+  'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.deb.sh'
 ```
 +
-. Get updated pagkage information for your machine:
+. Get updated package information for your machine:
 +
-```
+```bash
 sudo apt-get update
 ```
 . Install Redpanda:
 +
-```
+```bash
 sudo apt-get install redpanda
 ```
 ====
@@ -160,12 +156,13 @@ Kubernetes::
 
 Install Redpanda with Helm from the RC build in https://hub.docker.com/r/redpandadata/redpanda-unstable/tags[dockerhub^]:
 
-```
+[source,bash,subs="attributes+"]
+----
 helm repo add redpanda https://charts.redpanda.com
 helm install redpanda redpanda/redpanda \
   --namespace <namespace> \
-  --create-namespace --set image.repository=docker.redpanda.com/redpandadata/redpanda-unstable --set image.tag=v24.1.1-rc4
-```
+  --create-namespace --set image.repository=docker.redpanda.com/redpandadata/redpanda-unstable --set image.tag={redpanda-beta-version}
+----
 
 --
 =====

--- a/package-lock.json
+++ b/package-lock.json
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.3.3.tgz",
-      "integrity": "sha512-DhZ2Ix8aTVdJHcAzIqWOt/hhFToINu+P/bV2ZgxCNDrtaamdSxAtEVjo+WoFF9PzI4alrysrP/3TfRjoTjdBWA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.4.1.tgz",
+      "integrity": "sha512-RaXyjjkZ0fEzqhZ70kEacOH1KF+5pVS6lyTZHnvvxIkWPfF5ufOgypROPJRoxVfOkvrkQfMy3YyTlEHU8emN2w==",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",
         "@octokit/rest": "~19.0.7",


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2438
Review deadline: June 12

Related: https://github.com/redpanda-data/docs-extensions-and-macros/pull/51

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)