### PR TITLE
Update GitHub user

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -111,8 +111,8 @@ jobs:
       - name: Set up git config
         run: |
           echo "Setting up git config..."
-          git config user.name "GitHub Actions Bot"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "vbotbuildovich"
+          git config user.email "vbotbuildovich@users.noreply.github.com"
       - name: Checkout maintenance branch and cherry-pick
         run: |
           echo "Fetching latest changes..."

--- a/.github/workflows/generate-crd.yml
+++ b/.github/workflows/generate-crd.yml
@@ -78,8 +78,8 @@ jobs:
         if: env.has_changes == 'true'
         run: |
           cd ./redpanda-docs
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "GitHub Actions"
+          git config --global user.email "vbotbuildovich@users.noreply.github.com"
+          git config --global user.name "vbotbuildovich"
           git add .
           git commit -m "auto-docs: Update CRD reference doc"
           git push origin main

--- a/.github/workflows/generate-helm-spec.yml
+++ b/.github/workflows/generate-helm-spec.yml
@@ -99,8 +99,8 @@ jobs:
         if: env.has_changes == 'true'
         run: |
           cd ./redpanda-docs
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "GitHub Actions"
+          git config --global user.email "vbotbuildovich@users.noreply.github.com"
+          git config --global user.name "vbotbuildovich"
           git add modules/reference/*
           git commit -m "auto-docs: Update Helm spec"
           git push origin main

--- a/.github/workflows/generate-kubernetes-compatibility.yaml
+++ b/.github/workflows/generate-kubernetes-compatibility.yaml
@@ -67,8 +67,8 @@ jobs:
         if: env.has_changes == 'true'
         run: |
           cd ./redpanda-docs
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "GitHub Actions"
+          git config --global user.email "vbotbuildovich@users.noreply.github.com"
+          git config --global user.name "vbotbuildovich"
           git add .
           git commit -m "auto-docs: Update K8s compatibility matrix"
           git push origin main

--- a/.github/workflows/get-cloud-api-spec.yml
+++ b/.github/workflows/get-cloud-api-spec.yml
@@ -61,8 +61,8 @@ jobs:
         if: env.has_changes == 'true'
         run: |
           cd ./redpanda-docs
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "GitHub Actions"
+          git config --global user.email "vbotbuildovich@users.noreply.github.com"
+          git config --global user.name "vbotbuildovich"
           git add modules/ROOT/attachments/cloud-api.yaml
           git commit -m "auto-docs: Update Cloud API spec"
           git push origin api

--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "vbotbuildovich"
+          git config --global user.email "vbotbuildovich@users.noreply.github.com"
           git add package.json package-lock.json
           git commit -m "Update @redpanda-data/docs-extensions-and-macros"
         env:


### PR DESCRIPTION
## Description

GitHub treats the placeholder email as a user and requires the CLA to be signed. This change sets the user to [vbotbuildovich](https://github.com/vbotbuildovich) which doesn't require this.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)