### PR TITLE
update properties with 24.2.1

### DIFF
--- a/modules/manage/pages/security/fips-compliance.adoc
+++ b/modules/manage/pages/security/fips-compliance.adoc
@@ -56,9 +56,9 @@ Available `fips_mode` values are:
 
 You must specify the following SSL configurations for brokers you want to run in FIPS compliance mode: 
 
-* `openssl_config_file`: Specifies the path to the OpenSSL configuration file that was created as part of the `redpanda-fips` package installation.  This file is used when OpenSSL is initialized to find the `fipsmodule.cnf` file that was created by the `openssl fipsinstall` command. Typically, this value should be `/opt/redpanda/openssl/openssl.cnf`.
+* xref:reference:properties/broker-properties.adoc#openssl_config_file[`openssl_config_file`]: Specifies the path to the OpenSSL configuration file that was created as part of the `redpanda-fips` package installation.  This file is used when OpenSSL is initialized to find the `fipsmodule.cnf` file that was created by the `openssl fipsinstall` command. Typically, this value should be `/opt/redpanda/openssl/openssl.cnf`.
 
-* `openssl_module_directory`: Specifies the path to the directory that contains the `fips.so` cryptographic provider. Typically, this value should be: `/opt/redpanda/lib/ossl-modules/`.
+* xref:reference:properties/broker-properties.adoc#openssl_module_directory[`openssl_module_directory`]: Specifies the path to the directory that contains the `fips.so` cryptographic provider. Typically, this value should be: `/opt/redpanda/lib/ossl-modules/`.
 +
 The following configuration starts Redpanda in FIPS mode: 
 +

--- a/modules/manage/partials/internal-use-property.adoc
+++ b/modules/manage/partials/internal-use-property.adoc
@@ -1,1 +1,0 @@
-WARNING: This property is for Redpanda internal use only. Do not use or modify this property unless specifically instructed to do so by [https://support.redpanda.com/hc/en-us[Redpanda](https://support.redpanda.com/hc/en-us%5BRedpanda) Support^]. Using this property without explicit guidance from Redpanda Support could result in data loss.

--- a/modules/reference/pages/properties/broker-properties.adoc
+++ b/modules/reference/pages/properties/broker-properties.adoc
@@ -216,6 +216,34 @@ CAUTION: The `node_id` property must not be changed after a broker joins the clu
 
 ---
 
+=== openssl_config_file
+
+Path to the configuration file used by OpenSSL to properly load the FIPS-compliant module.
+
+*Optional:* Yes
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
+
+---
+
+=== openssl_module_directory
+
+Path to the directory that contains the OpenSSL FIPS-compliant module.
+
+*Optional:* Yes
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
+
+---
+
 === rack
 
 A label that identifies a failure zone. Apply the same label to all brokers in the same failure zone. When xref:./cluster-properties.adoc#enable_rack_awareness[enable_rack_awareness] is set to `true` at the cluster level, the system uses the rack labels to spread partition replicas across different failure zones.

--- a/modules/reference/pages/properties/broker-properties.adoc
+++ b/modules/reference/pages/properties/broker-properties.adoc
@@ -232,7 +232,7 @@ Path to the configuration file used by OpenSSL to properly load the FIPS-complia
 
 === openssl_module_directory
 
-Path to the directory that contains the OpenSSL FIPS-compliant module.
+Path to the directory that contains the OpenSSL FIPS-compliant module. The filename that Redpanda looks for is `fips.so`.
 
 *Optional:* Yes
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -810,6 +810,8 @@ The amount of memory to give an instance of a Data Transform (Wasm) virtual mach
 
 === data_transforms_read_buffer_memory_percentage
 
+include::reference:partial$internal-use-property.adoc[]
+
 The percentage of available memory in the transform subsystem to use for read buffers.
 
 *Requires restart:* Yes
@@ -845,6 +847,8 @@ The maximum amount of runtime to start up a data transform, and the time it take
 ---
 
 === data_transforms_write_buffer_memory_percentage
+
+include::reference:partial$internal-use-property.adoc[]
 
 The percentage of available memory in the transform subsystem to use for write buffers.
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -562,6 +562,58 @@ Maximum amount of time before Redpanda attempts to create a controller snapshot 
 
 ---
 
+=== core_balancing_continuous
+
+If set to `true`, move partitions between cores in runtime to maintain balanced partition distribution.
+
+*Requires restart:* No
+
+*Optional:* No
+
+*Visibility:* `user`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== core_balancing_debounce_timeout
+
+Interval, in milliseconds, between trigger and invocation of core balancing.
+
+*Unit*: milliseconds
+
+*Requires restart:* No
+
+*Optional:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `10000`
+
+---
+
+=== core_balancing_on_core_count_change
+
+If set to `true`, and if after a restart the number of cores changes, Redpanda will move partitions between cores to maintain balanced partition distribution.
+
+*Requires restart:* No
+
+*Optional:* No
+
+*Visibility:* `user`
+
+*Type:* boolean
+
+*Default:* `true`
+
+---
+
 === cpu_profiler_enabled
 
 Enables CPU profiling for Redpanda.
@@ -756,6 +808,22 @@ The amount of memory to give an instance of a Data Transform (Wasm) virtual mach
 
 ---
 
+=== data_transforms_read_buffer_memory_percentage
+
+The percentage of available memory in the transform subsystem to use for read buffers.
+
+*Requires restart:* Yes
+
+*Optional:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Default:* `45`
+
+---
+
 === data_transforms_runtime_limit_ms
 
 The maximum amount of runtime to start up a data transform, and the time it takes for a single record to be transformed.
@@ -773,6 +841,22 @@ The maximum amount of runtime to start up a data transform, and the time it take
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
 *Default:* `3000`
+
+---
+
+=== data_transforms_write_buffer_memory_percentage
+
+The percentage of available memory in the transform subsystem to use for write buffers.
+
+*Requires restart:* Yes
+
+*Optional:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Default:* `45`
 
 ---
 
@@ -5168,9 +5252,7 @@ Target quota byte rate.
 
 The `target_quota_byte_rate` property applies to a producer client that isn't a member of a client group configured by <<kafka_client_group_byte_rate_quota,`kafka_client_group_byte_rate_quota`>>. It sets the maximum throughput quota of a client sending to a Redpanda broker node.
 
-*Related topics*:
-
-* xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[Client throughput limits]
+When set to 0, this property is disabled. 
 
 *Unit*: bytes per second
 
@@ -5184,7 +5266,11 @@ The `target_quota_byte_rate` property applies to a producer client that isn't a 
 
 *Accepted values:* [`0`, `4294967295`]
 
-*Default:* `2147483648`
+*Default:* `0`
+
+*Related topics*:
+
+* xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[Client throughput limits]
 
 ---
 
@@ -5371,26 +5457,6 @@ Expiration time of producer IDs. Measured starting from the time of the last wri
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
 *Default:* `604800000` (10080min)
-
----
-
-=== tx_log_stats_interval_s
-
-How often to log per partition tx stats, works only with debug logging enabled.
-
-*Unit:* seconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17179869184`, `17179869183`]
-
-*Default:* `10`
 
 ---
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -629,7 +629,7 @@ The cache performs a recursive directory inspection during the cache trim. The i
 
 === cloud_storage_cache_trim_threshold_percent_objects
 
-Trim is triggered when the cache reaches this percent of the maximum object count. If this is unset, the default behavior is to start trim when the cache is about 100% full.
+Cache trimming is triggered when the number of objects in the cache reaches this percentage relative to it's maximum object count. If unset, the default behavior is to start trimming when the cache is full.
 
 *Requires restart:* No
 
@@ -645,7 +645,7 @@ Trim is triggered when the cache reaches this percent of the maximum object coun
 
 === cloud_storage_cache_trim_threshold_percent_size
 
-Trim is triggered when the cache reaches this percent of the maximum cache size. If this is unset, the default behavior is to start trim when the cache is about 100% full.
+Cache trimming is triggered when the cache size reaches this percentage relative to it's maximum capacity. If unset, the default behavior is to start trimming when the cache is full.
 
 *Requires restart:* No
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -629,7 +629,7 @@ The cache performs a recursive directory inspection during the cache trim. The i
 
 === cloud_storage_cache_trim_threshold_percent_objects
 
-Cache trimming is triggered when the number of objects in the cache reaches this percentage relative to it's maximum object count. If unset, the default behavior is to start trimming when the cache is full.
+Cache trimming is triggered when the number of objects in the cache reaches this percentage relative to its maximum object count. If unset, the default behavior is to start trimming when the cache is full.
 
 *Requires restart:* No
 
@@ -645,7 +645,7 @@ Cache trimming is triggered when the number of objects in the cache reaches this
 
 === cloud_storage_cache_trim_threshold_percent_size
 
-Cache trimming is triggered when the cache size reaches this percentage relative to it's maximum capacity. If unset, the default behavior is to start trimming when the cache is full.
+Cache trimming is triggered when the cache size reaches this percentage relative to its maximum capacity. If unset, the default behavior is to start trimming when the cache is full.
 
 *Requires restart:* No
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -129,9 +129,9 @@ Time interval to wait between cluster metadata uploads.
 The source of credentials used to authenticate to object storage services.
 Required for AWS and GCS authentication with IAM roles.
 
-To authenticate using access keys, see <<cloud_storage_access_key>>.
+To authenticate using access keys, see <<cloud_storage_access_key,`cloud_storage_access_key`>>.
 
-*Valid values*: `config_file`, `aws_instance_metadata`, `sts, gcp_instance_metadata`, `azure_vm_instance_metadata`, `azure_aks_oidc_federation`
+*Accepted values*: `config_file`, `aws_instance_metadata`, `sts, gcp_instance_metadata`, `azure_vm_instance_metadata`, `azure_aks_oidc_federation`
 
 *Requires restart:* Yes
 
@@ -140,6 +140,22 @@ To authenticate using access keys, see <<cloud_storage_access_key>>.
 *Visibility:* `user`
 
 *Default:* `config_file`
+
+---
+
+=== cloud_storage_crl_file
+
+Path to certificate revocation list for <<cloud_storage_trust_file, `cloud_storage_trust_file`>>.
+
+*Requires Restart:* No
+
+*Optional:* Yes
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
 
 ---
 
@@ -599,7 +615,7 @@ The cache performs a recursive directory inspection during the cache trim. The i
 
 *Requires restart:* No
 
-*Nullable:* No
+*Optional:* No
 
 *Visibility:* `tunable`
 
@@ -608,6 +624,38 @@ The cache performs a recursive directory inspection during the cache trim. The i
 *Accepted values:* [`0`, `4294967295`]
 
 *Default:* `262144`
+
+---
+
+=== cloud_storage_cache_trim_threshold_percent_objects
+
+Trim is triggered when the cache reaches this percent of the maximum object count. If this is unset, the default behavior is to start trim when the cache is about 100% full.
+
+*Requires restart:* No
+
+*Optional:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_cache_trim_threshold_percent_size
+
+Trim is triggered when the cache reaches this percent of the maximum cache size. If this is unset, the default behavior is to start trim when the cache is about 100% full.
+
+*Requires restart:* No
+
+*Optional:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `null`
 
 ---
 
@@ -1626,5 +1674,32 @@ Maximum backoff interval when there is nothing to upload for a partition, in mil
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
 *Default:* `10000`
+
+---
+
+=== cloud_storage_url_style
+
+Specifies the addressing style to use for Amazon S3 requests. 
+
+This configuration determines how S3 bucket URLs are formatted. You can choose between: 
+* `virtual_host` - Example: `<bucket-name>.s3.amazonaws.com` 
+* `path` - Example: `s3.amazonaws.com/<bucket-name>`
+* `null`
+
+Path style is supported for backward compatibility with legacy systems. 
+
+When this property is not set (`null`), the client tries to use `virtual_host` addressing. 
+
+If the initial request fails, the client automatically tries the `path` style. 
+
+If neither addressing style works, Redpanda terminates the startup, requiring manual configuration to proceed.
+
+*Requires restart:* Yes
+
+*Optional:* Yes
+
+*Visibility:* `user`
+
+*Default:* `null`
 
 ---

--- a/modules/reference/partials/internal-use-property.adoc
+++ b/modules/reference/partials/internal-use-property.adoc
@@ -1,0 +1,1 @@
+WARNING: This property is for Redpanda internal use only. Do not use or modify this property unless specifically instructed to do so by https://support.redpanda.com/hc/en-us[Redpanda Support^]. Using this property without explicit guidance from Redpanda Support could result in data loss.

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -207,6 +207,8 @@ This is an exhaustive list of all the deprecated properties.
 
 - transaction_coordinator_replication
 
+- tx_log_stats_interval_s
+
 - tx_registry_log_capacity
 
 - tx_registry_sync_timeout_ms

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@antora/cli": "3.1.2",
         "@antora/site-generator": "3.1.2",
         "@asciidoctor/tabs": "^1.0.0-beta.5",
-        "@redpanda-data/docs-extensions-and-macros": "latest"
+        "@redpanda-data/docs-extensions-and-macros": "^3.5.5"
       },
       "devDependencies": {
         "@web/dev-server": "^0.2.1",


### PR DESCRIPTION
## Description

Adds properties for 24.2.

## Changelog

### New properties
#### Broker properties

openssl_config_file
openssl_module_directory

#### Object Storage properties

cloud_storage_crl_file
cloud_storage_cache_trim_threshold_percent_objects
cloud_storage_cache_trim_threshold_percent_size
cloud_storage_url_style

#### Cluster Properties
core_balancing_continuous
core_balancing_debounce_timeout
core_balancing_on_core_count_change
data_transforms_read_buffer_memory_percentage
data_transforms_write_buffer_memory_percentage


### Deprecations

#### Cluster properties
tx_log_stats_interval_s

### Description changes

#### Cluster properties
target_quota_byte_rate


## Page previews

https://deploy-preview-594--redpanda-docs-preview.netlify.app/24.2/reference/properties/broker-properties/
https://deploy-preview-594--redpanda-docs-preview.netlify.app/24.2/reference/properties/cluster-properties/
https://deploy-preview-594--redpanda-docs-preview.netlify.app/24.2/reference/properties/object-storage-properties/

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)