### PR TITLE
Fix rpk topic add-partitions -n

### DIFF
--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-add-partitions.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-add-partitions.adoc
@@ -23,7 +23,7 @@ For example, the internal topic __consumer_offsets.
 
 |-h, --help |- |Help for add-partitions.
 
-|-n, --num |int |Number of partitions to add to each topic.
+|-n, --num |int |Number of desired partitions for each topic.
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 


### PR DESCRIPTION
## Description

`--num` is the target, not the number of partitions to _add_ to the current number of partitions.

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)