### PR TITLE
Update licenses.adoc

### DIFF
--- a/modules/get-started/pages/licenses.adoc
+++ b/modules/get-started/pages/licenses.adoc
@@ -33,6 +33,7 @@ Redpanda Enterprise Edition is licensed with the https://github.com/redpanda-dat
 * xref:manage:security/fips-compliance.adoc[FIPS Compliance]
 * xref:manage:schema-reg/schema-id-validation.adoc[Server-side Schema ID Validation]
 * xref:manage:security/authentication.adoc#enable-kerberos[Kerberos Authentication]
+* xref:manage:security/authentication.adoc#oidc [OAUTHBEARER/OIDC Authentication]
 * xref:manage:security/authorization/rbac.adoc[Redpanda Role-Based Access Control (RBAC)]
 * xref:manage:security/console/authorization.adoc[Redpanda Console Authorization (RBAC)]
 * xref:manage:security/console/authentication.adoc[Redpanda Console Authentication]


### PR DESCRIPTION
OAUTHBEARER/OIDC authentication has always been an enterprise-only feature.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)