### PR TITLE
Fix warning in the build logs for missing attribute

### DIFF
--- a/modules/console/pages/quickstart.adoc
+++ b/modules/console/pages/quickstart.adoc
@@ -66,7 +66,7 @@ This file contains an example schema that the `redpandarpk` Docker Compose servi
 [%collapsible]
 ====
 .`transactions-schema.json`
-[,yaml,subs="attributes+"]
+[,yaml]
 ----
 include::console:attachment$transactions-schema.json[]
 ----


### PR DESCRIPTION
## Description

This is a warning that we discussed at the docs team offsite. To avoid polluting the build logs, we agreed to avoid allowing any warnings in our builds. The fix here was to tell Antora not to replace attributes in the given include.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)