### PR TITLE
Ensure there is only one `kafka_api` section, and that each listener …

### DIFF
--- a/modules/manage/pages/security/listener-configuration.adoc
+++ b/modules/manage/pages/security/listener-configuration.adoc
@@ -84,9 +84,8 @@ redpanda:
       port: 9092
       name: sasl_listener
       authentication_method: sasl
-  kafka_api:
     - address: 0.0.0.0
-      port: 9092
+      port: 9192
       name: mtls_listener
       authentication_method: mtls_identity
   kafka_api_tls:


### PR DESCRIPTION
…uses a different port

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)