### PR TITLE
Backport operator v1 redirects to 24.1

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/get-started-dev.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/get-started-dev.adoc
@@ -1,6 +1,6 @@
 = Get Started with Redpanda in Kubernetes
 :description: Find guides for setting up a three-broker Redpanda cluster in different Kubernetes platforms.
-:page-aliases: quickstart:kubernetes-qs-dev.adoc, getting-started:quick-start-kubernetes.adoc, get-started:quick-start/kubernetes-qs-dev.adoc, quickstart:index.adoc, quickstart:index/index.adoc, quickstart:kubernetes-qs-cloud.adoc, getting-started:kubernetes-qs-cloud.adoc
+:page-aliases: quickstart:kubernetes-qs-dev.adoc, getting-started:quick-start-kubernetes.adoc, get-started:quick-start/kubernetes-qs-dev.adoc, quickstart:index.adoc, quickstart:index/index.adoc, quickstart:kubernetes-qs-cloud.adoc, getting-started:kubernetes-qs-cloud.adoc, reference:redpanda-operator/kubernetes-qs-cloud.adoc, reference:redpanda-operator/kubernetes-qs-local-access.adoc, reference:redpanda-operator/operator-install/index.adoc, reference:redpanda-operator/kubernetes-qs-minikube.adoc, reference:redpanda-operator/operator-deploy/index.adoc
 :env-kubernetes: true
 :page-categories: Deployment, GitOps
 

--- a/modules/manage/pages/kubernetes/k-cluster-property-configuration.adoc
+++ b/modules/manage/pages/kubernetes/k-cluster-property-configuration.adoc
@@ -1,7 +1,7 @@
 = Configure Cluster Properties in Kubernetes
 :description: Learn how to configure cluster properties in Kubernetes.
 :page-context-links: [{"name": "Linux", "to": "manage:cluster-maintenance/cluster-property-configuration.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-cluster-property-configuration.adoc" } ]
-:page-aliases: manage:kubernetes/cluster-property-configuration.adoc
+:page-aliases: manage:kubernetes/cluster-property-configuration.adoc, reference:redpanda-operator/kubernetes-additional-config.adoc, reference:redpanda-operator/arbitrary-configuration.adoc
 :page-categories: Management
 :env-kubernetes: true
 

--- a/modules/manage/pages/kubernetes/networking/index.adoc
+++ b/modules/manage/pages/kubernetes/networking/index.adoc
@@ -1,5 +1,6 @@
 = Networking and Connectivity in Kubernetes
 :description: Learn how to set up and manage network connections for Redpanda in Kubernetes. This section covers a range of topics, including how to enable external access, connect clients to a Redpanda cluster, and configure listeners.
+:page-aliases: reference:redpanda-operator/kubernetes-connectivity.adoc, reference:redpanda-operator/kubernetes-external-connect.adoc
 :page-layout: index
 :page-categories: Management, Networking
 :env-kubernetes: true

--- a/modules/manage/pages/kubernetes/security/authentication/k-authentication.adoc
+++ b/modules/manage/pages/kubernetes/security/authentication/k-authentication.adoc
@@ -2,7 +2,7 @@
 :description: Learn how to configure authentication for Redpanda in Kubernetes.
 :page-context-links: [{"name": "Linux", "to": "manage:security/authentication.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/security/authentication/k-authentication.adoc" } ]
 :tags: ["Kubernetes", "Helm configuration"]
-:page-aliases: security:sasl-kubernetes.adoc, manage:kubernetes/security/sasl-kubernetes.adoc, security:kubernetes-sasl.adoc, manage:kubernetes/security/authentication/sasl-kubernetes.adoc
+:page-aliases: security:sasl-kubernetes.adoc, manage:kubernetes/security/sasl-kubernetes.adoc, security:kubernetes-sasl.adoc, manage:kubernetes/security/authentication/sasl-kubernetes.adoc, reference:redpanda-operator/kubernetes-mtls.adoc, reference:redpanda-operator/kubernetes-sasl.adoc
 :page-categories: Management, Security
 :env-kubernetes: true
 :page-toclevels: 3

--- a/modules/manage/pages/kubernetes/security/index.adoc
+++ b/modules/manage/pages/kubernetes/security/index.adoc
@@ -1,7 +1,7 @@
 = Security for Redpanda in Kubernetes
 :description: Learn what options are available for securing Redpanda clusters, including TLS encryption, authentication, authorization, and audit logging.
 :page-layout: index
-:page-aliases: security:kubernetes-security.adoc, security:security-kubernetes.adoc
+:page-aliases: security:kubernetes-security.adoc, security:security-kubernetes.adoc, reference:redpanda-operator/operator-security/index.adoc, reference:redpanda-operator/security-kubernetes.adoc
 :page-categories: Management, Security
 :env-kubernetes: true
 

--- a/modules/manage/pages/kubernetes/security/tls/index.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/index.adoc
@@ -2,7 +2,7 @@
 :description: Use TLS to authenticate Redpanda brokers and encrypt communication between clients and brokers.
 :page-context-links: [{"name": "Linux", "to": "manage:security/encryption.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/security/kubernetes-tls.adoc" } ]
 :tags: ["Kubernetes", "Security"]
-:page-aliases: manage:kubernetes/security/kubernetes-tls.adoc, security:kubernetes-tls.adoc, security:kubernetes-mtls.adoc, features:tls-kubernetes.adoc, security:tls-kubernetes.adoc
+:page-aliases: manage:kubernetes/security/kubernetes-tls.adoc, security:kubernetes-tls.adoc, security:kubernetes-mtls.adoc, features:tls-kubernetes.adoc, security:tls-kubernetes.adoc, reference:redpanda-operator/tls-kubernetes.adoc
 :page-layout: index
 :page-categories: Management, Security
 :env-kubernetes: true

--- a/modules/reference/pages/k-crd-index.adoc
+++ b/modules/reference/pages/k-crd-index.adoc
@@ -1,4 +1,4 @@
 = Kubernetes Custom Resource Definitions
 :page-layout: index
 :description: Explore all custom resource definitions (CRDs) that are supported by the Redpanda Operator.
-:page-aliases: reference:topic-crd.adoc, reference:crd.adoc, reference:kubernetes-crd-index.adoc
+:page-aliases: reference:topic-crd.adoc, reference:crd.adoc, reference:kubernetes-crd-index.adoc, reference:redpanda-operator/crd.adoc

--- a/modules/upgrade/pages/migrate/kubernetes/operator.adoc
+++ b/modules/upgrade/pages/migrate/kubernetes/operator.adoc
@@ -1,6 +1,6 @@
 = Migrate from Cluster and Console Custom Resources
 :description: To ensure compatibility with future versions of Redpanda and to benefit from new features, enhancements, and security updates, you must migrate from the deprecated Cluster and Console custom resources to the Redpanda custom resource.
-:page-aliases: reference:redpanda-operator/arbitrary-configuration.adoc, reference:redpanda-operator/crd.adoc, reference:redpanda-operator/index.adoc, reference:redpanda-operator/kubernetes-additional-config.adoc, reference:redpanda-operator/kubernetes-connectivity.adoc, reference:redpanda-operator/kubernetes-external-connect.adoc, reference:redpanda-operator/kubernetes-mtls.adoc, reference:redpanda-operator/kubernetes-qs-cloud.adoc, reference:redpanda-operator/kubernetes-qs-local-access.adoc, reference:redpanda-operator/kubernetes-qs-minikube.adoc, reference:redpanda-operator/kubernetes-sasl.adoc, reference:redpanda-operator/security-kubernetes.adoc, reference:redpanda-operator/tls-kubernetes.adoc, reference:redpanda-operator/operator-deploy/index.adoc, reference:redpanda-operator/operator-install/index.adoc, reference:redpanda-operator/operator-security/index.adoc
+:page-aliases: reference:redpanda-operator/index.adoc
 :page-categories: Upgrades, Migration
 :env-kubernetes: true
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2684
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)