### PR TITLE
rpk 24.2.7. New info on admin brokers list, and update on rpk cluster…

### DIFF
--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-license-info.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-license-info.adoc
@@ -6,7 +6,6 @@ Retrieve license information:
 Organization:    Organization the license was generated for.
 Type:            Type of license: free, enterprise, etc.
 Expires:         Expiration date of the license.
-Version:         License schema version.
 ----
 
 == Usage

--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-admin-brokers-list.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-admin-brokers-list.adoc
@@ -5,6 +5,36 @@ include::reference:partial$unsupported-os-rpk.adoc[]
 
 List the brokers in your cluster.
 
+This command lists all brokers in the cluster, active and inactive, unless they have been decommissioned. Using the `--include-decommissioned` flag, it lists decommissioned brokers with associated UUIDs too.
+
+The output table contains the following columns:
+
+[.sortable] 
+|===
+| *Column* | *Description*
+
+|ID |Node ID, an exclusive identifier for a broker.
+
+|HOST |Internal RPC address for communication between brokers.
+
+|PORT |Internal RPC port for communication between brokers.
+
+|RACK |Assigned rack ID.
+
+|CORES |Number of cores (shards) on a broker.
+
+|MEMBERSHIP |Whether a broker is decommissioned or not.
+
+|IS-ALIVE |Whether a broker is alive or offline.
+
+|VERSION |Broker version.
+
+|UUID |Additional exclusive identifier for a broker (Optional).
+|===
+
+
+NOTE: The UUID column is hidden when the cluster doesn't expose the UUID in the Admin API, or the API call fails to retrieve UUIDs.
+
 == Usage
 
 [,bash]
@@ -24,6 +54,8 @@ list, ls
 [cols="1m,1a,2a"]
 |===
 |*Value* |*Type* |*Description*
+
+|-d, --include-decommissioned |- |Include decommissioned brokers.
 
 |-h, --help |- |Help for list.
 


### PR DESCRIPTION
## Changelog

New descriptions/features for:
`rpk redpanda admin brokers list`
`rpk cluster license info` 

Based on autoextraction https://github.com/redpanda-data/docs/commit/5368480a50c7050246ca670d3e6afa9b503640d9


## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)