### PR TITLE
add marketing as codeowners in partner integration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @redpanda-data/documentation  
+
+# Auto-add marketing as reviewers in partner integration page
+modules/get-started/pages/partner-integration.adoc @weimeilin79 @larsenpanda @mikebroberg


### PR DESCRIPTION
## Description

Adds marketing as codeowners in partner integration page

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)