### PR TITLE
update rpk cloud byoc

### DIFF
--- a/modules/reference/partials/rpk-cloud-byoc-concept.adoc
+++ b/modules/reference/partials/rpk-cloud-byoc-concept.adoc
@@ -6,4 +6,4 @@ The BYOC command runs Terraform to create and start the agent. You first need
 a `redpanda-id` (or cluster ID); this is used to get the details of how your
 agent should be provisioned. 
 
-NOTE: To create a BYOC cluster, follow the instructions in the Redpanda Cloud UI. The UI contains the parameters necessary to run `rpk cloud byoc apply` with your cloud provider.
+NOTE: To create a BYOC cluster, use the xref:redpanda-cloud:manage:api/cloud-byoc-controlplane-api.adoc#create-a-new-cluster[Cloud API] or the Redpanda Cloud UI. The UI contains the parameters necessary to run `rpk cloud byoc apply` with your cloud provider.

--- a/modules/reference/partials/rpk-cloud-byoc-concept.adoc
+++ b/modules/reference/partials/rpk-cloud-byoc-concept.adoc
@@ -1,8 +1,9 @@
 Redpanda installs an agent service in your BYOC cluster. The agent
 then provisions infrastructure and, eventually, a full
-Redpanda cluster. The command downloads the `byoc` plugin from Redpanda Cloud and can execute many operations.
+Redpanda cluster. The command downloads the `byoc` plugin from Redpanda Cloud.
 
 The BYOC command runs Terraform to create and start the agent. You first need
 a `redpanda-id` (or cluster ID); this is used to get the details of how your
-agent should be provisioned. You can create a BYOC cluster in the Redpanda Cloud UI
-and then come back to this command to complete the process.
+agent should be provisioned. 
+
+NOTE: To create a BYOC cluster, follow the instructions in the Redpanda Cloud UI. The UI contains the parameters necessary to run `rpk cloud byoc apply` with your cloud provider.


### PR DESCRIPTION
## Description

This PR updates the `rpk byoc cloud` reference page in the docs repo.  [PR 39](https://github.com/redpanda-data/cloud-docs/pull/39) updates the cloud-docs repo. All to address issue https://github.com/redpanda-data/documentation-private/issues/2226:
Review deadline: August 28

## Page previews
[rpk cloud byoc](https://deploy-preview-716--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cloud/rpk-cloud-byoc/) Self-Managed
[rpk cloud byoc](https://deploy-preview-716--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-cloud/rpk-cloud-byoc/) Cloud

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)