### PR TITLE
DOC-625 update install rpk to include update

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -8,7 +8,7 @@
 ** xref:get-started:licenses.adoc[Redpanda Licensing]
 ** xref:get-started:rpk/index.adoc[Redpanda CLI]
 *** xref:get-started:intro-to-rpk.adoc[Introduction to rpk]
-*** xref:get-started:rpk-install.adoc[Install rpk]
+*** xref:get-started:rpk-install.adoc[]
 *** xref:get-started:config-rpk-profile.adoc[]
 *** xref:get-started:broker-admin.adoc[]
 *** xref:get-started:admin-addresses.adoc[]

--- a/modules/get-started/pages/rpk-install.adoc
+++ b/modules/get-started/pages/rpk-install.adoc
@@ -5,21 +5,17 @@
 // tag::single-source[]
 :description: pass:q[Install or update `rpk` to interact with Redpanda from the command line.]
 
-The `rpk` tool is a single binary application that provides a way to interact with your Redpanda clusters from the command line. For example, you can use `rpk` to:
+The `rpk` tool is a single binary application that provides a way to interact with your Redpanda clusters from the command line. For example, you can use `rpk` to do the following:
 
-* Monitor your cluster's health.
-* Create topics, produce to topics, and consume from topics.
-* Set up access control lists (ACLs) and other security features.
+* Monitor your cluster's health
+* Create topics, produce to topics, and consume from topics
+* Set up access control lists (ACLs) and other security features
 
 ifndef::env-cloud[]
 For Redpanda Self-Managed deployments, the `rpk` binary is automatically installed on each Redpanda broker. So, you can use the locally installed `rpk` binary to communicate with the local Redpanda cluster.
 
-You can also install `rpk` on your local machine as a standalone binary. With this setup, you can connect to both a Redpanda cluster on your local machine, or an external one on a remote server.
-
-If you use `rpk` as a standalone binary to communicate with a Redpanda cluster, ensure the version of `rpk` that you install matches the version of Redpanda running in your cluster.
+You can also install `rpk` on your local machine as a standalone binary. With this setup, you can connect to a Redpanda cluster on your local machine and to an external one on a remote server. If you use `rpk` as a standalone binary to communicate with a Redpanda cluster, your installed version of `rpk` must match the version of Redpanda running in your cluster.
 endif::[]
-
-To install the `rpk` binary as a standalone application, follow the instructions for your operating system.
 
 == Check rpk version
 

--- a/modules/get-started/pages/rpk-install.adoc
+++ b/modules/get-started/pages/rpk-install.adoc
@@ -8,7 +8,7 @@
 The `rpk` tool is a single binary application that provides a way to interact with your Redpanda clusters from the command line. For example, you can use `rpk` to do the following:
 
 * Monitor your cluster's health
-* Create topics, produce to topics, and consume from topics
+* Create, produce, and consume from topics
 * Set up access control lists (ACLs) and other security features
 
 ifndef::env-cloud[]

--- a/modules/get-started/pages/rpk-install.adoc
+++ b/modules/get-started/pages/rpk-install.adoc
@@ -12,9 +12,13 @@ The `rpk` tool is a single binary application that provides a way to interact wi
 * Set up access control lists (ACLs) and other security features
 
 ifndef::env-cloud[]
-For Redpanda Self-Managed deployments, the `rpk` binary is automatically installed on each Redpanda broker. So, you can use the locally installed `rpk` binary to communicate with the local Redpanda cluster.
+For Redpanda Self-Managed deployments, the `rpk` binary is automatically installed on each Redpanda broker, so you can use the locally installed `rpk` binary to communicate with the local Redpanda cluster.
 
 You can also install `rpk` on your local machine as a standalone binary. With this setup, you can connect to a Redpanda cluster on your local machine and to an external one on a remote server. If you use `rpk` as a standalone binary to communicate with a Redpanda cluster, your installed version of `rpk` must match the version of Redpanda running in your cluster.
+endif::[]
+
+ifdef::env-cloud[]
+Redpanda Cloud deployments should always use the latest version of `rpk`.
 endif::[]
 
 == Check rpk version

--- a/modules/get-started/pages/rpk-install.adoc
+++ b/modules/get-started/pages/rpk-install.adoc
@@ -1,15 +1,15 @@
-= Install rpk
+= Install or Update rpk
 :page-aliases: quickstart:rpk-install.adoc
 :page-categories: rpk
 // Do not put page aliases in the single-sourced content
 // tag::single-source[]
-:description: pass:q[The `rpk` tool is a single binary application that provides a way to interact with your Redpanda clusters from the command line.]
+:description: pass:q[Install or update `rpk` to interact with Redpanda from the command line.]
 
 The `rpk` tool is a single binary application that provides a way to interact with your Redpanda clusters from the command line. For example, you can use `rpk` to:
 
 * Monitor your cluster's health.
-* Set up access control lists (ACLs) and other security features.
 * Create topics, produce to topics, and consume from topics.
+* Set up access control lists (ACLs) and other security features.
 
 ifndef::env-cloud[]
 For Redpanda Self-Managed deployments, the `rpk` binary is automatically installed on each Redpanda broker. So, you can use the locally installed `rpk` binary to communicate with the local Redpanda cluster.
@@ -21,16 +21,20 @@ endif::[]
 
 To install the `rpk` binary as a standalone application, follow the instructions for your operating system.
 
-== Install rpk on Linux
+== Check rpk version
+
+include::get-started:partial$rpk-version.adoc[]
+
+== Install or update rpk on Linux
 
 include::get-started:partial$install-rpk-linux.adoc[]
 
-== Install rpk on macOS
+== Install or update rpk on macOS
 
 include::get-started:partial$install-rpk-macos.adoc[]
 
 == Next steps
 
-For a list of all `rpk` commands and their syntax, see the xref:reference:rpk/index.adoc[rpk documentation].
+For a list of `rpk` commands and their syntax, see the xref:reference:rpk/index.adoc[rpk reference].
 
 // end::single-source[]

--- a/modules/get-started/partials/install-rpk-apple-silicon.adoc
+++ b/modules/get-started/partials/install-rpk-apple-silicon.adoc
@@ -1,15 +1,15 @@
 To install, or update to, the latest version of `rpk` for Apple Silicon:
-
++
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-darwin-arm64.zip &&
   mkdir -p ~/.local/bin &&
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-darwin-arm64.zip -d ~/.local/bin/
 ```
-
++
 // tag::custom-version[]
 To install, or update to, a version other than the latest:
-
++
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-darwin-arm64.zip &&
   mkdir -p ~/.local/bin &&

--- a/modules/get-started/partials/install-rpk-apple-silicon.adoc
+++ b/modules/get-started/partials/install-rpk-apple-silicon.adoc
@@ -1,4 +1,4 @@
-To install, or update to, the latest version of `rpk` for Apple Silicon:
+To install, or update to, the latest version of `rpk` for Apple Silicon, run:
 +
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-darwin-arm64.zip &&
@@ -8,7 +8,7 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
 ```
 +
 // tag::custom-version[]
-To install, or update to, a version other than the latest:
+To install, or update to, a version other than the latest, run:
 +
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-darwin-arm64.zip &&

--- a/modules/get-started/partials/install-rpk-apple-silicon.adoc
+++ b/modules/get-started/partials/install-rpk-apple-silicon.adoc
@@ -1,16 +1,15 @@
-. Install `rpk` for macOS:
-+
-- To install the latest version of `rpk`:
-+
+To install the latest version of `rpk` for Apple Silicon:
+
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-darwin-arm64.zip &&
   mkdir -p ~/.local/bin &&
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-darwin-arm64.zip -d ~/.local/bin/
 ```
+
 // tag::custom-version[]
-- To install a version other than the latest:
-+
+To install a version other than the latest:
+
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-darwin-arm64.zip &&
   mkdir -p ~/.local/bin &&
@@ -18,5 +17,3 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/
   unzip rpk-darwin-arm64.zip -d ~/.local/bin/
 ```
 // end::custom-version[]
-
-include::get-started:partial$rpk-version.adoc[]

--- a/modules/get-started/partials/install-rpk-apple-silicon.adoc
+++ b/modules/get-started/partials/install-rpk-apple-silicon.adoc
@@ -1,4 +1,4 @@
-To install the latest version of `rpk` for Apple Silicon:
+To install, or update to, the latest version of `rpk` for Apple Silicon:
 
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-darwin-arm64.zip &&
@@ -8,7 +8,7 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
 ```
 
 // tag::custom-version[]
-To install a version other than the latest:
+To install, or update to, a version other than the latest:
 
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-darwin-arm64.zip &&

--- a/modules/get-started/partials/install-rpk-homebrew.adoc
+++ b/modules/get-started/partials/install-rpk-homebrew.adoc
@@ -1,5 +1,5 @@
 . If you don't have Homebrew installed, https://brew.sh/[install it^].
-. Install `rpk`:
+. To install or update `rpk`, run:
 +
 [,bash]
 ----

--- a/modules/get-started/partials/install-rpk-homebrew.adoc
+++ b/modules/get-started/partials/install-rpk-homebrew.adoc
@@ -5,7 +5,5 @@
 ----
 brew install redpanda-data/tap/redpanda
 ----
-
-include::get-started:partial$rpk-version.adoc[]
 +
 NOTE: This method installs the latest version of `rpk`, which is supported only with the latest version of Redpanda.

--- a/modules/get-started/partials/install-rpk-intel-macos.adoc
+++ b/modules/get-started/partials/install-rpk-intel-macos.adoc
@@ -1,4 +1,5 @@
-To install the latest version of `rpk` for Intel macOS:
+
+To install, or update to, the latest version of `rpk` for Intel macOS:
 
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-darwin-amd64.zip &&
@@ -6,9 +7,8 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-darwin-amd64.zip -d ~/.local/bin/
 ```
-
 // tag::custom-version[]
-To install a version other than the latest:
+To install, or update to, a version other than the latest:
 
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-darwin-amd64.zip &&

--- a/modules/get-started/partials/install-rpk-intel-macos.adoc
+++ b/modules/get-started/partials/install-rpk-intel-macos.adoc
@@ -1,5 +1,5 @@
 
-To install, or update to, the latest version of `rpk` for Intel macOS:
+To install, or update to, the latest version of `rpk` for Intel macOS, run:
 +
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-darwin-amd64.zip &&
@@ -9,7 +9,7 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
 ```
 +
 // tag::custom-version[]
-To install, or update to, a version other than the latest:
+To install, or update to, a version other than the latest, run:
 +
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-darwin-amd64.zip &&

--- a/modules/get-started/partials/install-rpk-intel-macos.adoc
+++ b/modules/get-started/partials/install-rpk-intel-macos.adoc
@@ -1,15 +1,16 @@
 
 To install, or update to, the latest version of `rpk` for Intel macOS:
-
++
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-darwin-amd64.zip &&
   mkdir -p ~/.local/bin &&
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-darwin-amd64.zip -d ~/.local/bin/
 ```
++
 // tag::custom-version[]
 To install, or update to, a version other than the latest:
-
++
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-darwin-amd64.zip &&
   mkdir -p ~/.local/bin &&

--- a/modules/get-started/partials/install-rpk-intel-macos.adoc
+++ b/modules/get-started/partials/install-rpk-intel-macos.adoc
@@ -1,16 +1,15 @@
-. Install `rpk` for macOS:
-+
-- To install the latest version of `rpk`:
-+
+To install the latest version of `rpk` for Intel macOS:
+
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-darwin-amd64.zip &&
   mkdir -p ~/.local/bin &&
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-darwin-amd64.zip -d ~/.local/bin/
 ```
+
 // tag::custom-version[]
-- To install a version other than the latest:
-+
+To install a version other than the latest:
+
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-darwin-amd64.zip &&
   mkdir -p ~/.local/bin &&
@@ -18,5 +17,3 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/
   unzip rpk-darwin-amd64.zip -d ~/.local/bin/
 ```
 // end::custom-version[]
-
-include::get-started:partial$rpk-version.adoc[]

--- a/modules/get-started/partials/install-rpk-linux.adoc
+++ b/modules/get-started/partials/install-rpk-linux.adoc
@@ -1,4 +1,4 @@
-To install the latest version of `rpk` for Linux, run:
+To install, or update to, the latest version of `rpk` for Linux, run:
 
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-amd64.zip &&
@@ -8,7 +8,7 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
 ```
 
 ifndef::env-cloud[]
-To install a version other than the latest, run:
+To install, or update to, a version other than the latest, run:
 
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-linux-amd64.zip &&

--- a/modules/get-started/partials/install-rpk-linux.adoc
+++ b/modules/get-started/partials/install-rpk-linux.adoc
@@ -1,7 +1,5 @@
-. Install `rpk` for Linux:
-+
-- To install the latest version of `rpk`:
-+
+To install the latest version of `rpk` for Linux, run:
+
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-amd64.zip &&
   mkdir -p ~/.local/bin &&
@@ -9,13 +7,13 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
 ```
 
-- To install a version other than the latest:
-+
+ifndef::env-cloud[]
+To install a version other than the latest, run:
+
 ```bash
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-linux-amd64.zip &&
   mkdir -p ~/.local/bin &&
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
 ```
-
-include::get-started:partial$rpk-version.adoc[]
+endif::[]

--- a/modules/get-started/partials/install-rpk-macos.adoc
+++ b/modules/get-started/partials/install-rpk-macos.adoc
@@ -8,7 +8,7 @@ include::get-started:partial$install-rpk-homebrew.adoc[]
 Manual Download::
 +
 --
-To install `rpk` through a manual download, choose the option for your system architecture. For example, if you have an M1 or M2 chip, select *Apple Silicon*.
+To install or update `rpk` through a manual download, choose the option for your system architecture. For example, if you have an M1 or M2 chip, select *Apple Silicon*.
 
 [tabs]
 ====

--- a/modules/get-started/partials/install-rpk-macos.adoc
+++ b/modules/get-started/partials/install-rpk-macos.adoc
@@ -8,7 +8,7 @@ include::get-started:partial$install-rpk-homebrew.adoc[]
 Manual Download::
 +
 --
-To install rpk through a manual download, choose an option that corresponds to your system architecture. For example, if you have an M1 or M2 chip, use the *Apple Silicon* instructions.
+To install `rpk` through a manual download, choose the option for your system architecture. For example, if you have an M1 or M2 chip, select *Apple Silicon*.
 
 [tabs]
 ====

--- a/modules/get-started/partials/rpk-version.adoc
+++ b/modules/get-started/partials/rpk-version.adoc
@@ -1,10 +1,10 @@
-. Run `rpk --version` to display the version of the rpk binary:
-+
+To display the current version of the rpk binary, run `rpk --version`. The following command shows the latest version of `rpk`. If your installed version is lower than this latest version, then continue to update `rpk`.
+
 [,bash]
 ----
 rpk --version
 ----
-+
+
 [,bash,role=no-copy,subs="attributes+"]
 ----
 rpk version {full-version} (rev {latest-release-commit})

--- a/modules/get-started/partials/rpk-version.adoc
+++ b/modules/get-started/partials/rpk-version.adoc
@@ -1,4 +1,6 @@
-To check your current version of the rpk binary, run `rpk --version`. The following example lists the latest version of `rpk`. If your installed version is lower than this latest version, then update `rpk`.
+To check your current version of the rpk binary, run `rpk --version`. 
+
+The following example lists the latest version of `rpk`. If your installed version is lower than this latest version, then update `rpk`. For a list of versions, see https://github.com/redpanda-data/redpanda/releases/[Redpanda releases^].
 
 [,bash]
 ----

--- a/modules/get-started/partials/rpk-version.adoc
+++ b/modules/get-started/partials/rpk-version.adoc
@@ -1,4 +1,4 @@
-To display the current version of the rpk binary, run `rpk --version`. The following command shows the latest version of `rpk`. If your installed version is lower than this latest version, then continue to update `rpk`.
+To check your current version of the rpk binary, run `rpk --version`. The following example lists the latest version of `rpk`. If your installed version is lower than this latest version, then update `rpk`.
 
 [,bash]
 ----


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-625
Review deadline: Oct 11

## Page previews
https://deploy-preview-801--redpanda-docs-preview.netlify.app/current/get-started/rpk-install/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)