### PR TITLE
Add community-supported notice to Connectors Helm chart reference

### DIFF
--- a/modules/reference/pages/k-connector-helm-spec.adoc
+++ b/modules/reference/pages/k-connector-helm-spec.adoc
@@ -2,6 +2,8 @@
 
 :description: Find the default values and descriptions of settings in the Redpanda Connectors Helm chart.
 
+include::shared:partial$community-supported-connectors.adoc[]
+
 image:https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square[Version:
 0.1.11]
 image:https://img.shields.io/badge/Type-application-informational?style=flat-square[Type:


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2603
Review deadline: 25 July

## Page previews

[Preview](https://deploy-preview-624--redpanda-docs-preview.netlify.app/24.2/reference/k-connector-helm-spec/#:~:text=The%20Redpanda%20Connectors%20Docker%20image%20contains%20only%20the%20MirrorMaker2%20connector%20but%20you%20can%20build%20a%20custom%20image%20to%20install%20additional%20connectors.%20For%20a%20smoother%20experience%2C%20consider%20using%20the%20Managed%20Connectors%20available%20in%20Redpanda%20Cloud.)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)