### PR TITLE
Document current support for tombstone markers as of 24.2

### DIFF
--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -48,10 +48,10 @@ Redpanda does not currently support the following Apache Kafka features:
 
 * Managing SASL users with Kafka APIs: DescribeUserSCRAMCredentialsRequest and AlterUserSCRAMCredentialsRequest APIs.
 * HTTP Proxy (pandaproxy): Unlike other REST proxy implementations in the Kafka ecosystem, Redpanda HTTP Proxy does not support topic and ACLs CRUD through the HTTP Proxy. HTTP Proxy is designed for clients producing and consuming data that do not perform administrative functions.
+* The `delete.retention.ms` topic configuration in Kafka is not supported. Tombstone markers are not removed for topics with a `compact` xref:manage:cluster-maintenance/compaction-settings.adoc#configure-cleanup-policy[cleanup policy]. Redpanda only deletes tombstone markers when topics with a cleanup policy of `compact,delete` have reached their xref:manage:cluster-maintenance/disk-utilization.adoc[retention limits].
 ifndef::env-cloud[]
 +
 * Quotas per user for bandwidth and API request rates. However, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[quotas per client and per client group] using AlterClientQuotas and DescribeClientQuotas APIs are supported.
-* The `delete.retention.ms` topic configuration in Kafka is not supported. Tombstone markers are not removed for topics with a `compact` xref:manage:cluster-maintenance/compaction-settings.adoc#configure-cleanup-policy[cleanup policy]. Redpanda only deletes tombstone markers when topics with a cleanup policy of `compact,delete` have reached their xref:manage:cluster-maintenance/disk-utilization.adoc[retention limits].
 endif::[]
 
 If you have any issues while working with a Kafka tool, you can https://github.com/redpanda-data/redpanda/issues/new[file an issue^].

--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -51,6 +51,7 @@ Redpanda does not currently support the following Apache Kafka features:
 ifndef::env-cloud[]
 +
 * Quotas per user for bandwidth and API request rates. However, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[quotas per client and per client group] using AlterClientQuotas and DescribeClientQuotas APIs are supported.
+* The `delete.retention.ms` topic configuration in Kafka is not supported. Tombstone markers are not removed for topics with a `compact` xref:manage:cluster-maintenance/compaction-settings.adoc#configure-cleanup-policy[cleanup policy]. Redpanda only deletes tombstone markers when topics with a cleanup policy of `compact,delete` have reached their xref:manage:cluster-maintenance/disk-utilization.adoc[retention limits].
 endif::[]
 
 If you have any issues while working with a Kafka tool, you can https://github.com/redpanda-data/redpanda/issues/new[file an issue^].

--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -48,9 +48,13 @@ Redpanda does not currently support the following Apache Kafka features:
 
 * Managing SASL users with Kafka APIs: DescribeUserSCRAMCredentialsRequest and AlterUserSCRAMCredentialsRequest APIs.
 * HTTP Proxy (pandaproxy): Unlike other REST proxy implementations in the Kafka ecosystem, Redpanda HTTP Proxy does not support topic and ACLs CRUD through the HTTP Proxy. HTTP Proxy is designed for clients producing and consuming data that do not perform administrative functions.
-* The `delete.retention.ms` topic configuration in Kafka is not supported. Tombstone markers are not removed for topics with a `compact` xref:develop:config-topics.adoc#change-the-cleanup-policy[cleanup policy]. Redpanda only deletes tombstone markers when topics with a cleanup policy of `compact,delete` have reached their xref:manage:cluster-maintenance/disk-utilization.adoc[retention limits].
+ifdef::env-cloud[]
++
+* The `delete.retention.ms` topic configuration in Kafka is not supported. Tombstone markers are not removed for topics with a `compact` xref:get-started:config-topics.adoc#change-the-cleanup-policy[cleanup policy]. Redpanda only deletes tombstone markers when topics with a cleanup policy of `compact,delete` have reached their xref:get-started:create-topic.adoc[retention limits].
+endif::[]
 ifndef::env-cloud[]
 +
+* The `delete.retention.ms` topic configuration in Kafka is not supported. Tombstone markers are not removed for topics with a `compact` xref:develop:config-topics.adoc#change-the-cleanup-policy[cleanup policy]. Redpanda only deletes tombstone markers when topics with a cleanup policy of `compact,delete` have reached their xref:manage:cluster-maintenance/disk-utilization.adoc#configure-message-retention[retention limits].
 * Quotas per user for bandwidth and API request rates. However, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[quotas per client and per client group] using AlterClientQuotas and DescribeClientQuotas APIs are supported.
 endif::[]
 

--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -48,7 +48,7 @@ Redpanda does not currently support the following Apache Kafka features:
 
 * Managing SASL users with Kafka APIs: DescribeUserSCRAMCredentialsRequest and AlterUserSCRAMCredentialsRequest APIs.
 * HTTP Proxy (pandaproxy): Unlike other REST proxy implementations in the Kafka ecosystem, Redpanda HTTP Proxy does not support topic and ACLs CRUD through the HTTP Proxy. HTTP Proxy is designed for clients producing and consuming data that do not perform administrative functions.
-* The `delete.retention.ms` topic configuration in Kafka is not supported. Tombstone markers are not removed for topics with a `compact` xref:manage:cluster-maintenance/compaction-settings.adoc#configure-cleanup-policy[cleanup policy]. Redpanda only deletes tombstone markers when topics with a cleanup policy of `compact,delete` have reached their xref:manage:cluster-maintenance/disk-utilization.adoc[retention limits].
+* The `delete.retention.ms` topic configuration in Kafka is not supported. Tombstone markers are not removed for topics with a `compact` xref:develop:config-topics.adoc#change-the-cleanup-policy[cleanup policy]. Redpanda only deletes tombstone markers when topics with a cleanup policy of `compact,delete` have reached their xref:manage:cluster-maintenance/disk-utilization.adoc[retention limits].
 ifndef::env-cloud[]
 +
 * Quotas per user for bandwidth and API request rates. However, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[quotas per client and per client group] using AlterClientQuotas and DescribeClientQuotas APIs are supported.


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2679
Review deadline: 23 Oct

This will soon be updated in the upcoming release in which support for `delete.retention.ms` is added

## Page previews

Self-managed: [Kafka compatibility > Unsupported Kafka features](https://deploy-preview-821--redpanda-docs-preview.netlify.app/current/develop/kafka-clients/#unsupported-kafka-features) 
Cloud: [Kafka compatibility > Unsupported Kafka features](https://deploy-preview-821--redpanda-docs-preview.netlify.app/redpanda-cloud/develop/kafka-clients/#unsupported-kafka-features)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)