### PR TITLE
DOC-287 [API] Mountable topics

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -5372,7 +5372,7 @@ components:
           description: Topic name
         ns:
           type: string
-          description: "Topic namespace. If not present, assume that the topic is in the `kafka` namespace"
+          description: "Topic namespace. If not present, assume that the topic is in the `kafka` namespace".
       type: object
     outbound_migration:
       properties: 
@@ -5434,7 +5434,7 @@ components:
             - sts
           type: string
         topic_manifest_prefix:
-          description: Path where topic manifests are copied
+          description: Path where topic manifests are copied to
           type: string
     outbound_migration_state:
       type: object

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -808,7 +808,65 @@ paths:
       responses:
         200:
           description: Stop maintenance success
-          content: {}
+          content: {}    
+  /v1/topics/mountable:
+    get: 
+      operationId: list_mountable_topics
+      tags: 
+        -  Mount and unmount topics
+      summary: List mountable topics
+      description: List mountable topics available in object storage.
+      responses: 
+        200:
+          description: List of mountable topics
+          content:
+            application/json:
+              schema: 
+                $ref: "#/components/schemas/list_mountable_topics_response"
+  /v1/topics/mount:
+    post:
+      operationId: mount_topics 
+      tags: 
+        - Mount and unmount topics
+      summary: Mount a topic to a cluster
+      description: Mount a topic in object storage to a cluster according to the specified configuration.
+      requestBody: 
+        description: Mount topic configuration
+        content: 
+          application/json:
+            schema:              
+              $ref: '#/components/schemas/mount_configuration'
+        required: true    
+      responses: 
+        200:
+          description: Underlying migration information
+          content: 
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/migration_info'
+  /v1/topics/unmount:
+    post:
+      operationId: unmount_topics 
+      tags: 
+        - Mount and unmount topics
+      summary: Unmount topics from a cluster
+      description: Unmount provided list of topics from a cluster to object storage.
+      requestBody: 
+        description: List of topics to unmount
+        content: 
+          application/json:
+            schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/namespaced_topic'
+        required: true    
+      responses: 
+        200:
+          description: Underlying migration information
+          content: 
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/migration_info'
   /v1/migrations:
     get: 
       summary: List all available migrations
@@ -818,14 +876,19 @@ paths:
           description: OK
           content: 
             application/json:
-              {}
+              schema: 
+                type: array
+                items:
+                  oneOf: 
+                    - $ref: "#/components/schemas/outbound_migration_state"
+                    - $ref: "#/components/schemas/inbound_migration_state"
       tags: 
-        - Migrations
+        - Mount and unmount topics
     put: 
       summary: Create migration
       operationId: add_migration
       tags: 
-        - Migrations
+        - Mount and unmount topics
       requestBody: 
         description: Migration configuration
         required: true
@@ -854,7 +917,7 @@ paths:
       summary: Get migration state
       operationId: get_migration
       tags: 
-        - Migrations
+        - Mount and unmount topics
       parameters: 
         - name: id
           description: Mount or unmount operation ("migration") ID 
@@ -876,7 +939,7 @@ paths:
       summary: Execute migration action
       operationId: execute_migration_action
       tags: 
-        - Migrations
+        - Mount and unmount topics
       parameters: 
         - name: id 
           description: Mount or unmount operation ("migration") ID
@@ -905,7 +968,7 @@ paths:
       description: Delete specified migration.
       operationId: delete_migration
       tags: 
-        - Migrations
+        - Mount and unmount topics
       parameters: 
         - name: id
           description: Mount or unmount operation ("migration") ID.
@@ -917,63 +980,7 @@ paths:
       responses: 
         200:
           description: OK
-          content: {}    
-  /v1/topics/mountable:
-    get: 
-      operationId: list_mountable_topics
-      summary: List mountable topics
-      description: List mountable topics available in object storage.
-      responses: 
-        200:
-          description: List of mountable topics
-          content:
-            application/json:
-              schema: 
-                $ref: "#/components/schemas/list_mountable_topics_response"
-  /v1/topics/mount:
-    post:
-      operationId: mount_topics 
-      tags: 
-        - Migrations
-      summary: Mount a topic to a cluster
-      description: Mount a topic in object storage to a cluster according to the specified configuration.
-      requestBody: 
-        description: Mount topic configuration
-        content: 
-          application/json:
-            schema:              
-              $ref: '#/components/schemas/mount_configuration'
-        required: true    
-      responses: 
-        200:
-          description: Underlying migration information
-          content: 
-            application/json:
-              schema: 
-                $ref: '#/components/schemas/migration_info'
-  /v1/topics/unmount:
-    post:
-      operationId: unmount_topics 
-      tags: 
-        - Migrations
-      summary: Unmount topics from a cluster
-      description: Unmount provided list of topics from a cluster to object storage.
-      requestBody: 
-        description: List of topics to unmount
-        content: 
-          application/json:
-            schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/namespaced_topic'
-        required: true    
-      responses: 
-        200:
-          description: Underlying migration information
-          content: 
-            application/json:
-              schema: 
-                $ref: '#/components/schemas/migration_info'           
+          content: {}                         
   /v1/partitions:
     get:
       tags:
@@ -5396,7 +5403,7 @@ components:
       properties: 
         topic_location:
           type: string
-          description: "Unique topic location in object storage with the format <topic-name>/<cluster-uuid>/<initial-revision>"
+          description: "Unique topic location in object storage with the format `<topic-name>/<cluster-uuid>/<initial-revision>`. Redpanda assigns the number `initial-revision` to a topic upon creation."
         topic:
           type: string
           description: Topic name
@@ -5455,7 +5462,7 @@ components:
       type: object
       properties: 
         source_topic_reference:
-          description: "Name of topic in object storage. To uniquely identify the topic, append the name with `/<cluster-uuid>/<initial-revision>."
+          description: "Name of topic in object storage. To uniquely identify the topic, append the name with `/<cluster-uuid>/<initial-revision>. Redpanda assigns the number `initial-revision` to a topic upon creation."
           $ref: "#/components/schemas/namespaced_topic"
         alias:
           description: Name of topic in destination cluster
@@ -5537,16 +5544,15 @@ tags:
       * Start and start broker maintenance
       * Decommission and recommision brokers
 
-  - name: Migrations
-    description: |
-        [Mount and unmount topics](https://docs.redpanda.com/24.3/manage/mountable-topics/) in Redpanda clusters. Requires that you have [Tiered Storage](https://docs.redpanda.com/current/manage/tiered-storage/) enabled.
-
   - name: Partitions
     description: |
       Manage partitions of a Redpanda cluster.
 
   - name: Tiered Storage
-    description: Manage Tiered Storage.
+    description: Manage [Tiered Storage](https://docs.redpanda.com/current/manage/tiered-storage/).
+  - name: Mount and unmount topics
+    description: |
+        [Mount and unmount topics](https://docs.redpanda.com/24.3/manage/mountable-topics/) in Redpanda clusters. Requires that you have [Tiered Storage](https://docs.redpanda.com/current/manage/tiered-storage/) enabled.
   - name: Transactions
   - name: Users
     description: Manage SCRAM (Salted Challenge Response Authentication Mechanism) users.

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -5372,7 +5372,7 @@ components:
           description: Topic name
         ns:
           type: string
-          description: "Topic namespace. If not present, assume that the topic is in the `kafka` namespace".
+          description: "Topic namespace. If not present, assume that the topic is in the `kafka` namespace."
       type: object
     outbound_migration:
       properties: 

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -5396,7 +5396,7 @@ components:
       properties: 
         topic_location:
           type: string
-          description: "Unique topic location in object storage with the format {topic_name}/{cluster_uuid}/initial_revision"
+          description: "Unique topic location in object storage with the format <topic-name>/<cluster-uuid>/<initial-revision>"
         topic:
           type: string
           description: Topic name
@@ -5454,8 +5454,8 @@ components:
     inbound_topic:
       type: object
       properties: 
-        source_topic:
-          description: "Name of topic in object storage. To uniquely identify the topic, append the name with `/{cluster_uuid}/initial_revision`."
+        source_topic_reference:
+          description: "Name of topic in object storage. To uniquely identify the topic, append the name with `/<cluster-uuid>/<initial-revision>."
           $ref: "#/components/schemas/namespaced_topic"
         alias:
           description: Name of topic in destination cluster

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -843,7 +843,12 @@ paths:
       responses: 
         200:
           description: OK
-          content: {}
+          content:
+            application/json:
+              schema:                 
+                oneOf: 
+                - $ref: "#/components/schemas/inbound_migration"
+                - $ref: "#/components/schemas/outbound_migration"
   /v1/migrations/{id}:
     get:
       summary: Get migration state
@@ -860,7 +865,12 @@ paths:
       responses: 
         200:
           description: OK
-          content: {}
+          content:
+            application/json:
+              schema:                 
+                oneOf: 
+                - $ref: "#/components/schemas/inbound_migration"
+                - $ref: "#/components/schemas/outbound_migration"
     post: 
       summary: Execute migration action
       operationId: execute_migration_action
@@ -5374,11 +5384,6 @@ components:
           items: 
             $ref: "#/components/schemas/namespaced_topic"
           description: List of migrated topics
-        consumer_groups:
-          type: array
-          items: 
-            type: string
-          description: List of migrated consumer groups
         copy_to:
           $ref: "#/components/schemas/bucket_configuration"
         auto_advance:
@@ -5394,11 +5399,6 @@ components:
           type: array
           items: 
             $ref: "#/components/schemas/inbound_topic"
-        consumer_groups:
-          type: array
-          items: 
-            type: string
-          description: List of migrated consumer groups 
         auto_advance:
           type: boolean
           description: If set, you do not need to take manual action for the migration to progress.
@@ -5492,7 +5492,7 @@ tags:
 
   - name: Migrations
     description: |
-        Mount and unmount topics in Redpanda clusters.
+        [Mount and unmount topics](https://docs.redpanda.com/current/manage/mountable-topics/) in Redpanda clusters. Must have [Tiered Storage](https://docs.redpanda.com/current/manage/tiered-storage/) enabled.
 
   - name: Partitions
     description: |

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -8,7 +8,7 @@ info:
     ---
 
 servers:
-- url: http://localhost:9644/
+- url: http://localhost:9644
 paths:
   # /config:
   #   get:
@@ -809,6 +809,145 @@ paths:
         200:
           description: Stop maintenance success
           content: {}
+  /v1/migrations:
+    get: 
+      summary: List all available migrations
+      operationId: list_migrations
+      responses: 
+        200:
+          description: OK
+          content: 
+            application/json:
+              {}
+      tags: 
+        - Migrations
+    put: 
+      summary: Create migration
+      operationId: add_migration
+      tags: 
+        - Migrations
+      requestBody: 
+        description: Migration configuration
+        required: true
+        content: 
+          application/json:
+            schema:                 
+              oneOf: 
+              - $ref: "#/components/schemas/inbound_migration"
+              - $ref: "#/components/schemas/outbound_migration"
+              discriminator: 
+                propertyName: migration_type
+                mapping: 
+                  inbound: '#/components/schemas/inbound_migration'
+                  outbound: '#/components/schemas/outbound_migration'        
+      responses: 
+        200:
+          description: OK
+          content: {}
+  /v1/migrations/{id}:
+    get:
+      summary: Get migration state
+      operationId: get_migration
+      tags: 
+        - Migrations
+      parameters: 
+        - name: id
+          in: path 
+          required: true
+          schema: 
+            type: integer
+            format: int32  
+      responses: 
+        200:
+          description: OK
+          content: {}
+    post: 
+      summary: Execute migration action
+      operationId: execute_migration_action
+      tags: 
+        - Migrations
+      parameters: 
+        - name: id 
+          in: path
+          required: true
+          schema: 
+            type: integer
+            format: int32
+        - name: action
+          in: query
+          required: true
+          description: Action to execute for migration
+          schema: 
+            type: string
+            enum: 
+            - prepare
+            - execute
+            - finish
+            - cancel  
+      responses: 
+        200:
+          description: OK
+          content: {}
+    delete:
+      summary: Delete migration
+      operationId: delete_migration
+      tags: 
+        - Migrations
+      parameters: 
+        - name: id
+          in: path 
+          required: true
+          schema: 
+            type: integer
+            format: int32 
+      responses: 
+        200:
+          description: OK
+          content: {}    
+  /v1/topics/mount:
+    post:
+      operationId: mount_topics 
+      tags: 
+        - Migrations
+      summary: Mount a topic to a cluster
+      description: Mount a topic in object storage to a cluster according to the specified configuration.
+      requestBody: 
+        description: Mount topic configuration
+        content: 
+          application/json:
+            schema:              
+              $ref: '#/components/schemas/mount_configuration'
+        required: true    
+      responses: 
+        200:
+          description: Underlying migration information
+          content: 
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/migration_info'
+  /v1/topics/unmount:
+    post:
+      operationId: unmount_topics 
+      tags: 
+        - Migrations
+      summary: Unmount topics from a cluster
+      description: Unmount provided list of topics from a cluster to object storage.
+      requestBody: 
+        description: List of topics to unmount
+        content: 
+          application/json:
+            schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/namespaced_topic'
+        required: true    
+      responses: 
+        200:
+          description: Underlying migration information
+          content: 
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/migration_info'           
   /v1/partitions:
     get:
       tags:
@@ -5215,7 +5354,124 @@ components:
             $ref: '#/components/schemas/role_description'
           type: array
       type: object
-
+    namespaced_topic:
+      properties:
+        topic:
+          type: string
+          description: Topic name
+        ns:
+          type: string
+          description: "Topic namespace. If not present, assume that the topic is in the `kafka` namespace"
+      type: object
+    outbound_migration:
+      properties: 
+        migration_type:
+          type: string
+          enum: 
+            - outbound
+        topics:
+          type: array
+          items: 
+            $ref: "#/components/schemas/namespaced_topic"
+          description: List of migrated topics
+        consumer_groups:
+          type: array
+          items: 
+            type: string
+          description: List of migrated consumer groups
+        copy_to:
+          $ref: "#/components/schemas/bucket_configuration"
+        auto_advance:
+          description: If set, you do not need to take manual action for the migration to progress.
+          type: boolean
+    inbound_migration:
+      properties: 
+        migration_type:
+          enum:
+            - inbound
+        topics:
+          type: array
+          items: 
+            $ref: "#/components/schemas/inbound_topic"
+        consumer_groups:
+          type: array
+          items: 
+            type: string
+          description: List of migrated consumer groups 
+        auto_advance:
+          type: boolean
+          description: If set, you do not need to take manual action for the migration to progress.
+      required: 
+        -  migration_type
+    inbound_topic:
+      type: object
+      properties: 
+        source_topic:
+          description: Name of topic in source cluster
+          $ref: "#/components/schemas/namespaced_topic"
+        alias:
+          description: Name of topic in destination cluster
+          $ref: "#/components/schemas/namespaced_topic"
+    bucket_configuration:
+      type: object
+      required: 
+        -  bucket
+      properties: 
+        access_key:
+          type: string
+        secret_key:
+          type: string
+        region:
+          type: string
+        bucket:
+          type: string
+        credential_source:
+          enum: 
+            - config
+            - instance_metadata
+            - sts
+          type: string
+        topic_manifest_prefix:
+          description: Path where topic manifests are copied
+          type: string
+    outbound_migration_state:
+      type: object
+      properties: 
+        id:
+          type: integer
+          format: int32
+          description: Unique identifier of migration
+        state:
+          type: string
+        migration: 
+          $ref: "#/components/schemas/outbound_migration"
+    inbound_migration_state:
+      type: object
+      properties: 
+        id:
+          type: integer
+          format: int32
+          description: Unique identifier of migration
+        state:
+          type: string
+        migration: 
+          $ref: "#/components/schemas/inbound_migration"
+    mount_configuration:
+      type: object
+      required: 
+        -  topics
+      properties: 
+        topics:
+          type: array
+          items: 
+            $ref: "#/components/schemas/inbound_topic"
+          description: List of topics to mount
+    migration_info:
+      type: object
+      properties: 
+        id:
+          type: integer
+          format: int32
 tags:
   - name: Authentication
     description: |
@@ -5232,6 +5488,11 @@ tags:
 
       * Start and start broker maintenance
       * Decommission and recommision brokers
+
+  - name: Migrations
+    description: |
+        Mount and unmount topics in Redpanda clusters.
+
   - name: Partitions
     description: |
       Manage partitions of a Redpanda cluster.

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -918,6 +918,18 @@ paths:
         200:
           description: OK
           content: {}    
+  /v1/topics/mountable:
+    get: 
+      operationId: list_mountable_topics
+      summary: List mountable topics
+      description: List mountable topics available in object storage.
+      responses: 
+        200:
+          description: List of mountable topics
+          content:
+            application/json:
+              schema: 
+                $ref: "#/components/schemas/list_mountable_topics_response"
   /v1/topics/mount:
     post:
       operationId: mount_topics 
@@ -5375,8 +5387,29 @@ components:
           description: Topic name
         ns:
           type: string
-          description: "Topic namespace. If not present, assume that the topic is in the `kafka` namespace."
+          description: "Topic namespace. If not present, it is assumed that the topic is in the `kafka` namespace."
       type: object
+      required: 
+        -  topic
+    mountable_topic:
+      type: object
+      properties: 
+        topic_location:
+          type: string
+          description: "Unique topic location in object storage with the format {topic_name}/{cluster_uuid}/initial_revision"
+        topic:
+          type: string
+          description: Topic name
+        ns:
+          type: string
+          description: "Topic namespace. If not present, it is assumed that topic is in the `kafka` namespace"
+    list_mountable_topics_response:
+      type: object
+      properties:
+        topics:
+          type: array
+          items: 
+            $ref: "#/components/schemas/mountable_topic"   
     outbound_migration:
       properties: 
         migration_type:
@@ -5388,6 +5421,11 @@ components:
           items: 
             $ref: "#/components/schemas/namespaced_topic"
           description: List of migrated topics
+        consumer_groups:
+          type: array
+          description: List of migrated consumer groups
+          items:
+            type: string
         copy_to:
           $ref: "#/components/schemas/bucket_configuration"
         auto_advance:
@@ -5403,6 +5441,11 @@ components:
           type: array
           items: 
             $ref: "#/components/schemas/inbound_topic"
+        consumer_groups:
+          type: array
+          description: List of migrated consumer groups
+          items:
+            type: string
         auto_advance:
           type: boolean
           description: If set, you do not need to take manual action for the migration to progress.
@@ -5412,7 +5455,7 @@ components:
       type: object
       properties: 
         source_topic:
-          description: Name of topic in source cluster
+          description: "Name of topic in object storage. To uniquely identify the topic, append the name with `/{cluster_uuid}/initial_revision`."
           $ref: "#/components/schemas/namespaced_topic"
         alias:
           description: Name of topic in destination cluster

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -5496,7 +5496,7 @@ tags:
 
   - name: Migrations
     description: |
-        [Mount and unmount topics](https://docs.redpanda.com/24.3/manage/mountable-topics/) in Redpanda clusters. Must have [Tiered Storage](https://docs.redpanda.com/current/manage/tiered-storage/) enabled.
+        [Mount and unmount topics](https://docs.redpanda.com/24.3/manage/mountable-topics/) in Redpanda clusters. Requires that you have [Tiered Storage](https://docs.redpanda.com/current/manage/tiered-storage/) enabled.
 
   - name: Partitions
     description: |

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -900,6 +900,7 @@ paths:
           content: {}
     delete:
       summary: Delete migration
+      description: Delete specified migration.
       operationId: delete_migration
       tags: 
         - Migrations

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -857,6 +857,7 @@ paths:
         - Migrations
       parameters: 
         - name: id
+          description: Mount or unmount operation ("migration") ID 
           in: path 
           required: true
           schema: 
@@ -878,6 +879,7 @@ paths:
         - Migrations
       parameters: 
         - name: id 
+          description: Mount or unmount operation ("migration") ID
           in: path
           required: true
           schema: 
@@ -906,6 +908,7 @@ paths:
         - Migrations
       parameters: 
         - name: id
+          description: Mount or unmount operation ("migration") ID.
           in: path 
           required: true
           schema: 
@@ -5493,7 +5496,7 @@ tags:
 
   - name: Migrations
     description: |
-        [Mount and unmount topics](https://docs.redpanda.com/current/manage/mountable-topics/) in Redpanda clusters. Must have [Tiered Storage](https://docs.redpanda.com/current/manage/tiered-storage/) enabled.
+        [Mount and unmount topics](https://docs.redpanda.com/24.3/manage/mountable-topics/) in Redpanda clusters. Must have [Tiered Storage](https://docs.redpanda.com/current/manage/tiered-storage/) enabled.
 
   - name: Partitions
     description: |

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -838,8 +838,8 @@ paths:
               discriminator: 
                 propertyName: migration_type
                 mapping: 
-                  inbound: '#/components/schemas/inbound_migration'
-                  outbound: '#/components/schemas/outbound_migration'        
+                  inbound: "#/components/schemas/inbound_migration"
+                  outbound: "#/components/schemas/outbound_migration"
       responses: 
         200:
           description: OK
@@ -5387,6 +5387,7 @@ components:
     inbound_migration:
       properties: 
         migration_type:
+          type: string
           enum:
             - inbound
         topics:


### PR DESCRIPTION
## Description

Some descriptions are copy edits from the original spec in the redpanda repo.

There is a link to the main doc for mountable TS - it will not be live until the PR https://github.com/redpanda-data/docs/pull/725 is merged.

Resolves https://github.com/redpanda-data/documentation-private/issues/2504
Review deadline: 9 Oct

## Page previews

[Admin API reference > Migrations](https://deploy-preview-798--redpanda-docs-preview.netlify.app/api/admin-api/#tag--Migrations)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)