### PR TITLE
update wording on rpk self test

### DIFF
--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-self-test-start.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-self-test-start.adoc
@@ -55,7 +55,7 @@ network test runs (default `30000`).
 
 |--no-confirm |- |Acknowledge warning prompt skipping read from stdin.
 
-|--only-cloud-test |- |Runs only cloud storage benchmarks.
+|--only-cloud-test |- |Runs only cloud storage verification.
 
 |--only-disk-test |- |Runs only the disk benchmarks.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-self-test-start.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-self-test-start.adoc
@@ -17,8 +17,8 @@ Available tests to run:
 *** Unique pairs of Redpanda nodes each act as a client and a server.
 *** The test pushes as much data over the wire, within the test parameters.
 * *Cloud storage tests*
-** Latency test: 1024-bit object.
-** Depending on cluster read/write permissions (xref:reference:properties/object-storage-properties.adoc#cloud_storage_enable_remote_read[`cloud_storage_enable_remote_read`], xref:reference:properties/object-storage-properties.adoc#cloud_storage_enable_remote_write[`cloud_storage_enable_remote_write`]), a series of cloud storage operations are performed:
+** Configuration/Latency test: 1024-byte object.
+** If cloud storage is enabled xref:reference:properties/object-storage-properties.adoc#cloud_storage_enabled[(`cloud_storage_enabled`)]), a series of remote operations are performed:
 +
 --
 include::reference:partial$rpk-self-test-cloud-tests.adoc[]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-self-test-start.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-self-test-start.adoc
@@ -17,7 +17,7 @@ Available tests to run:
 *** Unique pairs of Redpanda nodes each act as a client and a server.
 *** The test pushes as much data over the wire, within the test parameters.
 * *Cloud storage tests*
-** Configuration/Latency test: 1024-byte object.
+** Configuration/latency test: 1024-byte object.
 ** If cloud storage is enabled (xref:reference:properties/object-storage-properties.adoc#cloud_storage_enabled[`cloud_storage_enabled`]), a series of remote operations are performed:
 +
 --

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-self-test-start.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-self-test-start.adoc
@@ -18,7 +18,7 @@ Available tests to run:
 *** The test pushes as much data over the wire, within the test parameters.
 * *Cloud storage tests*
 ** Configuration/Latency test: 1024-byte object.
-** If cloud storage is enabled xref:reference:properties/object-storage-properties.adoc#cloud_storage_enabled[(`cloud_storage_enabled`)]), a series of remote operations are performed:
+** If cloud storage is enabled (xref:reference:properties/object-storage-properties.adoc#cloud_storage_enabled[`cloud_storage_enabled`]), a series of remote operations are performed:
 +
 --
 include::reference:partial$rpk-self-test-cloud-tests.adoc[]


### PR DESCRIPTION
## Description

Update wording on rpk self test to reflect https://github.com/redpanda-data/redpanda/pull/22656 and https://github.com/redpanda-data/redpanda/pull/22667/files#diff-e6b899efec06cad52b2d9de9c3820284ed993969ed622efefbe1f47e388fa60a

**Should only be merged after Redpanda releases v24.2.2.** Check https://github.com/redpanda-data/redpanda/releases



## Page previews

https://deploy-preview-674--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-self-test-start/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)