### PR TITLE
auto-docs: Update extensions on v/23.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.6.4.tgz",
-      "integrity": "sha512-Kxa65lTwajic1xLrdMRjSCvYoFp7njruuI1UOGdVpo90cof7ZlLV3KX2GIig0sLfwSIWMgvimV1i3ZnxIUAbNw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.6.5.tgz",
+      "integrity": "sha512-1WnRGhit7wDTZqVChy5KlUAT/Vg/OgR/+O6/nuB3zeSpAzntZb7SaTAQhXI84fEWg3ka2ALuy+/wk13r4AXBVA==",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",
         "@octokit/core": "^6.1.2",


### PR DESCRIPTION
This PR updates the @redpanda-data/docs-extensions-and-macros package on the v/23.3 branch.