### PR TITLE
ephemeral read replica topic only clusters

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -96,6 +96,7 @@
 **** xref:deploy:deployment-option/cloud/configure-private-service-connect-in-cloud-ui.adoc[]
 **** xref:deploy:deployment-option/cloud/gcp-private-service-connect.adoc[]
 *** xref:deploy:deployment-option/cloud/monitor-cloud.adoc[]
+*** xref:deploy:deployment-option/cloud/remote-read-replicas.adoc[]
 *** xref:deploy:deployment-option/cloud/managed-connectors/index.adoc[Managed Connectors]
 **** xref:deploy:deployment-option/cloud/managed-connectors/converters-and-serialization.adoc[Converters and serialization]
 **** xref:deploy:deployment-option/cloud/managed-connectors/monitor-connectors.adoc[Monitor Connectors]

--- a/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
@@ -1,0 +1,55 @@
+= Remote Read Replicas
+:description: Learn how to create a remote read replica topic, which is a read-only topic that mirrors a topic on a different cluster.
+
+A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. You can create a separate remote cluster just for consumers of this topic and populate its topics from object storage. A read-only topic on a remote cluster can serve any consumer, without increasing the load on the origin cluster. Because these read-only topics access data directly from object storage, there's no impact to the performance of the cluster.
+
+Redpanda Cloud supports remote read replicas with ephemeral clusters, which are temporary clusters created to handle specific, transient workloads or tasks. After processing, the cluster is terminated to free up resources and reduce costs. 
+
+== Prerequisites
+
+* A BYOC source cluster
+* A BYOC reader cluster in the same cloud provider account and region as the source cluster
+
+== Configure remote read replicas
+
+You can create remote read replica topics in Redpanda Cloud with the xref:api:ROOT:cloud-api.adoc[Cloud API]. For information on accessing the Cloud API see xref:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[].
+
+. To update your source cluster to add one or more reader cluster IDs, use the PATCH operation. The full list of clusters is expected on every call. If an ID is removed from the list, it will be removed as a reader cluster.
++
+```bash
+export SOURCE_CLUSTER_ID=.......
+export READER_CLUSTER_ID=.......
+
+curl -X PATCH $API_HOST/v1beta1/clusters/$SOURCE_CLUSTER_ID \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $API_TOKEN" \
+-d @- << EOF 
+{
+  "read_replica_cluster_ids": ["$READER_CLUSTER_ID"] 
+}
+EOF
+```
+
+. To create a remote read replica topic, run:
++
+```bash
+rpk topic create my-topic -c redpanda.remote.readreplica=redpanda-cloud-storage-${SOURCE_CLUSTER_ID}
+```
+
+. To see the list of reader clusters on a given source cluster, use the GET operation:
++
+```bash
+export SOURCE_CLUSTER_ID=.......
+
+curl -X GET $API_HOST/v1beta1/clusters/$SOURCE_CLUSTER_ID \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $API_TOKEN"
+```
+
+== Optional configuration
+
+For remote read replicas that are reading from a live topic (that is, a topic that's being actively written to by a source cluster), it may be advantageous to tune `cloud_storage_segment_max_upload_interval_sec` to control how often segments are flushed to object storage. By default, this is set to 60 minutes. To tune `cloud_storage_segment_max_upload_interval_sec` on the source cluster, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
+
+For cold topics, where segments are closed and already older than 60 minutes, this configuration is unnecessary: the data was already uploaded to object storage.
+
+

--- a/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
@@ -4,12 +4,12 @@
 
 A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. You can create a separate remote cluster just for consumers of this topic and populate its topics from object storage. A read-only topic on a remote cluster can serve any consumer, without increasing the load on the origin cluster. Because these read-only topics access data directly from object storage, there's no impact to the performance of the cluster.
 
-Redpanda Cloud supports remote read replicas with ephemeral clusters, which are temporary clusters created to handle specific, transient workloads or tasks. After processing, the cluster is terminated to free up resources and reduce costs. 
+Redpanda Cloud supports remote read replicas with ephemeral BYOC clusters (not with a customer-managed VPC). Ephemeral clusters are temporary clusters created to handle specific, transient workloads or tasks. After processing, the cluster is terminated to free up resources and reduce costs. 
 
 == Prerequisites
 
-* A BYOC source cluster
-* A BYOC reader cluster in the same cloud provider account and region as the source cluster
+* A BYOC source cluster in Ready state.
+* A BYOC reader cluster in Ready state. This separate reader cluster must exist in the same Redpanda organization and the same cloud provider account and region as the source cluster.
 
 == Configure remote read replicas
 
@@ -48,5 +48,10 @@ curl -X GET $API_HOST/v1beta1/clusters/$SOURCE_CLUSTER_ID \
 ```
 
 . Optional: For remote read replicas reading from a live topic (that is, a topic that's being actively written to by a source cluster), it may be advantageous to control how often segments are flushed to object storage. By default, this is set to 60 minutes. To tune `cloud_storage_segment_max_upload_interval_sec` on the source cluster, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^]. (For cold topics, where segments are closed and older than 60 minutes, this configuration is unnecessary: the data is already uploaded to object storage.)
+
+[NOTE]
+====
+To delete a cluster with remote read replica topics, you must first remove the read replica topics.
+==== 
 
 

--- a/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
@@ -1,6 +1,7 @@
 = Remote Read Replicas
 :description: Learn how to create a remote read replica topic, which is a read-only topic that mirrors a topic on a different cluster.
 :page-cloud: true
+:page-beta: true
 
 A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. You can create a separate remote cluster just for consumers of this topic and populate its topics from object storage. A read-only topic on a remote cluster can serve any consumer, without increasing the load on the source cluster. Because these read-only topics access data directly from object storage, there's no impact to the performance of the cluster.
 

--- a/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
@@ -38,7 +38,7 @@ EOF
 rpk topic create my-topic -c redpanda.remote.readreplica=redpanda-cloud-storage-${SOURCE_CLUSTER_ID}
 ```
 
-. Optional: To see the list of reader clusters on a given source cluster, use the GET operation:
+. Optional: To see the list of reader clusters on a given source cluster, make a xref:api:ROOT:cloud-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1beta2/clusters/\{id}] request:
 +
 ```bash
 export SOURCE_CLUSTER_ID=.......

--- a/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
@@ -16,7 +16,7 @@ Redpanda Cloud supports remote read replicas with ephemeral BYOC clusters (not w
 
 You can add or remove reader clusters to a source cluster in Redpanda Cloud with the xref:api:ROOT:cloud-api.adoc[Cloud API]. For information on accessing the Cloud API, see xref:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[]. 
 
-. To update your source cluster to add one or more reader cluster IDs, make a xref:api:ROOT:cloud-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/\{cluster.id}] request. The full list of clusters is expected on every call. If an ID is removed from the list, it will be removed as a reader cluster.
+. To update your source cluster to add one or more reader cluster IDs, make a xref:api:ROOT:cloud-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/\{cluster.id}`] request. The full list of clusters is expected on every call. If an ID is removed from the list, it will be removed as a reader cluster.
 +
 ```bash
 export SOURCE_CLUSTER_ID=.......
@@ -38,7 +38,7 @@ EOF
 rpk topic create my-topic -c redpanda.remote.readreplica=redpanda-cloud-storage-${SOURCE_CLUSTER_ID}
 ```
 
-. Optional: To see the list of reader clusters on a given source cluster, make a xref:api:ROOT:cloud-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1beta2/clusters/\{id}] request:
+. Optional: To see the list of reader clusters on a given source cluster, make a xref:api:ROOT:cloud-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1beta2/clusters/\{id}`] request:
 +
 ```bash
 export SOURCE_CLUSTER_ID=.......

--- a/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
@@ -13,7 +13,7 @@ Redpanda Cloud supports remote read replicas with ephemeral BYOC clusters (not w
 
 == Configure remote read replicas
 
-You can create remote read replica topics in Redpanda Cloud with the xref:api:ROOT:cloud-api.adoc[Cloud API]. For information on accessing the Cloud API, see xref:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[].
+You can add or remove reader clusters to a source cluster in Redpanda Cloud with the xref:api:ROOT:cloud-api.adoc[Cloud API]. For information on accessing the Cloud API, see xref:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[]. 
 
 . To update your source cluster to add one or more reader cluster IDs, use the PATCH operation. The full list of clusters is expected on every call. If an ID is removed from the list, it will be removed as a reader cluster.
 +
@@ -51,7 +51,8 @@ curl -X GET $API_HOST/v1beta1/clusters/$SOURCE_CLUSTER_ID \
 
 [NOTE]
 ====
-To delete a cluster with remote read replica topics, you must first remove the read replica topics.
+A source cluster cannot be deleted if it has remote read replica topics. When you delete a reader cluster, that cluster's ID is removed from any existing source cluster `read_replica_cluster_ids` lists.
+
 ==== 
 
 

--- a/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
@@ -1,5 +1,6 @@
 = Remote Read Replicas
 :description: Learn how to create a remote read replica topic, which is a read-only topic that mirrors a topic on a different cluster.
+:page-cloud: true
 
 A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. You can create a separate remote cluster just for consumers of this topic and populate its topics from object storage. A read-only topic on a remote cluster can serve any consumer, without increasing the load on the origin cluster. Because these read-only topics access data directly from object storage, there's no impact to the performance of the cluster.
 
@@ -12,7 +13,7 @@ Redpanda Cloud supports remote read replicas with ephemeral clusters, which are 
 
 == Configure remote read replicas
 
-You can create remote read replica topics in Redpanda Cloud with the xref:api:ROOT:cloud-api.adoc[Cloud API]. For information on accessing the Cloud API see xref:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[].
+You can create remote read replica topics in Redpanda Cloud with the xref:api:ROOT:cloud-api.adoc[Cloud API]. For information on accessing the Cloud API, see xref:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[].
 
 . To update your source cluster to add one or more reader cluster IDs, use the PATCH operation. The full list of clusters is expected on every call. If an ID is removed from the list, it will be removed as a reader cluster.
 +
@@ -36,7 +37,7 @@ EOF
 rpk topic create my-topic -c redpanda.remote.readreplica=redpanda-cloud-storage-${SOURCE_CLUSTER_ID}
 ```
 
-. To see the list of reader clusters on a given source cluster, use the GET operation:
+. Optional: To see the list of reader clusters on a given source cluster, use the GET operation:
 +
 ```bash
 export SOURCE_CLUSTER_ID=.......
@@ -46,10 +47,6 @@ curl -X GET $API_HOST/v1beta1/clusters/$SOURCE_CLUSTER_ID \
 -H "Authorization: Bearer $API_TOKEN"
 ```
 
-== Optional configuration
-
-For remote read replicas that are reading from a live topic (that is, a topic that's being actively written to by a source cluster), it may be advantageous to tune `cloud_storage_segment_max_upload_interval_sec` to control how often segments are flushed to object storage. By default, this is set to 60 minutes. To tune `cloud_storage_segment_max_upload_interval_sec` on the source cluster, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
-
-For cold topics, where segments are closed and already older than 60 minutes, this configuration is unnecessary: the data was already uploaded to object storage.
+. Optional: For remote read replicas reading from a live topic (that is, a topic that's being actively written to by a source cluster), it may be advantageous to control how often segments are flushed to object storage. By default, this is set to 60 minutes. To tune `cloud_storage_segment_max_upload_interval_sec` on the source cluster, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^]. (For cold topics, where segments are closed and older than 60 minutes, this configuration is unnecessary: the data is already uploaded to object storage.)
 
 

--- a/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
@@ -16,7 +16,7 @@ Redpanda Cloud supports remote read replicas with ephemeral BYOC clusters (not w
 
 You can add or remove reader clusters to a source cluster in Redpanda Cloud with the xref:api:ROOT:cloud-api.adoc[Cloud API]. For information on accessing the Cloud API, see xref:deploy:deployment-option/cloud/api/cloud-api-authentication.adoc[]. 
 
-. To update your source cluster to add one or more reader cluster IDs, use the PATCH operation. The full list of clusters is expected on every call. If an ID is removed from the list, it will be removed as a reader cluster.
+. To update your source cluster to add one or more reader cluster IDs, make a xref:api:ROOT:cloud-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/\{cluster.id}] request. The full list of clusters is expected on every call. If an ID is removed from the list, it will be removed as a reader cluster.
 +
 ```bash
 export SOURCE_CLUSTER_ID=.......

--- a/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
@@ -22,7 +22,7 @@ You can add or remove reader clusters to a source cluster in Redpanda Cloud with
 export SOURCE_CLUSTER_ID=.......
 export READER_CLUSTER_ID=.......
 
-curl -X PATCH $API_HOST/v1beta1/clusters/$SOURCE_CLUSTER_ID \
+curl -X PATCH $API_HOST/v1beta2/clusters/$SOURCE_CLUSTER_ID \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $API_TOKEN" \
 -d @- << EOF 
@@ -43,7 +43,7 @@ rpk topic create my-topic -c redpanda.remote.readreplica=redpanda-cloud-storage-
 ```bash
 export SOURCE_CLUSTER_ID=.......
 
-curl -X GET $API_HOST/v1beta1/clusters/$SOURCE_CLUSTER_ID \
+curl -X GET $API_HOST/v1beta2/clusters/$SOURCE_CLUSTER_ID \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $API_TOKEN"
 ```

--- a/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/remote-read-replicas.adoc
@@ -2,7 +2,7 @@
 :description: Learn how to create a remote read replica topic, which is a read-only topic that mirrors a topic on a different cluster.
 :page-cloud: true
 
-A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. You can create a separate remote cluster just for consumers of this topic and populate its topics from object storage. A read-only topic on a remote cluster can serve any consumer, without increasing the load on the origin cluster. Because these read-only topics access data directly from object storage, there's no impact to the performance of the cluster.
+A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. You can create a separate remote cluster just for consumers of this topic and populate its topics from object storage. A read-only topic on a remote cluster can serve any consumer, without increasing the load on the source cluster. Because these read-only topics access data directly from object storage, there's no impact to the performance of the cluster.
 
 Redpanda Cloud supports remote read replicas with ephemeral BYOC clusters (not with a customer-managed VPC). Ephemeral clusters are temporary clusters created to handle specific, transient workloads or tasks. After processing, the cluster is terminated to free up resources and reduce costs. 
 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -9,7 +9,7 @@ This page lists new features added in Redpanda Cloud.
 
 === Remote read replica topics on BYOC: beta
 
-You can now create remote read replica topics on a BYOC cluster with the Cloud API. A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. It can serve any consumer, without increasing the load on the source cluster. 
+You can now create xref:deploy:deployment-option/cloud/remote-read-replicas.adoc[remote read replica topics] on a BYOC cluster with the Cloud API. A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. It can serve any consumer, without increasing the load on the source cluster. 
 
 === Higher connection limits in usage tiers
 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -7,6 +7,10 @@ This page lists new features added in Redpanda Cloud.
 
 == June 2024
 
+=== Remote read replica topics on BYOC
+
+You can now create remote read replica topics on a BYOC cluster with the Cloud API. A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. It can serve any consumer, without increasing the load on the source cluster. 
+
 === Higher connection limits in usage tiers
 
 Redpanda has increased the number of client connections in all xref:deploy:deployment-option/cloud/byoc-tiers.adoc[tiers]. For example, tier 1 now supports up to 9,000 maximum connections, and tier 9 supports up to 450,000 maximum connections. Connections are regulated per broker for best performance. 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -7,7 +7,7 @@ This page lists new features added in Redpanda Cloud.
 
 == June 2024
 
-=== Remote read replica topics on BYOC
+=== Remote read replica topics on BYOC: beta
 
 You can now create remote read replica topics on a BYOC cluster with the Cloud API. A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. It can serve any consumer, without increasing the load on the source cluster. 
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2385
Review deadline: Wed June 19

## Page previews

- [What's New](https://deploy-preview-553--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/whats-new-cloud/)
- [Remote Read Replicas](https://deploy-preview-553--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/remote-read-replicas/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)