### PR TITLE
Remove information about custom roles

### DIFF
--- a/modules/console/pages/config/security/authorization.adoc
+++ b/modules/console/pages/config/security/authorization.adoc
@@ -3,7 +3,7 @@
 :page-aliases: console:single-sign-on/authorization.adoc, manage:security/console/authorization.adoc, console:features/role-bindings.adoc, console:reference/role-bindings.adoc, reference:console/role-bindings.adoc
 :page-categories: Management, Security, Redpanda Console
 
-Redpanda Console uses role-based access control (RBAC) to manage and restrict access to various system resources. This document covers how to configure and use RBAC in Redpanda Console, including setting up predefined and custom roles, binding roles to users, and leveraging advanced options such as regex-based resource inclusion.
+Redpanda Console uses role-based access control (RBAC) to manage and restrict access to various system resources. This document covers how to configure and use RBAC in Redpanda Console, including setting up predefined roles, binding roles to users, and leveraging advanced options such as regex-based resource inclusion.
 
 [NOTE]
 ====
@@ -22,11 +22,11 @@ Redpanda Console comes with three primitive roles:
 
 === Viewer
 
-The `viewer` role grants permissions to view all resources within Redpanda Console. This includes:
+The `viewer` role grants permission to view all resources within Redpanda Console. This includes:
 
 * Viewing all topic data (messages, configs, partitions, using search filters).
 * Viewing all cluster data (node configs, ACLs, service accounts, quotas).
-* Viewing all consumer group data (consumer groups, group offsets and lags).
+* Viewing all consumer group data (consumer groups, group offsets, and lags).
 * Viewing all Schema Registry data (registered schemas with their contents).
 * Viewing all Kafka Connect data (list configured clusters and their connectors, including the status and connector configs).
 
@@ -41,7 +41,7 @@ The `editor` role grants all permissions that come with the `viewer` role and ad
 * Managing all consumer group aspects, such as editing group offsets or deleting group offsets.
 * Managing all Kafka connect aspects, such as creating/updating/deleting or starting/pausing/stopping connectors.
 
-It does not include the permission to create/remove ACLs or to create or remove a service account.
+It does not include permission to create/remove ACLs or to create or remove a service account.
 
 === Admin
 
@@ -49,145 +49,6 @@ The `admin` role grants all permissions that come with the `editor` role and add
 
 * Managing all service account aspects (create/remove service accounts)
 * Managing all ACL aspects (create/remove ACLs)
-
-== Custom roles
-
-Redpanda Console allows you to define custom roles by specifying a set of permissions and actions that determine what resources a role can access and how it can interact with them. This section provides an overview of the available resource IDs, predefined actions, and the `includes` option, which can be used to configure custom roles.
-
-=== Predefined actions
-
-When defining roles in Redpanda Console, you can use predefined actions (`admin`, `edit`, `view`) to grant a group of related permissions to a resource. These predefined actions simplify the configuration process by grouping multiple granular permissions under a single label.
-
-* `admin`: Provides full control over the resource, including all possible permissions such as creation, editing, deletion, and viewing.
-* `edit`: Allows modifications, including creating, updating, and deleting records or configurations, but not full administrative control.
-* `view`: Grants read-only access to view the resource without making changes.
-
-When you assign these actions to roles, Redpanda Console automatically expands them into the relevant permissions set.
-
-The `includes` and `excludes` options in the role configuration allow you to specify which resources or parts of a resource the permissions apply to, using regular expressions (regex). These options give you fine-grained control over which resources a role can access.
-
-* **`includes`**: Specifies the resources to which the permissions should apply. Only the resources that match the regex patterns provided in `includes` will be affected.
-* **`excludes`**: Specifies the resources to be excluded from the permissions. Even if a resource matches the `includes` pattern, it will be excluded if it also matches a pattern in `excludes`.
-
-By using `includes` and `excludes` together, you can precisely control access to subsets of resources. For example, you might want to grant permissions to all topics that start with `team1-` but exclude those that contain the word `test`.
-
-NOTE: Ensure your regex patterns are valid. Invalid regex patterns will cause the configuration to fail. If no `includes` option is specified, the permissions apply to all resources of the specified type. If no `excludes` option is specified, no resources are excluded.
-
-=== Example custom role definition
-
-Here is an example of defining custom roles that grant different access levels to various resources:
-
-[,yaml]
-----
-roles:
-  - name: team1-admin
-    permissions:
-      - resource: consumerGroups
-        includes: ["team-.*"]   # Applies to consumer groups with names starting with 'team-'
-        allowedActions: ["admin"]  # Grants full administrative control
-      - resource: topics
-        includes: ["team1-.*"]   # Applies to topics with names starting with 'team1-'
-        allowedActions: ["admin"]  # Grants full administrative control
-      - resource: cluster
-        includes: ["team1-.*"]   # Applies to cluster resources related to 'team1'
-        allowedActions: ["admin"]  # Grants full administrative control
-
-  - name: team1-user
-    permissions:
-      - resource: consumerGroups
-        includes: ["team-.*"]
-        allowedActions: ["view"]  # Grants read-only access
-      - resource: topics
-        includes: ["team1-.*"]
-        excludes: [".*test.*"]    # Excludes any topic with 'test' in its name
-        allowedActions: ["view", "edit"]  # Grants view and edit access, but not delete or admin privileges
-----
-
-In this example:
-
-* The `team1-admin` role is granted full administrative access (`admin`) to consumer groups, topics, and cluster resources that match the regex patterns provided in `includes`.
-* The `team1-user` role is granted read-only access (`view`) and some editing capabilities (`edit`) to topics and consumer groups, with more limited access to cluster resources.
-
-This configuration demonstrates how to effectively use predefined actions and the `includes` option to control access to specific resources within Redpanda Console.
-
-=== Resource IDs
-
-Each resource in Redpanda Console is identified by a `resourceID`, which specifies the type of resource that a role can interact with. The following `resourceIDs` are available:
-
-* `application` - Refers to Console login and user management.
-* `topics` - Refers to Kafka Topics.
-* `consumerGroups` - Refers to Kafka consumer groups.
-* `cluster` - Refers to cluster-wide resources such as ACLs, partition reassignment, and more.
-* `kafkaConnect` - Refers to Kafka Connect clusters managed by the Console.
-* `secrets` - Refers to managing secrets in a secret store.
-* `schemaRegistry` - Refers to the Schema Registry API that Console connects to.
-
-You can use these `resourceIDs` to define which parts of the system a role should have access to.
-
-=== Permissions (actions)
-
-Each resource has associated actions that define which operations a role can perform. Here are the available actions grouped by resource:
-
-* *Topic actions*
-** `seeTopic` - View the topic.
-** `viewPartitions` - View the partitions of a topic.
-** `viewConfig` - View the configuration of a topic.
-** `editConfig` - Edit the configuration of a topic.
-** `viewMessages` - View messages within a topic.
-** `useSearchFilter` - Use search filters on a topic.
-** `viewConsumers` - View consumers of a topic.
-** `createTopic` - Create a new topic.
-** `deleteTopic` - Delete a topic.
-** `publishTopicRecords` - Publish records to a topic.
-** `deleteTopicRecords` - Delete records from a topic.
-
-* *Application actions*
-** `viewConsoleUsers` - View Console users.
-
-* *Cluster actions*
-** `viewAcl` - View ACLs in the cluster.
-** `createAcl` - Create a new ACL.
-** `deleteAcl` - Delete an ACL.
-** `reassignPartitions` - Reassign partitions within the cluster.
-** `patchConfigs` - Apply configuration changes to the cluster.
-** `viewQuotas` - View quotas within the cluster.
-** `viewKafkaUser` - View Kafka users.
-** `createKafkaUser` - Create a new Kafka user.
-** `deleteKafkaUser` - Delete a Kafka user.
-** `viewRedpandaRole` - View Redpanda roles.
-** `createRedpandaRole` - Create a new Redpanda role.
-** `deleteRedpandaRole` - Delete a Redpanda role.
-** `viewTransform` - View data transforms.
-** `createTransform` - Create a new data transform.
-** `deleteTransform` - Delete a data transform.
-** `viewPipeline` - View data pipelines.
-** `createPipeline` - Create a new data pipeline.
-** `updatePipeline` - Update an existing data pipeline.
-** `deletePipeline` - Delete a data pipeline.
-
-* *Consumer Group actions*
-** `seeConsumerGroup` - View consumer groups.
-** `editConsumerGroup` - Edit consumer groups.
-** `deleteConsumerGroup` - Delete consumer groups.
-
-* *Kafka Connect actions*
-** `viewConnectCluster` - View Kafka Connect clusters.
-** `editConnectCluster` - Edit Kafka Connect clusters.
-** `deleteConnectCluster` - Delete Kafka Connect clusters.
-
-* *Secrets actions*
-** `listSecrets` - List secrets in the secret store.
-** `createSecret` - Create a new secret.
-** `updateSecret` - Update an existing secret.
-** `deleteSecret` - Delete a secret.
-
-* *Schema Registry actions*
-** `viewSchemas` - View schemas in the Schema Registry.
-** `createSchema` - Create a new schema.
-** `deleteSchema` - Delete a schema.
-** `manageSchemaRegistry` - Manage the Schema Registry.
-
-When defining a custom role, you can specify any combination of these actions for the relevant resources. For example, to create a role that can only view topics and consumer groups, you would specify `seeTopic` and `seeConsumerGroup` actions in the role's permissions.
 
 == Configure roles and role bindings
 
@@ -202,18 +63,16 @@ licenseFilepath: "/etc/redpanda/redpanda.license"
 enterprise:
   rbac:
     enabled: true
-    rolesFilepath: "/etc/redpanda/roles.yaml"
     roleBindingsFilepath: "/etc/redpanda/role-bindings.yaml"
 ----
 
-- `rolesFilepath` specifies the path to your custom roles definition file. This file should contain the definition of all roles and their permissions.
-- `roleBindingsFilepath` specifies the path to your role bindings file. This file should contain the role bindings that associate the roles with specific users or groups.
+- `roleBindingsFilepath` specifies the path to your role bindings file. This file should contain the role bindings that associate the <<default-roles, default roles>> with specific users or groups.
 
 Ensure that the paths provided are correct and that the Redpanda Console process has read access to these files.
 
-* The `roles.yaml` and `role-bindings.yaml` files should be stored in a secure location, with appropriate file permissions to prevent unauthorized access or modification.
-* Regularly review and update the `roles.yaml` and `role-bindings.yaml` files to ensure that they reflect your organization's current access control policies.
-* After making changes to these files, restart Redpanda Console to apply the updates.
+* The `role-bindings.yaml` file should be stored in a secure location, with appropriate file permissions to prevent unauthorized access or modification.
+* Regularly review and update the `role-bindings.yaml` file to ensure that they reflect your organization's current access control policies.
+* After making changes to this file, restart Redpanda Console to apply the updates.
 
 == Role bindings
 

--- a/modules/console/pages/config/security/authorization.adoc
+++ b/modules/console/pages/config/security/authorization.adoc
@@ -3,7 +3,7 @@
 :page-aliases: console:single-sign-on/authorization.adoc, manage:security/console/authorization.adoc, console:features/role-bindings.adoc, console:reference/role-bindings.adoc, reference:console/role-bindings.adoc
 :page-categories: Management, Security, Redpanda Console
 
-Redpanda Console uses role-based access control (RBAC) to manage and restrict access to various system resources. This document covers how to configure and use RBAC in Redpanda Console, including setting up predefined roles, binding roles to users, and leveraging advanced options such as regex-based resource inclusion.
+Redpanda Console uses role-based access control (RBAC) to manage and restrict access to various system resources. This document covers how to configure and use RBAC in Redpanda Console, including binding roles to users.
 
 [NOTE]
 ====


### PR DESCRIPTION
Custom roles will soon be deprecated and this info has been live for only a week. As a result, we have decided to remove this information.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)