### PR TITLE
fix link

### DIFF
--- a/modules/reference/pages/rpk/rpk-debug/rpk-debug-bundle.adoc
+++ b/modules/reference/pages/rpk/rpk-debug/rpk-debug-bundle.adoc
@@ -100,13 +100,13 @@ supported, e.g. 3MB, 1GiB (default `20MB`).
 
 |-l, --label-selector |stringArray |Comma-separated label selectors to filter your resources. e.g: <label>=<value>,<label>=<value> (k8s only) (default ` [app.kubernetes.io/name=redpanda]`).
 
-|--logs-since |string |Include logs dated from specified date onward. This flag accepts a `journalctl` date format such as `YYYY-MM-DD`, `yesterday`, or `today`. Refer to the xref:https://man7.org/linux/man-pages/man1/journalctl.1.html[`journalctl` documentation] for more options (default `yesterday`).
+|--logs-since |string |Include logs dated from specified date onward. This flag accepts a `journalctl` date format such as `YYYY-MM-DD`, `yesterday`, or `today`. Refer to the link:https://man7.org/linux/man-pages/man1/journalctl.1.html[`journalctl` documentation] for more options (default `yesterday`).
 
 |--logs-size-limit |string |Read the logs until the given size is
 reached. Multipliers are also supported, e.g. 3MB, 1GiB (default
 `100MiB`).
 
-|--logs-until |string |Include logs older than the specified date. This flag accepts a `journalctl` date format such as `YYYY-MM-DD`, `yesterday`, or `today`. Refer to the xref:https://man7.org/linux/man-pages/man1/journalctl.1.html[`journalctl` documentation] for more options (default `yesterday`). +
+|--logs-until |string |Include logs older than the specified date. This flag accepts a `journalctl` date format such as `YYYY-MM-DD`, `yesterday`, or `today`. Refer to the link:https://man7.org/linux/man-pages/man1/journalctl.1.html[`journalctl` documentation] for more options (default `yesterday`). +
 *Not supported in Kubernetes*
 
 |--metrics-interval |duration |The amount of time to wait before


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)