### PR TITLE
Add QuestDB to partner-integration.adoc

### DIFF
--- a/modules/get-started/pages/partner-integration.adoc
+++ b/modules/get-started/pages/partner-integration.adoc
@@ -21,6 +21,7 @@ Learn about Redpanda integrations built and supported by our partners.
 | https://www.timeplus.com/[Timeplus^] |Timeplus is a stream processor that provides powerful end-to-end capabilities, leveraging the open source streaming engine Proton. | https://redpanda.com/blog/low-latency-streaming-analytics-timeplus-redpanda[Realizing low latency streaming analytics with Timeplus and Redpanda^]  
 | https://www.tinybird.co/[Tinybird^] |Tinybird is a data platform for data and engineering teams to solve complex real-time, operational, and user-facing analytics use cases at any scale. | https://www.tinybird.co/live-coding-sessions/end-to-end-iot-with-redpanda[Building a complete IoT backend with Redpanda and Tinybird^]
 | https://quix.io/[Quix^] |Quix is a complete platform for building, deploying, and monitoring stream processing pipelines in Python. | https://quix.io/docs/integrations/brokers/redpanda.html[Integrating Redpanda with Quix^]
+| https://questdb.io/[QuestDB^] |QuestDB is a fast open-source time-series database for financial market data and IoT. | https://questdb.io/docs/third-party-tools/redpanda/[Integrating Redpanda with QuestDB^]
 
 
 |===


### PR DESCRIPTION
## Description

Adding the following Redpanda partner: QuestDB

Existing Redpanda resources mentioning QuestDB:
- https://redpanda.com/blog/real-time-crypto-tracker-questdb-redpanda
- https://redpanda.com/blog/announcing-redpanda-serverless

QuestDB documentation section about Redpanda: https://questdb.io/docs/third-party-tools/redpanda/

## Page previews

https://deploy-preview-577--redpanda-docs-preview.netlify.app/current/get-started/partner-integration/

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)