### PR TITLE
[Schema Registry API reference] Support `/mode` for Schema Registry 

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -851,6 +851,17 @@ paths:
         200:
           description: Success
           content: {}
+  /partitions/rebalance_cores:
+    post:
+      tags:
+      - Partitions
+      summary: Rebalance partitions among broker cores
+      description: Trigger an on-demand rebalancing of core assignment of partitions in this broker.
+      operationId: trigger_partitions_shard_rebalance
+      responses:
+        200:
+          description: Success
+          content: {}
   /partitions/reconfigurations:
     get:
       tags:
@@ -1013,6 +1024,44 @@ paths:
         required: true
         schema:
           type: integer
+      responses:
+        200:
+          description: Update partition replicas success
+          content: {}
+  /partitions/{namespace}/{topic}/{partition}/replicas/{node}:
+    post:
+      tags:
+      - Partitions
+      summary: Update partition replica core
+      description: Assign a partition replica to a broker core (shard).
+      operationId: set_partition_replica_core
+      parameters:
+      - name: namespace
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: topic
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: partition
+        in: path
+        required: true
+        schema:
+          type: integer
+      - name: node
+        in: path
+        required: true
+        schema:
+          type: integer
+      requestBody: 
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/core'
+        required: true 
       responses:
         200:
           description: Update partition replicas success
@@ -4276,6 +4325,13 @@ components:
           type: integer
           description: ID of a broker
           format: int32
+      description: Replica placement
+    core:
+      type: object
+      properties:
+        core:
+          type: number
+          description: Broker core
       description: Replica placement
     cluster_view:
       type: object

--- a/modules/ROOT/attachments/pandaproxy-schema-registry.json
+++ b/modules/ROOT/attachments/pandaproxy-schema-registry.json
@@ -2,9 +2,9 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy Schema Registry",
-    "version": "1.0.2"
+    "version": "1.0.6"
   },
-  "host": "{{Host}}",
+  "host": "localhost:18081",
   "basePath": "/",
   "schemes": [
     "http"
@@ -14,30 +14,30 @@
       "get": {
         "summary": "Get the compatibility level for a subject.",
         "operationId": "get_config_subject",
-        "consumes": [
-          "application/vnd.schemaregistry.v1+json",
-          "application/vnd.schemaregistry+json",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "subject",
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "defaultToGlobal",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibilityLevel": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/get_compatibility"
             }
           },
           "500": {
@@ -67,26 +67,57 @@
             "name": "config",
             "in": "body",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibility": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/put_compatibility"
             }
           }
         ],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibility": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/put_compatibility"
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete the compatibility level for a subject.",
+        "operationId": "delete_config_subject",
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/get_compatibility"
+            }
+          },
+          "404": {
+            "description": "Subject not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
             }
           },
           "500": {
@@ -102,23 +133,17 @@
       "get": {
         "summary": "Get the global compatibility level.",
         "operationId": "get_config",
-        "consumes": [
+        "parameters": [],
+        "produces": [
           "application/vnd.schemaregistry.v1+json",
           "application/vnd.schemaregistry+json",
           "application/json"
         ],
-        "parameters": [],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
         "responses": {
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibilityLevel": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/get_compatibility"
             }
           },
           "500": {
@@ -142,26 +167,20 @@
             "name": "config",
             "in": "body",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibility": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/put_compatibility"
             }
           }
         ],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibility": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/put_compatibility"
             }
           },
           "500": {
@@ -177,13 +196,9 @@
       "get": {
         "summary": "Get the global mode.",
         "operationId": "get_mode",
-        "consumes": [
-          "application/vnd.schemaregistry.v1+json",
-          "application/vnd.schemaregistry+json",
-          "application/json"
-        ],
         "parameters": [],
-        "produces": ["application/vnd.schemaregistry.v1+json",
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
           "application/vnd.schemaregistry+json",
           "application/json"
         ],
@@ -250,11 +265,6 @@
       "get": {
         "summary": "Get the mode for a subject.",
         "operationId": "get_mode_subject",
-        "consumes": [
-          "application/vnd.schemaregistry.v1+json",
-          "application/vnd.schemaregistry+json",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "subject",
@@ -356,11 +366,6 @@
       "delete": {
         "summary": "Delete the mode for a subject.",
         "operationId": "delete_mode_subject",
-        "consumes": [
-          "application/vnd.schemaregistry.v1+json",
-          "application/vnd.schemaregistry+json",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "subject",
@@ -401,13 +406,12 @@
       "get": {
         "summary": "Get the supported schema types.",
         "operationId": "get_schemas_types",
-        "consumes": [
+        "parameters": [],
+        "produces": [
           "application/vnd.schemaregistry.v1+json",
           "application/vnd.schemaregistry+json",
           "application/json"
         ],
-        "parameters": [],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
         "responses": {
           "200": {
             "description": "OK",
@@ -431,11 +435,6 @@
       "get": {
         "summary": "Get a schema by ID.",
         "operationId": "get_schemas_ids_id",
-        "consumes": [
-          "application/vnd.schemaregistry.v1+json",
-          "application/vnd.schemaregistry+json",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -444,7 +443,11 @@
             "type": "integer"
           }
         ],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -479,11 +482,6 @@
       "get": {
         "summary": "Get a list of subject-version for the schema ID.",
         "operationId": "get_schemas_ids_id_versions",
-        "consumes": [
-          "application/vnd.schemaregistry.v1+json",
-          "application/vnd.schemaregistry+json",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -492,7 +490,11 @@
             "type": "integer"
           }
         ],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -526,6 +528,54 @@
         }
       }
     },
+    "/schemas/ids/{id}/subjects": {
+      "get": {
+        "summary": "Retrieve a list of subjects associated with some schema ID.",
+        "operationId": "get_schemas_ids_id_subjects",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "404": {
+            "description": "Schema not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
     "/subjects": {
       "get": {
         "summary": "Retrieve a list of subjects.",
@@ -533,6 +583,12 @@
         "parameters": [
           {
             "name": "deleted",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "subjectPrefix",
             "in": "query",
             "required": false,
             "type": "string"
@@ -549,7 +605,7 @@
             "schema": {
               "type": "array",
               "items": {
-                  "type": "string"
+                "type": "string"
               }
             }
           },
@@ -579,19 +635,41 @@
             "type": "string"
           },
           {
+            "name": "normalize",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "schema_def",
             "in": "body",
-            "schema":  {
+            "schema": {
               "$ref": "#/definitions/schema_def"
             }
           }
         ],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "schema": {
               "$ref": "#/definitions/subject_schema"
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
             }
           },
           "409": {
@@ -617,11 +695,6 @@
       "delete": {
         "summary": "Delete all schemas for the subject.",
         "operationId": "delete_subject",
-        "consumes": [
-          "application/vnd.schemaregistry.v1+json",
-          "application/vnd.schemaregistry+json",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "subject",
@@ -636,7 +709,11 @@
             "type": "boolean"
           }
         ],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -691,7 +768,7 @@
             "schema": {
               "type": "array",
               "items": {
-                  "type": "integer"
+                "type": "integer"
               }
             }
           },
@@ -725,14 +802,24 @@
             "type": "string"
           },
           {
+            "name": "normalize",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "schema_def",
             "in": "body",
-            "schema":  {
+            "schema": {
               "$ref": "#/definitions/schema_def"
             }
           }
         ],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -964,7 +1051,7 @@
             "schema": {
               "type": "array",
               "items": {
-                  "type": "integer"
+                "type": "integer"
               }
             }
           },
@@ -1019,7 +1106,7 @@
             "schema": {
               "type": "array",
               "items": {
-                  "type": "integer"
+                "type": "integer"
               }
             }
           },
@@ -1069,22 +1156,21 @@
           {
             "name": "schema_def",
             "in": "body",
-            "schema":  {
+            "schema": {
               "$ref": "#/definitions/schema_def"
             }
           }
         ],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                }
-              }
+              "$ref": "#/definitions/is_compatibile"
             }
           },
           "409": {
@@ -1107,9 +1193,22 @@
           }
         }
       }
+    },
+    "/status/ready": {
+      "get": {
+        "summary": "Health check",
+        "operationId": "schema_registry_status_ready",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "503": {
+            "description": "Service Unavailable"
+          }
+        }
+      }
     }
-  },
-  "definitions": {
+  },"definitions": {
     "error_body": {
       "type": "object",
       "properties": {
@@ -1142,7 +1241,7 @@
                 "type": "string"
               },
               "version": {
-                  "type": "integer"
+                "type": "integer"
               }
             }
           }
@@ -1176,12 +1275,28 @@
                 "type": "string"
               },
               "version": {
-                  "type": "integer"
+                "type": "integer"
               }
             }
           }
         },
         "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "get_compatibility": {
+      "type": "object",
+      "properties": {
+        "compatibilityLevel": {
+          "type": "string"
+        }
+      }
+    },
+    "put_compatibility": {
+      "type": "object",
+      "properties": {
+        "compatibility": {
           "type": "string"
         }
       }
@@ -1197,6 +1312,13 @@
           ]
         }
       }
+    },
+    "is_compatibile": {
+      "type": "object",
+      "properties": {
+        "is_compatible": {
+          "type": "boolean"
+        }
+      }
     }
-  }
-}
+}}

--- a/modules/ROOT/attachments/pandaproxy-schema-registry.json
+++ b/modules/ROOT/attachments/pandaproxy-schema-registry.json
@@ -9,7 +9,8 @@
   "schemes": [
     "http"
   ],
-  "paths": {"/config/{subject}": {
+  "paths": {
+    "/config/{subject}": {
       "get": {
         "summary": "Get the compatibility level for a subject.",
         "operationId": "get_config_subject",
@@ -182,17 +183,209 @@
           "application/json"
         ],
         "parameters": [],
-        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "produces": ["application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "mode": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/mode"
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Set the global mode.",
+        "operationId": "put_mode",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "mode",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/mode"
+            }
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/mode"
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
+    "/mode/{subject}": {
+      "get": {
+        "summary": "Get the mode for a subject.",
+        "operationId": "get_mode_subject",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subject",
+            "description": "The subject to get the mode for.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "defaultToGlobal",
+            "description": "If true, return the global mode if the subject doesn't have a mode set.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/mode"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Set the mode for a subject.",
+        "operationId": "put_mode_subject",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subject",
+            "description": "The subject to set the mode for.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mode",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/mode"
+            }
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/mode"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete the mode for a subject.",
+        "operationId": "delete_mode_subject",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subject",
+            "description": "The subject to delete the mode for.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/mode"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
             }
           },
           "500": {
@@ -915,7 +1108,8 @@
         }
       }
     }
-},"definitions": {
+  },
+  "definitions": {
     "error_body": {
       "type": "object",
       "properties": {
@@ -989,6 +1183,18 @@
         },
         "schema": {
           "type": "string"
+        }
+      }
+    },
+    "mode": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "READWRITE",
+            "READONLY"
+          ]
         }
       }
     }


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2619
Resolves https://github.com/redpanda-data/documentation-private/issues/2526
Review deadline: 30 July 2024

Related to https://github.com/redpanda-data/docs/pull/647

## Page previews

[`GET /mode`](https://deploy-preview-646--redpanda-docs-preview.netlify.app/api/pandaproxy-schema-registry/#get-/mode)
`PUT /mode`
`GET /mode/{subject}`
`PUT /mode/{subject}`
`DELETE /mode/{subject}`

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)