### PR TITLE
[Admin API] Intra-broker partition balancing

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -851,6 +851,17 @@ paths:
         200:
           description: Success
           content: {}
+  /partitions/rebalance_cores:
+    post:
+      tags:
+      - Partitions
+      summary: Rebalance partitions among broker cores
+      description: Trigger an on-demand rebalancing of core assignment of partitions in this broker.
+      operationId: trigger_partitions_shard_rebalance
+      responses:
+        200:
+          description: Success
+          content: {}
   /partitions/reconfigurations:
     get:
       tags:
@@ -1013,6 +1024,44 @@ paths:
         required: true
         schema:
           type: integer
+      responses:
+        200:
+          description: Update partition replicas success
+          content: {}
+  /partitions/{namespace}/{topic}/{partition}/replicas/{node}:
+    post:
+      tags:
+      - Partitions
+      summary: Update partition replica core
+      description: Assign a partition replica to a broker core (shard).
+      operationId: set_partition_replica_core
+      parameters:
+      - name: namespace
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: topic
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: partition
+        in: path
+        required: true
+        schema:
+          type: integer
+      - name: node
+        in: path
+        required: true
+        schema:
+          type: integer
+      requestBody: 
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/core'
+        required: true 
       responses:
         200:
           description: Update partition replicas success
@@ -4276,6 +4325,13 @@ components:
           type: integer
           description: ID of a broker
           format: int32
+      description: Replica placement
+    core:
+      type: object
+      properties:
+        core:
+          type: number
+          description: Broker core
       description: Replica placement
     cluster_view:
       type: object

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -4332,7 +4332,7 @@ components:
         core:
           type: number
           description: Broker core
-      description: Replica placement
+      description: Broker core
     cluster_view:
       type: object
       properties:

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -1052,6 +1052,7 @@ paths:
         schema:
           type: integer
       - name: node
+        description: Broker ID
         in: path
         required: true
         schema:
@@ -1064,7 +1065,7 @@ paths:
         required: true 
       responses:
         200:
-          description: Update partition replicas success
+          description: Replica core updated successfully
           content: {}
   /partitions/{namespace}/{topic}/{partition}/transactions:
     get:


### PR DESCRIPTION
## Description

Related: https://github.com/redpanda-data/docs/pull/609
Review deadline: 24 July 2024

## Page previews

[POST /partitions/rebalance_cores](https://deploy-preview-615--redpanda-docs-preview.netlify.app/api/admin-api/#post-/partitions/rebalance_cores)
[POST /partitions/{namespace}/{topic}/{partition}/replicas/{node}](https://deploy-preview-615--redpanda-docs-preview.netlify.app/api/admin-api/#post-/partitions/-namespace-/-topic-/-partition-/replicas/-node-)


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)