### PR TITLE
2641 update AlterConfigs update

### DIFF
--- a/modules/upgrade/partials/incompat-changes.adoc
+++ b/modules/upgrade/partials/incompat-changes.adoc
@@ -1,6 +1,6 @@
 === Review incompatible changes
 
-* Starting in version 24.2, when managing configuration properties using the AlterConfigs API directly, or the `kafka-configs.sh` shell script without incremental flags, Redpanda resets all unspecified values to the default values. This aligns more closely with the behavior in Apache Kafka. There is no change if you're managing your configuration with tools like `rpk`, Redpanda Console, Kubernetes, Helm, or Terraform. 
+* Starting in version 24.2, when managing configuration properties using the AlterConfigs API directly, Redpanda resets all unspecified values to the default values. This aligns more closely with the behavior in Apache Kafka. There is no change if you're managing your configuration with tools like `rpk`, Redpanda Console, Kubernetes, Helm, or Terraform. 
 +
 NOTE: This does not pertain to the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. The remote properties are not reset to their defaults by the AlterConfigs API to avoid the possibility of unintentionally disabling Tiered Storage for a topic, which could cause significant operational issues for clusters designed to use Tiered Storage exclusively or with object storage as the only durable storage tier.
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2641
Review deadline:

## Page previews
https://deploy-preview-664--redpanda-docs-preview.netlify.app/current/upgrade/rolling-upgrade/
https://deploy-preview-664--redpanda-docs-preview.netlify.app/current/upgrade/k-rolling-upgrade/#review-incompatible-changes

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->
