### PR TITLE
document incompatible change in AlterConfigs behavior

### DIFF
--- a/modules/upgrade/pages/k-rolling-upgrade.adoc
+++ b/modules/upgrade/pages/k-rolling-upgrade.adoc
@@ -16,6 +16,8 @@ include::partial$rolling-upgrades/upgrade-limitations.adoc[]
 * xref:deploy:deployment-option/self-hosted/kubernetes/index.adoc[A Redpanda cluster running in Kubernetes].
 * The default xref:reference:k-redpanda-helm-spec.adoc#statefulset-updatestrategy-type[RollingUpdate strategy] configured in the Helm values.
 
+include::partial$incompat-changes.adoc[]
+
 include::partial$rolling-upgrades/restart-impact.adoc[leveloffset=+1]
 
 == Incompatible changes

--- a/modules/upgrade/pages/rolling-upgrade.adoc
+++ b/modules/upgrade/pages/rolling-upgrade.adoc
@@ -19,15 +19,7 @@ include::partial$rolling-upgrades/upgrade-limitations.adoc[]
 * An understanding of the <<impact-of-broker-restarts,impact of broker restarts>> on clients, node CPU, and any alerting systems you use.
 * Review incompatible changes in new versions.
 
-=== Review incompatible changes
-
-* Starting in version 24.2, Redpanda removes topic-level configuration overrides for unspecified fields, instead of setting them to their type's default value. This aligns more closely with the AlterConfigs API. 
-+
-NOTE: An exception to this is made for the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. The remote properties are intentionally sticky to avoid the possibility of deleting data in Tiered Storage.
-
-* Starting in version 24.2, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[client throughput limits] are compatible with the https://cwiki.apache.org/confluence/display/KAFKA/KIP-546%3A+Add+Client+Quota+APIs+to+the+Admin+Client[AlterClientQuotas and DescribeClientQuotas^] Kafka APIs. Redpanda determines client throughput limits on a per-broker basis. In earlier versions, client throughput quotas were applied from cluster configurations on a per-shard basis. 
-
-* Patch releases in https://github.com/redpanda-data/redpanda/discussions/9522[22.3.14^] and https://github.com/redpanda-data/redpanda/discussions/9523[23.1.2^] changed the behavior when remote read is disabled and the requested Raft term falls below the local log's beginning. In earlier versions, Redpanda returned an offset -1. With the patch, when you request a value older than the lowest offset, Redpanda returns the lowest offset, not -1.
+include::partial$incompat-changes.adoc[]
 
 == Find a new version
 

--- a/modules/upgrade/pages/rolling-upgrade.adoc
+++ b/modules/upgrade/pages/rolling-upgrade.adoc
@@ -21,9 +21,13 @@ include::partial$rolling-upgrades/upgrade-limitations.adoc[]
 
 === Review incompatible changes
 
-Starting in version 24.2, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[client throughput limits] are compatible with the https://cwiki.apache.org/confluence/display/KAFKA/KIP-546%3A+Add+Client+Quota+APIs+to+the+Admin+Client[AlterClientQuotas and DescribeClientQuotas^] Kafka APIs. Redpanda determines client throughput limits on a per-broker basis. In earlier versions, client throughput quotas were applied from cluster configurations on a per-shard basis. 
+* Starting in version 24.2, Redpanda removes topic-level configuration overrides for unspecified fields, instead of setting them to their type's default value. This aligns more closely with the AlterConfigs API. 
++
+NOTE: An exception to this is made for the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. The remote properties are intentionally sticky to avoid the possibility of deleting data in Tiered Storage.
 
-Patch releases in https://github.com/redpanda-data/redpanda/discussions/9522[22.3.14^] and https://github.com/redpanda-data/redpanda/discussions/9523[23.1.2^] changed the behavior when remote read is disabled and the requested Raft term falls below the local log's beginning. In earlier versions, Redpanda returned an offset -1. With the patch, when you request a value older than the lowest offset, Redpanda returns the lowest offset, not -1.
+* Starting in version 24.2, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[client throughput limits] are compatible with the https://cwiki.apache.org/confluence/display/KAFKA/KIP-546%3A+Add+Client+Quota+APIs+to+the+Admin+Client[AlterClientQuotas and DescribeClientQuotas^] Kafka APIs. Redpanda determines client throughput limits on a per-broker basis. In earlier versions, client throughput quotas were applied from cluster configurations on a per-shard basis. 
+
+* Patch releases in https://github.com/redpanda-data/redpanda/discussions/9522[22.3.14^] and https://github.com/redpanda-data/redpanda/discussions/9523[23.1.2^] changed the behavior when remote read is disabled and the requested Raft term falls below the local log's beginning. In earlier versions, Redpanda returned an offset -1. With the patch, when you request a value older than the lowest offset, Redpanda returns the lowest offset, not -1.
 
 == Find a new version
 

--- a/modules/upgrade/partials/incompat-changes.adoc
+++ b/modules/upgrade/partials/incompat-changes.adoc
@@ -2,7 +2,7 @@
 
 * Starting in version 24.2, when managing configuration properties using the AlterConfigs API directly, or the `kafka-configs.sh` shell script without incremental flags, Redpanda resets all unspecified values to the default values. This aligns more closely with the behavior in Apache Kafka. There is no change if you're managing your configuration with tools like `rpk`, Redpanda Console, Kubernetes, Helm, or Terraform. 
 +
-NOTE: This does not pertain to the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. These property values persist to avoid the possibility of unintentionally disabling Tiered Storage for a topic, which could cause significant operational issues for clusters designed to use Tiered Storage exclusively or with object storage as the only durable storage tier.
+NOTE: This does not pertain to the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. The remote properties are not reset to their defaults by the AlterConfigs API to avoid the possibility of unintentionally disabling Tiered Storage for a topic, which could cause significant operational issues for clusters designed to use Tiered Storage exclusively or with object storage as the only durable storage tier.
 
 * Starting in version 24.2, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[client throughput limits] are compatible with the https://cwiki.apache.org/confluence/display/KAFKA/KIP-546%3A+Add+Client+Quota+APIs+to+the+Admin+Client[AlterClientQuotas and DescribeClientQuotas^] Kafka APIs. Redpanda determines client throughput limits on a per-broker basis. In earlier versions, client throughput quotas were applied from cluster configurations on a per-shard basis. 
 

--- a/modules/upgrade/partials/incompat-changes.adoc
+++ b/modules/upgrade/partials/incompat-changes.adoc
@@ -2,7 +2,7 @@
 
 * Starting in version 24.2, when managing configuration properties using the AlterConfigs API directly, or the `kafka-configs.sh` shell script without incremental flags, Redpanda resets all unspecified values to the default values. This aligns more closely with the behavior in Apache Kafka. There is no change if you're managing your configuration with tools like `rpk`, Redpanda Console, Kubernetes, Helm, or Terraform. 
 +
-NOTE: An exception is made for the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. The remote properties are intentionally sticky to avoid the possibility of disabling Tiered Storage.
+NOTE: This does not pertain to the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. These property values persist to avoid the possibility of unintentionally disabling Tiered Storage for a topic, which could cause significant operational issues for clusters designed to use Tiered Storage exclusively or with object storage as the only durable storage tier.
 
 * Starting in version 24.2, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[client throughput limits] are compatible with the https://cwiki.apache.org/confluence/display/KAFKA/KIP-546%3A+Add+Client+Quota+APIs+to+the+Admin+Client[AlterClientQuotas and DescribeClientQuotas^] Kafka APIs. Redpanda determines client throughput limits on a per-broker basis. In earlier versions, client throughput quotas were applied from cluster configurations on a per-shard basis. 
 

--- a/modules/upgrade/partials/incompat-changes.adoc
+++ b/modules/upgrade/partials/incompat-changes.adoc
@@ -2,7 +2,7 @@
 
 * Starting in version 24.2, when managing configuration properties using the AlterConfigs API directly or the `kafka-configs.sh` shell script without incremental flags, Redpanda now resets all unspecified values to their default values. This aligns more closely with the behavior in Apache Kafka. There is no change if you're managing configuration with tools like `rpk`, Redpanda Console, Kubernetes, Helm, or Terraform. 
 +
-NOTE: An exception is made for the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. The remote properties are intentionally sticky to avoid the possibility of deleting data in Tiered Storage.
+NOTE: An exception is made for the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. The remote properties are intentionally sticky to avoid the possibility of disabling Tiered Storage.
 
 * Starting in version 24.2, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[client throughput limits] are compatible with the https://cwiki.apache.org/confluence/display/KAFKA/KIP-546%3A+Add+Client+Quota+APIs+to+the+Admin+Client[AlterClientQuotas and DescribeClientQuotas^] Kafka APIs. Redpanda determines client throughput limits on a per-broker basis. In earlier versions, client throughput quotas were applied from cluster configurations on a per-shard basis. 
 

--- a/modules/upgrade/partials/incompat-changes.adoc
+++ b/modules/upgrade/partials/incompat-changes.adoc
@@ -1,6 +1,6 @@
 === Review incompatible changes
 
-* Starting in version 24.2, when managing configuration properties using the AlterConfigs API directly or the `kafka-configs.sh` shell script without incremental flags, Redpanda now resets all unspecified values to their default values. This aligns more closely with the behavior in Apache Kafka. There is no change if you're managing configuration with tools like `rpk`, Redpanda Console, Kubernetes, Helm, or Terraform. 
+* Starting in version 24.2, when managing configuration properties using the AlterConfigs API directly, or the `kafka-configs.sh` shell script without incremental flags, Redpanda resets all unspecified values to the default values. This aligns more closely with the behavior in Apache Kafka. There is no change if you're managing your configuration with tools like `rpk`, Redpanda Console, Kubernetes, Helm, or Terraform. 
 +
 NOTE: An exception is made for the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. The remote properties are intentionally sticky to avoid the possibility of disabling Tiered Storage.
 

--- a/modules/upgrade/partials/incompat-changes.adoc
+++ b/modules/upgrade/partials/incompat-changes.adoc
@@ -1,0 +1,9 @@
+=== Review incompatible changes
+
+* Starting in version 24.2, when managing configuration properties using the AlterConfigs API directly or the `kafka-configs.sh` shell script without incremental flags, Redpanda now resets all unspecified values to their default values. This aligns more closely with the behavior in Apache Kafka. There is no change if you're managing configuration with tools like `rpk`, Redpanda Console, Kubernetes, Helm, or Terraform. 
++
+NOTE: An exception is made for the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. The remote properties are intentionally sticky to avoid the possibility of deleting data in Tiered Storage.
+
+* Starting in version 24.2, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[client throughput limits] are compatible with the https://cwiki.apache.org/confluence/display/KAFKA/KIP-546%3A+Add+Client+Quota+APIs+to+the+Admin+Client[AlterClientQuotas and DescribeClientQuotas^] Kafka APIs. Redpanda determines client throughput limits on a per-broker basis. In earlier versions, client throughput quotas were applied from cluster configurations on a per-shard basis. 
+
+* Patch releases in https://github.com/redpanda-data/redpanda/discussions/9522[22.3.14^] and https://github.com/redpanda-data/redpanda/discussions/9523[23.1.2^] changed the behavior when remote read is disabled and the requested Raft term falls below the local log's beginning. In earlier versions, Redpanda returned an offset -1. With the patch, when you request a value older than the lowest offset, Redpanda returns the lowest offset, not -1.


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2604 
Review deadline: Monday, July 29

## Page previews
[Linux: Review incompatible changes](https://deploy-preview-635--redpanda-docs-preview.netlify.app/24.2/upgrade/rolling-upgrade/)
[Kubernetes: Review incompatible changes](https://deploy-preview-635--redpanda-docs-preview.netlify.app/24.2/upgrade/k-rolling-upgrade/) (duplicated here)
<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)