### PR TITLE
Add redirect for data archiving

### DIFF
--- a/modules/manage/pages/tiered-storage.adoc
+++ b/modules/manage/pages/tiered-storage.adoc
@@ -1,7 +1,7 @@
 = Use Tiered Storage
 :description: Configure your Redpanda cluster to offload log segments to cloud storage and save storage costs.
 :page-context-links: [{"name": "Linux", "to": "manage:tiered-storage.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/storage/tiered-storage/k-tiered-storage.adoc" } ]
-:page-aliases: data-management:shadow-indexing.adoc, data-management:tiered-storage.adoc, manage:data-archiving.adoc
+:page-aliases: data-management:shadow-indexing.adoc, data-management:tiered-storage.adoc, data-management:data-archiving.adoc, manage:data-archiving.adoc
 :page-categories: Management, High Availability, Data Replication
 :env-linux: true
 


### PR DESCRIPTION
## Description

Fixes 404 error with `https://docs.redpanda.com/current/data-management/data-archiving/`

## Page previews

https://deploy-preview-701--redpanda-docs-preview.netlify.app/current/data-management/data-archiving/ should redirect to [Tiered Storage](https://deploy-preview-701--redpanda-docs-preview.netlify.app/current/manage/tiered-storage/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)