### PR TITLE
New license guidance per Alex

### DIFF
--- a/modules/get-started/pages/licenses.adoc
+++ b/modules/get-started/pages/licenses.adoc
@@ -39,13 +39,7 @@ Redpanda Enterprise Edition is licensed with the https://github.com/redpanda-dat
 * xref:redpanda-connect:components:outputs/snowflake_put.adoc[Snowflake connector for Redpanda Connect]
 * xref:redpanda-connect:components:outputs/splunk_hec.adoc[Splunk connector for Redpanda Connect]
 
-Enterprise features require a license key. You can evaluate enterprise features with a free 30-day trial. Contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda Sales^] to request a trial license, to extend your trial period, or to purchase an Enterprise Edition license. If you access an enterprise feature without a valid license, you get the following message:
-
-----
-Looks like you've enabled a Redpanda Enterprise feature without a valid license.
-Please enter an active Redpanda license key (for example, rpk cluster license set <key>).
-If you don't have one, please request a new/trial license at https://redpanda.com/license-request.
-----
+Enterprise features require a license key. You can evaluate enterprise features with a free 30-day trial. Contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda Sales^] to request a trial license, to extend your trial period, or to purchase an Enterprise Edition license.
 
 === Apply a license key to Redpanda
 


### PR DESCRIPTION
## Description

Resolves (https://github.com/redpanda-data/documentation-private/issues/2696)
Review deadline: **August 26th**

[Preview](https://deploy-preview-715--redpanda-docs-preview.netlify.app/current/get-started/licenses/#redpanda-enterprise-edition)

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)