### PR TITLE
[Tiered Storage] Add rpk topic describe-storage to doc

### DIFF
--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1068,7 +1068,7 @@ You can configure Redpanda to start a remote write periodically. This is useful 
 
 Setting idle timeout to a very short interval can create a lot of small files, which can affect throughput. If you decide to set a value for idle timeout, start with 600 seconds, which prevents the creation of so many small files that throughput is affected when you recover the files.
 
-Use the xref:reference:properties/object-storage-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] property to set the number of seconds for idle timeout. If this property is empty, Redpanda uploads metadata to object storage, but the segment is not uploaded until it reaches the `segment.bytes` size. By default, `cloud_storage_segment_max_upload_interval_sec` is set to one hour (3600 seconds).
+Use the xref:reference:properties/object-storage-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] property to set the number of seconds for idle timeout. If this property is set to null, Redpanda uploads metadata to object storage, but the segment is not uploaded until it reaches the `segment.bytes` size.
 
 === Reconciliation
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1049,7 +1049,16 @@ rpk topic alter-config <topic_name> --set redpanda.remote.write=true
 
 If remote write is enabled, log segments are not deleted until they're uploaded to object storage. Because of this, the log segments may exceed the configured retention period until they're uploaded, so the topic might require more disk space. This prevents data loss if segments cannot be uploaded fast enough or if the retention period is very short.
 
-TIP: A constant stream of data is necessary to build up the log segments and roll them into object storage. To see new log segments faster, you can edit the `segment.bytes` topic-level property. Or, you can edit the config_ref:cloud_storage_segment_max_upload_interval_sec,true,tunable-properties[] cluster-level property, which sets the frequency with which new segments are generated in Tiered Storage, even if the local segment has not exceeded the `segment.bytes` size or the `segment.ms` age.
+To see the object storage status for a given topic:
+
+[,bash]
+----
+rpk topic describe-storage <topic_name> --print-all
+----
+
+See the xref:reference/rpk/rpk-topic-describe-storage.adoc[reference] for a list of flags you can use to filter the command output.
+
+TIP: A constant stream of data is necessary to build up the log segments and roll them into object storage. To see new log segments faster, you can edit the `segment.bytes` topic-level property. Or, you can edit the xref:reference:properties/object-storage-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] property, which sets the frequency with which new segments are generated in Tiered Storage, even if the local segment has not exceeded the `segment.bytes` size or the `segment.ms` age.
 
 NOTE: Starting in version 22.3, when you delete a topic in Redpanda, the data is also deleted in object storage. See <<Enable Tiered Storage for specific topics>>.
 
@@ -1059,7 +1068,7 @@ You can configure Redpanda to start a remote write periodically. This is useful 
 
 Setting idle timeout to a very short interval can create a lot of small files, which can affect throughput. If you decide to set a value for idle timeout, start with 600 seconds, which prevents the creation of so many small files that throughput is affected when you recover the files.
 
-Use the config_ref:cloud_storage_segment_max_upload_interval_sec,true,tunable-properties[] property to set the number of seconds for idle timeout. If this property is empty, Redpanda uploads metadata to object storage, but the segment is not uploaded until it reaches the `segment.bytes` size. By default, the property is null.
+Use the xref:reference:properties/object-storage-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] property to set the number of seconds for idle timeout. If this property is empty, Redpanda uploads metadata to object storage, but the segment is not uploaded until it reaches the `segment.bytes` size. By default, `cloud_storage_segment_max_upload_interval_sec` is set to one hour (3600 seconds).
 
 === Reconciliation
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1056,7 +1056,7 @@ To see the object storage status for a given topic:
 rpk topic describe-storage <topic_name> --print-all
 ----
 
-See the xref:reference/rpk/rpk-topic-describe-storage.adoc[reference] for a list of flags you can use to filter the command output.
+See the xref:reference:rpk/rpk-topic/rpk-topic-describe-storage.adoc[reference] for a list of flags you can use to filter the command output.
 
 TIP: A constant stream of data is necessary to build up the log segments and roll them into object storage. To see new log segments faster, you can edit the `segment.bytes` topic-level property. Or, you can edit the xref:reference:properties/object-storage-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] property, which sets the frequency with which new segments are generated in Tiered Storage, even if the local segment has not exceeded the `segment.bytes` size or the `segment.ms` age.
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/1775
Review deadline: **3 July 2024**

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)