### PR TITLE
Clarify Admin API URLs

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -8,7 +8,7 @@ info:
     ---
 
 servers:
-- url: http://localhost:9644/v1
+- url: http://localhost:9644/
 paths:
   # /config:
   #   get:
@@ -29,7 +29,7 @@ paths:
   #                 type: array
   #                 items:
   #                   $ref: '#/components/schemas/cluster_config_properties'
-  /node_config:
+  /v1/node_config:
     get:
       tags:
       - Clusters
@@ -50,7 +50,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/node_config_properties'
-  /loggers:
+  /v1/loggers:
     get:
       tags:
       - Logging
@@ -66,7 +66,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/logger'
-  /config/log_level/{name}:
+  /v1/config/log_level/{name}:
     put:
       tags:
       - Logging
@@ -105,7 +105,7 @@ paths:
         200:
           description: Log level set successfully
           content: {}
-  /cluster_config:
+  /v1/cluster_config:
     get:
       tags:
       - Clusters
@@ -154,7 +154,7 @@ paths:
         200:
           description: Success
           content: {}
-  /cluster_config/schema:
+  /v1/cluster_config/schema:
     get:
       tags:
       - Clusters
@@ -168,7 +168,7 @@ paths:
             application/json:
               schema:
                 type: object
-  /cluster_config/status:
+  /v1/cluster_config/status:
     get:
       tags:
       - Clusters
@@ -184,7 +184,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/cluster_config_status'
-  /raft/{group_id}/transfer_leadership:
+  /v1/raft/{group_id}/transfer_leadership:
     post:
       tags:
       - Partitions
@@ -391,7 +391,7 @@ paths:
                   type: array
               type: object
       summary: Update role membership
-  /security/users:
+  /v1/security/users:
     get:
       tags:
       - Users
@@ -428,7 +428,7 @@ paths:
         200:
           description: User successfully created
           content: {}
-  /security/users/{user}:
+  /v1/security/users/{user}:
     put:
       tags:
       - Users
@@ -488,7 +488,7 @@ paths:
         - Users
       operationId: list_user_roles
       summary: List role assignments for a user
-  /security/oidc/whoami:
+  /v1/security/oidc/whoami:
     get:
       tags: 
         -  Authentication
@@ -505,7 +505,7 @@ paths:
         401:
           description: Unauthorized
           content: {}      
-  /security/oidc/keys/cache_invalidate:
+  /v1/security/oidc/keys/cache_invalidate:
     post:
       tags: 
         -  Authentication
@@ -522,7 +522,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/oidc_keys_cache_invalidate_error_response'
-  /security/oidc/revoke:
+  /v1/security/oidc/revoke:
     post: 
       tags: 
         -  Authentication
@@ -539,7 +539,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/oidc_keys_cache_invalidate_error_response' 
-  /status/ready:
+  /v1/status/ready:
     get:
       tags:
       - Clusters
@@ -553,7 +553,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/cluster_ready_status'
-  /features:
+  /v1/features:
     get:
       tags:
       - Licenses and Features
@@ -568,7 +568,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/features_response'
-  /features/license:
+  /v1/features/license:
     get:
       tags:
       - Licenses and Features
@@ -597,7 +597,7 @@ paths:
         200:
           description: Upload license success
           content: {}
-  /features/{feature_name}:
+  /v1/features/{feature_name}:
     put:
       tags:
       - Licenses and Features
@@ -614,7 +614,7 @@ paths:
         200:
           description: Activate feature success
           content: {}
-  /brokers:
+  /v1/brokers:
     get:
       tags:
       - Brokers
@@ -630,7 +630,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/broker'
-  /brokers/{id}:
+  /v1/brokers/{id}:
     get:
       tags:
       - Brokers
@@ -651,7 +651,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/broker'
-  /brokers/{id}/cancel_partition_moves:
+  /v1/brokers/{id}/cancel_partition_moves:
     post:
       tags:
       - Brokers
@@ -669,7 +669,7 @@ paths:
         200:
           description: Cancel partition moves success
           content: {}
-  /brokers/{id}/decommission:
+  /v1/brokers/{id}/decommission:
     get:
       tags:
       - Brokers
@@ -708,7 +708,7 @@ paths:
         200:
           description: Decommission broker success
           content: {}
-  /brokers/{id}/maintenance:
+  /v1/brokers/{id}/maintenance:
     put:
       tags:
       - Brokers
@@ -743,7 +743,7 @@ paths:
         200:
           description: Exit broker maintenance mode success
           content: {}
-  /brokers/{id}/recommission:
+  /v1/brokers/{id}/recommission:
     put:
       tags:
       - Brokers
@@ -761,7 +761,7 @@ paths:
         200:
           description: Recommission broker success
           content: {}
-  /cluster_view:
+  /v1/cluster_view:
     get:
       tags:
       - Clusters
@@ -775,7 +775,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/cluster_view'
-  /maintenance:
+  /v1/maintenance:
     get:
       tags:
       - Brokers
@@ -809,7 +809,7 @@ paths:
         200:
           description: Stop maintenance success
           content: {}
-  /partitions:
+  /v1/partitions:
     get:
       tags:
       - Partitions
@@ -825,7 +825,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/partition_summary'
-  /partitions/local_summary:
+  /v1/partitions/local_summary:
     get:
       tags:
       - Partitions
@@ -840,7 +840,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/partitions_local_summary'
-  /partitions/majority_lost:
+  /v1/partitions/majority_lost:
     get: 
       tags: 
       - Partitions
@@ -861,7 +861,7 @@ paths:
           description: 'Use a comma-separated list of IDs, for example `1,3,5`.'
           schema:
             type: string
-  /partitions/force_recover_from_nodes:
+  /v1/partitions/force_recover_from_nodes:
     post: 
       tags: 
       - Partitions
@@ -881,7 +881,7 @@ paths:
         200:
           content: {}
           description: OK
-  /partitions/rebalance:
+  /v1/partitions/rebalance:
     post:
       tags:
       - Partitions
@@ -892,7 +892,7 @@ paths:
         200:
           description: Success
           content: {}
-  /partitions/rebalance_cores:
+  /v1/partitions/rebalance_cores:
     post:
       tags:
       - Partitions
@@ -903,7 +903,7 @@ paths:
         200:
           description: Success
           content: {}
-  /partitions/reconfigurations:
+  /v1/partitions/reconfigurations:
     get:
       tags:
       - Partitions
@@ -919,7 +919,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/reconfiguration'
-  /partitions/{namespace}/{topic}:
+  /v1/partitions/{namespace}/{topic}:
     get:
       tags:
       - Partitions
@@ -946,7 +946,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/partition'
-  /partitions/{namespace}/{topic}/{partition}:
+  /v1/partitions/{namespace}/{topic}/{partition}:
     get:
       tags:
       - Partitions
@@ -978,7 +978,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/partition'
-  /partitions/{namespace}/{topic}/{partition}/cancel_reconfiguration:
+  /v1/partitions/{namespace}/{topic}/{partition}/cancel_reconfiguration:
     post:
       tags:
       - Partitions
@@ -1005,7 +1005,7 @@ paths:
         200:
           description: Cancel reconfiguration success
           content: {}
-  /partitions/{namespace}/{topic}/{partition}/mark_transaction_expired:
+  /v1/partitions/{namespace}/{topic}/{partition}/mark_transaction_expired:
     post:
       tags:
       - Transactions
@@ -1042,7 +1042,7 @@ paths:
         200:
           description: Transaction expired success
           content: {}
-  /partitions/{namespace}/{topic}/{partition}/replicas:
+  /v1/partitions/{namespace}/{topic}/{partition}/replicas:
     post:
       tags:
       - Partitions
@@ -1069,7 +1069,7 @@ paths:
         200:
           description: Update partition replicas success
           content: {}
-  /partitions/{namespace}/{topic}/{partition}/replicas/{node}:
+  /v1/partitions/{namespace}/{topic}/{partition}/replicas/{node}:
     post:
       tags:
       - Partitions
@@ -1108,7 +1108,7 @@ paths:
         200:
           description: Replica core updated successfully
           content: {}
-  /partitions/{namespace}/{topic}/{partition}/transactions:
+  /v1/partitions/{namespace}/{topic}/{partition}/transactions:
     get:
       tags:
       - Partitions
@@ -1138,7 +1138,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/transactions'
-  /partitions/{namespace}/{topic}/{partition}/transfer_leadership:
+  /v1/partitions/{namespace}/{topic}/{partition}/transfer_leadership:
     post:
       tags:
       - Partitions
@@ -1169,7 +1169,7 @@ paths:
         200:
           description: Transfer leadership success
           content: {}
-  /partitions/{namespace}/{topic}/{partition}/unclean_abort_reconfiguration:
+  /v1/partitions/{namespace}/{topic}/{partition}/unclean_abort_reconfiguration:
     post:
       tags:
       - Unstable APIs
@@ -1196,7 +1196,7 @@ paths:
         200:
           description: Abort reconfiguration success
           content: {}
-  /transaction/{transactional_id}/find_coordinator:
+  /v1/transaction/{transactional_id}/find_coordinator:
     get:
       tags:
       - Transactions
@@ -1216,7 +1216,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/find_coordinator_reply'      
-  /transaction/{transactional_id}/delete_partition:
+  /v1/transaction/{transactional_id}/delete_partition:
     post:
       tags:
       - Transactions
@@ -1253,7 +1253,7 @@ paths:
         200:
           description: Delete partition success
           content: {}
-  /transactions:
+  /v1/transactions:
     get:
       tags:
       - Transactions
@@ -1269,7 +1269,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/transaction_summary'
-  /cluster/cancel_reconfigurations:
+  /v1/cluster/cancel_reconfigurations:
     post:
       tags:
       - Partitions
@@ -1280,7 +1280,7 @@ paths:
         200:
           description: Cancel reconfigurations successful
           content: {}
-  /cluster/health_overview:
+  /v1/cluster/health_overview:
     get:
       tags:
       - Clusters
@@ -1294,7 +1294,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/cluster_health_overview'
-  /cluster/partitions:
+  /v1/cluster/partitions:
     get: 
       summary: Get cluster-level metadata for all partitions in cluster
       description: Get cluster-level metadata for all partitions in cluster.
@@ -1321,7 +1321,7 @@ paths:
                   $ref: '#/components/schemas/cluster_partition'
       tags: 
         -  Partitions    
-  /cluster/partitions/{namespace}/{topic}:
+  /v1/cluster/partitions/{namespace}/{topic}:
     post:
       summary: Disable/enable all partitions of a topic
       description: "Disable or enable all partitions of a topic. To disable, use `{'disabled': true}` in request body. To enable, use `{'disabled': false}`."
@@ -1380,7 +1380,7 @@ paths:
                   $ref: '#/components/schemas/cluster_partition'
       tags: 
         -  Partitions 
-  /cluster/partitions/{namespace}/{topic}/{partition}:
+  /v1/cluster/partitions/{namespace}/{topic}/{partition}:
     post: 
       summary: Disable/enable a single partition
       description: "Disable or enable a single partition. To disable, use `{'disabled': true}` in request body. To enable, use `{'disabled': false}`."
@@ -1414,7 +1414,7 @@ paths:
           content: {}
       tags: 
         -  Partitions 
-  /cluster/partition_balancer/status:
+  /v1/cluster/partition_balancer/status:
     get:
       tags:
       - Partitions
@@ -1428,7 +1428,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/partition_balancer_status'
-  /cluster/uuid:
+  /v1/cluster/uuid:
     get:
       tags:
       - Clusters
@@ -1443,7 +1443,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/uuid'
-  /debug/self_test/start:
+  /v1/debug/self_test/start:
     post:
       tags:
       - Debugging
@@ -1454,7 +1454,7 @@ paths:
         200:
           description: Start self-test success
           content: {}
-  /debug/self_test/status:
+  /v1/debug/self_test/status:
     get:
       tags:
       - Debugging
@@ -1470,7 +1470,7 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/self_test_node_report'
-  /debug/self_test/stop:
+  /v1/debug/self_test/stop:
     post:
       tags:
       - Debugging
@@ -1481,7 +1481,7 @@ paths:
         200:
           description: Stop self-test success
           content: {}
-  /debug/cpu_profile:
+  /v1/debug/cpu_profile:
     get:
       operationId: get_cpu_profile
       tags:
@@ -1517,7 +1517,7 @@ paths:
         schema:
           type: integer
           format: int64
-  /debug/partitions/{namespace}/{topic}/{partition}/force_replicas:
+  /v1/debug/partitions/{namespace}/{topic}/{partition}/force_replicas:
     post:
       tags:
       -  Partitions
@@ -1554,7 +1554,7 @@ paths:
         schema:
           type: integer
           format: int64
-  /debug/restart_service:
+  /v1/debug/restart_service:
     put:
       tags: 
         -  Debugging
@@ -1579,7 +1579,7 @@ paths:
           description: Service not found
         500:
           description: Internal Server Error 
-  /cloud_storage/initiate_topic_scan_and_recovery:
+  /v1/cloud_storage/initiate_topic_scan_and_recovery:
     get:
       tags:
       - Tiered Storage
@@ -1610,7 +1610,7 @@ paths:
           description: Topic scan and recovery started successfully
           content: {}
       x-codegen-request-body-name: body
-  /cloud_storage/status/{topic}/{partition}:
+  /v1/cloud_storage/status/{topic}/{partition}:
     get:
       tags:
       - Tiered Storage
@@ -1635,7 +1635,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/partition_cloud_storage_status'
-  /cloud_storage/manifest/{topic}/{partition}:
+  /v1/cloud_storage/manifest/{topic}/{partition}:
     get:
       tags:
       - Tiered Storage
@@ -1660,7 +1660,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/manifest_json'
-  /cloud_storage/lifecycle:
+  /v1/cloud_storage/lifecycle:
     get:
       tags:
       - Tiered Storage
@@ -1670,7 +1670,7 @@ paths:
       responses:
         200:
           description: Success
-  /cloud_storage/lifecycle/{topic}/{revision}:
+  /v1/cloud_storage/lifecycle/{topic}/{revision}:
     delete:
       tags:
       - Tiered Storage
@@ -1692,7 +1692,7 @@ paths:
         200:
           description: Success
           content: {}
-  /cloud_storage/sync_local_state/{topic}/{partition}:
+  /v1/cloud_storage/sync_local_state/{topic}/{partition}:
     post:
       tags:
       - Tiered Storage


### PR DESCRIPTION
## Description

The Admin API URLs consist of hostname (e.g. `http://localhost:9644`) + `/v1` + endpoint paths. Currently in our Admin API docs we display `http://localhost:9644/v1` under [Servers](https://docs.redpanda.com/api/admin-api/#servers), but the full URLs aren't displayed for the endpoints, for example: `GET /node_config`. It is easy to forget or miss the `v1` in the URL.

The most straightforward solution seems to be to just add `v1` to all of the individual `paths` in the spec. 

This will now also make our version of the Admin API spec match the engineering version of the [spec](https://github.com/redpanda-data/redpanda/tree/dev/src/v/redpanda/admin/api-doc), although it might be worth noting that [header.json](https://github.com/redpanda-data/redpanda/blob/dev/src/v/redpanda/admin/api-doc/header.json) will still include `v1` in the base path so we may have to talk about resolving that inconsistency.

Resolves https://github.com/redpanda-data/documentation-private/issues/2269
Review deadline: 27 Aug

## Page previews

[Admin API Reference](https://deploy-preview-705--redpanda-docs-preview.netlify.app/api/admin-api/#tag--Authentication)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)