### PR TITLE
Add Schema Registry mode support to What's New

### DIFF
--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -58,6 +58,10 @@ xref:manage:cluster-maintenance/cluster-balancing.adoc#intra-broker-partition-ba
 
 This is a beta feature for v24.2 and is not recommended for use for production clusters.
 
+== Schema Registry read-only mode
+
+The xref:manage:schema-reg/schema-reg-api.adoc#use-readonly-mode-for-disaster-recovery[Schema Registry API] now supports the `/mode` endpoint, so you can put individual subjects or the entire Schema Registry in read-only or read-write mode. The `READONLY` mode can be used in an active/passive disaster recovery configuration.
+
 == New commands
 
 The following `rpk` commands are new in this version:

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -60,7 +60,7 @@ This is a beta feature for v24.2 and is not recommended for use for production c
 
 == Schema Registry read-only mode
 
-The xref:manage:schema-reg/schema-reg-api.adoc#use-readonly-mode-for-disaster-recovery[Schema Registry API] now supports the `/mode` endpoint, so you can put individual subjects or the entire Schema Registry in read-only or read-write mode. The `READONLY` mode can be used in an active/passive disaster recovery configuration.
+The xref:manage:schema-reg/schema-reg-api.adoc#use-readonly-mode-for-disaster-recovery[Schema Registry API] now supports the `/mode` endpoint, so you can put individual subjects or the entire Schema Registry in read-only or read-write mode. You can use the `READONLY` mode in an active/passive disaster recovery configuration.
 
 == New commands
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2649 
Review deadline:

## Page previews
https://deploy-preview-676--redpanda-docs-preview.netlify.app/current/get-started/whats-new/#schema-registry-read-only-mode
<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)