### PR TITLE
Update rpk-connect-run.adoc

### DIFF
--- a/modules/reference/pages/rpk/rpk-connect/rpk-connect-run.adoc
+++ b/modules/reference/pages/rpk/rpk-connect/rpk-connect-run.adoc
@@ -6,14 +6,14 @@ Run Redpanda Connect in normal mode against a specified config file.
 
 [,bash]
 ----
-redpanda-connect run [command options] [arguments...]
+rpk connect run [command options] [arguments...]
 ----
 
 == Example
 
 [,bash]
 ----
-redpanda-connect run ./foo.yaml
+rpk connect run ./foo.yaml
 ----
 
 == Flags 


### PR DESCRIPTION
changed "redpanda-connect" to "rpk connect"

## Description

Fixing a command typo. Changing "redpanda-connect" to "rpk connect"


## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ x] Small fix (typos, links, copyedits, etc)