### PR TITLE
fix white space in glossterms

### DIFF
--- a/modules/terms/partials/acl.adoc
+++ b/modules/terms/partials/acl.adoc
@@ -1,4 +1,4 @@
-=== access control list (ACL) 
+=== access control list (ACL)
 :term-name: ACL
 :hover-text: A security feature used to define and enforce granular permissions to resources, ensuring only authorized users or applications can perform specific operations. ACLs act on principals. 
 :category: Redpanda security

--- a/modules/terms/partials/data-plane.adoc
+++ b/modules/terms/partials/data-plane.adoc
@@ -1,4 +1,4 @@
-=== data plane 
+=== data plane
 :term-name: data plane 
 :hover-text: This part of Redpanda Cloud contains Redpanda clusters and other components, such as Redpanda Console, Redpanda Operator, and `rpk`. It is managed by an agent that receives cluster specifications from the control plane. Sometimes used interchangeably with clusters. 
 :category: Redpanda Cloud

--- a/modules/terms/partials/dedicated.adoc
+++ b/modules/terms/partials/dedicated.adoc
@@ -1,4 +1,4 @@
-=== Dedicated Cloud 
+=== Dedicated Cloud
 :term-name: Dedicated Cloud 
 :hover-text: A fully-managed Redpanda Cloud deployment option where you host your data in Redpanda's VPC, and Redpanda handles provisioning, operations, and maintenance. Dedicated clusters are single-tenant deployments that support private networking (for example, VPC peering to talk over private IPs) for better data isolation.
 :category: Redpanda Cloud

--- a/modules/terms/partials/rrr.adoc
+++ b/modules/terms/partials/rrr.adoc
@@ -1,4 +1,4 @@
-=== Remote Read Replica 
+=== Remote Read Replica
 :term-name: Remote Read Replica 
 :hover-text: A read-only topic that mirrors a topic on a different cluster, using data from Tiered Storage.
 :category: Redpanda features


### PR DESCRIPTION
## Description

This removes extra white space from glossterms, so links work properly.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)