### PR TITLE
#2562 Update broken link to point to correct fragment raft_replica_max_pending_flush_bytes and raft_replica_max_flush_delay_ms

### DIFF
--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -107,7 +107,7 @@ To enable write caching by default in all user topics, set the cluster-level pro
 
 `rpk cluster config set write_caching_default=true`
 
-With `write_caching_default` set to true at the cluster level, Redpanda fsyncs to disk according to xref:reference:cluster-properties.adoc#raft_replica_max_pending_flush_bytes[`raft_replica_max_pending_flush_bytes`] and xref:reference:cluster-properties.adoc#raftreplicamaxflushdelayms[`raft_replica_max_flush_delay_ms`], whichever is reached first.
+With `write_caching_default` set to true at the cluster level, Redpanda fsyncs to disk according to xref:reference:cluster-properties.adoc#raft_replica_max_pending_flush_bytes[`raft_replica_max_pending_flush_bytes`] and xref:reference:cluster-properties.adoc#raft_replica_max_flush_delay_ms[`raft_replica_max_flush_delay_ms`], whichever is reached first.
 
 ==== Configure at topic level
 

--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -107,7 +107,7 @@ To enable write caching by default in all user topics, set the cluster-level pro
 
 `rpk cluster config set write_caching_default=true`
 
-With `write_caching_default` set to true at the cluster level, Redpanda fsyncs to disk according to xref:reference:cluster-properties.adoc#raftreplicamaxpendingflushbytes[`raft_replica_max_pending_flush_bytes`] and xref:reference:cluster-properties.adoc#raftreplicamaxflushdelayms[`raft_replica_max_flush_delay_ms`], whichever is reached first.
+With `write_caching_default` set to true at the cluster level, Redpanda fsyncs to disk according to xref:reference:cluster-properties.adoc#raft_replica_max_pending_flush_bytes[`raft_replica_max_pending_flush_bytes`] and xref:reference:cluster-properties.adoc#raftreplicamaxflushdelayms[`raft_replica_max_flush_delay_ms`], whichever is reached first.
 
 ==== Configure at topic level
 

--- a/modules/manage/pages/kubernetes/k-manage-topics.adoc
+++ b/modules/manage/pages/kubernetes/k-manage-topics.adoc
@@ -194,7 +194,7 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 --
 ======
 
-With `write_caching` enabled at the cluster level, Redpanda fsyncs to disk according to xref:reference:cluster-properties.adoc#raftreplicamaxpendingflushbytes[`raft_replica_max_pending_flush_bytes`] and xref:reference:cluster-properties.adoc#raftreplicamaxflushdelayms[`raft_replica_max_flush_delay_ms`], whichever is reached first.
+With `write_caching` enabled at the cluster level, Redpanda fsyncs to disk according to xref:reference:cluster-properties.adoc#raft_replica_max_pending_flush_bytes[`raft_replica_max_pending_flush_bytes`] and xref:reference:cluster-properties.adoc#raft_replica_max_flush_delay_ms[`raft_replica_max_flush_delay_ms`], whichever is reached first.
 
 ==== Configure at topic level
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -5542,7 +5542,7 @@ Timeout to wait for leadership in metadata cache.
 
 === write_caching_default
 
-The default write caching mode to apply to user topics. Write caching acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to be written to disk. With `acks=all`, this provides lower latency while still ensuring that a majority of brokers acknowledge the write. Fsyncs follow <<`raft_replica_max_pending_flush_bytes`>> and <<`raft_replica_max_flush_delay_ms`>>, whichever is reached first.
+The default write caching mode to apply to user topics. Write caching acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to be written to disk. With `acks=all`, this provides lower latency while still ensuring that a majority of brokers acknowledge the write. Fsyncs follow <<raft_replica_max_pending_flush_bytes,`raft_replica_max_pending_flush_bytes`>> and <<raft_replica_max_flush_delay_ms,`raft_replica_max_flush_delay_ms`>>, whichever is reached first.
 
 The `write_caching_default` cluster property can be overridden with the xref:topic-properties.adoc#writecaching[`write.caching`] topic property.
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -15,10 +15,10 @@ NOTE: All topic properties take effect immediately after being set.
 | xref:./cluster-properties.adoc#log_cleanup_policy[`log_cleanup_policy`]
 
 | <<flushbytes,`flush.bytes`>>
-| xref:./cluster-properties.adoc#raftreplicamaxpendingflushbytes[`raft_replica_max_pending_flush_bytes`]
+| xref:./cluster-properties.adoc#raft_replica_max_pending_flush_bytes[`raft_replica_max_pending_flush_bytes`]
 
 | <<flushms,`flush.ms`>>
-| xref:./cluster-properties.adoc#raftreplicamaxflushdelayms[`raft_replica_max_flush_delay_ms`]
+| xref:./cluster-properties.adoc#raft_replica_max_flush_delay_ms[`raft_replica_max_flush_delay_ms`]
 
 | <<initialretentionlocaltargetms,`initial.retention.local.target.ms`>>
 | xref:./cluster-properties.adoc#initial_retention_local_target_ms_default[`initial_retention_local_target_ms_default`]


### PR DESCRIPTION
## Description

[Resolves https://github.com/redpanda-data/documentation-private/issues/#2562](https://github.com/redpanda-data/documentation-private/issues/2562)
Review deadline: 28 June

## Page previews

Previews:

- [Manage topics](https://deploy-preview-580--redpanda-docs-preview.netlify.app/current/develop/config-topics/#configure-write-caching)
- [Cluster configuration properties](https://deploy-preview-580--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/)
- [Topic configuration properties](https://deploy-preview-580--redpanda-docs-preview.netlify.app/current/reference/properties/topic-properties/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)