### PR TITLE
auto-docs: Update extensions on v/23.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.6.6.tgz",
-      "integrity": "sha512-g3qlTDg2fSNIZivL/lyWsqMR5CjsfWMHmFrxmBNkfn54Ukgs20ka4Mg+KXFqdrsLrNHmxh34Hfy/uigWeqxglA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.7.0.tgz",
+      "integrity": "sha512-pA+GqfbE9KSaw2FSNhWIow6/WuIsqqGNHx+2uojwyCWEjhPnQ9som9qzTYnvpuGlZtfUgkJ6K68/xC6nJHF+Hw==",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",
         "@octokit/core": "^6.1.2",


### PR DESCRIPTION
This PR updates the @redpanda-data/docs-extensions-and-macros package on the v/23.3 branch.