### PR TITLE
Add a note about changing TLS settings for the RPC listener

### DIFF
--- a/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
@@ -73,6 +73,10 @@ spec:
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
 ```
 
+[NOTE]
+====
+include::manage:partial$kubernetes/tls-update-note.adoc[]
+====
 --
 Helm::
 +
@@ -249,6 +253,10 @@ spec:
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
 ```
 
+[NOTE]
+====
+include::manage:partial$kubernetes/tls-update-note.adoc[]
+====
 --
 Helm::
 +

--- a/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
@@ -306,7 +306,7 @@ include::manage:partial$kubernetes/tls-update-note.adoc[]
 kubectl get certificate --namespace <namespace>
 ```
 
-By default, this certificate will be used to encrypt traffic between clients and all external listeners. You can select specific certificates for each external listener. See xref:manage:kubernetes/networking/k-configure-listeners.adoc#tls[Configure Listeners in Kubernetes].
+By default, this certificate is used to encrypt traffic between clients and all external listeners. You can select specific certificates for each external listener. See xref:manage:kubernetes/networking/k-configure-listeners.adoc#tls[Configure Listeners in Kubernetes].
 
 == Connect to Redpanda
 

--- a/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
@@ -72,11 +72,6 @@ spec:
 ```bash
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
 ```
-
-[NOTE]
-====
-include::manage:partial$kubernetes/tls-update-note.adoc[]
-====
 --
 Helm::
 +
@@ -106,6 +101,11 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 ====
 --
 ======
++
+[NOTE]
+====
+include::manage:partial$kubernetes/tls-update-note.adoc[]
+====
 
 . Make sure the Certificates are in a `READY` state.
 +
@@ -253,10 +253,6 @@ spec:
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
 ```
 
-[NOTE]
-====
-include::manage:partial$kubernetes/tls-update-note.adoc[]
-====
 --
 Helm::
 +
@@ -299,13 +295,18 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 --
 ======
 +
-By default, this certificate will be used to encrypt traffic between clients and all external listeners. You can select specific certificates for each external listener. See xref:manage:kubernetes/networking/k-configure-listeners.adoc#tls[Configure Listeners in Kubernetes].
+[NOTE]
+====
+include::manage:partial$kubernetes/tls-update-note.adoc[]
+====
 
 . Make sure the Certificates are in a `READY` state.
 +
 ```bash
 kubectl get certificate --namespace <namespace>
 ```
+
+By default, this certificate will be used to encrypt traffic between clients and all external listeners. You can select specific certificates for each external listener. See xref:manage:kubernetes/networking/k-configure-listeners.adoc#tls[Configure Listeners in Kubernetes].
 
 == Connect to Redpanda
 

--- a/modules/manage/pages/kubernetes/security/tls/k-secrets.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-secrets.adoc
@@ -117,11 +117,6 @@ spec:
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
 ```
 
-[NOTE]
-====
-include::manage:partial$kubernetes/tls-update-note.adoc[]
-====
-
 --
 Helm::
 +
@@ -190,6 +185,11 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 ====
 --
 ======
+
+[NOTE]
+====
+include::manage:partial$kubernetes/tls-update-note.adoc[]
+====
 
 By default, certificates will be used to encrypt traffic between clients and all external listeners. You can also select specific certificates for each external listener. See xref:manage:kubernetes/networking/k-configure-listeners.adoc#tls[Configure Listeners].
 

--- a/modules/manage/pages/kubernetes/security/tls/k-secrets.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-secrets.adoc
@@ -62,6 +62,7 @@ You can configure Redpanda to use your TLS certificates for internal or external
 Helm + Operator::
 +
 --
+
 .`redpanda-cluster.yaml`
 [,yaml]
 ----
@@ -115,6 +116,11 @@ spec:
 ```bash
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
 ```
+
+[NOTE]
+====
+include::manage:partial$kubernetes/tls-update-note.adoc[]
+====
 
 --
 Helm::

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -754,6 +754,10 @@ kubectl exec redpanda-0 -c redpanda --namespace <namespace> -- \
   -X brokers=<subdomain>.<domain>:<external-port> \
   -X tls.enabled=true
 ```
+
+=== Redpanda Operator not applying TLS changes
+
+include::manage:partial$kubernetes/tls-update-note.adoc[]
 //end::tls[]
 
 //tag::networking[]

--- a/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
+++ b/modules/manage/pages/kubernetes/troubleshooting/k-troubleshoot.adoc
@@ -755,7 +755,7 @@ kubectl exec redpanda-0 -c redpanda --namespace <namespace> -- \
   -X tls.enabled=true
 ```
 
-=== Redpanda Operator not applying TLS changes
+=== Redpanda not applying TLS changes
 
 include::manage:partial$kubernetes/tls-update-note.adoc[]
 //end::tls[]

--- a/modules/manage/partials/kubernetes/disable-tls.adoc
+++ b/modules/manage/partials/kubernetes/disable-tls.adoc
@@ -20,3 +20,5 @@ listeners:
     tls:
       enabled: false
 ----
+
+include::manage:partial$kubernetes/tls-update-note.adoc[]

--- a/modules/manage/partials/kubernetes/tls-update-note.adoc
+++ b/modules/manage/partials/kubernetes/tls-update-note.adoc
@@ -1,6 +1,8 @@
-Enabling or disabling TLS for the RPC listener requires you to delete all Pods that run Redpanda. When you change the `rpc.tls.enabled` setting, or if it is not overridden and you change the global `tls.enabled` option, Redpanda does not automatically apply the change. To apply the change, you must delete all the Pods that run Redpanda.
+Enabling or disabling TLS for the RPC listener requires you to delete all Pods that run Redpanda. When you change the `rpc.tls.enabled` setting, or if it is not overridden and you change the global `tls.enabled` option, Redpanda cannot safely apply the change because RPC listener configurations must be the same across all brokers. To apply the change, all Redpanda Pods must be deleted simultaneously so that they all start with the updated RPC listener. This action results in temporary downtime of the cluster.
+
+Although you can use the `--force` option to speed up the rollout, it may result in data loss as Redpanda will not be given time to shut down gracefully.
 
 [,bash]
 ----
-kubectl delete pod -l app=redpanda --namespace <namespace> --force
+kubectl delete pod -l app=redpanda --namespace <namespace>
 ----

--- a/modules/manage/partials/kubernetes/tls-update-note.adoc
+++ b/modules/manage/partials/kubernetes/tls-update-note.adoc
@@ -1,4 +1,4 @@
-When you change one of the `tls.enabled` settings for brokers in an existing Redpanda cluster, the Redpanda Operator does not apply the change automatically. To apply the change, you must delete all the Pods that run Redpanda.
+Enabling or disabling TLS for the RPC listener requires you to delete all Pods that run Redpanda. When you change the `rpc.tls.enabled` setting, or if it is not overridden and you change the global `tls.enabled` option, Redpanda does not automatically apply the change. To apply the change, you must delete all the Pods that run Redpanda.
 
 [,bash]
 ----

--- a/modules/manage/partials/kubernetes/tls-update-note.adoc
+++ b/modules/manage/partials/kubernetes/tls-update-note.adoc
@@ -1,0 +1,6 @@
+When you change one of the `tls.enabled` settings for brokers in an existing Redpanda cluster, the Redpanda Operator does not apply the change automatically. To apply the change, you must delete all the Pods that run Redpanda.
+
+[,bash]
+----
+kubectl delete pod -l app=redpanda --namespace <namespace> --force
+----


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2617
Review deadline: 9 August

## Page previews

- [cert-manager](https://deploy-preview-670--redpanda-docs-preview.netlify.app/current/manage/kubernetes/security/tls/k-cert-manager/#:~:text=Make%20sure%20that%20TLS%20is%20enabled%3A)
- [Secrets](https://deploy-preview-670--redpanda-docs-preview.netlify.app/current/manage/kubernetes/security/tls/k-secrets/#:~:text=If%20you%20are%20using%20a%20private%20CA%2C%20set%20caEnabled%20to%20true.)
- [Troubleshooting](https://deploy-preview-670--redpanda-docs-preview.netlify.app/current/manage/kubernetes/troubleshooting/k-troubleshoot/#redpanda-not-applying-tls-changes)

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)