### PR TITLE
fix typo in create topic page

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/create-topic.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/create-topic.adoc
@@ -26,10 +26,4 @@ IMPORTANT: Redpanda recommends that you do not change the replication factor val
 | *Retention size*
 | The maximum size of each partition. If a partition reaches this size and more messages are added, the oldest messages are deleted. The default is *infinite*.
 |===
-+
-Under *Additional Configuration*, you can add more topic properties. See xref:reference:cluster-properties.adoc#topic-and-partition-properties[topic and partition properties].
-
-. Click *Create*.
-
-The *Topics* page adds the topic you created to the list of topics.
 

--- a/modules/deploy/pages/deployment-option/cloud/security/cloud-authentication.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/security/cloud-authentication.adoc
@@ -52,8 +52,7 @@ the TCP endpoint or listener.
 When connecting through Redpanda's HTTP Proxy, authentication is done through an
 HTTP Basic Authentication header encrypted over TLS 1.2.
 
-The following features use AWS and GCP xref:./authorization/cloud-authorization.adoc#iam-policies[IAM Policies] to generate
-dynamic and short-lived credentials to interact with cloud provider APIs:
+The following features use AWS and GCP xref:./authorization/cloud-iam-policies.adoc[IAM Policies] to generate dynamic and short-lived credentials to interact with cloud provider APIs:
 
 * Data plane agent
 * Tiered Storage


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2541
Review deadline: June 14

## Page previews

- https://deploy-preview-555--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/create-topic/
- https://deploy-preview-555--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/security/cloud-authentication/#service-authentication

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)