### PR TITLE
Changing cloud_storage keys requires restart

### DIFF
--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -15,7 +15,7 @@ AWS or GCP access key. This access key is part of the credentials that Redpanda 
 
 To authenticate using IAM roles, see <<cloud_storage_credentials_source>>.
 
-*Requires restart:* No
+*Requires restart:* Yes
 
 *Optional:* No
 
@@ -307,7 +307,7 @@ AWS or GCP region that houses the bucket or container used for storage.
 
 AWS or GCP secret key.
 
-*Requires restart:* No
+*Requires restart:* Yes
 
 *Optional:* No
 


### PR DESCRIPTION
## Description

Confirmed with @abhijat in https://redpandadata.slack.com/archives/C02BDN76HUK/p1728629388679519

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)