### PR TITLE
Update aks-guide.adoc

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/aks-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/aks-guide.adoc
@@ -53,7 +53,7 @@ az group create --name redpandaResourceGroup --location eastus
 az aks create -g redpandaResourceGroup -n <cluster-name> \
   --node-count 3 \
   --generate-ssh-keys \
-  --enable-node-public-ip
+  --enable-node-public-ip \
   --node-vm-size Standard_L8s_v3 \
   --disable-file-driver
 ----


### PR DESCRIPTION
```
az aks create -g redpandaResourceGroup -n <cluster-name> \
  --node-count 3 \
  --generate-ssh-keys \
  --enable-node-public-ip
  --node-vm-size Standard_L8s_v3 \
  --disable-file-driver
```

should be 

```
az aks create -g redpandaResourceGroup -n <cluster-name> \
  --node-count 3 \
  --generate-ssh-keys \
  --enable-node-public-ip \
  --node-vm-size Standard_L8s_v3 \
  --disable-file-driver

```
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)