### PR TITLE
rpk references: add caution for user update

### DIFF
--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc
@@ -4,6 +4,8 @@
 
 Update SASL user credentials
 
+CAUTION: The default value for the `--mechanism` flag is `SCRAM-SHA-256`. Specify the flag when using a different mechanism to avoid unexpected changes.
+
 == Usage
 
 [,bash]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc
@@ -4,7 +4,7 @@
 
 Update SASL user credentials
 
-CAUTION: The default value for the `--mechanism` flag is `SCRAM-SHA-256`. Specify the flag when using a different mechanism to avoid unexpected changes.
+CAUTION: The default value for the `--mechanism` flag is `SCRAM-SHA-256`. Set the flag when using a different mechanism to avoid unexpected changes.
 
 == Usage
 


### PR DESCRIPTION
This is fixed already, but it's better to add the
caution for users that might be using older rpk
versions

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2585

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)