### PR TITLE
connectors: extended Troubleshoot section for JDBC connectors

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-sink-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-sink-connector.adoc
@@ -233,5 +233,5 @@ Select *Show Logs* to view error details.
 | The JDBC Sink connector is not compatible with the Debezium PostgreSQL Source connector. Kafka Connect JSON produced by the Debezium Connector is not compatible with what the JDBC Sink Connector is expecting. Try changing a topic name. The JDBC Source connector is compatible with the JDBC Sink connector, and can be used as an alternative for a Debezium PostgreSQL source connector.
 
 | *java.sql.SQLException: No suitable driver found for*
-| There is no suitable JDBC driver available for given database type. The database type is not supported by the connector.
+| There is no suitable JDBC driver available for the given database type. The connector does not support the database type. 
 |===

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-sink-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-sink-connector.adoc
@@ -20,9 +20,13 @@ The JDBC Sink connector has the following limitations:
 * Only `JSON` or `AVRO` formats can be used as a value converter.
 * Only the following databases are supported:
 ** MySQL 5.7 and 8.0
+*** JDBC URL template: `jdbc:mysql://database:port`
 ** PostgreSQL 8.2 and higher using the version 3.0 of the PostgreSQL® protocol
+*** JDBC URL template: `jdbc:postgresql://database:port`
 ** SQLite
+*** JDBC URL template: `jdbc:sqlite://database:port`
 ** SQL Server - Microsoft SQL versions: Azure SQL Database, Azure Synapse Analytics, Azure SQL Managed Instance, SQL Server 2014, SQL Server 2016, SQL Server 2017, SQL Server 2019
+*** JDBC URL template: `jdbc:sqlserver://database:port`
 
 == Create a JDBC Sink connector
 
@@ -227,4 +231,7 @@ Select *Show Logs* to view error details.
 
 | *ConnectException: topic_name.Value (STRUCT) type doesn't have a mapping to the SQL database column type*
 | The JDBC Sink connector is not compatible with the Debezium PostgreSQL Source connector. Kafka Connect JSON produced by the Debezium Connector is not compatible with what the JDBC Sink Connector is expecting. Try changing a topic name. The JDBC Source connector is compatible with the JDBC Sink connector, and can be used as an alternative for a Debezium PostgreSQL source connector.
+
+| *java.sql.SQLException: No suitable driver found for*
+| There is no suitable JDBC driver available for given database type. The database type is not supported by the connector.
 |===

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-source-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-source-connector.adoc
@@ -17,9 +17,13 @@ The JDBC Source connector has the following limitations:
 * Only `JSON` or `AVRO` formats can be used as a value converter.
 * Only the following databases are supported:
 ** MySQL 5.7 and 8.0
+*** JDBC URL template: `jdbc:mysql://database:port`
 ** PostgreSQL 8.2 and higher using the version 3.0 of the PostgreSQL® protocol
+*** JDBC URL template: `jdbc:postgresql://database:port`
 ** SQLite
+*** JDBC URL template: `jdbc:sqlite://database:port`
 ** SQL Server - Microsoft SQL versions: Azure SQL Database, Azure Synapse Analytics, Azure SQL Managed Instance, SQL Server 2014, SQL Server 2016, SQL Server 2017, SQL Server 2019
+*** JDBC URL template: `jdbc:sqlserver://database:port`
 
 == Create a JDBC Source connector
 
@@ -240,4 +244,7 @@ a|
 . Make sure `Include tables` contains a valid tables list.
 . `Include tables` setting is case-sensitive, even though the underlying database isn't. Revise `Include tables = tablename` to `Include Tables`: `tableName`.
 . Postgres occasionally refuses a connection for the first time. Retry creating the connector.
+
+| *java.sql.SQLException: No suitable driver found for*
+| There is no suitable JDBC driver available for given database type. The database type is not supported by the connector.
 |===

--- a/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-source-connector.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/managed-connectors/create-jdbc-source-connector.adoc
@@ -246,5 +246,5 @@ a|
 . Postgres occasionally refuses a connection for the first time. Retry creating the connector.
 
 | *java.sql.SQLException: No suitable driver found for*
-| There is no suitable JDBC driver available for given database type. The database type is not supported by the connector.
+| There is no suitable JDBC driver available for the given database type. The connector does not support the database type.
 |===


### PR DESCRIPTION
Extended Troubleshoot section for JDBC connectors, added description for `No suitable driver found for` error

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)