### PR TITLE
fix link in what's new

### DIFF
--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -71,4 +71,4 @@ The following `rpk` commands are new in this version:
 
 == Doc enhancements
 
-The https://docs.redpanda.com/current/home/[Redpanda Docs home page] has been redesigned, so you can stay within the context of Redpanda Enterprise, Redpanda Cloud, or Redpanda Connect docs. We hope that our docs help and inspire our users. Please share your feedback with the links at the bottom of any doc page. 
+The https://docs.redpanda.com/home/[Redpanda Docs home page] has been redesigned, so you can stay within the context of Redpanda Enterprise, Redpanda Cloud, or Redpanda Connect docs. We hope that our docs help and inspire our users. Please share your feedback with the links at the bottom of any doc page. 


### PR DESCRIPTION
## Description
Change link to go to docs home instead of landing page