### PR TITLE
auto-docs: Update extensions on v/23.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -749,10 +749,11 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.6.1.tgz",
-      "integrity": "sha512-kl3PUeT9a3g7KZ1G0dg362QMlEJTb4/vmPyUKR9jYvdX8GACs1Bse75A0SwLjxnHTIAd+1QKfQpcUFdT6AwyGw==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.6.4.tgz",
+      "integrity": "sha512-Kxa65lTwajic1xLrdMRjSCvYoFp7njruuI1UOGdVpo90cof7ZlLV3KX2GIig0sLfwSIWMgvimV1i3ZnxIUAbNw==",
       "dependencies": {
+        "@asciidoctor/tabs": "^1.0.0-beta.6",
         "@octokit/core": "^6.1.2",
         "@octokit/plugin-retry": "^7.1.1",
         "@octokit/rest": "^21.0.1",


### PR DESCRIPTION
This PR updates the @redpanda-data/docs-extensions-and-macros package on the v/23.3 branch.