### PR TITLE
Remove reference to Kubernetes 1.26 and earlier

### DIFF
--- a/modules/upgrade/pages/k-upgrade-kubernetes.adoc
+++ b/modules/upgrade/pages/k-upgrade-kubernetes.adoc
@@ -63,7 +63,7 @@ rpk topic alter-config [<topic-name>,] --set replication.factor=<replication-fac
 +
 After increasing the replication factor, xref:manage:kubernetes/monitoring/index.adoc#under-replicated-partitions[monitor for under-replicated partitions] and wait until all partitions are replicated.
 
-* *Delete PVCs*: If you are using local PVs in Kubernetes version 1.26 or earlier, make sure to delete the PersistentVolumeClaims (PVC) before upgrading the worker node. Otherwise, your Pods will remain in a pending state when they are rescheduled because the PVs are bound to the node through node affinity.
+* *Delete PersistentVolumeClaims (PVCs)*: If you are using local PVs in Kubernetes, make sure to delete the PVC before upgrading the worker node. Otherwise, your Pods will remain in a pending state when they are rescheduled because the PVs are bound to the node through node affinity.
 +
 NOTE: Deleting a PVC does not remove it from the system immediately. Instead, a `deletionTimestamp` is set on the PVC, but it will not be deleted until the associated Pod is terminated.
 * *Decommission brokers*: Decommission the broker on the worker node planned for an upgrade. Decommissioning helps prevent data loss by gracefully moving the broker's topic partitions and replicas to other brokers in the cluster. See xref:manage:kubernetes/k-decommission-brokers.adoc[Decommission Brokers].


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2717
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)