### PR TITLE
kustomize helm installation instruction results in an error

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -15,9 +15,9 @@ asciidoc:
     # Fallback versions
     # We try to fetch the latest from GitHub at build time
     # --
-    full-version: 24.2.1
-    latest-release-commit: '08ae9f9c'
-    latest-operator-version: 'v2.1.11-24.1.1'
+    full-version: 24.2.2
+    latest-release-commit: '72ba3d3'
+    latest-operator-version: 'v2.2.0-24.2.2'
     latest-redpanda-helm-chart-version: 5.8.3
     # --
     supported-kubernetes-version: 1.21


### PR DESCRIPTION
## Description

The [installation instructions](https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/kubernetes/k-production-deployment/) ask the user to run the following step, which fails because it references a tag that doesn't exist:
```
kubectl kustomize "https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref=v2.1.11-24.1.1" \
    | kubectl apply --server-side -f -
```

## Page previews
https://deploy-preview-713--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/kubernetes/k-production-deployment/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)