### PR TITLE
Add missing closing tags

### DIFF
--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-get.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-get.adoc
@@ -32,3 +32,4 @@ rpk registry mode get [SUBJECT...] [flags]
 
 |-v, --verbose |- |Enable verbose logging.
 |===
+// end::single-source[]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-reset.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-reset.adoc
@@ -30,3 +30,4 @@ rpk registry mode reset [SUBJECT...] [flags]
 
 |-v, --verbose |- |Enable verbose logging.
 |===
+// end::single-source[]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-set.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-set.adoc
@@ -58,3 +58,4 @@ rpk registry mode set <subject-1> <subject-2> --mode READWRITE
 ----
 
 NOTE: Replace the placeholder values.
+// end::single-source[]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode.adoc
@@ -28,3 +28,4 @@ rpk registry mode [command] [flags]
 
 |-v, --verbose |- |Enable verbose logging.
 |===
+// end::single-source[]


### PR DESCRIPTION
## Description

The deploy logs flagged that some `rpk` reference pages are missing the ending tags. Cloud docs are using these pages for single-sourcing. While these tags are missing, the Cloud docs can't fetch the content.

```
6:10:21 PM: [17:10:21.564] WARN (asciidoctor): detected unclosed tag 'single-source' starting at line 2 of include file
6:10:21 PM:     file: modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-get.adoc:2
6:10:21 PM:     source: https://github.com/redpanda-data/docs (branch: main)
6:10:21 PM:     stack:
6:10:21 PM:         file: modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-get.adoc:2
6:10:21 PM:         source: https://github.com/redpanda-data/cloud-docs (branch: main)
6:10:21 PM: [17:10:21.570] WARN (asciidoctor): detected unclosed tag 'single-source' starting at line 2 of include file
6:10:21 PM:     file: modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-reset.adoc:2
6:10:21 PM:     source: https://github.com/redpanda-data/docs (branch: main)
6:10:21 PM:     stack:
6:10:21 PM:         file: modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-reset.adoc:2
6:10:21 PM:         source: https://github.com/redpanda-data/cloud-docs (branch: main)
6:10:21 PM: [17:10:21.572] WARN (asciidoctor): detected unclosed tag 'single-source' starting at line 2 of include file
6:10:21 PM:     file: modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-set.adoc:2
6:10:21 PM:     source: https://github.com/redpanda-data/docs (branch: main)
6:10:21 PM:     stack:
6:10:21 PM:         file: modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-set.adoc:2
6:10:21 PM:         source: https://github.com/redpanda-data/cloud-docs (branch: main)
6:10:21 PM: [17:10:21.574] WARN (asciidoctor): detected unclosed tag 'single-source' starting at line 2 of include file
6:10:21 PM:     file: modules/reference/pages/rpk/rpk-registry/rpk-registry-mode.adoc:2
6:10:21 PM:     source: https://github.com/redpanda-data/docs (branch: main)
```

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)