### PR TITLE
add leftover properties for 24.2

### DIFF
--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -5190,7 +5190,7 @@ The minimum TLS version that Redpanda supports.
 
 *Type:* string
 
-*Default:* `v1.3`
+*Default:* `v1.2`
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -4796,6 +4796,22 @@ A list of supported SASL mechanisms.
 
 ---
 
+=== schema_registry_normalize_on_startup
+
+Normalize schemas as they are read from the topic on startup.
+
+*Requires restart:* Yes
+
+*Optional:* No
+
+*Visibility:* `user`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
 === segment_appender_flush_timeout_ms
 
 Maximum delay until buffered data is written.
@@ -5160,6 +5176,24 @@ List of superuser usernames.
 
 ---
 
+=== tls_min_version
+
+The minimum TLS version that Redpanda supports.
+
+*Requires restart:* Yes
+
+*Optional:* No
+
+*Visibility:* `user`
+
+*Accepted values:* `v1.0`, `v1.1`, `v1.2`, `v1.3`
+
+*Type:* string
+
+*Default:* `v1.3`
+
+---
+
 === tm_sync_timeout_ms
 
 Transaction manager's synchronization timeout. Maximum time to wait for internal state machine to catch up before rejecting a request.
@@ -5323,6 +5357,26 @@ Number of partitions for transactions coordinator.
 *Accepted values:* [`-2147483648`, `2147483647`]
 
 *Default:* `50`
+
+---
+
+=== transaction_max_timeout_ms
+
+The maximum allowed timeout for transactions. If a client requested transaction timeout exceeds this configuration, the broker will return an error during transactional producer initialization. This guardrail prevents hanging transactions from blocking consumer progress.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Optional:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `900000`
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -5362,7 +5362,7 @@ Number of partitions for transactions coordinator.
 
 === transaction_max_timeout_ms
 
-The maximum allowed timeout for transactions. If a client requested transaction timeout exceeds this configuration, the broker will return an error during transactional producer initialization. This guardrail prevents hanging transactions from blocking consumer progress.
+The maximum allowed timeout for transactions. If a client-requested transaction timeout exceeds this configuration, the broker returns an error during transactional producer initialization. This guardrail prevents hanging transactions from blocking consumer progress.
 
 *Unit:* milliseconds
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -5178,7 +5178,7 @@ List of superuser usernames.
 
 === tls_min_version
 
-The minimum TLS version that Redpanda supports.
+The minimum TLS version that Redpanda clusters support. This property prevents client applications from negotiating a downgrade to the TLS version when they make a connection to a Redpanda cluster.
 
 *Requires restart:* Yes
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -609,24 +609,6 @@ The property <<cloud_storage_cache_size>> controls the same limit expressed as a
 
 ---
 
-=== cloud_storage_cache_trim_carryover_bytes
-
-The cache performs a recursive directory inspection during the cache trim. The information obtained during the inspection can be carried over to the next trim operation. This property sets a limit on the memory occupied by objects that can be carried over from one trim to next, and it allows the cache to quickly unblock readers before starting the directory inspection.
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `4294967295`]
-
-*Default:* `262144`
-
----
-
 === cloud_storage_cache_trim_threshold_percent_objects
 
 Cache trimming is triggered when the number of objects in the cache reaches this percentage relative to its maximum object count. If unset, the default behavior is to start trimming when the cache is full.
@@ -822,6 +804,24 @@ Begins the read replica sync loop in topic partitions with Tiered Storage enable
 *Requires restart:* No
 
 *Optional:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_disable_remote_labels_for_tests
+
+If `true`, Redpanda disables remote labels and falls back on the hash-based object naming scheme for new topics. 
+
+CAUTION: This property exists to simplify testing and shouldn't be set in production.
+
+*Requires restart:* No
+
+*Optional:* No
 
 *Visibility:* `tunable`
 

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -173,6 +173,8 @@ This is an exhaustive list of all the deprecated properties.
 
 === Cluster properties
 
+- cloud_storage_cache_trim_carryover_bytes
+
 - cloud_storage_max_materialized_segments_per_shard
 
 - cloud_storage_max_partition_readers_per_shard


### PR DESCRIPTION
## Description

Add leftover 24.2 properties that were not introduced by https://github.com/redpanda-data/docs/pull/594

## Page previews

https://deploy-preview-641--redpanda-docs-preview.netlify.app/24.2/reference/properties/cluster-properties/
https://deploy-preview-641--redpanda-docs-preview.netlify.app/24.2/reference/properties/object-storage-properties/
https://deploy-preview-641--redpanda-docs-preview.netlify.app/24.2/upgrade/deprecated/

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)