### PR TITLE
Replace deprecated installCRDs option for cert-manager

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -50,7 +50,7 @@ You need these cluster-level permissions to install glossterm:cert-manager[^] an
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 helm install cert-manager jetstack/cert-manager \
-  --set installCRDs=true \
+  --set crds.enabled=true \
   --namespace cert-manager  \
   --create-namespace
 ```
@@ -194,7 +194,7 @@ Helm::
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 helm install cert-manager jetstack/cert-manager \
-  --set installCRDs=true \
+  --set crds.enabled=true \
   --namespace cert-manager  \
   --create-namespace
 ```

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
@@ -144,7 +144,7 @@ You need these cluster-level permissions to install glossterm:cert-manager[] and
 ```bash
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
-helm install cert-manager jetstack/cert-manager --set installCRDs=true --namespace cert-manager --create-namespace
+helm install cert-manager jetstack/cert-manager --set crds.enabled=true --namespace cert-manager --create-namespace
 ```
 +
 TLS is enabled by default. The Redpanda Helm chart uses cert-manager to manage TLS certificates by default.
@@ -233,7 +233,7 @@ Helm::
 helm repo add redpanda https://charts.redpanda.com
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
-helm install cert-manager jetstack/cert-manager  --set installCRDs=true --namespace cert-manager  --create-namespace
+helm install cert-manager jetstack/cert-manager  --set crds.enabled=true --namespace cert-manager  --create-namespace
 ```
 +
 The Redpanda Helm chart uses cert-manager to manage TLS certificates.

--- a/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
+++ b/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
@@ -24,7 +24,7 @@ You need these cluster-level permissions to install glossterm:cert-manager[] and
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 helm install cert-manager jetstack/cert-manager \
-  --set installCRDs=true \
+  --set crds.enabled=true \
   --namespace cert-manager  \
   --create-namespace
 ```
@@ -127,7 +127,7 @@ Helm::
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 helm install cert-manager jetstack/cert-manager \
-  --set installCRDs=true \
+  --set crds.enabled=true \
   --namespace cert-manager \
   --create-namespace
 ```


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2571
Review deadline: 5 July

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)