### PR TITLE
[Tiered Storage] Clarify behavior for topics that already contain data

### DIFF
--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -843,6 +843,8 @@ For additional properties, see <<Tiered Storage configuration properties>>.
 * <<Enable Tiered Storage for a cluster>>
 * <<Enable Tiered Storage for specific topics>>
 
+When Tiered Storage is enabled on a topic already containing data, it will proceed to upload any existing data in that topic on local storage to the object store bucket. It will start from the earliest offset available on local disk.
+
 ==== Enable Tiered Storage for a cluster
 
 To enable Tiered Storage for a cluster (in addition to setting `cloud_storage_enabled` to `true`), set the following cluster-level properties to `true`:

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -843,14 +843,14 @@ For additional properties, see <<Tiered Storage configuration properties>>.
 * <<Enable Tiered Storage for a cluster>>
 * <<Enable Tiered Storage for specific topics>>
 
-When Tiered Storage is enabled on a topic already containing data, it will proceed to upload any existing data in that topic on local storage to the object store bucket. It will start from the earliest offset available on local disk.
+When you enable Tiered Storage on a topic already containing data, Redpanda uploads any existing data in that topic on local storage to the object store bucket. It will start from the earliest offset available on local disk. It is strongly recommended to avoid repeatedly toggling remote write on and off, because this can result in inconsistent data and data gaps in Tiered Storage for a topic.
 
 ==== Enable Tiered Storage for a cluster
 
 To enable Tiered Storage for a cluster (in addition to setting `cloud_storage_enabled` to `true`), set the following cluster-level properties to `true`:
 
-* config_ref:cloud_storage_enable_remote_write,true,tunable-properties[]
-* config_ref:cloud_storage_enable_remote_read,true,tunable-properties[]
+* config_ref:cloud_storage_enable_remote_write,true,properties/object-storage-properties[]
+* config_ref:cloud_storage_enable_remote_read,true,properties/object-storage-properties[]
 
 When you enable Tiered Storage for a cluster, you enable it for all existing topics in the cluster. When cluster-level properties are changed, the changes apply only to new topics, not existing topics.
 
@@ -1029,9 +1029,9 @@ Third-party tools that query space utilization from the Redpanda cluster might n
 
 Remote write is the process that constantly uploads log segments to object storage. The process is created for each partition and runs on the leader broker of the partition. It only uploads the segments that contain offsets that are smaller than the last stable offset. This is the latest offset that the client can read.
 
-To ensure all data is uploaded, you must enable remote write before any data is produced to the topic. If remote write is not enabled, data may be deleted due to retention settings.
+To ensure all data is uploaded, you must enable remote write before any data is produced to the topic. If you enable remote write after data has been written to the topic, only the data that currently exists on disk based on local retention settings will be scheduled for uploading. It is also strongly recommended to avoid repeatedly toggling remote write on and off, because this can result in inconsistent data and data gaps in Tiered Storage for a topic.
 
-To enable Tiered Storage, use remote write and remote read.
+To enable Tiered Storage, use both remote write and remote read.
 
 NOTE: If you only enable remote write on a topic, you have a simple backup that you can use for recovery. See xref:{data-archiving-link}[Data Archiving].
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -843,7 +843,7 @@ For additional properties, see <<Tiered Storage configuration properties>>.
 * <<Enable Tiered Storage for a cluster>>
 * <<Enable Tiered Storage for specific topics>>
 
-When you enable Tiered Storage on a topic already containing data, Redpanda uploads any existing data in that topic on local storage to the object store bucket. It will start from the earliest offset available on local disk. It is strongly recommended to avoid repeatedly toggling remote write on and off, because this can result in inconsistent data and data gaps in Tiered Storage for a topic.
+When you enable Tiered Storage on a topic already containing data, Redpanda uploads any existing data in that topic on local storage to the object store bucket. It will start from the earliest offset available on local disk. Redpanda strongly recommends that you avoid repeatedly toggling remote write on and off, because this can result in inconsistent data and data gaps in Tiered Storage for a topic.
 
 ==== Enable Tiered Storage for a cluster
 
@@ -1029,7 +1029,7 @@ Third-party tools that query space utilization from the Redpanda cluster might n
 
 Remote write is the process that constantly uploads log segments to object storage. The process is created for each partition and runs on the leader broker of the partition. It only uploads the segments that contain offsets that are smaller than the last stable offset. This is the latest offset that the client can read.
 
-To ensure all data is uploaded, you must enable remote write before any data is produced to the topic. If you enable remote write after data has been written to the topic, only the data that currently exists on disk based on local retention settings will be scheduled for uploading. It is also strongly recommended to avoid repeatedly toggling remote write on and off, because this can result in inconsistent data and data gaps in Tiered Storage for a topic.
+To ensure all data is uploaded, you must enable remote write before any data is produced to the topic. If you enable remote write after data has been written to the topic, only the data that currently exists on disk based on local retention settings will be scheduled for uploading. Redpanda strongly recommends that you avoid repeatedly toggling remote write on and off, because this can result in inconsistent data and data gaps in Tiered Storage for a topic.
 
 To enable Tiered Storage, use both remote write and remote read.
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2282
Review deadline: **3 July 2024**

## Page previews

[Tiered Storage > Enable Tiered Storage](https://deploy-preview-583--redpanda-docs-preview.netlify.app/current/manage/tiered-storage/#enable-tiered-storage)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)