### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -28,7 +28,6 @@ jobs:
       pull-requests: write
       issues: write
     strategy:
-      fail-fast: false  # Ensure all matrix jobs run to completion even if one fails
       matrix:
         os: [ubuntu-latest]  # Only using Linux for now since macOS takes a long time
     runs-on: ${{ matrix.os }}
@@ -36,11 +35,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          path: redpanda-docs
       - name: Test docs
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
-        run: npm i && npm run test-docs
-        working-directory: setup-tests
+        uses: doc-detective/github-action@v1
+        with:
+          input: ../modules
+          working_directory: redpanda-docs/setup-tests
+          exit_on_fail: true
+          # create a PR/issue only if the workflow wasn't already triggered by a PR
+          create_pr_on_change: true
+          create_issue_on_fail: true
+
       - name: Test Console docs
         if: needs.setup.outputs.console == 'true'
-        run: npm i && npm run test-console-docs
-        working-directory: setup-tests
+        uses: doc-detective/github-action@v1
+        with:
+          input: ../modules/console
+          working_directory: redpanda-docs/setup-tests
+          exit_on_fail: true

--- a/modules/console/test-resources/docker-compose.yml
+++ b/modules/console/test-resources/docker-compose.yml
@@ -151,7 +151,7 @@ services:
               enabled: true
               repository:
                 url: https://github.com/redpanda-data/docs
-                branch: console-updates
+                branch: main
                 baseDirectory: modules/console/test-resources
     ports:
       - 8080:8080


### PR DESCRIPTION
## Description

Our Console quickstart test was using a branch for topic documentation that has now been deleted. This PR updates the branch. It also updates the GitHub Action to use the official Doc Detective GitHub Action for running tests.

The invalid branch was causing our tests to fail but the error message was unclear. So I've opened an issue in the Console repo to clarify the error: https://github.com/redpanda-data/console/issues/1480

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)