### PR TITLE
Update with the latest changes from rpk for 24.2.5

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -250,6 +250,7 @@
 ***** xref:reference:rpk/rpk-cluster/rpk-cluster-maintenance-status.adoc[]
 **** xref:reference:rpk/rpk-cluster/rpk-cluster-info.adoc[]
 **** xref:reference:rpk/rpk-cluster/rpk-cluster-partitions.adoc[]
+***** xref:reference:rpk/rpk-cluster/rpk-cluster-partitions-balance.adoc[]
 ***** xref:reference:rpk/rpk-cluster/rpk-cluster-partitions-disable.adoc[]
 ***** xref:reference:rpk/rpk-cluster/rpk-cluster-partitions-enable.adoc[]
 ***** xref:reference:rpk/rpk-cluster/rpk-cluster-partitions-list.adoc[]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-health.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-health.adoc
@@ -23,8 +23,7 @@ rpk cluster health [flags]
 |===
 |*Value* |*Type* |*Description*
 
-|-e, --exit-when-healthy |- |Exits when the cluster
-is back in a healthy state.
+|-e, --exit-when-healthy |- |Exits when the cluster is back in a healthy state.
 
 |-h, --help |- |Help for health.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-balance.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-balance.adoc
@@ -1,0 +1,42 @@
+= rpk cluster partitions balance
+:description: rpk cluster partitions balance
+
+Triggers on-demand partition balancing.
+
+With Redpanda Community Edition, the partition count on each broker can easily become uneven, which leads to data skewing. To distribute partitions across brokers, you can run this command to trigger on-demand partition balancing.
+
+With Redpanda Enterprise Edition, Continuous Data Balancing monitors broker and rack availability, as well as disk usage, to avoid topic hotspots. However, there are edge cases where users should manually trigger partition balancing (such as a node becoming unavailable for a prolonged time and rejoining the cluster thereafter). In such cases, you should run this command to trigger partition balancing manually.
+
+After you run this command, monitor the balancer progress using:
+```bash
+rpk cluster partitions balancer-status
+```
+
+To see more detailed movement status, monitor the progress using:
+```bash
+rpk cluster partitions move-status
+```
+
+== Usage
+
+[,bash]
+----
+rpk cluster partitions balance [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a"]
+|===
+|*Value* |*Type* |*Description*
+
+|-h, --help |- |Help for balance.
+
+|--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
+
+|-X, --config-opt |stringArray |Override `rpk` configuration settings. See xref:reference:rpk/rpk-x-options.adoc[`rpk -X`] or execute `rpk -X help` for inline detail or `rpk -X list` for terser detail.
+
+|--profile |string |Profile to use. See xref:reference:rpk/rpk-profile.adoc[`rpk profile`] for more details.
+
+|-v, --verbose |- |Enable verbose logging.
+|===

--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
@@ -95,8 +95,7 @@ numbers, each with optional fraction and a unit suffix, such as
 
 |--tune |- |When present will enable tuning before starting Redpanda.
 
-|--well-known-io |string |The cloud vendor and VM type, in the format
-\|vendor\|:\|vm type\|:\|storage type\|.
+|--well-known-io |string |The cloud provider and VM type, in the format <provider>:<vm type>:<storage type>.
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-consume.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-consume.adoc
@@ -61,7 +61,7 @@ Prints `1` if the record is a part of a transaction or `0` if it is not.
 
 Prints `1` if the record is a commit marker or `0` if it is not.
 
-=== Text
+== Text
 
 Text fields without modifiers default to writing the raw bytes. Alternatively,
 there are the following modifiers:
@@ -86,7 +86,7 @@ value is a big-endian uint32, `%v` prints the raw four bytes, while
 input before something is unpacked fully, an error message is appended to the
 output.
 
-=== Headers
+== Headers
 
 Headers are formatted with percent encoding inside of the modifier:
 
@@ -94,38 +94,18 @@ Headers are formatted with percent encoding inside of the modifier:
 %h{%k=%v{hex}}
 ```
 
-=== Values
-
-Values for consumed records can be omitted by using the `--meta-only` flag.
-
-Tombstone records (records with a `null` value) have their value omitted from the JSON output by default. All other records, including those with an empty-string value (`""`), will have their values printed.
-
 This prints all headers with a space before the key and after the value, an
 equals sign between the key and value, and with the value hex encoded. Header
 formatting actually just parses the internal format as a record format, so all
 of the above rules about `%K`, `%V`, text, and numbers apply.
 
-=== Examples
+== Values
 
-A key and value, separated by a space and ending in newline:
+Values for consumed records can be omitted by using the `--meta-only` flag.
 
-```
--f '%k %v\n'
-```
+Tombstone records (records with a `null` value) have their value omitted from the JSON output by default. All other records, including those with an empty-string value (`""`), will have their values printed.
 
-A key length as four big endian bytes and the key as hex:
-
-```
--f '%K{big32}%k{hex}'
-```
-
-A little endian uint32 and a string unpacked from a value:
-
-```
--f '%v{unpack[is$]}'
-```
-
-=== Offsets
+== Offsets
 
 The `--offset` flag allows for specifying where to begin consuming, and
 optionally, where to stop consuming. The literal words `start` and `end`
@@ -189,6 +169,26 @@ For example:
 -o @-48h:-24h       consume from 2 days ago to 1 day ago
 -o @-1m:end         consume from 1m ago until now
 -o @:-1hr           consume from the start until an hour ago
+```
+
+== Examples
+
+A key and value, separated by a space and ending in newline:
+
+```
+-f '%k %v\n'
+```
+
+A key length as four big endian bytes and the key as hex:
+
+```
+-f '%K{big32}%k{hex}'
+```
+
+A little endian uint32 and a string unpacked from a value:
+
+```
+-f '%v{unpack[is$]}'
 ```
 
 == Usage

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-consume.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-consume.adoc
@@ -98,7 +98,7 @@ Headers are formatted with percent encoding inside of the modifier:
 
 Values for consumed records can be omitted by using the `--meta-only` flag.
 
-Tombstone records (records with a `null` value) have their value omitted from the JSON output by default. All other records, including those with an empty-string value (`""``), will have their values printed.
+Tombstone records (records with a `null` value) have their value omitted from the JSON output by default. All other records, including those with an empty-string value (`""`), will have their values printed.
 
 This prints all headers with a space before the key and after the value, an
 equals sign between the key and value, and with the value hex encoded. Header

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-consume.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-consume.adoc
@@ -94,6 +94,12 @@ Headers are formatted with percent encoding inside of the modifier:
 %h{%k=%v{hex}}
 ```
 
+=== Values
+
+Values for consumed records can be omitted by using the `--meta-only` flag.
+
+Tombstone records (records with a `null` value) have their value omitted from the JSON output by default. All other records, including those with an empty-string value (`""``), will have their values printed.
+
 This prints all headers with a space before the key and after the value, an
 equals sign between the key and value, and with the value hex encoded. Header
 formatting actually just parses the internal format as a record format, so all

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-produce.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-produce.adoc
@@ -16,7 +16,7 @@ your specified format.
 include::reference:partial$topic-format.adoc[]
 
 
-== Schema registry
+=== Schema registry
 
 Records can be encoded using a specified schema from our schema registry. Use the `--schema-id` or `--schema-key-id` flags to define the schema ID, `rpk` will retrieve the schemas and encode the record accordingly.
 
@@ -38,6 +38,24 @@ Produce to `foo`, using schema ID 1, message FQN Person.Name:
 ----
 rpk topic produce foo --schema-id 1 --schema-type Person.Name
 ----
+
+=== Tombstones
+
+By default, records produced without a value will have an empty-string value, `""`. The below example produces a record with the key `not_a_tombstone_record` and the value `""`:
+
+```bash
+rpk topic produce foo -k not_a_tombstone_record
+[Enter]
+```
+    
+Tombstone records (records with a `null` value) can be produced by using the `-Z` flag and creating empty-string value records. Using the same example from above, but adding the `-Z` flag will produce a record with the key `tombstone_record` and the value `null`:
+
+```bash
+rpk topic produce foo -k tombstone_record -Z 
+[Enter]
+```
+
+It is important to note that records produced with values of string `null` are not considered tombstones by Redpanda.
 
 === Examples
 

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-produce.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-produce.adoc
@@ -16,7 +16,7 @@ your specified format.
 include::reference:partial$topic-format.adoc[]
 
 
-=== Schema registry
+== Schema registry
 
 Records can be encoded using a specified schema from our schema registry. Use the `--schema-id` or `--schema-key-id` flags to define the schema ID, `rpk` will retrieve the schemas and encode the record accordingly.
 
@@ -39,7 +39,7 @@ Produce to `foo`, using schema ID 1, message FQN Person.Name:
 rpk topic produce foo --schema-id 1 --schema-type Person.Name
 ----
 
-=== Tombstones
+== Tombstones
 
 By default, records produced without a value will have an empty-string value, `""`. The below example produces a record with the key `not_a_tombstone_record` and the value `""`:
 
@@ -57,7 +57,7 @@ rpk topic produce foo -k tombstone_record -Z
 
 It is important to note that records produced with values of string `"null"` are not considered tombstones by Redpanda.
 
-=== Examples
+== Examples
 
 In the below examples, we can parse many records at once. The produce command
 reads input and tokenizes based on your specified format. Every time the format
@@ -76,7 +76,7 @@ is completely matched, a record is produced and parsing begins anew.
 * A key and a json value, separated by a space:
 `+-f '%k %v{json}'+`
 
-=== Miscellaneous
+== Miscellaneous
 
 Producing requires a topic to produce to. The topic can be specified either
 directly on as an argument, or in the input text through %t. A parsed topic

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-produce.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-produce.adoc
@@ -55,7 +55,7 @@ rpk topic produce foo -k tombstone_record -Z
 [Enter]
 ```
 
-It is important to note that records produced with values of string `null` are not considered tombstones by Redpanda.
+It is important to note that records produced with values of string `"null"` are not considered tombstones by Redpanda.
 
 === Examples
 

--- a/modules/reference/pages/rpk/rpk-transform/rpk-transform-logs.adoc
+++ b/modules/reference/pages/rpk/rpk-transform/rpk-transform-logs.adoc
@@ -5,7 +5,7 @@ View logs for a transform.
 
 Data transform's STDOUT and STDERR are captured during runtime and written to an internally managed topic `_redpanda.transform_logs`.
 
-This command outputs logs for a single transform over a period of time, printing them to STDOUT. The logs can be printed in various formats.
+This command outputs logs for a single transform over a period of time and printing them to STDOUT. The logs can be printed in various formats.
 
 By default, only logs that have been emitted are displayed. Use the `--follow` flag to stream new logs continuously.
 
@@ -70,7 +70,7 @@ rpk transform logs --until=-30m
 The following command reads logs between noon and 1pm on March 12th:
 
 ```bash
-rpk transform logs my-tranform --since=2024-03-12T12:00:00Z --until=2024-03-12T13:00:00Z
+rpk transform logs my-transform --since=2024-03-12T12:00:00Z --until=2024-03-12T13:00:00Z
 ```
 
 == Usage


### PR DESCRIPTION
## Should only be merged after 24.2.5
Check https://github.com/redpanda-data/redpanda/releases to make sure the version is out. 

## Description

Adds the new changes extracted from rpk.

Disconsider the branch name. Should be 24.2.5
Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

https://deploy-preview-775--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-partitions-balance/
https://deploy-preview-775--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-health/
https://deploy-preview-775--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-redpanda/rpk-redpanda-start/
https://deploy-preview-775--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-topic/rpk-topic-consume/
https://deploy-preview-775--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-topic/rpk-topic-produce/
https://deploy-preview-775--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-transform/rpk-transform-logs/

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)