### PR TITLE
DOC-502 Add /features/enterprise endpoint to Admin API

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -568,12 +568,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/features_response'
+  /v1/features/enterprise:
+    get:
+      summary: Get license and feature status
+      operationId: get_enterprise_license_status
+      tags:
+        - Licenses and Features
+      responses:
+        '200':
+          description: The status of the Enterprise Edition license and details about Enterprise features that are in-use in the cluster.
+          externalDocs:
+            url: https://docs.redpanda.com/docs/get-started/licensing/monitor-license-status/
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/enterprise_response'
+      description: >
+        This endpoint reports the current status of the [Enterprise Edition license](https://docs.redpanda.com/docs/get-started/licensing/overview/) and lists all Enterprise features currently in use.
+        Use this endpoint to monitor license compliance and detect if any Enterprise features are active without a valid license.
   /v1/features/license:
     get:
       tags:
       - Licenses and Features
-      summary: Get license information
-      description: Get currently loaded license information
+      summary: Get license details
+      description: Get details about the currently loaded Enterprise Edition license.
       operationId: get_license
       responses:
         200:
@@ -1734,6 +1752,37 @@ components:
           type: integer
         family:
           type: string
+    enterprise_feature:
+      type: object
+      description: Information about an Enterprise feature and whether it is enabled in the cluster.
+      properties:
+        name:
+          type: string
+          description: The name of the Enterprise feature such as `tiered_storage`.
+        enabled:
+          type: boolean
+          description: Whether the feature is currently enabled (`true`) or not (`false`).
+    enterprise_response:
+      type: object
+      description: License status and Enterprise features in use.
+      properties:
+        license_status:
+          type: string
+          description: The current status of the Enterprise Edition license.
+          enum:
+            - valid
+            - expired
+            - not_present
+        violation:
+          type: boolean
+          description: >
+            Whether there is a violation. This will be `true` if the license status is not 'valid'
+            and one or more Enterprise features are enabled.
+        features:
+          type: array
+          description: A list of Enterprise features in use.
+          items:
+            $ref: '#/components/schemas/enterprise_feature'
     node_config_properties:
       type: object
       properties:

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -578,13 +578,13 @@ paths:
         '200':
           description: The status of the Enterprise Edition license and details about Enterprise features that are in-use in the cluster.
           externalDocs:
-            url: https://docs.redpanda.com/docs/get-started/licensing/monitor-license-status/
+            url: https://docs.redpanda.com/docs/get-started/licenses/
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/enterprise_response'
       description: >
-        This endpoint reports the current status of the [Enterprise Edition license](https://docs.redpanda.com/docs/get-started/licensing/overview/) and lists all Enterprise features currently in use.
+        This endpoint reports the current status of the [Enterprise Edition license](https://docs.redpanda.com/docs/get-started/licenses/) and lists all Enterprise features currently in use.
         Use this endpoint to monitor license compliance and detect if any Enterprise features are active without a valid license.
   /v1/features/license:
     get:


### PR DESCRIPTION
## Description

Part of https://redpandadata.atlassian.net/browse/DOC-502
Review deadline: 14 October

Although this is a new feature for 24.3, it was [backported and released in 24.2.5](https://github.com/redpanda-data/redpanda/pull/23368) so we can merge it before the release of 24.3.

## Page previews

[Preview](https://deploy-preview-802--redpanda-docs-preview.netlify.app/api/admin-api/#get-/v1/features/enterprise)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)