### PR TITLE
Update cluster-property-configuration.adoc - Add reference to updating cluster properties on K8s 

### DIFF
--- a/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
@@ -22,6 +22,8 @@ See also:
 
 == Edit cluster properties
 
+NOTE: For managing cluster properties on Kubernetes, plee see xref:manage:kubernetes/k-cluster-property-configuration.adoc[Configure Cluster Properties in Kubernetes]
+
 To change any property settings, edit the configuration from the command line using your default text editor. As you make changes, the Redpanda Admin API verifies that the new value is valid. For example, if you change `fetch_max_bytes` from the default of `57671680` to `5o` (using the letter "`o`" by mistake), the system displays the following message:
 
 [,bash]

--- a/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
@@ -22,7 +22,7 @@ See also:
 
 == Edit cluster properties
 
-NOTE: For managing cluster properties on Kubernetes, see xref:manage:kubernetes/k-cluster-property-configuration.adoc[Configure Cluster Properties in Kubernetes]
+NOTE: For managing cluster properties on Kubernetes, see xref:manage:kubernetes/k-cluster-property-configuration.adoc[Configure Cluster Properties in Kubernetes].
 
 To change any property settings, edit the configuration from the command line using your default text editor. As you make changes, the Redpanda Admin API verifies that the new value is valid. For example, if you change `fetch_max_bytes` from the default of `57671680` to `5o` (using the letter "`o`" by mistake), the system displays the following message:
 

--- a/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
@@ -22,7 +22,7 @@ See also:
 
 == Edit cluster properties
 
-NOTE: For managing cluster properties on Kubernetes, plee see xref:manage:kubernetes/k-cluster-property-configuration.adoc[Configure Cluster Properties in Kubernetes]
+NOTE: For managing cluster properties on Kubernetes, see xref:manage:kubernetes/k-cluster-property-configuration.adoc[Configure Cluster Properties in Kubernetes]
 
 To change any property settings, edit the configuration from the command line using your default text editor. As you make changes, the Redpanda Admin API verifies that the new value is valid. For example, if you change `fetch_max_bytes` from the default of `57671680` to `5o` (using the letter "`o`" by mistake), the system displays the following message:
 

--- a/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
@@ -22,7 +22,7 @@ See also:
 
 == Edit cluster properties
 
-NOTE: For managing cluster properties on Kubernetes, see xref:manage:kubernetes/k-cluster-property-configuration.adoc[Configure Cluster Properties in Kubernetes].
+NOTE: For Kubernetes deployments, see xref:manage:kubernetes/k-cluster-property-configuration.adoc[Configure Cluster Properties in Kubernetes].
 
 To change any property settings, edit the configuration from the command line using your default text editor. As you make changes, the Redpanda Admin API verifies that the new value is valid. For example, if you change `fetch_max_bytes` from the default of `57671680` to `5o` (using the letter "`o`" by mistake), the system displays the following message:
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -4,7 +4,7 @@
 
 Cluster configuration properties are the same for all brokers in a cluster, and are set at the cluster level.
 
-For information on how to edit cluster properties, see xref:manage:cluster-maintenance/cluster-property-configuration.adoc[]. 
+For information on how to edit cluster properties, see xref:manage:cluster-maintenance/cluster-property-configuration.adoc[] or xref:manage:kubernetes/k-cluster-property-configuration.adoc[]. 
 
 NOTE: Some cluster properties require that you restart the cluster for any updates to take effect. See the specific property details to identify whether or not a restart is required.
 


### PR DESCRIPTION
## Description

I had trouble finding how to update cluster properties on K8s, as I was directed from https://docs.redpanda.com/current/reference/properties/cluster-properties/ to https://docs.redpanda.com/current/manage/cluster-maintenance/cluster-property-configuration/. 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)