### PR TITLE
DOC-638 Update rpk with 24.2.6. Minor text adjustment to rpk-redpanda-start

### DIFF
--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
@@ -95,7 +95,7 @@ numbers, each with optional fraction and a unit suffix, such as
 
 |--tune |- |When present will enable tuning before starting Redpanda.
 
-|--well-known-io |string |The cloud provider and VM type, in the format <provider>:<vm type>:<storage type>.
+|--well-known-io |string |The cloud vendor and VM type, in the format <vendor>:<vm type>:<storage type>.
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 

--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
@@ -56,12 +56,27 @@ rpk redpanda start [flags]
 |*Value* |*Type* |*Description*
 
 |--advertise-kafka-addr |strings |A comma-separated list of Kafka
-addresses to advertise (`<scheme>`:`<host>`:`<port>`|`<name>`).
+addresses to advertise.
+
+[,bash]
+----
+<scheme>:<host>:<port>\|<name>
+----
 
 |--advertise-pandaproxy-addr |strings |A comma-separated list of
-Pandaproxy addresses to advertise (`<scheme>`:`<host>`:`<port>`|`<name>`).
+Pandaproxy addresses to advertise.
 
-|--advertise-rpc-addr |string |The advertised RPC address (`<host>:`<port>`).
+[,bash]
+----
+<scheme>:<host>:<port>\|<name>
+----
+
+|--advertise-rpc-addr |string |The advertised RPC address 
+
+[,bash]
+----
+<host>:<port>
+----
 
 |--check |- |When set to false will disable system checking before
 starting `redpanda` (default true).
@@ -71,21 +86,46 @@ starting `redpanda` (default true).
 |--install-dir |string |Directory where `redpanda` has been installed.
 
 |--kafka-addr |strings |A comma-separated list of Kafka listener
-addresses to bind to (`<scheme>`:`<host>`:`<port>`|`<name>`).
+addresses to bind to.
+
+[,bash]
+----
+<scheme>:<host>:<port>\|<name>
+----
 
 |--mode |string |Mode sets well-known configuration properties for
 development or test environments; use `--mode help` for more info.
 
 |--pandaproxy-addr |strings |A comma-separated list of Pandaproxy
-listener addresses to bind to (`<scheme>`:`<host>`:`<port>`|`<name>`).
+listener addresses to bind to.
 
-|--rpc-addr |string |The RPC address to bind to (`<host>:`<port>`).
+[,bash]
+----
+<scheme>:<host>:<port>\|<name>
+----
+
+|--rpc-addr |string |The RPC address to bind to.
+
+[,bash]
+----
+<host>:<port>
+----
 
 |--schema-registry-addr |strings |A comma-separated list of Schema
-Registry listener addresses to bind to (`<scheme>`:`<host>`:`<port>`|`<name>`).
+Registry listener addresses to bind to.
+
+[,bash]
+----
+<scheme>:<host>:<port>\|<name>
+----
 
 |-s, --seeds |strings |A comma-separated list of seed nodes to connect
-to (`<scheme>`:`<host>`:`<port>`|`<name>`).
+to. 
+
+[,bash]
+----
+<scheme>:<host>:<port>\|<name>
+----
 
 |--timeout |duration |The maximum time to wait for the checks and tune
 processes to complete. The value passed is a sequence of decimal
@@ -95,7 +135,12 @@ numbers, each with optional fraction and a unit suffix, such as
 
 |--tune |- |When present will enable tuning before starting `redpanda`.
 
-|--well-known-io |string |The cloud vendor and VM type, in the format `<vendor>`:`<vm-type>`:`<storage-type>`.
+|--well-known-io |string |The cloud vendor and VM type, in the format
+
+[,bash]
+----
+<vendor>:<vm-type>:<storage-type>
+----
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 

--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
@@ -78,8 +78,8 @@ Pandaproxy addresses to advertise.
 <host>:<port>
 ----
 
-|--check |- |When set to false will disable system checking before
-starting `redpanda` (default true).
+|--check |- |When set to `false`, will disable system checking before
+starting `redpanda` (default `true`).
 
 |-h, --help |- |Help for start.
 
@@ -93,7 +93,7 @@ addresses to bind to.
 <scheme>:<host>:<port>\|<name>
 ----
 
-|--mode |string |Mode sets well-known configuration properties for
+|--mode |string |Sets well-known configuration properties for
 development or test environments; use `--mode help` for more info.
 
 |--pandaproxy-addr |strings |A comma-separated list of Pandaproxy

--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-start.adoc
@@ -56,36 +56,36 @@ rpk redpanda start [flags]
 |*Value* |*Type* |*Description*
 
 |--advertise-kafka-addr |strings |A comma-separated list of Kafka
-addresses to advertise (scheme://host:port\|name).
+addresses to advertise (`<scheme>`:`<host>`:`<port>`|`<name>`).
 
 |--advertise-pandaproxy-addr |strings |A comma-separated list of
-Pandaproxy addresses to advertise (scheme://host:port\|name).
+Pandaproxy addresses to advertise (`<scheme>`:`<host>`:`<port>`|`<name>`).
 
-|--advertise-rpc-addr |string |The advertised RPC address (host:port).
+|--advertise-rpc-addr |string |The advertised RPC address (`<host>:`<port>`).
 
 |--check |- |When set to false will disable system checking before
-starting redpanda (default true).
+starting `redpanda` (default true).
 
 |-h, --help |- |Help for start.
 
-|--install-dir |string |Directory where redpanda has been installed.
+|--install-dir |string |Directory where `redpanda` has been installed.
 
 |--kafka-addr |strings |A comma-separated list of Kafka listener
-addresses to bind to (scheme://host:port\|name).
+addresses to bind to (`<scheme>`:`<host>`:`<port>`|`<name>`).
 
 |--mode |string |Mode sets well-known configuration properties for
-development or test environments; use --mode help for more info.
+development or test environments; use `--mode help` for more info.
 
 |--pandaproxy-addr |strings |A comma-separated list of Pandaproxy
-listener addresses to bind to (scheme://host:port\|name).
+listener addresses to bind to (`<scheme>`:`<host>`:`<port>`|`<name>`).
 
-|--rpc-addr |string |The RPC address to bind to (host:port).
+|--rpc-addr |string |The RPC address to bind to (`<host>:`<port>`).
 
 |--schema-registry-addr |strings |A comma-separated list of Schema
-Registry listener addresses to bind to (scheme://host:port\|name).
+Registry listener addresses to bind to (`<scheme>`:`<host>`:`<port>`|`<name>`).
 
 |-s, --seeds |strings |A comma-separated list of seed nodes to connect
-to (scheme://host:port\|name).
+to (`<scheme>`:`<host>`:`<port>`|`<name>`).
 
 |--timeout |duration |The maximum time to wait for the checks and tune
 processes to complete. The value passed is a sequence of decimal
@@ -93,9 +93,9 @@ numbers, each with optional fraction and a unit suffix, such as
 `300ms`, `1.5s` or `2h45m`. Valid time units are `ns`, `us`
 (or `µs`), `ms`, `s`, `m`, `h` (default 10s).
 
-|--tune |- |When present will enable tuning before starting Redpanda.
+|--tune |- |When present will enable tuning before starting `redpanda`.
 
-|--well-known-io |string |The cloud vendor and VM type, in the format <vendor>:<vm type>:<storage type>.
+|--well-known-io |string |The cloud vendor and VM type, in the format `<vendor>`:`<vm-type>`:`<storage-type>`.
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 


### PR DESCRIPTION
## Description

Update rpk with 24.2.6.

Adds some improvements to `rpk redpanda start`

## Page previews

[rpk redpanda start](https://deploy-preview-803--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-redpanda/rpk-redpanda-start/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)