### PR TITLE
Add new cache trim properties backported to 24.1.10

### DIFF
--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -2,9 +2,9 @@
 :description: Summary of new features and updates in the release.
 :page-aliases: get-started:whats-new-233.adoc, get-started:whats-new-241.adoc
 
-This topic includes new content added in version 24.1. For a complete list of all product updates, see the https://github.com/redpanda-data/redpanda/releases/[Redpanda release notes^]. See also: 
+This topic includes new content added in version {page-component-version}. For a complete list of all product updates, see the https://github.com/redpanda-data/redpanda/releases/[Redpanda release notes^]. See also:
 
-* xref:deploy:deployment-option/cloud/whats-new-cloud.adoc[] 
+* xref:deploy:deployment-option/cloud/whats-new-cloud.adoc[]
 * xref:deploy:deployment-option/cloud/cloud-overview.adoc#redpanda-cloud-vs-self-hosted-feature-compatibility[Redpanda Cloud vs self-hosted feature compatibility]
 
 == Redpanda Connect 
@@ -24,11 +24,18 @@ Data transforms is now generally available for all Redpanda Community and Redpan
 
 The following features have been added since the 23.3 beta release:
 
-* Data transforms can now output to multiple topics.  For example, you can distribute different message types to multiple event streams, or you can write valid records to an output topic and invalid records to a dead-letter queue. 
+* Data transforms can now output to multiple topics. For example, you can distribute different message types to multiple event streams, or you can write valid records to an output topic and invalid records to a dead-letter queue. 
 
-* There is a new xref:reference:data-transform-rust-sdk.adoc[Rust SDK] for data transforms. This complements the existing xref:reference:data-transform-golang-sdk.adoc[Golang SDK]. 
+* There is a new xref:reference:data-transform-rust-sdk.adoc[Rust SDK] for data transforms. This complements the existing xref:reference:data-transform-golang-sdk.adoc[Golang SDK].
 
 * xref:develop:data-transforms/run-transforms.adoc#view-data-transform-logs[Data transform logs] are now stored in an internally-managed topic and are accessible via `rpk` and Redpanda Console.
+
+== Enhanced cache trimming
+
+From 24.1.10, Redpanda has two new properties that provide finer control over cache management. These settings allow you to define specific thresholds for triggering xref:manage:tiered-storage.adoc#cache-trimming[cache trimming] based on cache size and the number of objects, helping to optimize performance and prevent slow reads.
+
+- config_ref:cloud_storage_cache_trim_threshold_percent_size,true,properties/object-storage-properties[]
+- config_ref:cloud_storage_cache_trim_threshold_percent_objects,true,properties/object-storage-properties[]
 
 == Topic-aware partition balancing 
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1499,7 +1499,7 @@ NOTE: The lower you set the threshold, the earlier the trimming starts, but it c
 
 To support more concurrent consumers of historical data with less local storage, Redpanda can download small chunks of remote segments to the cache directory. For example, when a client fetch request spans a subsection of a 1 GiB segment, instead of downloading the entire 1 GiB segment, Redpanda can download 16 MiB chunks that contain just enough data required to fulfill the fetch request. Use the config_ref:cloud_storage_cache_chunk_size,true,properties/object-storage-properties[] property to define the size of the chunks.
 
-The paths on disk to a chunk are structured as `p_chunks/\{chunk_start_offset}`, where `p` is the original path to the segment in the object storage cache. The `_chunks/` subdirectory holds chunk files identified by the chunk start offset. These files can be reclaimed by the cache eviction process during the normal eviction path.
+The paths on disk to a chunk are structured as `p_chunks/\{chunk_start_offset}`, where `p` is the original path to the segment in the object storage cache. The `_chunks/` subdirectory holds chunk files identified by the chunk start offset. These files can be reclaimed by the cache eviction process from the normal eviction path.
 
 === Chunk eviction strategies
 
@@ -1507,7 +1507,7 @@ Selecting an appropriate chunk eviction strategy helps manage cache space effect
 
 - `eager` (default): Evicts chunks that aren't shared with other data sources. Eviction is fast, because no sorting is involved.
 - `capped`: Evicts chunks until the number of hydrated chunks is below or equal to the maximum hydrated chunks at a time. This limit is for each segment and calculated using `cloud_storage_hydrated_chunks_per_segment_ratio` by the remote segment. Eviction is fastest, because no sorting is involved, and the process stops after the cap is reached.
-- `predictive`: Uses statistics from readers to determine which chunks to evict. Chunks that aren't in use are sorted by the count of readers that will use the chunk in the future. The counts are populated by readers using the chunk data source. The chunks that are least expensive to re-hydrate are then evicted, taking into account the maximum hydrated chunk count. Eviction is slowest, because chunks are sorted before evicting them.
+- `predictive`: Uses statistics from readers to determine which chunks to evict. Chunks that aren't in use are sorted by the count of readers that will use the chunk in the future. The counts are populated by readers using the chunk data source. The chunks that are least expensive to rehydrate are then evicted, taking into account the maximum hydrated chunk count. Eviction is slowest, because chunks are sorted before evicting them.
 
 *Recommendation*: For general use, the `eager` strategy is recommended due to its speed. For workloads with specific access patterns, the `predictive` strategy may offer better cache efficiency.
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -127,7 +127,7 @@ Replace the following placeholders:
 - `<region>`: The region of your S3 bucket.
 - `<redpanda-bucket-name>`: The name of your S3 bucket.
 +
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
 
 To configure access to an S3 bucket with access keys instead of an IAM role:
 
@@ -256,7 +256,7 @@ storage:
 - `<region>`: The region of your S3 bucket.
 - `<redpanda-bucket-name>`: The name of your S3 bucket.
 +
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
 
 ==== Google Cloud Storage
 
@@ -339,7 +339,7 @@ Replace the following placeholders:
 - `<region>`: The region of your bucket.
 - `<redpanda-bucket-name>`: The name of your bucket.
 
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
 
 To configure access to Google Cloud Storage with access keys instead of an IAM role:
 
@@ -467,7 +467,7 @@ storage:
 - `<region>`: The region of your bucket.
 - `<redpanda-bucket-name>`: The name of your bucket.
 +
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
 
 ==== Microsoft ABS/ADLS
 
@@ -573,7 +573,7 @@ Replace the following placeholders:
 
 NOTE: The `serviceAccount` annotations and the `statefulset` Pod labels are essential for the Azure webhook to inject the necessary Azure-specific environment variables and the projected service account token volume into the pods. For more information, visit https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet[Microsoft Entra Workload ID with Azure Kubernetes Service (AKS)^].
 
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
 
 To configure access to ABS/ADLS with shared keys:
 
@@ -684,7 +684,7 @@ storage:
 - `<account-name>`: The name of your Azure account.
 - `<container-name>`: The name of the Azure container in your Azure account.
 +
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
 
 - For information about how to grant access from an internet IP range (if you need to open additional routes/ports between your broker nodes and Azure Blob Storage; for example, in a hybrid cloud deployment), see the https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json&tabs=azure-portal#grant-access-from-an-internet-ip-range[Microsoft documentation^].
 
@@ -718,7 +718,7 @@ cloud_storage_bucket: <redpanda_bucket_name>
 +
 Replace `<placeholders>` with your own values.
 
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value. To reset a property to its default value, run `rpk cluster config force-reset <config-name>` or remove that line from the cluster configuration with `rpk cluster config edit`.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value. To reset a property to its default value, run `rpk cluster config force-reset <config-name>` or remove that line from the cluster configuration with `rpk cluster config edit`.
 
 To configure access to an S3 bucket with access keys instead of an IAM role:
 
@@ -737,7 +737,7 @@ cloud_storage_bucket: <redpanda_bucket_name>
 +
 Replace `<placeholders>` with your own values.
 +
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value. To reset a property to its default value, run `rpk cluster config force-reset <config-name>` or remove that line from the cluster configuration with `rpk cluster config edit`.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value. To reset a property to its default value, run `rpk cluster config force-reset <config-name>` or remove that line from the cluster configuration with `rpk cluster config edit`.
 
 --
 Google Cloud Storage::
@@ -761,7 +761,7 @@ cloud_storage_bucket: <redpanda_bucket_name>
 +
 Replace `<placeholders>` with your own values.
 +
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value. To reset a property to its default value, run `rpk cluster config force-reset <config-name>` or remove that line from the cluster configuration with `rpk cluster config edit`.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value. To reset a property to its default value, run `rpk cluster config force-reset <config-name>` or remove that line from the cluster configuration with `rpk cluster config edit`.
 
 To configure access to Google Cloud Storage with access keys instead of an IAM role:
 
@@ -783,7 +783,7 @@ cloud_storage_region: <region>
 +
 Replace `<placeholders>` with your own values.
 +
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value. To reset a property to its default value, run `rpk cluster config force-reset <config-name>` or remove that line from the cluster configuration with `rpk cluster config edit`.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value. To reset a property to its default value, run `rpk cluster config force-reset <config-name>` or remove that line from the cluster configuration with `rpk cluster config edit`.
 
 --
 Microsoft ABS/ADLS::
@@ -827,7 +827,7 @@ For information about how to grant access from an internet IP range (if you need
 +
 For information about shared key authentication, see the https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key[Microsoft documentation^].
 +
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value. To reset a property to its default value, run `rpk cluster config force-reset <config-name>` or remove that line from the cluster configuration with `rpk cluster config edit`.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value. To reset a property to its default value, run `rpk cluster config force-reset <config-name>` or remove that line from the cluster configuration with `rpk cluster config edit`.
 
 --
 =====
@@ -1108,62 +1108,13 @@ rpk topic alter-config <topic_name> --set redpanda.remote.read=true
 
 See also: xref:manage:kubernetes/k-remote-read-replicas.adoc[Remote Read Replicas]
 
-=== Caching
+== Caching
 
-When a client fetches an offset range that isn't available locally in the Redpanda data directory, Redpanda downloads remote segments from object storage. These downloaded segments are stored in the object storage cache directory.
+When a consumer fetches an offset range that isn't available locally in the Redpanda data directory, Redpanda downloads remote segments from object storage. These downloaded segments are stored in the object storage cache.
 
-The cache directory is created in the Redpanda `data` directory by default, but it can be placed anywhere in the system. For example, you might want to put the cache directory on a dedicated drive with cheaper storage. If you don't specify a cache location in the `redpanda.yaml` file, the cache directory is created in `<redpanda_data_directory>/cloud_storage_cache`. Use the config_ref:cloud_storage_cache_directory,true,node-properties[] property on each broker to specify a different location for the cache directory. You must specify the full path.
+=== Change the cache directory
 
-Redpanda checks the cache periodically, and if the size of the stored data is larger than the configured limit, the eviction process starts. The eviction process removes segments that haven't been accessed recently, until the size of the cache drops 20%.
-
-==== Chunking remote segments
-
-To support more concurrent consumers of historical data with less local storage, Redpanda can download small chunks of remote segments to the cache directory. For example, when a client fetch request spans a subsection of a 1 GiB segment, instead of downloading the entire 1 GiB segment, Redpanda can download 16 MiB chunks that contain just enough data required to fulfill the fetch request.
-
-The paths on disk to a chunk are structured as `p_chunks/\{chunk_start_offset}`, where `p` is the original path to the segment in the object storage cache. The `_chunks` subdirectory holds chunk files identified by the chunk start offset. These files can be reclaimed by the cache eviction process during the normal eviction path.
-
-==== Chunk eviction strategies
-
-A chunk that isn't shared with any data source can be evicted from the cache, so space is returned to disk. Select a chunk eviction strategy with the configuration property `cloud_storage_chunk_eviction_strategy`:
-
-- `eager`: Evicts chunks that aren't shared with other data sources. Eviction is fast, because no sorting is involved. This is the default.
-- `capped`: Evicts chunks until the number of hydrated chunks is below or equal to the maximum hydrated chunks at a time. (This limit is for each segment and calculated using `cloud_storage_hydrated_chunks_per_segment_ratio` by the remote segment.) Eviction is fastest, because no sorting is involved, and the process stops after the cap is reached.
-- `predictive`: Uses statistics from readers to determine which chunks to evict. Chunks that aren't in use are sorted by the count of readers that will use the chunk in the future. The counts are populated by readers using the chunk data source. The chunks that are least expensive to re-hydrate are then evicted, taking into account the maximum hydrated chunk count. Eviction is slowest, because chunks are sorted before evicting them.
-
-==== Caching and chunking properties
-
-Use the following cluster-level properties to set the maximum cache size, the cache check interval, and chunking qualities.
-ifndef::env-kubernetes[Edit them with the `rpk cluster config edit` command.]
-
-|===
-| Property      | Description
-
-| config_ref:cloud_storage_cache_check_interval,true,properties/object-storage-properties[]
-| The time, in milliseconds, between cache checks. The size of the cache can grow quickly, so it's important to have a small interval between checks. However, if the checks are too frequent, they consume a lot of resources. Default is 30000 ms (30 sec).
-
-| config_ref:cloud_storage_cache_chunk_size,true,properties/object-storage-properties[]
-| The size of a chunk downloaded into object storage cache. Default is 16 MiB.
-
-| config_ref:cloud_storage_cache_size_percent,true,properties/object-storage-properties[]
-| Maximum size (as a percentage) of the disk cache used by Tiered Storage. +
-If both this property and `cloud_storage_cache_size` are set, Redpanda uses the minimum of the two. 
-
-| config_ref:cloud_storage_cache_size,true,properties/object-storage-properties[]
-| Maximum size (in bytes) of the disk cache used by Tiered Storage. +
-If both this property and `cloud_storage_cache_size_percent` are set, Redpanda uses the minimum of the two.
-
-| config_ref:cloud_storage_chunk_eviction_strategy,true,properties/object-storage-properties[]
-| Strategy for evicting unused cache chunks, either `eager` (default), `capped`, or `predictive`.
-
-| config_ref:cloud_storage_disable_chunk_reads,true,properties/object-storage-properties[]
-| Flag to turn off chunk-based reads and enable full-segment downloads.
-
-| config_ref:cloud_storage_hydrated_chunks_per_segment_ratio,true,properties/object-storage-properties[]
-| The ratio of hydrated to non-hydrated chunks for each segment, where a current ratio above this value results in unused chunks being evicted. Default is 0.7.
-
-| config_ref:cloud_storage_min_chunks_per_segment_threshold,true,properties/object-storage-properties[]
-| The threshold below which all chunks of a segment can be hydrated without eviction. If the number of chunks in a segment is below this threshold, the segment is small enough that all chunks in it can be hydrated at any given time. Default is 5.
-|===
+By default, the cache directory is created in Redpanda's data directory, but it can be placed anywhere in the system. For example, you might want to put the cache directory on a dedicated drive with cheaper storage. Use the config_ref:cloud_storage_cache_directory,true,properties/object-storage-properties[] property on each broker to specify a different location for the cache directory. You must specify the full path.
 
 ifdef::env-kubernetes[]
 To specify a different volume for the cache directory, use one of the following:
@@ -1177,8 +1128,6 @@ A PersistentVolume is storage in the cluster that has been provisioned by an adm
 For details about PersistentVolumes, see the https://kubernetes.io/docs/concepts/storage/persistent-volumes/[Kubernetes documentation^].
 
 You can configure the Helm chart to use a PersistentVolume for the cache directory with either a static provisioner or a dynamic provisioner.
-
-===== Dynamic provisioners
 
 A dynamic provisioner creates a PersistentVolume on demand for each Redpanda broker.
 
@@ -1353,9 +1302,7 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 --
 ======
 
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
-
-===== Static provisioners
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
 
 When you use a static provisioner, an existing PersistentVolume in the cluster is selected and bound to one PersistentVolumeClaim for each Redpanda broker.
 
@@ -1430,7 +1377,7 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 --
 ======
 
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
 
 ==== hostPath
 
@@ -1510,9 +1457,115 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 --
 ======
 
-IMPORTANT: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
+CAUTION: Do not set an object storage property to an empty string `""` or to `null` as a way to reset it to its default value.
 
 endif::[]
+
+[[max-cache]]
+=== Set a maximum cache size
+
+To ensure that the cache does not grow uncontrollably, which could lead to performance issues or disk space exhaustion, you can control the maximum size of the cache.
+
+Redpanda checks the cache periodically according to the interval set in config_ref:cloud_storage_cache_check_interval_ms,true,properties/object-storage-properties[]. If the size of the stored data exceeds the configured limit, the eviction process starts. This process removes segments that haven't been accessed recently until the cache size drops to the target level.
+
+*Related properties*:
+
+- config_ref:cloud_storage_cache_size_percent,true,properties/object-storage-properties[]
+- config_ref:cloud_storage_cache_max_objects,true,properties/object-storage-properties[]
+- config_ref:cloud_storage_cache_size,true,properties/object-storage-properties[]
+
+*Recommendation*: By default, `cloud_storage_cache_size_percent` is tuned for a shared disk configuration. If you are using a dedicated cache disk, consider increasing this value.
+
+==== Cache trimming
+
+Cache trimming helps to balance optimal cache use with the need to avoid blocking reads due to a full cache. The trimming process is triggered when the cache exceeds certain thresholds relative to the <<max-cache, maximum cache size>>.
+
+*Related properties*:
+
+- config_ref:cloud_storage_cache_trim_threshold_percent_objects,true,properties/object-storage-properties[]
+- config_ref:cloud_storage_cache_trim_threshold_percent_size,true,properties/object-storage-properties[]
+- config_ref:cloud_storage_cache_trim_carryover_bytes,true,properties/object-storage-properties[]
+- config_ref:cloud_storage_cache_trim_walk_concurrency,true,properties/object-storage-properties[]
+
+*Recommendations*:
+
+- A threshold of 70% is recommended for most use cases. This percentage helps balance optimal cache use and ensures the cache has enough free space to handle sudden spikes in data without blocking reads. For example, setting `cloud_storage_cache_trim_threshold_percent_size` to 80% means that the cache trimming process starts when the cache takes up 80% of the maximum cache size.
+
+- Monitor the behavior of your cache and the performance of your Redpanda cluster. If reads are taking longer than expected or if you encounter timeout errors, your cache may be filling up too quickly. In these cases, consider lowering the thresholds to trigger trimming sooner.
+
+NOTE: The lower you set the threshold, the earlier the trimming starts, but it can also waste cache space. A higher threshold uses more cache space efficiently, but it risks blocking reads if the cache fills up too quickly. Adjust the settings based on your workload and monitor the cache performance to find the right balance for your environment.
+
+=== Chunk remote segments
+
+To support more concurrent consumers of historical data with less local storage, Redpanda can download small chunks of remote segments to the cache directory. For example, when a client fetch request spans a subsection of a 1 GiB segment, instead of downloading the entire 1 GiB segment, Redpanda can download 16 MiB chunks that contain just enough data required to fulfill the fetch request. Use the config_ref:cloud_storage_cache_chunk_size,true,properties/object-storage-properties[] property to define the size of the chunks.
+
+The paths on disk to a chunk are structured as `p_chunks/\{chunk_start_offset}`, where `p` is the original path to the segment in the object storage cache. The `_chunks/` subdirectory holds chunk files identified by the chunk start offset. These files can be reclaimed by the cache eviction process during the normal eviction path.
+
+=== Chunk eviction strategies
+
+Selecting an appropriate chunk eviction strategy helps manage cache space effectively. A chunk that isn't shared with any data source can be evicted from the cache, so space is returned to disk. Use the config_ref:cloud_storage_chunk_eviction_strategy,true,properties/object-storage-properties[] property to change the eviction strategy. The strategies are:
+
+- `eager` (default): Evicts chunks that aren't shared with other data sources. Eviction is fast, because no sorting is involved.
+- `capped`: Evicts chunks until the number of hydrated chunks is below or equal to the maximum hydrated chunks at a time. This limit is for each segment and calculated using `cloud_storage_hydrated_chunks_per_segment_ratio` by the remote segment. Eviction is fastest, because no sorting is involved, and the process stops after the cap is reached.
+- `predictive`: Uses statistics from readers to determine which chunks to evict. Chunks that aren't in use are sorted by the count of readers that will use the chunk in the future. The counts are populated by readers using the chunk data source. The chunks that are least expensive to re-hydrate are then evicted, taking into account the maximum hydrated chunk count. Eviction is slowest, because chunks are sorted before evicting them.
+
+*Recommendation*: For general use, the `eager` strategy is recommended due to its speed. For workloads with specific access patterns, the `predictive` strategy may offer better cache efficiency.
+
+=== Caching and chunking properties
+
+Use the following cluster-level properties to set the maximum cache size, the cache check interval, and chunking qualities.
+ifndef::env-kubernetes[Edit them with the `rpk cluster config edit` command.]
+
+|===
+| Property      | Description
+
+| config_ref:cloud_storage_cache_check_interval_ms,true,properties/object-storage-properties[]
+| The time, in milliseconds, between cache checks. The size of the cache can grow quickly, so it's important to have a small interval between checks. However, if the checks are too frequent, they consume a lot of resources. Default is 30000 ms (30 sec).
+
+| config_ref:cloud_storage_cache_chunk_size,true,properties/object-storage-properties[]
+| The size of a chunk downloaded into object storage cache. Default is 16 MiB.
+
+| config_ref:cloud_storage_cache_directory,true,properties/object-storage-properties[]
+| The directory where the cache archive is stored.
+
+| config_ref:cloud_storage_cache_max_objects,true,properties/object-storage-properties[]
+| Maximum number of objects that may be held in the Tiered Storage cache. This applies simultaneously with `cloud_storage_cache_size`, and whichever limit is hit first will trigger trimming of the cache.
+
+| config_ref:cloud_storage_cache_num_buckets,true,properties/object-storage-properties[]
+| Divide the object storage cache across the specified number of buckets. This only works for objects with randomized prefixes. The names are not changed when the value is set to zero.
+
+| config_ref:cloud_storage_cache_size_percent,true,properties/object-storage-properties[]
+| Maximum size (as a percentage) of the disk cache used by Tiered Storage. +
+If both this property and `cloud_storage_cache_size` are set, Redpanda uses the minimum of the two.
+
+| config_ref:cloud_storage_cache_size,true,properties/object-storage-properties[]
+| Maximum size (in bytes) of the disk cache used by Tiered Storage. +
+If both this property and `cloud_storage_cache_size_percent` are set, Redpanda uses the minimum of the two.
+
+| config_ref:cloud_storage_cache_trim_carryover_bytes,true,properties/object-storage-properties[]
+| The cache performs a recursive directory inspection during the cache trim. The information obtained during the inspection can be carried over to the next trim operation. This property sets a limit on the memory occupied by objects that can be carried over from one trim to next, and it allows the cache to quickly unblock readers before starting the directory inspection.
+
+| config_ref:cloud_storage_cache_trim_threshold_percent_objects,true,properties/object-storage-properties[]
+| Trigger cache trimming when the number of objects in the cache reaches this percentage relative to its maximum object count. If unset, the default behavior is to start trimming when the cache is full.
+
+| config_ref:cloud_storage_cache_trim_threshold_percent_size,true,properties/object-storage-properties[]
+| Trigger cache trimming when the cache size reaches this percentage relative to its maximum capacity. If unset, the default behavior is to start trimming when the cache is full.
+
+| config_ref:cloud_storage_cache_trim_walk_concurrency,true,properties/object-storage-properties[]
+| The maximum number of concurrent tasks launched for traversing the directory structure during cache trimming. A higher number allows cache trimming to run faster but can cause latency spikes due to increased pressure on I/O subsystem and syscall threads.
+
+| config_ref:cloud_storage_chunk_eviction_strategy,true,properties/object-storage-properties[]
+| Strategy for evicting unused cache chunks, either `eager` (default), `capped`, or `predictive`.
+
+| config_ref:cloud_storage_disable_chunk_reads,true,properties/object-storage-properties[]
+| Flag to turn off chunk-based reads and enable full-segment downloads. Default is false.
+
+| config_ref:cloud_storage_hydrated_chunks_per_segment_ratio,true,properties/object-storage-properties[]
+| The ratio of hydrated to non-hydrated chunks for each segment, where a current ratio above this value results in unused chunks being evicted. Default is 0.7.
+
+| config_ref:cloud_storage_min_chunks_per_segment_threshold,true,properties/object-storage-properties[]
+| The threshold below which all chunks of a segment can be hydrated without eviction. If the number of chunks in a segment is below this threshold, the segment is small enough that all chunks in it can be hydrated at any given time. Default is 5.
+|===
 
 == Remote recovery
 
@@ -1757,7 +1810,7 @@ In addition, you might want to change the following property for each broker:
 |===
 | Property | Description
 
-| config_ref:cloud_storage_cache_directory,true,node-properties[]
+| config_ref:cloud_storage_cache_directory,true,properties/object-storage-properties[]
 | The directory for the Tiered Storage cache. You must specify the full path. Default is: `<redpanda-data-directory>/cloud_storage_cache.`
 |===
 
@@ -1790,7 +1843,7 @@ You may want to configure the following properties:
 | config_ref:cloud_storage_segment_max_upload_interval_sec,true,properties/object-storage-properties[]
 | Sets the number of seconds for idle timeout. If this property is empty, Redpanda uploads metadata to the object storage, but the segment is not uploaded until it reaches the `segment.bytes` size. By default, the property is empty.
 
-| config_ref:cloud_storage_cache_check_interval,true,properties/object-storage-properties[]
+| config_ref:cloud_storage_cache_check_interval_ms,true,properties/object-storage-properties[]
 | The time, in milliseconds, between cache checks. The size of the cache can grow quickly, so it's important to have a small interval between checks, but if the checks are too frequent, they consume a lot of resources. Default is 30000 ms.
 
 | config_ref:cloud_storage_idle_timeout_ms,true,properties/object-storage-properties[]

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -616,7 +616,7 @@ The cache performs a recursive directory inspection during the cache trim. The i
 
 Introduced in 24.1.10.
 
-Cache trimming is triggered when the number of objects in the cache reaches this percentage relative to its maximum object count. If unset, the default behavior is to start trimming when the cache is full.
+Cache trimming is triggered when the number of objects in the cache reaches this percentage of its maximum object count. If unset, the default behavior is to start trimming when the cache is full.
 
 *Requires restart:* No
 
@@ -634,7 +634,7 @@ Cache trimming is triggered when the number of objects in the cache reaches this
 
 Introduced in 24.1.10.
 
-Cache trimming is triggered when the cache size reaches this percentage relative to its maximum capacity. If unset, the default behavior is to start trimming when the cache is full.
+Cache trimming is triggered when the cache size reaches this percentage of its maximum capacity. If unset, the default behavior is to start trimming when the cache is full.
 
 *Requires restart:* No
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -615,6 +615,8 @@ The cache performs a recursive directory inspection during the cache trim. The i
 
 === cloud_storage_cache_trim_threshold_percent_objects
 
+Introduced in 24.1.10.
+
 Cache trimming is triggered when the number of objects in the cache reaches this percentage relative to its maximum object count. If unset, the default behavior is to start trimming when the cache is full.
 
 *Requires restart:* No
@@ -630,6 +632,8 @@ Cache trimming is triggered when the number of objects in the cache reaches this
 ---
 
 === cloud_storage_cache_trim_threshold_percent_size
+
+Introduced in 24.1.10.
 
 Cache trimming is triggered when the cache size reaches this percentage relative to its maximum capacity. If unset, the default behavior is to start trimming when the cache is full.
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -611,6 +611,40 @@ The cache performs a recursive directory inspection during the cache trim. The i
 
 ---
 
+---
+
+=== cloud_storage_cache_trim_threshold_percent_objects
+
+Cache trimming is triggered when the number of objects in the cache reaches this percentage relative to its maximum object count. If unset, the default behavior is to start trimming when the cache is full.
+
+*Requires restart:* No
+
+*Optional:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_cache_trim_threshold_percent_size
+
+Cache trimming is triggered when the cache size reaches this percentage relative to its maximum capacity. If unset, the default behavior is to start trimming when the cache is full.
+
+*Requires restart:* No
+
+*Optional:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `null`
+
+---
+
 === cloud_storage_cache_trim_walk_concurrency
 
 The maximum number of concurrent tasks launched for traversing the directory structure during cache trimming. A higher number allows cache trimming to run faster but can cause latency spikes due to increased pressure on I/O subsystem and syscall threads.

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -611,7 +611,6 @@ The cache performs a recursive directory inspection during the cache trim. The i
 
 ---
 
----
 
 === cloud_storage_cache_trim_threshold_percent_objects
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2598
Review deadline: 30 July

## Page previews

https://deploy-preview-637--redpanda-docs-preview.netlify.app/current/reference/properties/object-storage-properties/#cloud_storage_cache_trim_threshold_percent_objects

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)