### PR TITLE
k-redpanda-helm-spec: memory.enable_memory_locking and memory.container.min

### DIFF
--- a/modules/reference/pages/k-redpanda-helm-spec.adoc
+++ b/modules/reference/pages/k-redpanda-helm-spec.adoc
@@ -792,7 +792,7 @@ https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#sta
 
 === link:++https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory++[resources.memory]
 
-Memory resources For details, see the
+Memory resources. For details, see the
 https://docs.redpanda.com/docs/manage/kubernetes/manage-resources/#configure-memory-resources[Pod
 resources documentation].
 
@@ -802,23 +802,35 @@ resources documentation].
 {"container":{"max":"2.5Gi"}}
 ....
 
-=== link:++https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory.container++[resources.memory.container]
+=== link:++https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory++[resources.memory.enable_memory_locking]
 
 Enables memory locking. For production, set to `true`.
-enable_memory_locking: false It is recommended to have at least 2Gi of
+
+*Default:* `false`
+
+=== link:++https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory.container++[resources.memory.container]
+
+It is recommended to have at least 2Gi of
 memory per core for the Redpanda binary. This memory is taken from the
 total memory given to each container. The Helm chart allocates 80% of
 the container’s memory to Redpanda, leaving the rest for the Seastar
 subsystem (reserveMemory) and other container processes. So at least
 2.5Gi per core is recommended in order to ensure Redpanda has a full
-2Gi. These values affect `--memory` and `--reserve-memory` flags passed
+2Gi.
+
+These values affect `--memory` and `--reserve-memory` flags passed
 to Redpanda and the memory requests/limits in the StatefulSet. Valid
-suffixes: k, M, G, T, P, Ki, Mi, Gi, Ti, Pi To create `Guaranteed` Pod
+suffixes: k, M, G, T, P, Ki, Mi, Gi, Ti, Pi
+
+To create `Guaranteed` Pod
 QoS for Redpanda brokers, provide both container max and min values for
 the container. For details, see
 https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed
+
 * Every container in the Pod must have a memory limit and a memory
-request. * For every container in the Pod, the memory limit must equal
+request.
+
+* For every container in the Pod, the memory limit must equal
 the memory request.
 
 *Default:* `{"max":"2.5Gi"}`
@@ -829,6 +841,12 @@ Maximum memory count for each Redpanda broker. Equivalent to
 `resources.limits.memory`. For production, use `10Gi` or greater.
 
 *Default:* `"2.5Gi"`
+
+=== link:++https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory.container++[resources.memory.container.min]
+
+Minimum memory count for each Redpanda broker. If omitted, the `min` value is equal to the `max` value (requested resources defaults to limits). This setting is equivalent to `resources.requests.memory`. For production, use 10Gi or greater.
+
+*Default:* `""`
 
 === link:++https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=serviceAccount++[serviceAccount]
 


### PR DESCRIPTION
**From:**

> #### [resources.memory](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory)
> Memory resources For details, see the [Pod resources documentation](https://docs.redpanda.com/docs/manage/kubernetes/manage-resources/#configure-memory-resources).
> 
> Default:
> 
> ```
> {"container":{"max":"2.5Gi"}}
> ```
> #### [resources.memory.container](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory.container)
> Enables memory locking. For production, set to true. enable_memory_locking: false It is recommended to have at least 2Gi of memory per core for the Redpanda binary. This memory is taken from the total memory given to each container. The Helm chart allocates 80% of the container’s memory to Redpanda, leaving the rest for the Seastar subsystem (reserveMemory) and other container processes. So at least 2.5Gi per core is recommended in order to ensure Redpanda has a full 2Gi. These values affect --memory and --reserve-memory flags passed to Redpanda and the memory requests/limits in the StatefulSet. Valid suffixes: k, M, G, T, P, Ki, Mi, Gi, Ti, Pi To create Guaranteed Pod QoS for Redpanda brokers, provide both container max and min values for the container. For details, see https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed * Every container in the Pod must have a memory limit and a memory request. * For every container in the Pod, the memory limit must equal the memory request.
> 
> Default: `{"max":"2.5Gi"}`
> 
> #### [resources.memory.container.max](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory.container.max)
> Maximum memory count for each Redpanda broker. Equivalent to resources.limits.memory. For production, use 10Gi or greater.
> 
> Default: `"2.5Gi"`

**To:**

> #### [resources.memory](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory)
> Memory resources. For details, see the [Pod resources documentation](https://docs.redpanda.com/docs/manage/kubernetes/manage-resources/#configure-memory-resources).
> 
> Default:
> ```
> {"container":{"max":"2.5Gi"}}
> ```
> #### [resources.memory.enable_memory_locking](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory)
> Enables memory locking. For production, set to true.
> 
> Default: `false`
> 
> #### [resources.memory.container](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory.container)
> It is recommended to have at least 2Gi of memory per core for the Redpanda binary. This memory is taken from the total memory given to each container. The Helm chart allocates 80% of the container’s memory to Redpanda, leaving the rest for the Seastar subsystem (reserveMemory) and other container processes. So at least 2.5Gi per core is recommended in order to ensure Redpanda has a full 2Gi.
> 
> These values affect --memory and --reserve-memory flags passed to Redpanda and the memory requests/limits in the StatefulSet. Valid suffixes: k, M, G, T, P, Ki, Mi, Gi, Ti, Pi
> 
> To create Guaranteed Pod QoS for Redpanda brokers, provide both container max and min values for the container. For details, see https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed
> - Every container in the Pod must have a memory limit and a memory request.
> - For every container in the Pod, the memory limit must equal the memory request.
> 
> Default: `{"max":"2.5Gi"}`
> 
> #### [resources.memory.container.max](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory.container.max)
> Maximum memory count for each Redpanda broker. Equivalent to resources.limits.memory. For production, use 10Gi or greater.
> 
> Default: `"2.5Gi"`
> 
> #### [resources.memory.container.min](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory.container)
> Minimum memory count for each Redpanda broker. If omitted, the min value is equal to the max value (requested resources defaults to limits). This setting is equivalent to resources.requests.memory. For production, use 10Gi or greater.
> 
> Default: `""`