### PR TITLE
auto-docs: Update extensions on v/24.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -592,9 +592,9 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "3.5.9",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.5.9.tgz",
-      "integrity": "sha512-yQUmzdiHLoBalfOAnJ5DqWV/nvQSn7LZmWZrg7x7sZPSfC/Bxz/9RjAI6euwzA8vCtFPSOY11X8/AMZxksenwg==",
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.5.10.tgz",
+      "integrity": "sha512-Gj+8kjgDDmhV6pH8UNNF3hvpX+9sacndH4a4dz8Y4xAZfHHjWXKfb0N+aW/hjL6G0Z6aywZJ6qhdsL0lHXtKOg==",
       "dependencies": {
         "algoliasearch": "^4.17.0",
         "chalk": "4.1.2",


### PR DESCRIPTION
This PR updates the @redpanda-data/docs-extensions-and-macros package on the v/24.1 branch.