### PR TITLE
adjust some property default values

### DIFF
--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -1374,6 +1374,8 @@ Frequency rate at which the system should check for expired group offsets.
 
 Consumer group offset retention seconds. To disable offset retention, set this to null.
 
+*Unit:* seconds
+
 *Requires restart:* No
 
 *Optional:* No
@@ -1384,7 +1386,7 @@ Consumer group offset retention seconds. To disable offset retention, set this t
 
 *Accepted values:* [`-17179869184`, `17179869183`]
 
-*Default:* `24h * 7`
+*Default:* `604800` (24h*7d)
 
 ---
 
@@ -2911,7 +2913,7 @@ The amount of time to keep a log file before deleting it (in milliseconds). If s
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `604800000` (24h/7d)
+*Default:* `604800000` (24h*7d)
 
 ---
 
@@ -2958,7 +2960,7 @@ Upper bound on topic `segment.ms`: higher values will be clamped to this value.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `31536000000` (365d/24h)
+*Default:* `31536000000` (365d*24h)
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3308,7 +3308,7 @@ Cluster metrics reporter report interval.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `86400000` (24h)
+*Default:* `86400000` (one day)
 
 ---
 
@@ -4446,7 +4446,7 @@ NOTE: Both `retention_local_target_bytes_default` and `retention_local_target_ms
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `86400000` (24h)
+*Default:* `86400000` (one day)
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -1386,7 +1386,7 @@ Consumer group offset retention seconds. To disable offset retention, set this t
 
 *Accepted values:* [`-17179869184`, `17179869183`]
 
-*Default:* `604800` (24h*7d)
+*Default:* `604800` (one week)
 
 ---
 
@@ -2913,7 +2913,7 @@ The amount of time to keep a log file before deleting it (in milliseconds). If s
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `604800000` (24h*7d)
+*Default:* `604800000` (one week)
 
 ---
 
@@ -2960,7 +2960,7 @@ Upper bound on topic `segment.ms`: higher values will be clamped to this value.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `31536000000` (365d*24h)
+*Default:* `31536000000` (one year)
 
 ---
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -1377,7 +1377,7 @@ Time that a segment can be kept locally without uploading it to the object stora
 
 *Accepted values:* [`-17179869184`, `17179869183`]
 
-*Default:* `1h`
+*Default:* `3600` (one hour)
 
 ---
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

- [group_offset_retention_sec](https://deploy-preview-560--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/#group_offset_retention_sec)
 
- [log_retention_ms](https://deploy-preview-560--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/#log_retention_ms)

- [log_segment_ms_max](https://deploy-preview-560--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/#log_segment_ms_max)


## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)