### PR TITLE
clarify maintenance window times are in UTC

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -169,7 +169,7 @@ BYOC with customer-managed VPC::
 
 == Maintenance windows
 
-By default, all Redpanda Cloud upgrades take place on Tuesdays. Optionally, on the **Cluster settings** page, you can select a window of specific off-hours for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC). Updates may start at any time during that window. 
+By default, Redpanda Cloud upgrades take place on Tuesdays. Optionally, on the **Cluster settings** page, you can select a window of specific off-hours for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC). Updates may start at any time during that window. 
 
 == Redpanda Cloud architecture
 

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -223,6 +223,8 @@ Redpanda Cloud does not support the following self-hosted functionality:
 - Admin API
 - The following `rpk` commands:
 
+** `rpk connect` commands
+** `rpk redpanda` commands
 ** `rpk cluster config`
 ** `rpk cluster health`
 ** `rpk cluster license`
@@ -230,12 +232,10 @@ Redpanda Cloud does not support the following self-hosted functionality:
 ** `rpk cluster partitions`
 ** `rpk cluster self-test`
 ** `rpk cluster storage`
-** `rpk generate app`
-** `rpk security user`
+** `rpk generate app` (supported in Serverless clusters)
+** `rpk security user` (supported in Serverless clusters)
 ** `rpk topic describe-storage` (all other `rpk topic` commands are supported)
 ** `rpk transform` (currently in beta for Redpanda Cloud)
-** `rpk connect` commands
-** `rpk redpanda` commands
 +
 NOTE: The `rpk cloud` commands are not supported in self-hosted deployments.
 

--- a/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/cloud-overview.adoc
@@ -167,6 +167,10 @@ BYOC with customer-managed VPC::
 --
 =====
 
+== Maintenance windows
+
+By default, all Redpanda Cloud upgrades take place on Tuesdays. Optionally, on the **Cluster settings** page, you can select a window of specific off-hours for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC). Updates may start at any time during that window. 
+
 == Redpanda Cloud architecture
 
 When you sign up for a Redpanda account, Redpanda creates an organization for you. Your organization contains all your Redpanda resources, including your clusters and networks. Within your organization, Redpanda creates a default resource group to contain your resources. You can rename this resource group, and you can create more resource groups. For example, you may want different resource groups for production and testing. 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -97,4 +97,4 @@ In the Redpanda Console UI, you can xref:manage:schema-registry.adoc[perform Sch
 
 === Maintenance windows
 
-With maintenance windows, you have greater flexibility to plan upgrades to your cluster. By default, all Redpanda Cloud upgrades take place on Tuesdays. Optionally, on the **Cluster settings** page, you can select a window of specific off-hours for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC). Updates may start at any time during that window. 
+With maintenance windows, you have greater flexibility to plan upgrades to your cluster. By default, Redpanda Cloud upgrades take place on Tuesdays. Optionally, on the **Cluster settings** page, you can select a window of specific off-hours for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC). Updates may start at any time during that window. 

--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -97,4 +97,4 @@ In the Redpanda Console UI, you can xref:manage:schema-registry.adoc[perform Sch
 
 === Maintenance windows
 
-With maintenance windows, you have greater flexibility to plan upgrades to your cluster. By default, all Redpanda Cloud upgrades take place anytime on Tuesdays. Optionally, on the **Cluster settings** page, you can select a window of specific off-hours for your business for Redpanda to apply updates. Updates may start at any time during that window.
+With maintenance windows, you have greater flexibility to plan upgrades to your cluster. By default, all Redpanda Cloud upgrades take place on Tuesdays. Optionally, on the **Cluster settings** page, you can select a window of specific off-hours for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC). Updates may start at any time during that window. 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2576

This clarifies that maintenance windows are in UTC and added the content about maintenance windows to the Cloud Overview for visibility. Also in the overview, where we list rpk commands not supported in cloud, this now notes that `rpk security user` and `rpk generate app` are supported in Serverless clusters. 

Review deadline: Tuesday, July 9

## Page previews
[What's New](https://deploy-preview-593--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/whats-new-cloud/#november-2023): Clarify time is UTC
[Cloud Overview](https://deploy-preview-593--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/cloud-overview/#maintenance-windows): Add maintentance windows here (so it's not only in What's New) 
[Cloud  vs self-hosted feature compatibility](https://deploy-preview-593--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/cloud/cloud-overview/#redpanda-cloud-vs-self-hosted-feature-compatibility)
<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)