### PR TITLE
DOC-287 Mountable TS topics

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -161,6 +161,7 @@
 ** xref:manage:tiered-storage-linux/index.adoc[Tiered Storage]
 *** xref:manage:tiered-storage.adoc[]
 *** xref:manage:fast-commission-decommission.adoc[]
+*** xref:manage:mountable-topics.adoc[]
 *** xref:manage:remote-read-replicas.adoc[Remote Read Replicas]
 *** xref:manage:topic-recovery.adoc[Topic Recovery]
 *** xref:manage:whole-cluster-restore.adoc[Whole Cluster Restore]

--- a/modules/manage/pages/mountable-topics.adoc
+++ b/modules/manage/pages/mountable-topics.adoc
@@ -1,0 +1,7 @@
+= Mountable Topics
+:description: Relocate a topic between your Redpanda cluster and object storage.
+:page-context-links: [{"name": "Linux", "to": "manage:mountable-topics.adoc" } ]
+:page-categories: Management
+:env-linux: true
+
+include::manage:partial$mountable-topics.adoc[]

--- a/modules/manage/pages/mountable-topics.adoc
+++ b/modules/manage/pages/mountable-topics.adoc
@@ -1,5 +1,5 @@
 = Mountable Topics
-:description: Relocate a topic between your Redpanda cluster and object storage.
+:description: Safely attach and detach Tiered Storage topics to and from a Redpanda cluster.
 :page-context-links: [{"name": "Linux", "to": "manage:mountable-topics.adoc" } ]
 :page-categories: Management
 :env-linux: true

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -11,8 +11,8 @@ The following data is moved to object storage when unmounting a topic from a clu
 
 == Prerequisites
 
-. Enable Tiered Storage for specific topics, or for the entire cluster (all topics).
-. Install `rpk`, or ensure that you have access to the Admin API.
+. Enable xref:manage:tiered-storage.adoc[Tiered Storage] for specific topics, or for the entire cluster (all topics).
+. xref:get-started:rpk-install.adoc[Install `rpk`], or ensure that you have access to the Admin API.
 
 == Unmount a topic from a cluster to object storage
 
@@ -32,13 +32,10 @@ rpk topic unmount <namespace>/<topic-name>
 Admin API::
 +
 --
-To unmount a topic from a cluster using the Admin API, you must first create an outbound topic migration. The API returns the migration ID upon creation. Then, you make an API request with the migration ID to carry out the migration in steps: prepare, execute, and cut over.
+To unmount a topic from a cluster using the Admin API, you must first create an outbound topic migration. The API returns the migration ID upon creation. Then, you make an API request with the migration ID to carry out the migration in steps: prepare, execute, and cut over. You must wait for each step to complete and for the <<monitor-progress,migration state>> to update before proceeding to the next step.
 
-[[unmount-create-migration]]
-=== Create migration
-
-Make a PUT request to the `/migrations` endpoint to create a topic migration. Specify the names of the desired topics in the request body:
-
+. Make a PUT request to the `/migrations` endpoint to create a topic migration. Specify the names of the desired topics in the request body:
++
 ```
 curl -X PUT http://localhost:9644/v1/migrations -d {
   "migration_type":"outbound", 
@@ -58,41 +55,32 @@ curl -X PUT http://localhost:9644/v1/migrations -d {
   ], "consumer_groups": []
 }
 ```
-
-* `ns` is the topic namespace. This field is optional. Default: `kafka`
++
+* `ns` is the topic namespace. This field is optional. Default value: `kafka`
 * `consumer_groups` is required.
-
++
 If successful, the response returns the ID of the newly-created migration. Use the ID in subsequent API calls to run the migration.
 
-[[unmount-prepare-migration]]
-=== Prepare migration
-
-When preparing topics for migration, Redpanda copies all possible topic data, including topic manifest,s to the destination bucket or container in object storage. In this state, the cluster still accepts client reads and writes. 
-
+. When preparing topics for migration, Redpanda copies all possible topic data including topic manifests to the destination bucket or container in object storage. In this state, the cluster still accepts client reads and writes. 
++
 Make a `POST /v1/migrations/\{id}/?action=prepare` request:
-
++
 ```
 curl -X POST http://localhost:9644/v1/<migration-id>/?action=prepare
 ```
 
-[[unmount-execute-migration]]
-=== Execute migration
-
-When you execute the migration, the cluster rejects client reads and writes. Redpanda uploads any remaining topic data that has not yet been copied to object storage. 
-
+. When you execute the migration, the cluster rejects client reads and writes. Redpanda uploads any remaining topic data that has not yet been copied to object storage. 
++
 Make a `POST /v1/migrations/\{id}/?action=execute` request to execute the migration:
-
++
 ```
 curl -X POST http://localhost:9644/v1/<migration-id>/?action=execute
 ```
 
-[[unmount-cut-over]]
-=== Cut over
-
-Finally, the migration can be deleted. Redpanda deletes the unmounted topics from the cluster.
-
+. Finally, the migration can be deleted. Redpanda deletes the unmounted topics from the cluster.
++
 To cut over after executing the migration:
-
++
 ```
 curl -X POST http://localhost:9644/v1/<migration-id>/?action=finish
 ```
@@ -123,13 +111,10 @@ rpk topic mount <namespace>/<source-topic-name> --to <namespace>/<new-topic-name
 Admin API::
 +
 --
-To mount a topic to a target cluster using the Admin API, you must first create an inbound topic migration. The API returns the migration ID upon creation. Then, you make an API request with the migration ID to carry out the migration in steps: prepare, execute, and cut over.
+To mount a topic to a target cluster using the Admin API, you must first create an inbound topic migration. The API returns the migration ID upon creation. Then, you make an API request with the migration ID to carry out the migration in steps: prepare, execute, and cut over. You must wait for each step to complete and for the <<monitor-progress,migration state>> to update before proceeding to the next step.
 
-[[mount-create-migration]]
-=== Create migration
-
-Make a PUT request to the `/migrations` endpoint to create a topic migration. Specify the names of the topics in the request body:
-
+. Make a PUT request to the `/migrations` endpoint to create a topic migration. Specify the names of the topics in the request body:
++
 ```
 curl -X PUT http://localhost:9644/v1/migrations -d {
   "migration_type":"inbound", 
@@ -149,42 +134,33 @@ curl -X PUT http://localhost:9644/v1/migrations -d {
   "consumer_groups": []
 }
 ```
-
-* `ns` is the topic namespace. This field is optional. Default: `kafka`
++
+* `ns` is the topic namespace. This field is optional. Default value: `kafka`
 * To rename the topic in the target cluster, use the optional `alias` object in the request body. In the example, topics 1 and 3 are given new names in the target cluster, while topic 2 retains its original name.
 * `consumer_groups` is required.
-
++
 If successful, the response returns the ID of the newly-created migration. Use the ID in subsequent API calls to run the migration.
 
-[[mount-prepare-migration]]
-=== Prepare migration
-
-When preparing a topic for migration, Redpanda recreates the topic in a disabled state in the target cluster. The cluster allocates partitions but does not add log segments yet. Topic metadata is populated from the topic manifest found in object storage.
-
+. When preparing a topic for migration, Redpanda recreates the topic in a disabled state in the target cluster. The cluster allocates partitions but does not add log segments yet. Topic metadata is populated from the topic manifest found in object storage.
++
 Make a `POST /v1/migrations/\{id}/?action=prepare` request to prepare the migration:
-
++
 ```
 curl -X POST http://localhost:9644/v1/<migration-id>/?action=prepare
 ```
 
-[[mount-execute-migration]]
-=== Execute migration
-
-When you execute the migration, the target cluster starts the partitions with log segments downloaded from object storage.
-
+. When you execute the migration, the target cluster starts the partitions with log segments downloaded from object storage.
++
 Make a `POST /v1/migrations/\{id}/?action=execute` request to execute the migration:
-
++
 ```
 curl -X POST http://localhost:9644/v1/<migration-id>/?action=execute
 ```
 
-[[mount-cut-over]]
-=== Cut over
-
-Finally, the migration can be deleted. The target cluster starts to handle produce and consume workloads.
-
+. Finally, the migration can be deleted. The target cluster starts to handle produce and consume workloads.
++
 To cut over after executing the migration:
-
++
 ```
 curl -X POST http://localhost:9644/v1/<migration-id>/?action=finish
 ```
@@ -193,11 +169,35 @@ curl -X POST http://localhost:9644/v1/<migration-id>/?action=finish
 
 ======
 
+== Cancel a migration
+
+You can cancel a topic migration by running this command:
+
+```
+
+```
+
+You can only cancel a migration that is not in the following final <<monitor-progress,states>>:
+
+- `cut_over`
+- `finished`
+
 == Monitor progress
 
-Issue a GET request to the `/migrations` endpoint to view the status of topic migrations:
+Issue a GET request to the `/migrations` endpoint to view the state of topic migrations:
 
 ```
 curl http://localhost:9644/v1/migrations 
 ```
 
+The response returns the state of existing migrations:
+
+- `planned`
+- `preparing`
+- `prepared`
+- `executing`
+- `executed`
+- `cut_over`
+- `finished`
+- `canceling`
+- `cancelled`

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -1,0 +1,57 @@
+For topics with Tiered Storage enabled, you can mount and unmount topics to transfer the topic data between your cluster and object storage. This effectively frees up unused partition space that can be reclaimed, enables you to migrate a topic to a different cluster, and allows the topic or even the entire cluster to hibernate or be decommissioned.
+
+You can mount a topic from object storage that has been previously flushed from a source cluster to a different destination cluster, or back to the same source cluster.
+
+== Prerequisites
+
+. Enable Tiered Storage for specific topics, or for the entire cluster (all topics).
+. Install `rpk`, or ensure that you have access to the Admin API.
+
+
+== Mount a topic to a cluster
+
+In your target cluster, run this command to mount a topic from object storage:
+
+[tabs]
+====
+rpk::
++
+--
+```
+rpk topic mount <topic-name> -u <cloud-storage-url>
+```
+--
+Admin API::
++
+--
+```
+
+```
+--
+
+====
+
+== Unmount a topic from a cluster to object storage
+
+Run this command to flush a topic from the source cluster to object storage. This deletes the topic from the cluster. Once you initiate this process, all incoming writes to the topic are blocked. Producers and consumers of the topic receive an error message indicating that the topic is no longer available. 
+
+[tabs]
+====
+rpk::
++
+--
+```
+rpk topic unmount <topic-name>
+```
+--
+Admin API::
++
+--
+```
+
+```
+--
+
+====
+
+== Monitor progress

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -2,6 +2,10 @@ For topics with Tiered Storage enabled, you can mount and unmount topics to tran
 
 You can mount a topic from object storage that has been previously flushed from a source cluster to a different destination cluster, or back to the same source cluster.
 
+The following data is moved to object storage when unmounting a topic from a cluster:
+* Topic definitions. 
+* The consumer offsets topic. This allows the destination cluster to also restore consumer group state.
+
 == Prerequisites
 
 . Enable Tiered Storage for specific topics, or for the entire cluster (all topics).

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -3,6 +3,7 @@ For topics with Tiered Storage enabled, you can mount and unmount topics to tran
 You can mount a topic from object storage that has been previously flushed from a source cluster to a different destination cluster, or back to the same source cluster.
 
 The following data is moved to object storage when unmounting a topic from a cluster:
+
 * Topic definitions. 
 * The consumer offsets topic. This allows the destination cluster to also restore consumer group state.
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -174,7 +174,7 @@ curl -X POST http://localhost:9644/v1/<migration-id>/?action=finish
 You can cancel a topic migration by running this command:
 
 ```
-
+curl -X POST http://localhost:9644/v1/<migration-id>/?action=cancel
 ```
 
 You can only cancel a migration that is not in the following final <<monitor-progress,states>>:

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -1,5 +1,7 @@
 For topics with Tiered Storage enabled, you can mount and unmount topics to transfer the topic data between your cluster and object storage. This effectively frees up unused partition space that can be reclaimed, enables you to migrate a topic to a different cluster, and allows the topic or even the entire cluster to hibernate or be decommissioned.
 
+An unmounted topic in object storage is detached from all clusters. The original cluster releases ownership of the topic.
+
 You can mount a topic from object storage that has been previously flushed from a source cluster to a different destination cluster, or back to the same source cluster.
 
 The following data is moved to object storage when unmounting a topic from a cluster:
@@ -12,51 +14,190 @@ The following data is moved to object storage when unmounting a topic from a clu
 . Enable Tiered Storage for specific topics, or for the entire cluster (all topics).
 . Install `rpk`, or ensure that you have access to the Admin API.
 
+== Unmount a topic from a cluster to object storage
+
+When you unmount a topic, all incoming writes to the topic are blocked as Redpanda migrates the topic from the cluster to object storage. Producers and consumers of the topic receive an error message indicating that the topic is no longer available. The unmounted topic is deleted in the source cluster.
+
+[tabs]
+======
+rpk::
++
+--
+In your cluster, run this command to unmount a topic to object storage:
+
+```
+rpk topic unmount <namespace>/<topic-name>
+```
+--
+Admin API::
++
+--
+To unmount a topic from a cluster using the Admin API, you must first create an outbound topic migration. The API returns the migration ID upon creation. Then, you make an API request with the migration ID to carry out the migration in steps: prepare, execute, and cut over.
+
+[[unmount-create-migration]]
+=== Create migration
+
+Make a PUT request to the `/migrations` endpoint to create a topic migration. Specify the names of the desired topics in the request body:
+
+```
+curl -X PUT http://localhost:9644/v1/migrations -d {
+  "migration_type":"outbound", 
+  "topics": [
+    {
+      "ns": "kafka", 
+      "topic": "<topic-1-name>"
+    }, 
+    {
+      "ns": "kafka", 
+      "topic": "<topic-2-name>"
+    }, 
+    {
+      "ns": "kafka", 
+      "topic": "<topic-3-name>"
+    }
+  ], "consumer_groups": []
+}
+```
+
+* `ns` is the topic namespace. This field is optional. Default: `kafka`
+* `consumer_groups` is required.
+
+If successful, the response returns the ID of the newly-created migration. Use the ID in subsequent API calls to run the migration.
+
+[[unmount-prepare-migration]]
+=== Prepare migration
+
+When preparing topics for migration, Redpanda copies all possible topic data, including topic manifest,s to the destination bucket or container in object storage. In this state, the cluster still accepts client reads and writes. 
+
+Make a `POST /v1/migrations/\{id}/?action=prepare` request:
+
+```
+curl -X POST http://localhost:9644/v1/<migration-id>/?action=prepare
+```
+
+[[unmount-execute-migration]]
+=== Execute migration
+
+When you execute the migration, the cluster rejects client reads and writes. Redpanda uploads any remaining topic data that has not yet been copied to object storage. 
+
+Make a `POST /v1/migrations/\{id}/?action=execute` request to execute the migration:
+
+```
+curl -X POST http://localhost:9644/v1/<migration-id>/?action=execute
+```
+
+[[unmount-cut-over]]
+=== Cut over
+
+Finally, the migration can be deleted. Redpanda deletes the unmounted topics from the cluster.
+
+To cut over after executing the migration:
+
+```
+curl -X POST http://localhost:9644/v1/<migration-id>/?action=finish
+```
+
+--
+======
+
 
 == Mount a topic to a cluster
 
+[tabs]
+======
+rpk::
++
+--
 In your target cluster, run this command to mount a topic from object storage:
 
-[tabs]
-====
-rpk::
-+
---
 ```
-rpk topic mount <topic-name> -u <cloud-storage-url>
+rpk topic mount <source-topic-name>
+```
+
+You can also rename the topic as you mount it to the target cluster:
+
+```
+rpk topic mount <namespace>/<source-topic-name> --to <namespace>/<new-topic-name>
 ```
 --
 Admin API::
 +
 --
-```
+To mount a topic to a target cluster using the Admin API, you must first create an inbound topic migration. The API returns the migration ID upon creation. Then, you make an API request with the migration ID to carry out the migration in steps: prepare, execute, and cut over.
+
+[[mount-create-migration]]
+=== Create migration
+
+Make a PUT request to the `/migrations` endpoint to create a topic migration. Specify the names of the topics in the request body:
 
 ```
+curl -X PUT http://localhost:9644/v1/migrations -d {
+  "migration_type":"inbound", 
+  "topics": [
+    {
+      "source_topic": {"ns": "kafka", "topic": "<source-topic-1-name>"}, 
+      "alias": {"ns": "kafka", "topic": "<new-topic-1-name>"}
+    }, 
+    {
+      "source_topic": {"ns": "kafka", "topic": "<source-topic-2-name>"}
+    }, 
+    {
+      "source_topic": {"ns": "kafka", "topic": "source-topic-3-name"}, 
+      "alias": {"ns": "kafka", "topic": "<new-topic-3-name>"}
+    }
+  ], 
+  "consumer_groups": []
+}
+```
+
+* `ns` is the topic namespace. This field is optional. Default: `kafka`
+* To rename the topic in the target cluster, use the optional `alias` object in the request body. In the example, topics 1 and 3 are given new names in the target cluster, while topic 2 retains its original name.
+* `consumer_groups` is required.
+
+If successful, the response returns the ID of the newly-created migration. Use the ID in subsequent API calls to run the migration.
+
+[[mount-prepare-migration]]
+=== Prepare migration
+
+When preparing a topic for migration, Redpanda recreates the topic in a disabled state in the target cluster. The cluster allocates partitions but does not add log segments yet. Topic metadata is populated from the topic manifest found in object storage.
+
+Make a `POST /v1/migrations/\{id}/?action=prepare` request to prepare the migration:
+
+```
+curl -X POST http://localhost:9644/v1/<migration-id>/?action=prepare
+```
+
+[[mount-execute-migration]]
+=== Execute migration
+
+When you execute the migration, the target cluster starts the partitions with log segments downloaded from object storage.
+
+Make a `POST /v1/migrations/\{id}/?action=execute` request to execute the migration:
+
+```
+curl -X POST http://localhost:9644/v1/<migration-id>/?action=execute
+```
+
+[[mount-cut-over]]
+=== Cut over
+
+Finally, the migration can be deleted. The target cluster starts to handle produce and consume workloads.
+
+To cut over after executing the migration:
+
+```
+curl -X POST http://localhost:9644/v1/<migration-id>/?action=finish
+```
+
 --
 
-====
-
-== Unmount a topic from a cluster to object storage
-
-Run this command to flush a topic from the source cluster to object storage. This deletes the topic from the cluster. Once you initiate this process, all incoming writes to the topic are blocked. Producers and consumers of the topic receive an error message indicating that the topic is no longer available. 
-
-[tabs]
-====
-rpk::
-+
---
-```
-rpk topic unmount <topic-name>
-```
---
-Admin API::
-+
---
-```
-
-```
---
-
-====
+======
 
 == Monitor progress
+
+Issue a GET request to the `/migrations` endpoint to view the status of topic migrations:
+
+```
+curl http://localhost:9644/v1/migrations 
+```
+

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -206,7 +206,7 @@ You cannot cancel mount and unmount operations in the following <<monitor-progre
 
 == Additional considerations
 
-It is not currently possible to unmount a topic whose name matches multiple topics in the origin cluster.
+It is not possible to unmount a topic whose name matches multiple topics in the origin cluster.
 
 Redpanda prevents you from mounting the same topic to multiple clusters at once. This ensures that multiple clusters don't write to the same location in object storage and corrupt the topic.
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -2,14 +2,12 @@ For topics with Tiered Storage enabled, you can mount and unmount topics to tran
 
 Redpanda also transfers topic definitions when mounting or unmounting a topic.
 
-An unmounted topic in object storage is detached from all clusters. The original cluster releases ownership of the topic.
-
-You can mount a topic from object storage that has been previously flushed from a source cluster to a different destination cluster, or back to the same source cluster.
+An unmounted topic in object storage is detached from all clusters. The original cluster releases ownership of the topic. You can mount a topic from object storage that has been previously flushed from a source cluster to a different destination cluster, or back to the same source cluster.
 
 == Prerequisites
 
-. Enable xref:manage:tiered-storage.adoc[Tiered Storage] for specific topics, or for the entire cluster (all topics).
 . xref:get-started:rpk-install.adoc[Install `rpk`], or ensure that you have access to the Admin API.
+. Enable xref:manage:tiered-storage.adoc[Tiered Storage] for specific topics, or for the entire cluster (all topics).
 
 == Unmount a topic from a cluster to object storage
 
@@ -103,6 +101,37 @@ curl -X POST http://localhost:9644/v1/topics/mount -d {
 
 When the migration is complete, the target cluster handles produce and consume workloads for the topics.
 
+== Cancel a migration
+
+You can cancel a topic migration by running the command:
+
+[tabs]
+======
+rpk::
++
+--
+```
+rpk cluster storage cancel-mount <migration-id>
+```
+--
+
+Admin API::
++
+--
+```
+curl -X POST http://localhost:9644/v1/<migration-id>/?action=cancel
+```
+--
+======
+
+You cannot cancel migrations in the following <<monitor-progress,states>>:
+
+- `planned` (but you may still xref:api:ROOT:admin-api.adoc#delete-/v1/migrations/-id-[delete] a planned migration)
+- `cut_over`
+- `finished`
+- `canceling`
+- `cancelled`
+
 == Monitor progress
 
 [tabs]
@@ -171,40 +200,9 @@ The response returns the IDs and state of existing migrations:
 
 |===
 
-== Cancel a migration
-
-You can cancel a topic migration by running the command:
-
-[tabs]
-======
-rpk::
-+
---
-```
-rpk cluster storage cancel-mount <migration-id>
-```
---
-
-Admin API::
-+
---
-```
-curl -X POST http://localhost:9644/v1/<migration-id>/?action=cancel
-```
---
-======
-
-You can only cancel a migration that is not in the following <<monitor-progress,states>>:
-
-- `planned` (but you may still xref:api:ROOT:admin-api.adoc#delete-/v1/migrations/-id-[delete] a planned migration)
-- `cut_over`
-- `finished`
-- `canceling`
-- `cancelled`
-
 == Troubleshoot
 
-If Redpanda encounters errors during mounting and unmounting, it retries the operation indefinitely. If you see issues, make sure to check whether:
+If Redpanda encounters errors during mounting and unmounting, it retries the operation indefinitely. If you experience issues, check this list:
 
 * You are attempting to mount a topic that does not exist in object storage.
 * You are attempting to mount a topic that is already mounted to the current or a different cluster.

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -163,8 +163,8 @@ The response returns the IDs and state of existing migrations:
 | Migration state | Outbound migration (unmount) | Inbound migration (mount)
 
 | `planned`
-| Redpanda validates the migration definition.
-|
+2+| Redpanda validates the migration definition.
+
 
 | `preparing`
 | Redpanda copies all possible topic data including topic manifests to the destination bucket or container in object storage.
@@ -191,12 +191,11 @@ The response returns the IDs and state of existing migrations:
 | The migration is complete and then deleted. The target cluster starts to handle produce and consume workloads.
 
 | `canceling`
-| Redpanda is in the process of canceling the migration.
-|
+2+| Redpanda is in the process of canceling the migration.
+
 
 | `cancelled`
-| The migration is canceled.
-|
+2+| The migration is canceled.
 
 |===
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -1,8 +1,8 @@
-For topics with Tiered Storage enabled, you can mount and unmount topics to transfer the topic data between your cluster and object storage. This allows you to free up and reclaim unused partition space, or migrate a topic to a different cluster and hibernate or decommission the topic or even the entire cluster.
+For topics with Tiered Storage enabled, you can unmount a topic to detach segment data that is still on disk to object storage, and unmount a topic from object storage to attach the topic data to either the same origin cluster, or a different one. This allows you to hibernate a topic and free up and reclaim system resources taken up by the topic, or migrate a topic to a different cluster.
 
-Redpanda also transfers topic definitions when mounting or unmounting a topic.
+Redpanda also transfers topic manifests when mounting or unmounting a topic, so the topic can quickly accept reads and writes again and you can resume cluster workloads with ease. 
 
-An unmounted topic in object storage is detached from all clusters. The original cluster releases ownership of the topic. You can mount a topic from object storage that has been previously flushed from a source cluster to a different destination cluster, or back to the same source cluster.
+An unmounted topic in object storage is detached from all clusters. The original cluster releases ownership of the topic. You can mount a topic from object storage that has been previously unmounted from a source cluster to a different destination cluster, or back to the same source cluster.
 
 == Prerequisites
 
@@ -11,7 +11,7 @@ An unmounted topic in object storage is detached from all clusters. The original
 
 == Unmount a topic from a cluster to object storage
 
-When you unmount a topic, all incoming writes to the topic are blocked as Redpanda migrates the topic from the cluster to object storage. Producers and consumers of the topic receive an error message indicating that the topic is no longer available. The unmounted topic is deleted in the source cluster.
+When you unmount a topic, all incoming writes to the topic are blocked as Redpanda unmounts the topic from the cluster to object storage. Producers and consumers of the topic receive an error message indicating that the topic is no longer available. The unmounted topic is deleted in the source cluster.
 
 [tabs]
 ======
@@ -99,11 +99,11 @@ curl -X POST http://localhost:9644/v1/topics/mount -d {
 
 ======
 
-When the migration is complete, the target cluster handles produce and consume workloads for the topics.
+When the mount operation is complete, the target cluster handles produce and consume workloads for the topics.
 
-== Cancel a migration
+== Cancel a mount or unmount operation
 
-You can cancel a topic migration by running the command:
+You can cancel a topic mount or unmount by running the command:
 
 [tabs]
 ======
@@ -124,9 +124,9 @@ curl -X POST http://localhost:9644/v1/<migration-id>/?action=cancel
 --
 ======
 
-You cannot cancel migrations in the following <<monitor-progress,states>>:
+You cannot cancel mount and unmount operations in the following <<monitor-progress,states>>:
 
-- `planned` (but you may still xref:api:ROOT:admin-api.adoc#delete-/v1/migrations/-id-[delete] a planned migration)
+- `planned` (but you may still xref:api:ROOT:admin-api.adoc#delete-/v1/migrations/-id-[delete] a planned mount or unmount)
 - `cut_over`
 - `finished`
 - `canceling`
@@ -139,7 +139,7 @@ You cannot cancel migrations in the following <<monitor-progress,states>>:
 rpk::
 +
 --
-To list topic migrations, run the command:
+To list active mount and unmount operations, run the command:
 
 ```
 rpk cluster storage list-mount
@@ -149,7 +149,7 @@ rpk cluster storage list-mount
 Admin API::
 +
 --
-Issue a GET request to the `/migrations` endpoint to view the state of topic migrations:
+Issue a GET request to the `/migrations` endpoint to view the status of topic mount and unmount operations:
 
 ```
 curl http://localhost:9644/v1/migrations 
@@ -157,21 +157,21 @@ curl http://localhost:9644/v1/migrations
 --
 ======
 
-The response returns the IDs and state of existing migrations:
+The response returns the IDs and state of existing mount and unmount operations ("migrations"):
 
 |===
-| Migration state | Outbound migration (unmount) | Inbound migration (mount)
+| State | Unmount operation (outbound) | Mount operation (inbound)
 
 | `planned`
-2+| Redpanda validates the migration definition.
+2+| Redpanda validates the operation definition.
 
 
 | `preparing`
-| Redpanda copies all possible topic data, including topic manifests, to the destination bucket or container in object storage.
+| Redpanda flushes topic data, including topic manifests, to the destination bucket or container in object storage.
 | Redpanda recreates the topics in a disabled state in the target cluster. The cluster allocates partitions but does not add log segments yet. Topic metadata is populated from the topic manifests found in object storage.
 
 | `prepared` 
-| The migration is ready to execute. In this state, the cluster still accepts client reads and writes for the topics.
+| The operation is ready to execute. In this state, the cluster still accepts client reads and writes for the topics.
 | Topics exist in the cluster but clients do not yet have access to consume or produce.
 
 | `executing` 
@@ -180,32 +180,32 @@ The response returns the IDs and state of existing migrations:
 
 | `executed` 
 | All unmounted topic data from the cluster is available in object storage.
-| 
+| The target cluster has verified that the topic has not already been mounted.
 
 | `cut_over`
 | Redpanda deletes topic metadata from the cluster, and marks the data in object storage as available for mount operations.
 | The topic data in object storage is no longer available to mount to any clusters.
 
 | `finished`
-| The migration is complete and then deleted. 
-| The migration is complete and then deleted. The target cluster starts to handle produce and consume workloads.
+| The operation is complete and then deleted. 
+| The operation is complete and then deleted. The target cluster starts to handle produce and consume workloads.
 
 | `canceling`
-2+| Redpanda is in the process of canceling the migration.
+2+| Redpanda is in the process of canceling the operation.
 
 
 | `cancelled`
-2+| The migration is canceled.
+2+| The operation is canceled.
 
 |===
 
-== Troubleshoot
+It is not currently possible to unmount a topic whose name matches multiple topics in the origin cluster.
 
-If Redpanda encounters errors during mounting and unmounting, it retries the operation indefinitely. If you experience issues, check this list:
+Redpanda prevents you from mounting a topic to multiple clusters at once. This ensures that multiple clusters don't write to the same location in object storage and corrupt the topic.
 
-* Do not attempt to mount a topic that does not exist in object storage.
-* Do not attempt to mount a topic that is already mounted to the current or a different cluster.
-* Make sure your Redpanda deployment is not experiencing failures, such as Tiered Storage becoming unavailable, or multiple brokers going down.
+If you attempt to mount a topic where the name matches a topic already in the target cluster, Redpanda fails the operation and emits a warning message in the logs.
+
+ 
 
 
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -1,13 +1,10 @@
 For topics with Tiered Storage enabled, you can mount and unmount topics to transfer the topic data between your cluster and object storage. This effectively frees up unused partition space that can be reclaimed, enables you to migrate a topic to a different cluster, and allows the topic or even the entire cluster to hibernate or be decommissioned.
 
+Redpanda also transfers topic definitions when mounting or unmounting a topic.
+
 An unmounted topic in object storage is detached from all clusters. The original cluster releases ownership of the topic.
 
 You can mount a topic from object storage that has been previously flushed from a source cluster to a different destination cluster, or back to the same source cluster.
-
-The following data is moved to object storage when unmounting a topic from a cluster:
-
-* Topic definitions. 
-* The consumer offsets topic. This allows the destination cluster to also restore consumer group state.
 
 == Prerequisites
 
@@ -50,7 +47,7 @@ curl -X POST http://localhost:9644/v1/topics/unmount -d {
 }
 ```
 
-You may optionally include the topic namespace (`ns`). Default value: `kafka`
+You may optionally include the topic namespace (`ns`). Only `kafka` is currently supported.
 --
 ======
 
@@ -97,7 +94,7 @@ curl -X POST http://localhost:9644/v1/topics/mount -d {
 }
 ```
 
-* `ns` is the topic namespace. This field is optional. Default value: `kafka`
+* `ns` is the topic namespace. This field is optional and only `kafka` is currently supported.
 * To rename a topic in the target cluster, use the optional `alias` object in the request body. In the example, topics 1 and 3 are given new names in the target cluster, while topic 2 retains its original name.
 
 --
@@ -108,11 +105,28 @@ When the migration is complete, the target cluster handles produce and consume w
 
 == Monitor progress
 
+[tabs]
+======
+rpk::
++
+--
+To list topic migrations, run the command:
+
+```
+rpk cluster storage list-mount
+```
+--
+
+Admin API::
++
+--
 Issue a GET request to the `/migrations` endpoint to view the state of topic migrations:
 
 ```
 curl http://localhost:9644/v1/migrations 
 ```
+--
+======
 
 The response returns the state of existing migrations:
 
@@ -120,7 +134,7 @@ The response returns the state of existing migrations:
 | Migration state | Outbound migration (unmount) | Inbound migration (mount)
 
 | `planned`
-| Redpanda has initialized a migration.
+| Redpanda validates the migration definition.
 |
 
 | `preparing`
@@ -129,23 +143,23 @@ The response returns the state of existing migrations:
 
 | `prepared` 
 | The migration is ready to execute. In this state, the cluster still accepts client reads and writes for the topics.
-| 
+| Topics exist in the cluster but cannot be consumed or produced to yet.
 
 | `executing` 
-| The cluster rejects client reads and writes for the topics. Redpanda uploads any remaining topic data that has not yet been copied to object storage.
-| The target cluster starts topic partitions with log segments downloaded from object storage.
+| The cluster rejects client reads and writes for the topics. Redpanda uploads any remaining topic data that has not yet been copied to object storage. Uncommitted transactions involving the topic are aborted.
+| The target cluster checks that the topic to be mounted has not already been mounted in any cluster.
 
 | `executed` 
 | All unmounted topic data from the cluster is available in object storage.
-| All mounted topic data is available in the target cluster.
+| 
 
 | `cut_over`
-| The migration is complete and can be deleted. Redpanda deletes the unmounted topics from the cluster.
-| The migration is complete and can be deleted.
+| Redpanda deletes topic metadata from the cluster, and marks the data in object storage as available for mount operations.
+| The topic data in object storage is no longer available to mount to any clusters.
 
 | `finished`
-| The migration is deleted. 
-| The migration is deleted. The target cluster starts to handle produce and consume workloads.
+| The migration is complete and then deleted. 
+| The migration is complete and then deleted. The target cluster starts to handle produce and consume workloads.
 
 | `canceling`
 | Redpanda is in the process of canceling the migration.
@@ -165,8 +179,11 @@ You can cancel a topic migration by running this command:
 curl -X POST http://localhost:9644/v1/<migration-id>/?action=cancel
 ```
 
-You can only cancel a migration that is not in the following final <<monitor-progress,states>>:
+You can only cancel a migration that is not in the following <<monitor-progress,states>>:
 
+- `planned` (but you may still xref:api:ROOT:admin-api.adoc#delete-/v1/migrations/-id-[delete] a planned migration)
 - `cut_over`
 - `finished`
+- `canceling`
+- `cancelled`
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -47,7 +47,7 @@ curl -X POST http://localhost:9644/v1/topics/unmount -d {
 }
 ```
 
-You may optionally include the topic namespace (`ns`). Only `kafka` is currently supported.
+You may optionally include the topic namespace (`ns`). Only `kafka` is supported.
 --
 ======
 
@@ -95,7 +95,7 @@ curl -X POST http://localhost:9644/v1/topics/mount -d {
 }
 ```
 
-* `ns` is the topic namespace. This field is optional and only `kafka` is currently supported.
+* `ns` is the topic namespace. This field is optional and only `kafka` is supported.
 * To rename a topic in the target cluster, use the optional `alias` object in the request body. In the example, topics 1 and 3 are given new names in the target cluster, while topic 2 retains its original name.
 
 --

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -1,8 +1,6 @@
-For topics with Tiered Storage enabled, you can unmount a topic to detach segment data that is still on disk to object storage, and unmount a topic from object storage to attach the topic data to either the same origin cluster, or a different one. This allows you to hibernate a topic and free up and reclaim system resources taken up by the topic, or migrate a topic to a different cluster.
+For topics with Tiered Storage enabled, you can unmount a topic to detach segment data that is still on disk to object storage, and mount that topic to either the same origin cluster, or a different one. This allows you to hibernate a topic and free up system resources taken up by the topic, or migrate a topic to a different cluster.
 
-Redpanda also transfers topic manifests when mounting or unmounting a topic, so the topic can quickly accept reads and writes again and you can resume cluster workloads with ease. 
-
-An unmounted topic in object storage is detached from all clusters. The original cluster releases ownership of the topic. You can mount a topic from object storage that has been previously unmounted from a source cluster to a different destination cluster, or back to the same source cluster.
+Redpanda also transfers topic manifests when mounting or unmounting a topic, making it possible to quickly resume operations after mounting to the destination cluster.
 
 == Prerequisites
 
@@ -11,7 +9,11 @@ An unmounted topic in object storage is detached from all clusters. The original
 
 == Unmount a topic from a cluster to object storage
 
-When you unmount a topic, all incoming writes to the topic are blocked as Redpanda unmounts the topic from the cluster to object storage. Producers and consumers of the topic receive an error message indicating that the topic is no longer available. The unmounted topic is deleted in the source cluster.
+When you unmount a topic, all incoming writes to the topic are blocked as Redpanda unmounts the topic from the cluster to object storage. Producers and consumers of the topic receive an error message indicating that the topic is no longer available. 
+
+An unmounted topic in object storage is detached from all clusters. The original cluster releases ownership of the topic.
+
+NOTE: The unmounted topic is deleted in the source cluster, but can be mounted back again from object storage.
 
 [tabs]
 ======
@@ -49,6 +51,7 @@ You may optionally include the topic namespace (`ns`). Only `kafka` is currently
 --
 ======
 
+You can use the ID returned by the command to <<monitor-progress,monitor the progress>> of the unmount operation using `rpk` or the Admin API.
 
 == Mount a topic to a cluster
 
@@ -99,38 +102,9 @@ curl -X POST http://localhost:9644/v1/topics/mount -d {
 
 ======
 
+You can use the ID returned by the command to <<monitor-progress,monitor the progress>> of the mount operation using `rpk` or the Admin API.
+
 When the mount operation is complete, the target cluster handles produce and consume workloads for the topics.
-
-== Cancel a mount or unmount operation
-
-You can cancel a topic mount or unmount by running the command:
-
-[tabs]
-======
-rpk::
-+
---
-```
-rpk cluster storage cancel-mount <migration-id>
-```
---
-
-Admin API::
-+
---
-```
-curl -X POST http://localhost:9644/v1/<migration-id>/?action=cancel
-```
---
-======
-
-You cannot cancel mount and unmount operations in the following <<monitor-progress,states>>:
-
-- `planned` (but you may still xref:api:ROOT:admin-api.adoc#delete-/v1/migrations/-id-[delete] a planned mount or unmount)
-- `cut_over`
-- `finished`
-- `canceling`
-- `cancelled`
 
 == Monitor progress
 
@@ -163,8 +137,7 @@ The response returns the IDs and state of existing mount and unmount operations 
 | State | Unmount operation (outbound) | Mount operation (inbound)
 
 | `planned`
-2+| Redpanda validates the operation definition.
-
+2+| Redpanda validates the mount or unmount operation definition.
 
 | `preparing`
 | Redpanda flushes topic data, including topic manifests, to the destination bucket or container in object storage.
@@ -187,20 +160,54 @@ The response returns the IDs and state of existing mount and unmount operations 
 | The topic data in object storage is no longer available to mount to any clusters.
 
 | `finished`
-| The operation is complete and then deleted. 
-| The operation is complete and then deleted. The target cluster starts to handle produce and consume workloads.
+| The operation is complete and deleted. 
+| The operation is complete and deleted. The target cluster starts to handle produce and consume workloads.
 
 | `canceling`
-2+| Redpanda is in the process of canceling the operation.
-
+2+| Redpanda is in the process of canceling the mount or unmount operation.
 
 | `cancelled`
-2+| The operation is canceled.
+2+| The mount or unmount operation is cancelled.
 
 |===
 
+== Cancel a mount or unmount operation
+
+You can cancel a topic mount or unmount by running the command:
+
+[tabs]
+======
+rpk::
++
+--
+```
+rpk cluster storage cancel-mount <migration-id>
+```
+--
+
+Admin API::
++
+--
+```
+curl -X POST http://localhost:9644/v1/<migration-id>/?action=cancel
+```
+--
+======
+
+`<migration-id>` is the unique identifier of the operation. Redpanda returns this ID when you start a mount or unmount. You can also retrieve the ID by listing <<monitor-progress,existing migrations>>.
+
+You cannot cancel mount and unmount operations in the following <<monitor-progress,states>>:
+
+- `planned` (but you may still xref:api:ROOT:admin-api.adoc#delete-/v1/migrations/-id-[delete] a planned mount or unmount)
+- `cut_over`
+- `finished`
+- `canceling`
+- `cancelled`
+
+== Additional considerations
+
 It is not currently possible to unmount a topic whose name matches multiple topics in the origin cluster.
 
-Redpanda prevents you from mounting a topic to multiple clusters at once. This ensures that multiple clusters don't write to the same location in object storage and corrupt the topic.
+Redpanda prevents you from mounting the same topic to multiple clusters at once. This ensures that multiple clusters don't write to the same location in object storage and corrupt the topic.
 
 If you attempt to mount a topic where the name matches a topic already in the target cluster, Redpanda fails the operation and emits a warning message in the logs.

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -32,59 +32,25 @@ rpk topic unmount <namespace>/<topic-name>
 Admin API::
 +
 --
-To unmount a topic from a cluster using the Admin API, you must first create an outbound topic migration. The API returns the migration ID upon creation. Then, you make an API request with the migration ID to carry out the migration in steps: prepare, execute, and cut over. You must wait for each step to complete and for the <<monitor-progress,migration state>> to update before proceeding to the next step.
+To unmount topics from a cluster using the Admin API, make a POST request to the `/v1/topics/unmount` endpoint.  Specify the names of the desired topics in the request body:
 
-. Make a PUT request to the `/migrations` endpoint to create a topic migration. Specify the names of the desired topics in the request body:
-+
 ```
-curl -X PUT http://localhost:9644/v1/migrations -d {
-  "migration_type":"outbound", 
+curl -X POST http://localhost:9644/v1/topics/unmount -d {
   "topics": [
     {
-      "ns": "kafka", 
       "topic": "<topic-1-name>"
     }, 
     {
-      "ns": "kafka", 
       "topic": "<topic-2-name>"
     }, 
     {
-      "ns": "kafka", 
       "topic": "<topic-3-name>"
     }
-  ], "consumer_groups": []
+  ]
 }
 ```
-+
-* `ns` is the topic namespace. This field is optional. Default value: `kafka`
-* `consumer_groups` is required.
-+
-If successful, the response returns the ID of the newly-created migration. Use the ID in subsequent API calls to run the migration.
 
-. When preparing topics for migration, Redpanda copies all possible topic data including topic manifests to the destination bucket or container in object storage. In this state, the cluster still accepts client reads and writes. 
-+
-Make a `POST /v1/migrations/\{id}/?action=prepare` request:
-+
-```
-curl -X POST http://localhost:9644/v1/<migration-id>/?action=prepare
-```
-
-. When you execute the migration, the cluster rejects client reads and writes. Redpanda uploads any remaining topic data that has not yet been copied to object storage. 
-+
-Make a `POST /v1/migrations/\{id}/?action=execute` request to execute the migration:
-+
-```
-curl -X POST http://localhost:9644/v1/<migration-id>/?action=execute
-```
-
-. Finally, the migration can be deleted. Redpanda deletes the unmounted topics from the cluster.
-+
-To cut over after executing the migration:
-+
-```
-curl -X POST http://localhost:9644/v1/<migration-id>/?action=finish
-```
-
+You may optionally include the topic namespace (`ns`). Default value: `kafka`
 --
 ======
 
@@ -111,13 +77,10 @@ rpk topic mount <namespace>/<source-topic-name> --to <namespace>/<new-topic-name
 Admin API::
 +
 --
-To mount a topic to a target cluster using the Admin API, you must first create an inbound topic migration. The API returns the migration ID upon creation. Then, you make an API request with the migration ID to carry out the migration in steps: prepare, execute, and cut over. You must wait for each step to complete and for the <<monitor-progress,migration state>> to update before proceeding to the next step.
+To mount topics to a target cluster using the Admin API, make a POST request to the `/v1/topics/mount` endpoint. Specify the names of the topics in the request body:
 
-. Make a PUT request to the `/migrations` endpoint to create a topic migration. Specify the names of the topics in the request body:
-+
 ```
-curl -X PUT http://localhost:9644/v1/migrations -d {
-  "migration_type":"inbound", 
+curl -X POST http://localhost:9644/v1/topics/mount -d {
   "topics": [
     {
       "source_topic": {"ns": "kafka", "topic": "<source-topic-1-name>"}, 
@@ -130,44 +93,69 @@ curl -X PUT http://localhost:9644/v1/migrations -d {
       "source_topic": {"ns": "kafka", "topic": "source-topic-3-name"}, 
       "alias": {"ns": "kafka", "topic": "<new-topic-3-name>"}
     }
-  ], 
-  "consumer_groups": []
+  ]
 }
 ```
-+
+
 * `ns` is the topic namespace. This field is optional. Default value: `kafka`
-* To rename the topic in the target cluster, use the optional `alias` object in the request body. In the example, topics 1 and 3 are given new names in the target cluster, while topic 2 retains its original name.
-* `consumer_groups` is required.
-+
-If successful, the response returns the ID of the newly-created migration. Use the ID in subsequent API calls to run the migration.
-
-. When preparing a topic for migration, Redpanda recreates the topic in a disabled state in the target cluster. The cluster allocates partitions but does not add log segments yet. Topic metadata is populated from the topic manifest found in object storage.
-+
-Make a `POST /v1/migrations/\{id}/?action=prepare` request to prepare the migration:
-+
-```
-curl -X POST http://localhost:9644/v1/<migration-id>/?action=prepare
-```
-
-. When you execute the migration, the target cluster starts the partitions with log segments downloaded from object storage.
-+
-Make a `POST /v1/migrations/\{id}/?action=execute` request to execute the migration:
-+
-```
-curl -X POST http://localhost:9644/v1/<migration-id>/?action=execute
-```
-
-. Finally, the migration can be deleted. The target cluster starts to handle produce and consume workloads.
-+
-To cut over after executing the migration:
-+
-```
-curl -X POST http://localhost:9644/v1/<migration-id>/?action=finish
-```
+* To rename a topic in the target cluster, use the optional `alias` object in the request body. In the example, topics 1 and 3 are given new names in the target cluster, while topic 2 retains its original name.
 
 --
 
 ======
+
+When the migration is complete, the target cluster handles produce and consume workloads for the topics.
+
+== Monitor progress
+
+Issue a GET request to the `/migrations` endpoint to view the state of topic migrations:
+
+```
+curl http://localhost:9644/v1/migrations 
+```
+
+The response returns the state of existing migrations:
+
+|===
+| Migration state | Outbound migration (unmount) | Inbound migration (mount)
+
+| `planned`
+| Redpanda has initialized a migration.
+|
+
+| `preparing`
+| Redpanda copies all possible topic data including topic manifests to the destination bucket or container in object storage.
+| Redpanda recreates the topics in a disabled state in the target cluster. The cluster allocates partitions but does not add log segments yet. Topic metadata is populated from the topic manifests found in object storage.
+
+| `prepared` 
+| The migration is ready to execute. In this state, the cluster still accepts client reads and writes for the topics.
+| 
+
+| `executing` 
+| The cluster rejects client reads and writes for the topics. Redpanda uploads any remaining topic data that has not yet been copied to object storage.
+| The target cluster starts topic partitions with log segments downloaded from object storage.
+
+| `executed` 
+| All unmounted topic data from the cluster is available in object storage.
+| All mounted topic data is available in the target cluster.
+
+| `cut_over`
+| The migration is complete and can be deleted. Redpanda deletes the unmounted topics from the cluster.
+| The migration is complete and can be deleted.
+
+| `finished`
+| The migration is deleted. 
+| The migration is deleted. The target cluster starts to handle produce and consume workloads.
+
+| `canceling`
+| Redpanda is in the process of canceling the migration.
+|
+
+| `cancelled`
+| The migration is canceled.
+|
+
+|===
 
 == Cancel a migration
 
@@ -182,22 +170,3 @@ You can only cancel a migration that is not in the following final <<monitor-pro
 - `cut_over`
 - `finished`
 
-== Monitor progress
-
-Issue a GET request to the `/migrations` endpoint to view the state of topic migrations:
-
-```
-curl http://localhost:9644/v1/migrations 
-```
-
-The response returns the state of existing migrations:
-
-- `planned`
-- `preparing`
-- `prepared`
-- `executing`
-- `executed`
-- `cut_over`
-- `finished`
-- `canceling`
-- `cancelled`

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -23,7 +23,7 @@ rpk::
 In your cluster, run this command to unmount a topic to object storage:
 
 ```
-rpk topic unmount <namespace>/<topic-name>
+rpk cluster storage unmount <namespace>/<topic-name>
 ```
 --
 Admin API::
@@ -62,13 +62,13 @@ rpk::
 In your target cluster, run this command to mount a topic from object storage:
 
 ```
-rpk topic mount <source-topic-name>
+rpk cluster storage mount <source-topic-name>
 ```
 
 You can also rename the topic as you mount it to the target cluster:
 
 ```
-rpk topic mount <namespace>/<source-topic-name> --to <namespace>/<new-topic-name>
+rpk cluster storage mount <namespace>/<source-topic-name> --to <namespace>/<new-topic-name>
 ```
 --
 Admin API::
@@ -128,7 +128,7 @@ curl http://localhost:9644/v1/migrations
 --
 ======
 
-The response returns the state of existing migrations:
+The response returns the IDs and state of existing migrations:
 
 |===
 | Migration state | Outbound migration (unmount) | Inbound migration (mount)
@@ -173,11 +173,26 @@ The response returns the state of existing migrations:
 
 == Cancel a migration
 
-You can cancel a topic migration by running this command:
+You can cancel a topic migration by running the command:
 
+[tabs]
+======
+rpk::
++
+--
+```
+rpk cluster storage cancel-mount <migration-id>
+```
+--
+
+Admin API::
++
+--
 ```
 curl -X POST http://localhost:9644/v1/<migration-id>/?action=cancel
 ```
+--
+======
 
 You can only cancel a migration that is not in the following <<monitor-progress,states>>:
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -143,7 +143,7 @@ The response returns the IDs and state of existing migrations:
 
 | `prepared` 
 | The migration is ready to execute. In this state, the cluster still accepts client reads and writes for the topics.
-| Topics exist in the cluster but cannot be consumed or produced to yet.
+| Topics exist in the cluster but clients do not yet have access to consume or produce.
 
 | `executing` 
 | The cluster rejects client reads and writes for the topics. Redpanda uploads any remaining topic data that has not yet been copied to object storage. Uncommitted transactions involving the topic are aborted.
@@ -204,9 +204,11 @@ You can only cancel a migration that is not in the following <<monitor-progress,
 
 == Troubleshoot
 
-If you encounter issues with mounting and unmounting topics, make sure to check whether:
+If Redpanda encounters errors during mounting and unmounting, it retries the operation indefinitely. If you see issues, make sure to check whether:
 
 * You are attempting to mount a topic that does not exist in object storage.
 * You are attempting to mount a topic that is already mounted to the current or a different cluster.
 * Your Redpanda deployment is experiencing failures, such as Tiered Storage becoming unavailable, or multiple brokers going down.
+
+
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -204,8 +204,3 @@ It is not currently possible to unmount a topic whose name matches multiple topi
 Redpanda prevents you from mounting a topic to multiple clusters at once. This ensures that multiple clusters don't write to the same location in object storage and corrupt the topic.
 
 If you attempt to mount a topic where the name matches a topic already in the target cluster, Redpanda fails the operation and emits a warning message in the logs.
-
- 
-
-
-

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -1,4 +1,4 @@
-For topics with Tiered Storage enabled, you can mount and unmount topics to transfer the topic data between your cluster and object storage. This effectively frees up unused partition space that can be reclaimed, enables you to migrate a topic to a different cluster, and allows the topic or even the entire cluster to hibernate or be decommissioned.
+For topics with Tiered Storage enabled, you can mount and unmount topics to transfer the topic data between your cluster and object storage. This allows you to free up and reclaim unused partition space, or migrate a topic to a different cluster and hibernate or decommission the topic or even the entire cluster.
 
 Redpanda also transfers topic definitions when mounting or unmounting a topic.
 
@@ -167,7 +167,7 @@ The response returns the IDs and state of existing migrations:
 
 
 | `preparing`
-| Redpanda copies all possible topic data including topic manifests to the destination bucket or container in object storage.
+| Redpanda copies all possible topic data, including topic manifests, to the destination bucket or container in object storage.
 | Redpanda recreates the topics in a disabled state in the target cluster. The cluster allocates partitions but does not add log segments yet. Topic metadata is populated from the topic manifests found in object storage.
 
 | `prepared` 
@@ -203,9 +203,9 @@ The response returns the IDs and state of existing migrations:
 
 If Redpanda encounters errors during mounting and unmounting, it retries the operation indefinitely. If you experience issues, check this list:
 
-* You are attempting to mount a topic that does not exist in object storage.
-* You are attempting to mount a topic that is already mounted to the current or a different cluster.
-* Your Redpanda deployment is experiencing failures, such as Tiered Storage becoming unavailable, or multiple brokers going down.
+* Do not attempt to mount a topic that does not exist in object storage.
+* Do not attempt to mount a topic that is already mounted to the current or a different cluster.
+* Make sure your Redpanda deployment is not experiencing failures, such as Tiered Storage becoming unavailable, or multiple brokers going down.
 
 
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -202,3 +202,11 @@ You can only cancel a migration that is not in the following <<monitor-progress,
 - `canceling`
 - `cancelled`
 
+== Troubleshoot
+
+If you encounter issues with mounting and unmounting topics, make sure to check whether:
+
+* You are attempting to mount a topic that does not exist in object storage.
+* You are attempting to mount a topic that is already mounted to the current or a different cluster.
+* Your Redpanda deployment is experiencing failures, such as Tiered Storage becoming unavailable, or multiple brokers going down.
+

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -72,28 +72,30 @@ rpk::
 rpk cluster storage list-mountable
 ```
 +
-The `LOCATION` value returned in the command output is in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. For example:
+The command output returns a `LOCATION` value in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. This value uniquely identifies a topic in object storage if multiple topics had the same name when they were unmounted from different origin clusters. For example:
 +
 ```
 TOPIC      NAMESPACE  LOCATION
 testtopic  kafka      testtopic/67f5505a-32f3-4677-bcad-3c75a1a702a6/10
 ```
 +
-Redpanda assigns the number `initial-revision` to a topic upon creation. You can use the topic location instead of just the topic name to uniquely identify a topic to mount in the next step. 
+Redpanda assigns the number `initial-revision` to a topic upon creation. You can use the topic location as a reference instead of just the topic name to uniquely identify a topic to mount in the next step. 
 
 . Mount a topic from object storage:
 +
 ```
-rpk cluster storage mount <source-topic-reference>
+rpk cluster storage mount <topic-reference>
 ```
 +
-Replace `<source-topic-reference>` with the name of the topic to mount, or the topic location to uniquely identify a topic object storage.
+Replace `<topic-reference>` with the name of the topic to mount, or if there are multiple topics wih the same name in object storage, you are required to use the topic location to uniquely identify a topic.
 +
 You can also rename the topic as you mount it to the target cluster:
 +
 ```
-rpk cluster storage mount <source-topic-reference> --to <new-topic-name>
+rpk cluster storage mount <topic-reference> --to <new-topic-name>
 ```
++
+The new name acts as an alias for the topic in the target cluster, and does not rename any other mountable topics of the same name in object storage. 
 --
 Admin API::
 +
@@ -119,7 +121,7 @@ The response object contains an array of topics:
 ]
 ```
 +
-The `topic_location` is the unique topic location in object storage, in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. Redpanda assigns the number `initial-revision` to a topic upon creation. You can use `topic-location` instead of just the topic name to identify a unique topic to mount in the next step.
+The `topic_location` is the unique topic location in object storage, in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. Redpanda assigns the number `initial-revision` to a topic upon creation. You can use `topic-location` as a reference instead of just the topic name to identify a unique topic to mount in the next step.
 
 . To mount topics to a target cluster using the Admin API, make a POST request to the `/v1/topics/mount` endpoint. Specify the names of the topics in the request body:
 
@@ -142,7 +144,7 @@ curl -X POST http://localhost:9644/v1/topics/mount -d {
 ```
 
 * `ns` is the topic namespace. This field is optional and only `kafka` is supported.
-* You may have multiple topics with the same name that are available to mount from object storage. This can happen if you have unmounted topics with this name from different clusters. To uniquely identify a source topic, append the topic name with `/<cluster-uuid>/<initial-revision>.`
+* You may have multiple topics with the same name that are available to mount from object storage. This can happen if you have unmounted topics with this name from different clusters. To uniquely identify a source topic, use `<topic-name>/<cluster-uuid>/<initial-revision>` as the topic reference.
 * To rename a topic in the target cluster, use the optional `alias` object in the request body. In the example, topics 1 and 3 are given new names in the target cluster, while topic 2 retains its original name.
 
 --
@@ -229,7 +231,7 @@ The response returns the IDs and state of existing mount and unmount operations 
 
 | `finished`
 | The operation is complete. 
-| The operation is complete. The target cluster starts to handle produce and consume workloads.
+| The operation is complete. The target cluster starts to handle produce and consume requests.
 
 | `canceling`
 2+| Redpanda is in the process of canceling the mount or unmount operation.

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -7,7 +7,10 @@ For topics with Tiered Storage enabled, you can unmount a topic to safely detach
 
 == Unmount a topic from a cluster to object storage
 
-When you unmount a topic, all incoming writes to the topic are blocked as Redpanda unmounts the topic from the cluster to object storage. Producers and consumers of the topic receive a warning `Failed to download manifest for topic` indicating that the topic is no longer available. 
+When you unmount a topic, all incoming writes to the topic are blocked as Redpanda unmounts the topic from the cluster to object storage. Producers and consumers of the topic receive a message in the protocol replies indicating that the topic is no longer available:
+
+- Produce requests receive an `invalid_topic_exception` or `resource_is_being_migrated` response from the broker.
+- Consume requests receive an `invalid_topic_exception` response from the broker.
 
 An unmounted topic in object storage is detached from all clusters. The original cluster releases ownership of the topic.
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -76,20 +76,40 @@ rpk cluster storage mount <namespace>/<source-topic-name> --to <namespace>/<new-
 Admin API::
 +
 --
-To mount topics to a target cluster using the Admin API, make a POST request to the `/v1/topics/mount` endpoint. Specify the names of the topics in the request body:
+. List the topics that are available to mount from object storage by making a GET request to the `v1/topics/mountable` endpoint.
++
+```
+curl http://localhost:9644/v1/topics/mountable 
+```
++
+The response object contains an array of topics:
+```
+"topics": [
+  {
+    "topic_location": "",
+    "topic": ""
+  },
+  {
+    "topic_location": "",
+    "topic":
+  }
+]
+```
+
+. To mount topics to a target cluster using the Admin API, make a POST request to the `/v1/topics/mount` endpoint. Specify the names of the topics in the request body:
 
 ```
 curl -X POST http://localhost:9644/v1/topics/mount -d {
   "topics": [
     {
-      "source_topic": {"ns": "kafka", "topic": "<source-topic-1-name>"}, 
+      "source_topic": {"ns": "kafka", "topic": "<source-topic-1-name>/<cluster-A-uuid>/initial_revision"}, 
       "alias": {"ns": "kafka", "topic": "<new-topic-1-name>"}
     }, 
     {
       "source_topic": {"ns": "kafka", "topic": "<source-topic-2-name>"}
     }, 
     {
-      "source_topic": {"ns": "kafka", "topic": "<source-topic-3-name>"}, 
+      "source_topic": {"ns": "kafka", "topic": "<source-topic-3-name>/<cluster-B-uuid>/initial_revision"}, 
       "alias": {"ns": "kafka", "topic": "<new-topic-3-name>"}
     }
   ]

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -7,7 +7,7 @@ For topics with Tiered Storage enabled, you can unmount a topic to safely detach
 
 == Unmount a topic from a cluster to object storage
 
-When you unmount a topic, all incoming writes to the topic are blocked as Redpanda unmounts the topic from the cluster to object storage. Producers and consumers of the topic receive an error message indicating that the topic is no longer available. 
+When you unmount a topic, all incoming writes to the topic are blocked as Redpanda unmounts the topic from the cluster to object storage. Producers and consumers of the topic receive a warning `Failed to download manifest for topic` indicating that the topic is no longer available. 
 
 An unmounted topic in object storage is detached from all clusters. The original cluster releases ownership of the topic.
 
@@ -86,7 +86,7 @@ curl -X POST http://localhost:9644/v1/topics/mount -d {
       "source_topic": {"ns": "kafka", "topic": "<source-topic-2-name>"}
     }, 
     {
-      "source_topic": {"ns": "kafka", "topic": "source-topic-3-name"}, 
+      "source_topic": {"ns": "kafka", "topic": "<source-topic-3-name>"}, 
       "alias": {"ns": "kafka", "topic": "<new-topic-3-name>"}
     }
   ]

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -204,6 +204,8 @@ curl http://localhost:9644/v1/migrations/<migration-id>
 --
 ======
 
+`<migration-id>` is the unique identifier of the operation. Redpanda returns this ID when you start a mount or unmount. You can also retrieve the ID by listing <<monitor-progress,existing operations>>.
+
 The response returns the IDs and state of existing mount and unmount operations ("migrations"):
 
 |===
@@ -266,8 +268,6 @@ curl -X POST http://localhost:9644/v1/<migration-id>/?action=cancel
 ```
 --
 ======
-
-`<migration-id>` is the unique identifier of the operation. Redpanda returns this ID when you start a mount or unmount. You can also retrieve the ID by listing <<monitor-progress,existing migrations>>.
 
 You cannot cancel mount and unmount operations in the following <<monitor-progress,states>>:
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -71,17 +71,28 @@ rpk::
 ```
 rpk cluster storage list-mountable
 ```
++
+The `LOCATION` value returned in the command output is in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. For example:
++
+```
+TOPIC      NAMESPACE  LOCATION
+testtopic  kafka      testtopic/67f5505a-32f3-4677-bcad-3c75a1a702a6/10
+```
++
+Redpanda assigns the number `initial-revision` to a topic upon creation. You can use the topic location instead of just the topic name to uniquely identify a topic to mount in the next step. 
 
 . Mount a topic from object storage:
 +
 ```
-rpk cluster storage mount <source-topic-name>
+rpk cluster storage mount <source-topic-reference>
 ```
++
+Replace `<source-topic-reference>` with the name of the topic to mount, or the topic location to uniquely identify a topic object storage.
 +
 You can also rename the topic as you mount it to the target cluster:
 +
 ```
-rpk cluster storage mount <namespace>/<source-topic-name> --to <namespace>/<new-topic-name>
+rpk cluster storage mount <source-topic-reference> --to <new-topic-name>
 ```
 --
 Admin API::
@@ -108,7 +119,7 @@ The response object contains an array of topics:
 ]
 ```
 +
-The `topic_location` is the unique topic location in object storage, in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. Redpanda assigns the number `initial-revision` to a topic upon creation. You can use `initial-revision` to identify a unique topic to mount in the next step.
+The `topic_location` is the unique topic location in object storage, in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. Redpanda assigns the number `initial-revision` to a topic upon creation. You can use `topic-location` instead of just the topic name to identify a unique topic to mount in the next step.
 
 . To mount topics to a target cluster using the Admin API, make a POST request to the `/v1/topics/mount` endpoint. Specify the names of the topics in the request body:
 
@@ -138,7 +149,7 @@ curl -X POST http://localhost:9644/v1/topics/mount -d {
 
 ======
 
-You can use the ID returned by the command to <<monitor-progress,monitor the progress>> of the mount operation using `rpk` or the Admin API.
+You can use the ID returned by the operation to <<monitor-progress,monitor its progress>> using `rpk` or the Admin API.
 
 When the mount operation is complete, the target cluster handles produce and consume workloads for the topics.
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -72,14 +72,16 @@ rpk::
 rpk cluster storage list-mountable
 ```
 +
-The command output returns a `LOCATION` value in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. This value uniquely identifies a topic in object storage if multiple topics had the same name when they were unmounted from different origin clusters. For example:
+The command output returns a `LOCATION` value in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. Redpanda assigns an `initial-revision` number to a topic upon creation.
++
+The location value uniquely identifies a topic in object storage if multiple topics had the same name when they were unmounted from different origin clusters. For example:
 +
 ```
 TOPIC      NAMESPACE  LOCATION
 testtopic  kafka      testtopic/67f5505a-32f3-4677-bcad-3c75a1a702a6/10
 ```
 +
-Redpanda assigns the number `initial-revision` to a topic upon creation. You can use the topic location as a reference instead of just the topic name to uniquely identify a topic to mount in the next step. 
+You can use the location as the topic reference instead of just the topic name to uniquely identify a topic to mount in the next step. 
 
 . Mount a topic from object storage:
 +
@@ -87,15 +89,15 @@ Redpanda assigns the number `initial-revision` to a topic upon creation. You can
 rpk cluster storage mount <topic-reference>
 ```
 +
-Replace `<topic-reference>` with the name of the topic to mount, or if there are multiple topics wih the same name in object storage, you are required to use the topic location to uniquely identify a topic.
+Replace `<topic-reference>` with the name of the topic to mount. If there are multiple topics wih the same name in object storage, you are required to use the location value from `rpk cluster storage list-mountable` to uniquely identify a topic.
 +
-You can also rename the topic as you mount it to the target cluster:
+You can also specify a new name for the topic as you mount it to the target cluster:
 +
 ```
 rpk cluster storage mount <topic-reference> --to <new-topic-name>
 ```
 +
-The new name acts as an alias for the topic in the target cluster, and does not rename any other mountable topics of the same name in object storage. 
+You only use the new name for the topic in the target cluster. This name does not persist if you unmount this topic again. Redpanda keeps the original name in object storage if you remount the topic later.
 --
 Admin API::
 +
@@ -108,44 +110,45 @@ curl http://localhost:9644/v1/topics/mountable
 +
 The response object contains an array of topics:
 +
-```
+[,bash,role=no-placeholders]
+----
 "topics": [
   {
-    "topic_location": "topic_1_name/cluster_1_uuid/<initial_revision>",
+    "topic_location": "topic-1-name/<cluster-1-uuid>/<initial-revision>",
     "topic": "topic-1-name"
   },
   {
-    "topic_location": "topic_2_name/cluster_1_uuid/<initial_revision>",
+    "topic_location": "topic-2-name/<cluster-1-uuid>/<initial-revision>",
     "topic": "topic-2-name"
   }
 ]
-```
+----
 +
-The `topic_location` is the unique topic location in object storage, in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. Redpanda assigns the number `initial-revision` to a topic upon creation. You can use `topic-location` as a reference instead of just the topic name to identify a unique topic to mount in the next step.
+The `topic_location` is the unique topic location in object storage, in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. Redpanda assigns the number `initial-revision` to a topic upon creation. You can use `topic-location` as the topic reference instead of just the topic name to identify a unique topic to mount in the next step.
 
 . To mount topics to a target cluster using the Admin API, make a POST request to the `/v1/topics/mount` endpoint. Specify the names of the topics in the request body:
-
++
 ```
 curl -X POST http://localhost:9644/v1/topics/mount -d {
   "topics": [
     {
-      "source_topic_reference": {"ns": "kafka", "topic": "<source-topic-1-name>/<cluster-A-uuid>/<initial-revision>"}, 
+      "source_topic_reference": {"ns": "kafka", "topic": "<topic-1-name>/<cluster-1-uuid>/<initial-revision>"}, 
       "alias": {"ns": "kafka", "topic": "<new-topic-1-name>"}
     }, 
     {
-      "source_topic_reference": {"ns": "kafka", "topic": "<source-topic-2-name>"}
+      "source_topic_reference": {"ns": "kafka", "topic": "<topic-2-name>"}
     }, 
     {
-      "source_topic_reference": {"ns": "kafka", "topic": "<source-topic-3-name>/<cluster-B-uuid>/<initial-revision>"}, 
+      "source_topic_reference": {"ns": "kafka", "topic": "<topic-3-name>/<cluster-2-uuid>/<initial-revision>"}, 
       "alias": {"ns": "kafka", "topic": "<new-topic-3-name>"}
     }
   ]
 }
 ```
-
++
 * `ns` is the topic namespace. This field is optional and only `kafka` is supported.
 * You may have multiple topics with the same name that are available to mount from object storage. This can happen if you have unmounted topics with this name from different clusters. To uniquely identify a source topic, use `<topic-name>/<cluster-uuid>/<initial-revision>` as the topic reference.
-* To rename a topic in the target cluster, use the optional `alias` object in the request body. In the example, topics 1 and 3 are given new names in the target cluster, while topic 2 retains its original name.
+* To rename a topic in the target cluster, use the optional `alias` object in the request body. In the example, you specify new names for topics 1 and 3 in the target cluster, but topic 2 retains its original name in the target cluster.
 
 --
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -83,18 +83,21 @@ curl http://localhost:9644/v1/topics/mountable
 ```
 +
 The response object contains an array of topics:
++
 ```
 "topics": [
   {
-    "topic_location": "",
-    "topic": ""
+    "topic_location": "topic_1_name/cluster_1_uuid/<initial_revision>",
+    "topic": "topic-1-name"
   },
   {
-    "topic_location": "",
-    "topic":
+    "topic_location": "topic_2_name/cluster_1_uuid/<initial_revision>",
+    "topic": "topic-2-name"
   }
 ]
 ```
++
+The `topic_location` is the unique topic location in object storage, in the format `<topic-name>/<cluster-uuid>/<initial-revision>`. Redpanda assigns the number `initial-revision` to a topic upon creation. You can use `initial-revision` to identify a unique topic to mount in the next step.
 
 . To mount topics to a target cluster using the Admin API, make a POST request to the `/v1/topics/mount` endpoint. Specify the names of the topics in the request body:
 
@@ -102,14 +105,14 @@ The response object contains an array of topics:
 curl -X POST http://localhost:9644/v1/topics/mount -d {
   "topics": [
     {
-      "source_topic": {"ns": "kafka", "topic": "<source-topic-1-name>/<cluster-A-uuid>/initial_revision"}, 
+      "source_topic_reference": {"ns": "kafka", "topic": "<source-topic-1-name>/<cluster-A-uuid>/<initial-revision>"}, 
       "alias": {"ns": "kafka", "topic": "<new-topic-1-name>"}
     }, 
     {
-      "source_topic": {"ns": "kafka", "topic": "<source-topic-2-name>"}
+      "source_topic_reference": {"ns": "kafka", "topic": "<source-topic-2-name>"}
     }, 
     {
-      "source_topic": {"ns": "kafka", "topic": "<source-topic-3-name>/<cluster-B-uuid>/initial_revision"}, 
+      "source_topic_reference": {"ns": "kafka", "topic": "<source-topic-3-name>/<cluster-B-uuid>/<initial-revision>"}, 
       "alias": {"ns": "kafka", "topic": "<new-topic-3-name>"}
     }
   ]
@@ -117,6 +120,7 @@ curl -X POST http://localhost:9644/v1/topics/mount -d {
 ```
 
 * `ns` is the topic namespace. This field is optional and only `kafka` is supported.
+* You may have multiple topics with the same name that are available to mount from object storage. This can happen if you have unmounted topics with this name from different clusters. To uniquely identify a topic, append the topic name with `/<cluster-uuid>/<initial-revision>.`
 * To rename a topic in the target cluster, use the optional `alias` object in the request body. In the example, topics 1 and 3 are given new names in the target cluster, while topic 2 retains its original name.
 
 --

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -2,6 +2,11 @@ For topics with Tiered Storage enabled, you can unmount a topic to safely detach
 
 == Prerequisites
 
+[NOTE]
+====
+include::shared:partial$enterprise-license.adoc[]
+====
+
 . xref:get-started:rpk-install.adoc[Install `rpk`], or ensure that you have access to the Admin API.
 . Enable xref:manage:tiered-storage.adoc[Tiered Storage] for specific topics, or for the entire cluster (all topics).
 
@@ -120,7 +125,7 @@ curl -X POST http://localhost:9644/v1/topics/mount -d {
 ```
 
 * `ns` is the topic namespace. This field is optional and only `kafka` is supported.
-* You may have multiple topics with the same name that are available to mount from object storage. This can happen if you have unmounted topics with this name from different clusters. To uniquely identify a topic, append the topic name with `/<cluster-uuid>/<initial-revision>.`
+* You may have multiple topics with the same name that are available to mount from object storage. This can happen if you have unmounted topics with this name from different clusters. To uniquely identify a source topic, append the topic name with `/<cluster-uuid>/<initial-revision>.`
 * To rename a topic in the target cluster, use the optional `alias` object in the request body. In the example, topics 1 and 3 are given new names in the target cluster, while topic 2 retains its original name.
 
 --

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -1,6 +1,4 @@
-For topics with Tiered Storage enabled, you can unmount a topic to detach segment data that is still on disk to object storage, and mount that topic to either the same origin cluster, or a different one. This allows you to hibernate a topic and free up system resources taken up by the topic, or migrate a topic to a different cluster.
-
-Redpanda also transfers topic manifests when mounting or unmounting a topic, making it possible to quickly resume operations after mounting to the destination cluster.
+For topics with Tiered Storage enabled, you can unmount a topic to safely detach it from a cluster and keep the topic data in the cluster's object storage bucket or container. You can mount the detached topic to either the same origin cluster, or a different one. This allows you to hibernate a topic and free up system resources taken up by the topic, or migrate a topic to a different cluster.
 
 == Prerequisites
 
@@ -131,6 +129,27 @@ curl http://localhost:9644/v1/migrations
 --
 ======
 
+You can also retrieve the status of a specific operation by running the command:
+
+
+[tabs]
+======
+rpk::
++
+--
+```
+rpk cluster storage status-mount <migration-id>
+```
+--
+Admin API::
++
+--
+```
+curl http://localhost:9644/v1/migrations/<migration-id> 
+```
+--
+======
+
 The response returns the IDs and state of existing mount and unmount operations ("migrations"):
 
 |===
@@ -160,8 +179,8 @@ The response returns the IDs and state of existing mount and unmount operations 
 | The topic data in object storage is no longer available to mount to any clusters.
 
 | `finished`
-| The operation is complete and deleted. 
-| The operation is complete and deleted. The target cluster starts to handle produce and consume workloads.
+| The operation is complete. 
+| The operation is complete. The target cluster starts to handle produce and consume workloads.
 
 | `canceling`
 2+| Redpanda is in the process of canceling the mount or unmount operation.
@@ -205,8 +224,6 @@ You cannot cancel mount and unmount operations in the following <<monitor-progre
 - `cancelled`
 
 == Additional considerations
-
-It is not possible to unmount a topic whose name matches multiple topics in the origin cluster.
 
 Redpanda prevents you from mounting the same topic to multiple clusters at once. This ensures that multiple clusters don't write to the same location in object storage and corrupt the topic.
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -66,14 +66,20 @@ You can use the ID returned by the command to <<monitor-progress,monitor the pro
 rpk::
 +
 --
-In your target cluster, run this command to mount a topic from object storage:
+. In your target cluster, run this command to list the topics that are available to mount from object storage:
++
+```
+rpk cluster storage list-mountable
+```
 
+. Mount a topic from object storage:
++
 ```
 rpk cluster storage mount <source-topic-name>
 ```
-
++
 You can also rename the topic as you mount it to the target cluster:
-
++
 ```
 rpk cluster storage mount <namespace>/<source-topic-name> --to <namespace>/<new-topic-name>
 ```


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2504
Related: Migrations [API reference](https://github.com/redpanda-data/docs/pull/798)

Review deadline: 9 Oct.

## Page previews

24.3 beta: [Mountable Topics](https://deploy-preview-725--redpanda-docs-preview.netlify.app/24.3/manage/mountable-topics/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)