### PR TITLE
add new cloud property cloud_storage_cache_trim_walk_concurrency

### DIFF
--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -611,6 +611,24 @@ The cache performs a recursive directory inspection during the cache trim. The i
 
 ---
 
+=== cloud_storage_cache_trim_walk_concurrency
+
+The maximum number of concurrent tasks launched for directory walk during cache trimming. A higher number allows cache trimming to run faster but can cause latency spikes due to increased pressure on I/O subsystem and syscall threads.
+
+*Requires restart:* No
+
+*Nullable:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `65535`]
+
+*Default:* `1`
+
+---
+
 === cloud_storage_chunk_eviction_strategy
 
 Selects a strategy for evicting unused cache chunks.

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -613,7 +613,7 @@ The cache performs a recursive directory inspection during the cache trim. The i
 
 === cloud_storage_cache_trim_walk_concurrency
 
-The maximum number of concurrent tasks launched for directory walk during cache trimming. A higher number allows cache trimming to run faster but can cause latency spikes due to increased pressure on I/O subsystem and syscall threads.
+The maximum number of concurrent tasks launched for traversing the directory structure during cache trimming. A higher number allows cache trimming to run faster but can cause latency spikes due to increased pressure on I/O subsystem and syscall threads.
 
 *Requires restart:* No
 


### PR DESCRIPTION
## Description

Updates with Redpanda v24.1.9

Review deadline: June 28

## Page previews

https://deploy-preview-570--redpanda-docs-preview.netlify.app/current/reference/properties/object-storage-properties/#cloud_storage_cache_trim_walk_concurrency



## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)