### PR TITLE
Remove cloud tiers

### DIFF
--- a/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
+++ b/modules/deploy/pages/deployment-option/cloud/whats-new-cloud.adoc
@@ -25,7 +25,7 @@ To start using Dedicated, you can now sign up for a xref:deploy:deployment-optio
 For xref:deploy:deployment-option/cloud/byoc-tiers.adoc#byoc-supported-regions[BYOC clusters] and xref:deploy:deployment-option/cloud/dedicated/dedicated-tiers.adoc#dedicated-supported-regions[Dedicated clusters], Redpanda added support for the following regions:
 
 * GCP: asia-east1 (Taiwan), asia-northeast1 (Tokyo), southamerica-east1 (São Paulo)
-* AWS: ap-east-1 (Hong Kong), ap-northeast-1 (Tokyo), me-central-1 (UAE)
+* AWS: ap-east-1 (Hong Kong), ap-northeast-1 (Tokyo)
 
 == June 2024
 

--- a/modules/deploy/partials/cloud/tiers.adoc
+++ b/modules/deploy/partials/cloud/tiers.adoc
@@ -67,7 +67,6 @@ Amazon Web Services (AWS)::
 | eu-central-1
 | eu-west-1
 | eu-west-2
-| me-central-1
 | sa-east-1
 | us-east-1
 | us-east-2
@@ -138,7 +137,6 @@ Amazon Web Services (AWS)::
 | eu-central-1
 | eu-west-1
 | eu-west-2
-| me-central-1
 | us-east-1
 | us-east-2
 | us-west-2


### PR DESCRIPTION
## Description
Removes the AWS region me-central-1, per Praseed https://github.com/redpanda-data/cloudv2/issues/16917#issuecomment-2260892259

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)