### PR TITLE
remove superfluous info out of install beta

### DIFF
--- a/modules/get-started/pages/install-beta.adoc
+++ b/modules/get-started/pages/install-beta.adoc
@@ -147,8 +147,6 @@ sudo apt-get install redpanda
 ```
 ====
 
-See https://hub.docker.com/r/redpandadata/redpanda-unstable/tags[dockerhub^] for the list of RC builds.
-
 --
 Kubernetes::
 +


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)