### PR TITLE
Clarify how quickly segments get uploaded to object storage / data archiving

### DIFF
--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1089,13 +1089,15 @@ The upload backlog controller prevents Redpanda from running out of disk space. 
 
 === Data archiving
 
-If you only enable remote write on a topic, you have a simple backup to cloud storage that you can use for recovery. In the event of a data center failure, data corruption, or cluster migration, you can recover your archived data from the cloud back to your cluster.
+If you only enable remote write on a topic, you have a simple backup to object storage that you can use for recovery. In the event of a data center failure, data corruption, or cluster migration, you can recover your archived data from the cloud back to your cluster.
 
 ==== Configure data archiving
 
 Data archiving requires a <<set-up-tiered-storage,Tiered Storage configuration>>.
 
 To recover a topic from object storage, use xref:{topic-recovery-link}[single topic recovery].
+
+The current log segment stays on disk based on local retention settings. See <<manage-local-capacity-for-tiered-storage,Manage local capacity for Tiered Storage>> to configure how quickly remote write uploads segments to object storage.
 
 ==== Stop data archiving
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1063,7 +1063,15 @@ rpk topic describe-storage <topic_name> --print-all
 
 See the xref:reference:rpk/rpk-topic/rpk-topic-describe-storage.adoc[reference] for a list of flags you can use to filter the command output.
 
-TIP: A constant stream of data is necessary to build up the log segments and roll them into object storage. To see new log segments faster, you can edit the `segment.bytes` topic-level property. Or, you can edit the xref:reference:properties/object-storage-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] property, which sets the frequency with which new segments are generated in Tiered Storage, even if the local segment has not exceeded the `segment.bytes` size or the `segment.ms` age.
+[TIP]
+====
+A constant stream of data is necessary to build up the log segments and roll them into object storage. This upload process is asynchronous. You can monitor its status with the following metrics:
+
+* xref:reference:public-metrics-reference.adoc#redpanda_cloud_client_uploads[`/public_metrics/redpanda_cloud_client_uploads`]
+* xref:reference:internal-metrics-reference.adoc#vectorized_ntp_archiver_pending[`/metrics/vectorized_ntp_archiver_pending`]
+
+To see new log segments faster, you can edit the `segment.bytes` topic-level property. Or, you can edit the xref:reference:properties/object-storage-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] property, which sets the frequency with which new segments are generated in Tiered Storage, even if the local segment has not exceeded the `segment.bytes` size or the `segment.ms` age.
+====
 
 NOTE: Starting in version 22.3, when you delete a topic in Redpanda, the data is also deleted in object storage. See <<Enable Tiered Storage for specific topics>>.
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1065,9 +1065,8 @@ See the xref:reference:rpk/rpk-topic/rpk-topic-describe-storage.adoc[reference] 
 
 [TIP]
 ====
-A constant stream of data is necessary to build up the log segments and roll them into object storage. This upload process is asynchronous. You can monitor its status with the following metrics:
+A constant stream of data is necessary to build up the log segments and roll them into object storage. This upload process is asynchronous. You can monitor its status with the following metric:
 
-* xref:reference:public-metrics-reference.adoc#redpanda_cloud_client_uploads[`/public_metrics/redpanda_cloud_client_uploads`]
 * xref:reference:internal-metrics-reference.adoc#vectorized_ntp_archiver_pending[`/metrics/vectorized_ntp_archiver_pending`]
 
 To see new log segments faster, you can edit the `segment.bytes` topic-level property. Or, you can edit the xref:reference:properties/object-storage-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] property, which sets the frequency with which new segments are generated in Tiered Storage, even if the local segment has not exceeded the `segment.bytes` size or the `segment.ms` age.

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -18,7 +18,7 @@ image::shared:tiered_storage1.png[Tiered Storage architecture]
 
 [IMPORTANT]
 ====
-- When upgrading Redpanda, uploads to object storage are paused until all brokers in the cluster are upgraded. If the cluster gets stuck while upgrading, roll it back to the original version. In a mixed-version state, the cluster could run out of disk space. If you need to force a mixed-version cluster to upload, move partition leadership to brokers running the original version.
+When upgrading Redpanda, uploads to object storage are paused until all brokers in the cluster are upgraded. If the cluster gets stuck while upgrading, roll it back to the original version. In a mixed-version state, the cluster could run out of disk space. If you need to force a mixed-version cluster to upload, move partition leadership to brokers running the original version.
 ====
 
 == Prerequisites

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1065,7 +1065,7 @@ See the xref:reference:rpk/rpk-topic/rpk-topic-describe-storage.adoc[reference] 
 
 [TIP]
 ====
-A constant stream of data is necessary to build up the log segments and roll them into object storage. This upload process is asynchronous. You can monitor its status with the following metric: xref:reference:internal-metrics-reference.adoc#vectorized_ntp_archiver_pending[`/metrics/vectorized_ntp_archiver_pending`]
+A constant stream of data is necessary to build up the log segments and roll them into object storage. This upload process is asynchronous. You can monitor its status with the xref:reference:internal-metrics-reference.adoc#vectorized_ntp_archiver_pending[`/metrics/vectorized_ntp_archiver_pending`] metric.
 
 To see new log segments faster, you can edit the `segment.bytes` topic-level property. Or, you can edit the xref:reference:properties/object-storage-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] property, which sets the frequency with which new segments are generated in Tiered Storage, even if the local segment has not exceeded the `segment.bytes` size or the `segment.ms` age.
 ====

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1105,8 +1105,6 @@ Data archiving requires a <<set-up-tiered-storage,Tiered Storage configuration>>
 
 To recover a topic from object storage, use xref:{topic-recovery-link}[single topic recovery].
 
-The current log segment stays on disk based on local retention settings. See <<manage-local-capacity-for-tiered-storage,Manage local capacity for Tiered Storage>> to configure how quickly remote write uploads segments to object storage.
-
 ==== Stop data archiving
 
 To cancel archiving jobs, disable remote write.

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1065,9 +1065,7 @@ See the xref:reference:rpk/rpk-topic/rpk-topic-describe-storage.adoc[reference] 
 
 [TIP]
 ====
-A constant stream of data is necessary to build up the log segments and roll them into object storage. This upload process is asynchronous. You can monitor its status with the following metric:
-
-* xref:reference:internal-metrics-reference.adoc#vectorized_ntp_archiver_pending[`/metrics/vectorized_ntp_archiver_pending`]
+A constant stream of data is necessary to build up the log segments and roll them into object storage. This upload process is asynchronous. You can monitor its status with the following metric: xref:reference:internal-metrics-reference.adoc#vectorized_ntp_archiver_pending[`/metrics/vectorized_ntp_archiver_pending`]
 
 To see new log segments faster, you can edit the `segment.bytes` topic-level property. Or, you can edit the xref:reference:properties/object-storage-properties.adoc#cloud_storage_segment_max_upload_interval_sec[`cloud_storage_segment_max_upload_interval_sec`] property, which sets the frequency with which new segments are generated in Tiered Storage, even if the local segment has not exceeded the `segment.bytes` size or the `segment.ms` age.
 ====


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2152
Review deadline: 27 Aug 2024

## Page previews

[Use Tiered Storage > Remote write 
](https://deploy-preview-706--redpanda-docs-preview.netlify.app/current/manage/tiered-storage/#remote-write)
<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)