### PR TITLE
update rpk commands not supported in cloud

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -226,14 +226,14 @@ Redpanda Cloud does not support the following self-hosted functionality:
 ** `rpk cluster partitions`
 ** `rpk cluster self-test`
 ** `rpk cluster storage`
-** `rpk connect`
 ** `rpk generate app`
-** `rpk redpanda`
 ** `rpk security user`
 ** `rpk topic describe-storage` (all other `rpk topic` commands are supported)
-** `rpk transform`
+** `rpk connect` commands
+** `rpk redpanda` commands
+** `rpk transform` commands
 +
-NOTE: The `rpk cloud` commands are not supported for self-hosted deployments.
+NOTE: The `rpk cloud` commands are not supported in self-hosted deployments.
 
 == Next steps
 * xref:./serverless.adoc[Create a Serverless Cluster]

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -217,19 +217,23 @@ Redpanda Cloud does not support the following self-hosted functionality:
 - Redpanda Console topic documentation
 - Setting `auto_create_topics_enabled=true`
 - Admin API
-- The following `rpk` commands, which use the Admin API:
+- The following `rpk` commands:
 
-** `rpk security user`
-** `rpk cluster health`
 ** `rpk cluster config`
+** `rpk cluster health`
 ** `rpk cluster license`
 ** `rpk cluster maintenance`
 ** `rpk cluster partitions`
 ** `rpk cluster self-test`
 ** `rpk cluster storage`
+** `rpk connect`
 ** `rpk generate app`
 ** `rpk redpanda`
-** `rpk topic describe-storage` (all other `rpk topic` commands are supported on both Redpanda Cloud and self-hosted)
+** `rpk security user`
+** `rpk topic describe-storage` (all other `rpk topic` commands are supported)
+** `rpk transform`
++
+NOTE: The `rpk cloud` commands are not supported for self-hosted deployments.
 
 == Next steps
 * xref:./serverless.adoc[Create a Serverless Cluster]

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -229,6 +229,7 @@ Redpanda Cloud does not support the following self-hosted functionality:
 ** `rpk generate app`
 ** `rpk security user`
 ** `rpk topic describe-storage` (all other `rpk topic` commands are supported)
+** `rpk transform` (available for private beta)
 ** `rpk connect` commands
 ** `rpk redpanda` commands
 +

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -229,7 +229,7 @@ Redpanda Cloud does not support the following self-hosted functionality:
 ** `rpk generate app`
 ** `rpk security user`
 ** `rpk topic describe-storage` (all other `rpk topic` commands are supported)
-** `rpk transform` (available for private beta)
+** `rpk transform` (currently in beta for Redpanda Cloud)
 ** `rpk connect` commands
 ** `rpk redpanda` commands
 +

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -231,7 +231,6 @@ Redpanda Cloud does not support the following self-hosted functionality:
 ** `rpk topic describe-storage` (all other `rpk topic` commands are supported)
 ** `rpk connect` commands
 ** `rpk redpanda` commands
-** `rpk transform` commands
 +
 NOTE: The `rpk cloud` commands are not supported in self-hosted deployments.
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2556
Review deadline:

## Page previews
https://deploy-preview-565--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/cloud-overview/#redpanda-cloud-vs-self-hosted-feature-compatibility
<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)