### PR TITLE
Revert "auto-docs: Update Cloud API spec"

### DIFF
--- a/modules/ROOT/attachments/cloud-api.yaml
+++ b/modules/ROOT/attachments/cloud-api.yaml
@@ -843,11 +843,6 @@ components:
         network:
           $ref: '#/components/schemas/v1beta2.Network'
       type: object
-    CreatePipelineResponse:
-      properties:
-        pipeline:
-          $ref: '#/components/schemas/Pipeline'
-      type: object
     CreateResourceGroupResponse:
       description: CreateResourceGroupResponse is the response of CreateResourceGroup.
       properties:
@@ -1073,8 +1068,6 @@ components:
       properties:
         operation:
           $ref: '#/components/schemas/v1beta2.Operation'
-      type: object
-    DeletePipelineResponse:
       type: object
     DeleteResourceGroupResponse:
       description: DeleteResourceGroupResponse is the response of DeleteResourceGroup.
@@ -1397,17 +1390,6 @@ components:
           $ref: '#/components/schemas/v1beta2.Operation'
       title: GetOperationResponse is the request of GetOperation
       type: object
-    GetPipelineResponse:
-      properties:
-        pipeline:
-          $ref: '#/components/schemas/Pipeline'
-      type: object
-    GetPipelineServiceConfigSchemaResponse:
-      properties:
-        config_schema:
-          description: config_schema is the JSON schema of the configuration components that are allowed for pipelines.
-          type: string
-      type: object
     GetRegionResponse:
       properties:
         region:
@@ -1612,21 +1594,6 @@ components:
           type: array
         next_page_token:
           type: string
-      type: object
-    ListPipelinesRequest.Filter:
-      properties:
-        name_contains:
-          description: Substring match on pipeline name. Case-sensitive.
-          type: string
-      type: object
-    ListPipelinesResponse:
-      properties:
-        next_page_token:
-          type: string
-        pipelines:
-          items:
-            $ref: '#/components/schemas/Pipeline'
-          type: array
       type: object
     ListRedpandaVersionsResponse:
       properties:
@@ -1847,7 +1814,7 @@ components:
     MatchingACL:
       properties:
         error:
-          $ref: '#/components/schemas/rpc.Status'
+          $ref: '#/components/schemas/Status'
         host:
           description: The host address to use for this ACL.
           type: string
@@ -2054,79 +2021,6 @@ components:
         - PERMISSION_TYPE_DENY
         - PERMISSION_TYPE_ALLOW
       type: string
-    Pipeline:
-      description: Defines the pipeline resource.
-      properties:
-        config_yaml:
-          description: The configuration of the Pipeline as YAML. See https://docs.redpanda.com/redpanda-connect/configuration/about for more details.
-          title: |-
-            The configuration of the Pipeline as YAML.
-            See https://docs.redpanda.com/redpanda-connect/configuration/about/
-          type: string
-        description:
-          description: Optional pipeline description.
-          type: string
-        display_name:
-          description: User friendly display name.
-          type: string
-        id:
-          description: Pipeline ID.
-          type: string
-        limit:
-          $ref: '#/components/schemas/Resources'
-        request:
-          $ref: '#/components/schemas/Resources'
-        state:
-          $ref: '#/components/schemas/State'
-        status:
-          $ref: '#/components/schemas/Pipeline.Status'
-      required:
-        - id
-        - display_name
-        - config_yaml
-      type: object
-    Pipeline.Status:
-      description: Pipeline status can hold error message.
-      properties:
-        error:
-          type: string
-      type: object
-    PipelineCreate:
-      description: PipelineCreate contains the details for the pipeline creation request.
-      properties:
-        config_yaml:
-          description: The pipeline configuration in YAML format.
-          type: string
-        description:
-          description: Pipeline description.
-          type: string
-        display_name:
-          description: User friendly pipeline name.
-          type: string
-        limit:
-          $ref: '#/components/schemas/Resources'
-        request:
-          $ref: '#/components/schemas/Resources'
-      required:
-        - display_name
-        - config_yaml
-      type: object
-    PipelineUpdate:
-      properties:
-        config_yaml:
-          description: The pipeline configuration in YAML format.
-          type: string
-        description:
-          description: Pipeline description.
-          type: string
-        display_name:
-          description: Pipeline name.
-          type: string
-        limit:
-          $ref: '#/components/schemas/Resources'
-        request:
-          $ref: '#/components/schemas/Resources'
-      type: object
     PlannedDeletion:
       description: Date after which this cluster can and should be deleted.
       properties:
@@ -2497,40 +2391,6 @@ components:
         - RESOURCE_TYPE_DELEGATION_TOKEN
         - RESOURCE_TYPE_USER
       type: string
-    Resources:
-      properties:
-        cpu_shares:
-          description: |-
-            cpu_shares is a string specifying the amount of CPU to allocate for the
-            pipeline.
-
-            This follows the Kubernetes resource quantity format. Acceptable
-            units include:
-            - Decimal SI units: "m" (e.g., "500m" for 500 millicores, "2" for 2 cores)
-            If no unit is specified, the value is interpreted as the number of cores.
-            CPU shares can be specified in millicores (1 core = 1000 millicores).
-
-            More info: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/
-          type: string
-        memory_shares:
-          description: |-
-            memory_shares is a string specifying the amount of memory to allocate for
-            the pipeline.
-
-            This follows the Kubernetes resource quantity format. Acceptable units
-            include:
-            - Decimal SI units: "K", "M", "G", "T", "P", "E" (e.g., "128M" for 128
-              megabytes)
-            - Binary SI units: "Ki", "Mi", "Gi", "Ti", "Pi", "Ei" (e.g., "512Mi" for
-            512 mebibytes) If no unit is specified, the value is interpreted as
-            bytes.
-
-            More info: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/
-          type: string
-      required:
-        - memory_shares
-        - cpu_shares
-      type: object
     SASLMechanism:
       description: SASL mechanism to use for authentication.
       enum:
@@ -2730,27 +2590,79 @@ components:
             $ref: '#/components/schemas/Configuration'
           type: array
       type: object
-    StartPipelineResponse:
-      properties:
-        pipeline:
-          $ref: '#/components/schemas/Pipeline'
-      type: object
-    State:
+    Status:
       description: |-
-        State of the pipeline.
+        The `Status` type defines a logical error model that is suitable for
+        different programming environments, including REST APIs and RPC APIs. It is
+        used by [gRPC](https://github.com/grpc). Each `Status` message contains
+        three pieces of data: error code, error message, and error details.
 
-         - STATE_STARTING: The pipeline is starting.
-         - STATE_RUNNING: The pipeline is running.
-         - STATE_STOPPING: The pipeline is in the process of stopping.
-         - STATE_STOPPED: The pipeline is stopped and in paused state.
-         - STATE_ERROR: The pipeline is in error state.
-      enum:
-        - STATE_STARTING
-        - STATE_RUNNING
-        - STATE_STOPPING
-        - STATE_STOPPED
-        - STATE_ERROR
-      type: string
+        You can find out more about this error model and how to work with it in the
+        [API Design Guide](https://cloud.google.com/apis/design/errors).
+      properties:
+        code:
+          description: RPC status code, as described [here](https://github.com/googleapis/googleapis/blob/b4c238feaa1097c53798ed77035bbfeb7fc72e96/google/rpc/code.proto#L32).
+          enum:
+            - OK
+            - CANCELLED
+            - UNKNOWN
+            - INVALID_ARGUMENT
+            - DEADLINE_EXCEEDED
+            - NOT_FOUND
+            - ALREADY_EXISTS
+            - PERMISSION_DENIED
+            - UNAUTHENTICATED
+            - RESOURCE_EXHAUSTED
+            - FAILED_PRECONDITION
+            - ABORTED
+            - OUT_OF_RANGE
+            - UNIMPLEMENTED
+            - INTERNAL
+            - UNAVAILABLE
+            - DATA_LOSS
+          format: int32
+          type: string
+        details:
+          items:
+            description: Details of the error.
+            oneOf:
+              - allOf:
+                  - properties:
+                      '@type':
+                        description: Fully qualified protobuf type name of the underlying response, prefixed with `type.googleapis.com/`.
+                        enum:
+                          - type.googleapis.com/google.rpc.BadRequest
+                        type: string
+                  - $ref: '#/components/schemas/BadRequest'
+              - allOf:
+                  - properties:
+                      '@type':
+                        description: Fully qualified protobuf type name of the underlying response, prefixed with `type.googleapis.com/`.
+                        enum:
+                          - type.googleapis.com/google.rpc.ErrorInfo
+                        type: string
+                  - $ref: '#/components/schemas/ErrorInfo'
+              - allOf:
+                  - properties:
+                      '@type':
+                        description: Fully qualified protobuf type name of the underlying response, prefixed with `type.googleapis.com/`.
+                        enum:
+                          - type.googleapis.com/google.rpc.QuotaFailure
+                        type: string
+                  - $ref: '#/components/schemas/QuotaFailure'
+              - allOf:
+                  - properties:
+                      '@type':
+                        description: Fully qualified protobuf type name of the underlying response, prefixed with `type.googleapis.com/`.
+                        enum:
+                          - type.googleapis.com/google.rpc.Help
+                        type: string
+                  - $ref: '#/components/schemas/Help'
+          type: array
+        message:
+          description: Detailed error message. No compatibility guarantees are given for the text contained in this message.
+          type: string
+      type: object
     Status.ConnectedEndpoint:
       description: ConnectedEndpoint defines endpoint connection connected to Redpanda GCP PSC (Private Service Connect) service.
       properties:
@@ -2817,11 +2729,6 @@ components:
         hosted_zone_id:
           description: The ID of Route53 DNS zone.
           type: string
-      type: object
-    StopPipelineResponse:
-      properties:
-        pipeline:
-          $ref: '#/components/schemas/Pipeline'
       type: object
     Subnets:
       description: Azure subnets used by Redpand cluster deployment.
@@ -3001,11 +2908,6 @@ components:
         secret:
           $ref: '#/components/schemas/Secret'
       type: object
-    UpdatePipelineResponse:
-      properties:
-        pipeline:
-          $ref: '#/components/schemas/Pipeline'
-      type: object
     UpdateResourceGroupResponse:
       properties:
         resource_group:
@@ -3155,7 +3057,7 @@ components:
           description: Detailed error message. No compatibility guarantees are given for the text contained in this message.
           type: string
       type: object
-    v1alpha2.Topic:
+    v1alpha1.Topic:
       type: object
     v1beta1.CloudProvider:
       description: Cloud Provider where resources are created.
@@ -4369,7 +4271,7 @@ info:
   version: v1beta2
 openapi: 3.0.3
 paths:
-  /v1alpha2/acls:
+  /v1alpha1/acls:
     delete:
       description: Delete all ACLs that match the filter criteria. The `filter.` query string parameters find matching ACLs that meet all specified conditions.
       operationId: ACLService_DeleteACLs
@@ -4464,19 +4366,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Delete ACLs
       tags:
@@ -4571,19 +4473,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: List ACLs
       tags:
@@ -4609,24 +4511,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Create ACL
       tags:
         - ACLService
-  /v1alpha2/kafka-connect/clusters:
+  /v1alpha1/connect/clusters:
     get:
       description: List connect clusters available for being consumed by the console's kafka-connect service.
       operationId: KafkaConnectService_ListConnectClusters
@@ -4641,24 +4543,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: List connect clusters
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}:
+  /v1alpha1/connect/clusters/{cluster_name}:
     get:
       description: Get information about an available Kafka Connect cluster.
       operationId: KafkaConnectService_GetConnectCluster
@@ -4680,30 +4582,30 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Connect cluster not found
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Get connect cluster
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/connectors:
+  /v1alpha1/connect/clusters/{cluster_name}/connectors:
     get:
       description: List connectors managed by the Kafka Connect service.
       operationId: KafkaConnectService_ListConnectors
@@ -4736,19 +4638,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: List connectors
       tags:
@@ -4781,24 +4683,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Create connector
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/connectors/{name}:
+  /v1alpha1/connect/clusters/{cluster_name}/connectors/{name}:
     delete:
       description: Delete a connector. This operation force stops all tasks and also deletes the connector configuration.
       operationId: KafkaConnectService_DeleteConnector
@@ -4825,19 +4727,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Delete connector
       tags:
@@ -4869,24 +4771,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Get connector
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/connectors/{name}/config:
+  /v1alpha1/connect/clusters/{cluster_name}/connectors/{name}/config:
     get:
       description: Get the configuration for the connector.
       operationId: KafkaConnectService_GetConnectorConfig
@@ -4908,19 +4810,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Get connector configuration
       tags:
@@ -4970,24 +4872,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Upsert connector configuration
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/connectors/{name}/pause:
+  /v1alpha1/connect/clusters/{cluster_name}/connectors/{name}/pause:
     put:
       description: Pause the connector and its tasks, which stops messages from processing until the connector is resumed. This call is asynchronous and may take some time to process.
       operationId: KafkaConnectService_PauseConnector
@@ -5014,24 +4916,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Pause connector
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/connectors/{name}/restart:
+  /v1alpha1/connect/clusters/{cluster_name}/connectors/{name}/restart:
     post:
       description: Triggers a connector restart. You must specify whether or not tasks are also restarted, and whether only failed connectors are restarted.
       operationId: KafkaConnectService_RestartConnector
@@ -5065,24 +4967,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Restart connector
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/connectors/{name}/resume:
+  /v1alpha1/connect/clusters/{cluster_name}/connectors/{name}/resume:
     put:
       description: Resume a paused connector and its tasks, and resumes message processing. This call is asynchronous and may take some time to process. If the connector was not paused, this operation does not do anything.
       operationId: KafkaConnectService_ResumeConnector
@@ -5109,24 +5011,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Resume connector
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/connectors/{name}/status:
+  /v1alpha1/connect/clusters/{cluster_name}/connectors/{name}/status:
     get:
       description: Gets the current status of the connector, including the state for each of its tasks, error information, etc.
       operationId: KafkaConnectService_GetConnectorStatus
@@ -5154,24 +5056,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Get connector status
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/connectors/{name}/stop:
+  /v1alpha1/connect/clusters/{cluster_name}/connectors/{name}/stop:
     put:
       description: Stops a connector, but does not delete it. All tasks for the connector are shut down completely. This call is asynchronous and may take some time to process.
       operationId: KafkaConnectService_StopConnector
@@ -5198,24 +5100,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Stop connector
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/connectors/{name}/topics:
+  /v1alpha1/connect/clusters/{cluster_name}/connectors/{name}/topics:
     get:
       description: Returns a list of connector topic names. If the connector is inactive, this call returns an empty list.
       operationId: KafkaConnectService_ListConnectorTopics
@@ -5243,24 +5145,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: List connector topics
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/connectors/{name}/topics/reset:
+  /v1alpha1/connect/clusters/{cluster_name}/connectors/{name}/topics/reset:
     put:
       description: Resets the set of topic names that the connector is using.
       operationId: KafkaConnectService_ResetConnectorTopics
@@ -5287,24 +5189,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Reset connector topics
       tags:
         - KafkaConnectService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/secrets:
+  /v1alpha1/connect/clusters/{cluster_name}/secrets:
     get:
       description: 'List Kafka Connect cluster secrets. Optional: filter based on secret name and labels.'
       operationId: SecretService_ListConnectSecrets
@@ -5349,19 +5251,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: List Connect Cluster Secrets
       tags:
@@ -5411,24 +5313,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Create Connect Cluster Secret
       tags:
         - SecretService
-  /v1alpha2/kafka-connect/clusters/{cluster_name}/secrets/{id}:
+  /v1alpha1/connect/clusters/{cluster_name}/secrets/{id}:
     delete:
       description: Delete a Kafka Connect cluster secret.
       operationId: SecretService_DeleteConnectSecret
@@ -5455,25 +5357,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Not Found
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Delete Connect Cluster Secret
       tags:
@@ -5505,25 +5407,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Not Found
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Get Connect Cluster Secret
       tags:
@@ -5575,374 +5477,30 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Not Found
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Update Connect Cluster Secret
       tags:
         - SecretService
-  /v1alpha2/redpanda-connect/config-schema:
-    get:
-      operationId: PipelineService_GetPipelineServiceConfigSchema
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetPipelineServiceConfigSchemaResponse'
-          description: OK
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Unauthenticated.
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Internal Server Error. Reach out to support.
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: An unexpected error response.
-      summary: Retrieve the schema for configuring Redpanda Connect pipelines.
-      tags:
-        - PipelineService
-  /v1alpha2/redpanda-connect/pipelines:
-    get:
-      description: 'List Redpanda Connect pipelines. Optional: filter based on pipeline name.'
-      operationId: PipelineService_ListPipelines
-      parameters:
-        - description: Substring match on pipeline name. Case-sensitive.
-          in: query
-          name: filter.name_contains
-          schema:
-            type: string
-        - description: Limit the paginated response to a number of items. Defaults to 100. Use -1 to disable pagination.
-          in: query
-          name: page_size
-          schema:
-            format: int32
-            type: integer
-        - description: |-
-            Value of the next_page_token field returned by the previous response.
-            If not provided, the system assumes the first page is requested.
-          in: query
-          name: page_token
-          schema:
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListPipelinesResponse'
-          description: OK
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Unauthenticated.
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Internal Server Error. Reach out to support.
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: An unexpected error response.
-      summary: List Redpanda Connect pipelines
-      tags:
-        - PipelineService
-    post:
-      description: Create a new Redpanda Connect pipeline.
-      operationId: PipelineService_CreatePipeline
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PipelineCreate'
-        required: true
-        x-originalParamName: pipeline
-      responses:
-        "201":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListPipelinesResponse'
-          description: OK
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Unauthenticated.
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Internal Server Error. Reach out to support.
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: An unexpected error response.
-      summary: Create Redpanda Connect pipeline
-      tags:
-        - PipelineService
-  /v1alpha2/redpanda-connect/pipelines/{id}:
-    delete:
-      description: Delete a Redpanda Connect pipeline.
-      operationId: PipelineService_DeletePipeline
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "204":
-          content:
-            application/json:
-              schema: {}
-          description: Deleted
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Unauthenticated.
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Not Found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Internal Server Error. Reach out to support.
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: An unexpected error response.
-      summary: Delete a Redpanda Connect pipeline
-      tags:
-        - PipelineService
-    get:
-      description: Get a specific Redpanda Connect pipeline.
-      operationId: PipelineService_GetPipeline
-      parameters:
-        - description: The pipeline ID.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pipeline'
-          description: OK
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Unauthenticated.
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Not Found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Internal Server Error. Reach out to support.
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: An unexpected error response.
-      summary: Get Redpanda Connect pipeline
-      tags:
-        - PipelineService
-    put:
-      description: Update the configuration of a Redpanda Connect pipeline.
-      operationId: PipelineService_UpdatePipeline
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: The fields to be updated.
-          in: query
-          name: update_mask
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PipelineUpdate'
-        required: true
-        x-originalParamName: pipeline
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pipeline'
-          description: OK
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Unauthenticated.
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Internal Server Error. Reach out to support.
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: An unexpected error response.
-      summary: Update a Redpanda Connect pipeline
-      tags:
-        - PipelineService
-  /v1alpha2/redpanda-connect/pipelines/{id}/start:
-    put:
-      description: Start a stopped Redpanda Connect pipeline.
-      operationId: PipelineService_StartPipeline
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pipeline'
-          description: Started
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Unauthenticated.
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Not Found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Internal Server Error. Reach out to support.
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: An unexpected error response.
-      summary: Start a Redpanda Connect pipeline
-      tags:
-        - PipelineService
-  /v1alpha2/redpanda-connect/pipelines/{id}/stop:
-    put:
-      description: Stop a running Redpanda Connect pipeline.
-      operationId: PipelineService_StopPipeline
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pipeline'
-          description: Stopped
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Unauthenticated.
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Not Found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: Internal Server Error. Reach out to support.
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/rpc.Status'
-          description: An unexpected error response.
-      summary: Stops a Redpanda Connect pipeline
-      tags:
-        - PipelineService
-  /v1alpha2/topics:
+  /v1alpha1/topics:
     get:
       description: 'List topics, with partition count and replication factor. Optional: filter based on topic name.'
       operationId: TopicService_ListTopics
@@ -5974,19 +5532,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: List Topics
       tags:
@@ -6015,30 +5573,30 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1alpha2.Topic'
+                $ref: '#/components/schemas/v1alpha1.Topic'
           description: Topic created
         "401":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Create Topic
       tags:
         - TopicService
-  /v1alpha2/topics/{name}:
+  /v1alpha1/topics/{name}:
     delete:
       description: Delete the Kafka topic with the requested name.
       operationId: TopicService_DeleteTopic
@@ -6059,30 +5617,30 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Requested topic does not exist
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Delete Topic
       tags:
         - TopicService
-  /v1alpha2/topics/{topic_name}/configurations:
+  /v1alpha1/topics/{topic_name}/configurations:
     get:
       description: Get key-value configs for a topic.
       operationId: TopicService_GetTopicConfigurations
@@ -6104,25 +5662,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Not Found
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Get Topic Configurations
       tags:
@@ -6157,25 +5715,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Not Found
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Update Topic Configuration
       tags:
@@ -6210,30 +5768,30 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Not Found
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Set Topic Configurations
       tags:
         - TopicService
-  /v1alpha2/transforms:
+  /v1alpha1/transforms:
     get:
       description: 'Retrieve a list of Wasm transforms. Optional: filter based on transform name.'
       operationId: TransformService_ListTransforms
@@ -6292,19 +5850,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: List Transforms
       tags:
@@ -6316,7 +5874,7 @@ paths:
         content:
           multipart/form-data:
             schema:
-              example: '{"name":"redact-orders","input_topic_name":"orders","output_topic_names":["orders-redacted"],"environment_variables":[{"key":"LOGGER_LEVEL","value":"DEBUG"}]}'
+              example: '{"name":"redact-orders", "input_topic_name":"orders", "output_topic_names":["orders-redacted"], "environment_variables":[{"key":"LOGGER_LEVEL", "value":"DEBUG"}]}'
               properties:
                 metadata:
                   $ref: '#/components/schemas/DeployTransformRequest'
@@ -6337,7 +5895,7 @@ paths:
       summary: Deploy Transform
       tags:
         - TransformService
-  /v1alpha2/transforms/{name}:
+  /v1alpha1/transforms/{name}:
     delete:
       description: Delete a Wasm transform with the requested name.
       operationId: TransformService_DeleteTransform
@@ -6361,25 +5919,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Not Found
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Delete Transform
       tags:
@@ -6420,30 +5978,30 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Not Found
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Get Transform
       tags:
         - TransformService
-  /v1alpha2/users:
+  /v1alpha1/users:
     get:
       description: 'List users. Optional: filter based on username.'
       operationId: UserService_ListUsers
@@ -6487,19 +6045,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: List Users
       tags:
@@ -6547,30 +6105,30 @@ paths:
                         field: user.mechanism
                 message: provided parameters are invalid
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Bad request. Check API documentation and update request.
         "401":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Create User
       tags:
         - UserService
-  /v1alpha2/users/{name}:
+  /v1alpha1/users/{name}:
     delete:
       description: Delete the specified user
       operationId: UserService_DeleteUser
@@ -6592,7 +6150,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "404":
           content:
@@ -6606,24 +6164,24 @@ paths:
                     reason: REASON_RESOURCE_NOT_FOUND
                 message: user not found
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Not Found
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Delete User
       tags:
         - UserService
-  /v1alpha2/users/{user.name}:
+  /v1alpha1/users/{user.name}:
     put:
       description: Update a user's credentials.
       operationId: UserService_UpdateUser
@@ -6680,25 +6238,25 @@ paths:
                         field: user.mechanism
                 message: provided parameters are invalid
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Bad request. Check API documentation and update request.
         "401":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Unauthenticated.
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: Internal Server Error. Reach out to support.
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rpc.Status'
+                $ref: '#/components/schemas/Status'
           description: An unexpected error response.
       summary: Update User
       tags:
@@ -8198,7 +7756,6 @@ tags:
   - name: TransformService
   - description: Manage [connectors](https://docs.redpanda.com/current/deploy/deployment-option/cloud/managed-connectors/) and interact with the Kafka Connect API.
     name: KafkaConnectService
-  - name: PipelineService
   - description: Manage [secrets](https://docs.redpanda.com/current/deploy/deployment-option/cloud/security/secrets/) for Redpanda Cloud.
     name: SecretService
   - description: Manage Redpanda Cloud topics.


### PR DESCRIPTION
Per [Slack thread](https://redpandadata.slack.com/archives/C058KAULETE/p1724889675294689?thread_ts=1724872576.616419&cid=C058KAULETE)

This reverts the API reference to a point where
- Kafka Connect URLs contain [`connect`](https://deploy-preview-728--redpanda-docs-preview.netlify.app/api/cloud-api/#tag--KafkaConnectService) instead of `kafka-connect`
- all Data Plane API paths use `v1alpha1` (e.g. https://deploy-preview-728--redpanda-docs-preview.netlify.app/api/cloud-api/#tag--ACLService)
- the [Pipeline endpoints](https://docs.redpanda.com/api/cloud-api/#tag--PipelineService) are not published yet

This reverts commit 8bb01cd3ef2774075facdb2a97a3930a1464c7db.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)