### PR TITLE
k-redpanda-helm-spec: cpu.overprovisioned

### DIFF
--- a/modules/reference/pages/k-redpanda-helm-spec.adoc
+++ b/modules/reference/pages/k-redpanda-helm-spec.adoc
@@ -778,17 +778,33 @@ resources documentation].
 
 Redpanda makes use of a thread per core model. For details, see this
 https://redpanda.com/blog/tpc-buffers[blog]. For this reason, Redpanda
-should only be given full cores. Note: You can increase cores, but
+should only be given full cores.
+
+Note: You can increase cores, but
 decreasing cores is not currently supported. See the
-https://github.com/redpanda-data/redpanda/issues/350[GitHub issue]. This
+https://github.com/redpanda-data/redpanda/issues/350[GitHub issue].
+
+This
 setting is equivalent to `--smp`, `resources.requests.cpu`, and
-`resources.limits.cpu`. For production, use `4` or greater. To maximize
+`resources.limits.cpu`. For production, use `4` or greater.
+
+To maximize
 efficiency, use the `static` CPU manager policy by specifying an even
 integer for CPU resource requests and limits. This policy gives the Pods
 running Redpanda brokers access to exclusive CPUs on the node. See
 https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy.
 
 *Default:* `1`
+
+=== link:++https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.cpu++[resources.cpu.overprovisioned]
+
+Overprovisioned means Redpanda won't assume it has all of the provisioned CPU. This should
+be true unless the container has CPU affinity. Equivalent to:
+`--idle-poll-time-us 0 --thread-affinity 0 --poll-aio 0`
+
+If the value of full cores in `resources.cpu.cores` is less than `1`, this setting is set to `true`.
+
+*Default:* `false`
 
 === link:++https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=resources.memory++[resources.memory]
 


### PR DESCRIPTION
**Old:**

<img width="898" alt="Screenshot 2024-08-05 at 3 17 57 PM" src="https://github.com/user-attachments/assets/1f0f942d-7288-47e0-a710-f0dea67877df">

**New:**

<img width="880" alt="Screenshot 2024-08-05 at 3 18 24 PM" src="https://github.com/user-attachments/assets/e5f25034-52db-45ef-b029-42124206594b">
