### PR TITLE
[v23.2] rpk references: add caution for user update

### DIFF
--- a/modules/reference/pages/rpk/rpk-acl/rpk-acl-user-update.adoc
+++ b/modules/reference/pages/rpk/rpk-acl/rpk-acl-user-update.adoc
@@ -3,7 +3,7 @@
 
 Update SASL user credentials
 
-CAUTION: The default value for the `--mechanism` flag is `SCRAM-SHA-256`. Specify the flag when using a different mechanism to avoid unexpected changes.
+CAUTION: The default value for the `--mechanism` flag is `SCRAM-SHA-256`. Set the flag when using a different mechanism to avoid unexpected changes.
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-acl/rpk-acl-user-update.adoc
+++ b/modules/reference/pages/rpk/rpk-acl/rpk-acl-user-update.adoc
@@ -3,7 +3,7 @@
 
 Update SASL user credentials
 
-CAUTION: The default value for the --mechanism flag is SCRAM-SHA-256. Please specify the flag if you are using a different mechanism to avoid unexpected changes.
+CAUTION: The default value for the `--mechanism` flag is `SCRAM-SHA-256`. Specify the flag when using a different mechanism to avoid unexpected changes.
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-acl/rpk-acl-user-update.adoc
+++ b/modules/reference/pages/rpk/rpk-acl/rpk-acl-user-update.adoc
@@ -3,6 +3,8 @@
 
 Update SASL user credentials
 
+CAUTION: The default value for the --mechanism flag is SCRAM-SHA-256. Please specify the flag if you are using a different mechanism to avoid unexpected changes.
+
 == Usage
 
 [,bash]


### PR DESCRIPTION
This is fixed already, but it's better to add the
caution for users that might be using older rpk
versions

## Description

Fixes https://github.com/redpanda-data/documentation-private/issues/2585

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)