### PR TITLE
Add topic refresh interval to self-hosted MM2 migration config

### DIFF
--- a/modules/upgrade/pages/migrate/data-migration.adoc
+++ b/modules/upgrade/pages/migrate/data-migration.adoc
@@ -75,6 +75,9 @@ replication.factor = 1
 //Make sure that your target cluster can accept larger message sizes. For example, 30MB messages
 <cluster_name_2>.producer.max.request.size=31457280
 
+//Set the frequency at which to check the source cluster for new topics (default is 10 minutes)
+refresh.topics.interval.seconds = 5
+
 //Make sure topics are created without a prefix
 replication.policy.class=org.apache.kafka.connect.mirror.IdentityReplicationPolicy
 EOF


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/1851
Review deadline: **July 12, 2024**

## Page previews
https://deploy-preview-596--redpanda-docs-preview.netlify.app/current/upgrade/migrate/data-migration/#create-the-mirrormaker-2-configuration-files

## Checks

- [ ] New feature
- [ X] Content gap
- [ X] Support Follow-up
- [ X] Small fix (typos, links, copyedits, etc)