### PR TITLE
Clarify that Redpanda does not support K8s autoscalers

### DIFF
--- a/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
+++ b/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
@@ -21,7 +21,7 @@ If your existing worker nodes have either too many resources or not enough resou
 - Deleting the Pod's PersistentVolumeClaim (PVC).
 - Ensuring that the PersistentVolume's (PV) reclaim policy is set to `Retain` to make sure that you can roll back to the original worker node without losing data.
 
-The <<node-pvc, Nodewatcher controller>> can automate this process.
+As an emergency backstop, the <<node-pvc, Nodewatcher controller>> can automate the deletion of PVCs and set the reclaim policy of PVs to `Retain`.
 
 == Horizontal scaling
 

--- a/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
+++ b/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
@@ -17,7 +17,7 @@ IMPORTANT: You cannot decrease the number of CPU cores in a running cluster.
 If your existing worker nodes have either too many resources or not enough resources, you may need to move Redpanda brokers to new worker nodes that meet your resource requirements. This process involves:
 
 - Making sure the new worker nodes are available.
-- Deleting each worker node one-by-one.
+- Deleting each worker node one by one.
 - Deleting the Pod's PersistentVolumeClaim (PVC).
 - Ensuring that the PersistentVolume's (PV) reclaim policy is set to `Retain` to make sure that you can roll back to the original worker node without losing data.
 

--- a/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
+++ b/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
@@ -27,7 +27,7 @@ The <<node-pvc, Nodewatcher controller>> can automate this process.
 
 Horizontal scaling involves modifying the number of brokers in your cluster, either by adding new ones (scaling out) or removing existing ones (scaling in). In situations where the workload is variable, horizontal scaling allows for flexibility. You can scale out when demand is high and scale in when demand is low, optimizing resource usage and cost.
 
-NOTE: Redpanda does not support Kubernetes autoscalers in production. Autoscalers primarily rely on CPU and memory metrics for scaling decisions, which do not fully capture the complexities involved in scaling Redpanda clusters. Improper scaling can lead to operational challenges. Therefore, we recommend manually scaling your Redpanda clusters as described in this topic.
+CAUTION: Redpanda does not support Kubernetes autoscalers. Autoscalers rely on CPU and memory metrics for scaling decisions, which do not fully capture the complexities involved in scaling Redpanda clusters. Improper scaling can lead to operational challenges. Always manually scale your Redpanda clusters as described in this topic.
 
 === Scale out
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)