### PR TITLE
Add build trigger to api branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+---
+# This workflow triggers a build of the production docs site
+
+name: Build Production Site
+on:
+  push:
+    branches: [main, 'v/*', shared, api, site-search, 'v-WIP/*']
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: get secrets from aws sm
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/docs_netlify_build_hook
+          parse-json-secrets: true
+      - name: Trigger build
+        run: curl -X POST -d {} "${{ env.DOCS_NETLIFY_BUILD_HOOK }}"


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)