### PR TITLE
Properties 24 3

### DIFF
--- a/modules/reference/pages/properties/broker-properties.adoc
+++ b/modules/reference/pages/properties/broker-properties.adoc
@@ -26,8 +26,6 @@ Network address for the glossterm:Admin API[] server.
 
 Path to the API specifications for the Admin API.
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* string
@@ -39,8 +37,6 @@ Path to the API specifications for the Admin API.
 === admin_api_tls
 
 Specifies the TLS configuration for the HTTP Admin API.
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -61,7 +57,7 @@ The crash-tracking logic is reset (to zero consecutive crashes) by any of the fo
 * The `redpanda.yaml` broker configuration file is updated.
 * The `startup_log` file in the broker's <<data_directory,data_directory>> is manually deleted.
 
-*Units*: number of consecutive crashes of a broker
+*Unit*: number of consecutive crashes of a broker
 
 *Optional:* No
 
@@ -79,8 +75,6 @@ The crash-tracking logic is reset (to zero consecutive crashes) by any of the fo
 
 Path to the directory for storing Redpanda's streaming data files.
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* string
@@ -93,9 +87,7 @@ Path to the directory for storing Redpanda's streaming data files.
 
 CAUTION: Enabling `developer_mode` isn't recommended for production use.
 
-Flag to enable developer mode, which skips most of the checks performed at startup.
-
-*Optional:* Yes
+Enable developer mode, which skips most of the checks performed at startup.
 
 *Visibility:* `tunable`
 
@@ -108,8 +100,6 @@ Flag to enable developer mode, which skips most of the checks performed at start
 === emergency_disable_data_transforms
 
 Override the cluster property xref:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] and disable Wasm-powered data transforms. This is an emergency shutoff button.
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -161,8 +151,6 @@ Controls whether Redpanda starts in FIPS mode.  This property allows for three v
 
 IP address and port of the Kafka API endpoint that handles requests.
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Default:* `127.0.0.1:9092`
@@ -172,8 +160,6 @@ IP address and port of the Kafka API endpoint that handles requests.
 === kafka_api_tls
 
 Transport Layer Security (TLS) configuration for the Kafka API endpoint.
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -186,9 +172,6 @@ Transport Layer Security (TLS) configuration for the Kafka API endpoint.
 Threshold for log messages that contain a larger memory allocation than specified.
 
 *Unit:* bytes
-
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -203,14 +186,23 @@ A number that uniquely identifies the broker within the cluster. If `null` (the 
 
 CAUTION: The `node_id` property must not be changed after a broker joins the cluster.
 
-
 *Accepted values:* [`0`, `4294967295`]
 
 *Type:* integer
 
-*Optional:* No
+*Visibility:* `user`
+
+*Default:* `null`
+
+---
+
+=== node_id_overrides
+
+List of node ID and UUID overrides to be applied at broker startup. Each entry includes the current UUID and desired ID and UUID. Each entry applies to a given node if and only if 'current' matches that node's current UUID.
 
 *Visibility:* `user`
+
+*Type:* array
 
 *Default:* `null`
 
@@ -219,8 +211,6 @@ CAUTION: The `node_id` property must not be changed after a broker joins the clu
 === openssl_config_file
 
 Path to the configuration file used by OpenSSL to properly load the FIPS-compliant module.
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -234,8 +224,6 @@ Path to the configuration file used by OpenSSL to properly load the FIPS-complia
 
 Path to the directory that contains the OpenSSL FIPS-compliant module. The filename that Redpanda looks for is `fips.so`.
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* string
@@ -248,8 +236,6 @@ Path to the directory that contains the OpenSSL FIPS-compliant module. The filen
 
 A label that identifies a failure zone. Apply the same label to all brokers in the same failure zone. When xref:./cluster-properties.adoc#enable_rack_awareness[enable_rack_awareness] is set to `true` at the cluster level, the system uses the rack labels to spread partition replicas across different failure zones.
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Default:* `null`
@@ -259,8 +245,6 @@ A label that identifies a failure zone. Apply the same label to all brokers in t
 === recovery_mode_enabled
 
 If `true`, start Redpanda in xref:manage:recovery-mode.adoc[recovery mode], where user partitions are not loaded and only administrative operations are allowed.
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -274,8 +258,6 @@ If `true`, start Redpanda in xref:manage:recovery-mode.adoc[recovery mode], wher
 
 IP address and port for the Remote Procedure Call (RPC) server.
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Default:* `127.0.0.1:33145`
@@ -285,8 +267,6 @@ IP address and port for the Remote Procedure Call (RPC) server.
 === rpc_server_tls
 
 TLS configuration for the RPC server.
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -324,8 +304,6 @@ The `seed_servers` list must be consistent across all seed brokers to prevent cl
 
 Path to the configuration file used for low level storage failure injection.
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* string
@@ -337,8 +315,6 @@ Path to the configuration file used for low level storage failure injection.
 === storage_failure_injection_enabled
 
 If `true`, inject low level storage failures on the write path. Do _not_ use for production instances.
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -352,8 +328,6 @@ If `true`, inject low level storage failures on the write path. Do _not_ use for
 
 Whether to violate safety checks when starting a Redpanda version newer than the cluster's consensus version.
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -366,9 +340,7 @@ Whether to violate safety checks when starting a Redpanda version newer than the
 
 Maximum duration in seconds for verbose (`TRACE` or `DEBUG`) logging. Values configured above this will be clamped. If null (the default) there is no limit. Can be overridden in the Admin API on a per-request basis.
 
-*Units:* seconds
-
-*Optional:* No
+*Unit:* seconds
 
 *Visibility:* `tunable`
 
@@ -388,15 +360,37 @@ The Schema Registry provides configuration properties to help you enable produce
 
 For information on how to edit broker properties for the Schema Registry, see xref:manage:cluster-maintenance/node-property-configuration.adoc[].
 
+=== api_doc_dir
+
+API doc directory.
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `/usr/share/redpanda/proxy-api-doc`
+
+---
+
+=== mode_mutability
+
+Enable modifications to the read-only `mode` of the Schema Registry. When set to `true`, the entire Schema Registry or its subjects can be switched to `READONLY` or `READWRITE`. This property is useful for preventing unwanted changes to the entire Schema Registry or specific subjects.
+
+*Visibility:* `user`
+
+*Type:* boolean
+
+*Default:* `true`
+
+---
+
 === schema_registry_api
 
-Specifies the listener address and port in the Schema Registry API.
+Schema Registry API listener address and port.
 
-*Optional:* Yes
+*Visibility:* `user`
 
-*Visibility:* `None`
-
-*Default:* `127.0.0.1:8081`
+*Default:* `0.0.0.0:8081`
 
 ---
 
@@ -404,9 +398,7 @@ Specifies the listener address and port in the Schema Registry API.
 
 TLS configuration for Schema Registry API.
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Default:* `null`
 
@@ -416,9 +408,7 @@ TLS configuration for Schema Registry API.
 
 Replication factor for internal `_schemas` topic.  If unset, defaults to `default_topic_replication`.
 
-*Optional:* No
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -443,39 +433,9 @@ See xref:develop:http-proxy.adoc[]
 
 Network address for the HTTP Proxy API server to publish to clients.
 
-*Optional:* Yes
-
-*Visibility:* `None`
-
-*Default:* `null`
-
----
-
-=== api_doc_dir
-
-Path to the API specifications for the HTTP Proxy API.
-
-*Optional:* Yes
-
-*Visibility:* `None`
-
-*Type:* string
-
-*Default:* `/usr/share/redpanda/proxy-api-doc`
-
----
-
-=== mode_mutability
-
-Enable modifications to the read-only `mode` of the Schema Registry. When set to `true`, the entire Schema Registry or its subjects can be switched to `READONLY` or `READWRITE`. This property is useful for preventing unwanted changes to the entire Schema Registry or specific subjects.
-
-*Nullable:* No
-
 *Visibility:* `user`
 
-*Type:* boolean
-
-*Default:* `true`
+*Default:* `null`
 
 ---
 
@@ -483,9 +443,7 @@ Enable modifications to the read-only `mode` of the Schema Registry. When set to
 
 The maximum number of Kafka client connections that Redpanda can cache in the LRU (least recently used) cache. The LRU cache helps optimize resource utilization by keeping the most recently used clients in memory, facilitating quicker reconnections for frequent clients while limiting memory usage.
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -497,29 +455,9 @@ The maximum number of Kafka client connections that Redpanda can cache in the LR
 
 Time, in milliseconds, that an idle client connection may remain open to the HTTP Proxy API.
 
-*Units* : milliseconds
+*Unit:* milliseconds
 
-*Optional:* Yes
-
-*Visibility:* `None`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `300000`
-
----
-
-=== consumer_instance_timeout
-
-How long to wait for an idle consumer before removing it. A consumer is considered idle when it's not making requests or heartbeats.
-
-*Units*: milliseconds
-
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -529,15 +467,29 @@ How long to wait for an idle consumer before removing it. A consumer is consider
 
 ---
 
+=== consumer_instance_timeout_ms
+
+How long to wait for an idle consumer before removing it. A consumer is considered idle when it's not making requests or heartbeats.
+
+*Unit:* milliseconds
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `300000`
+
+---
+
 === pandaproxy_api
 
-Specifies the listener address and port for the Rest API.
+Rest API listen address and port.
 
-*Optional:* Yes
+*Visibility:* `user`
 
-*Visibility:* `None`
-
-*Default:* `127.0.0.1:8082`
+*Default:* `0.0.0.0:8082`
 
 ---
 
@@ -545,9 +497,7 @@ Specifies the listener address and port for the Rest API.
 
 TLS configuration for Pandaproxy api.
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Default:* `null`
 
@@ -561,11 +511,7 @@ Configuration options for HTTP Proxy Client.
 
 TLS configuration for the Kafka API servers to which the HTTP Proxy client should connect.
 
-*Optional:* Yes
-
-*Visibility:* `None`
-
-*Default:* `config::tls_config()`
+*Visibility:* `user`
 
 ---
 
@@ -573,13 +519,11 @@ TLS configuration for the Kafka API servers to which the HTTP Proxy client shoul
 
 Network addresses of the Kafka API servers to which the HTTP Proxy client should connect.
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* array
 
-*Default:* `["127.0.0.1:9092"]`
+*Default:* `['127.0.0.1:9092']`
 
 ---
 
@@ -587,9 +531,7 @@ Network addresses of the Kafka API servers to which the HTTP Proxy client should
 
 Custom identifier to include in the Kafka request header for the HTTP Proxy client. This identifier can help debug or monitor client activities.
 
-*Optional:* No
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* string
 
@@ -597,15 +539,13 @@ Custom identifier to include in the Kafka request header for the HTTP Proxy clie
 
 ---
 
-=== consumer_heartbeat_interval
+=== consumer_heartbeat_interval_ms
 
 Interval (in milliseconds) for consumer heartbeats.
 
-*Units*: milliseconds
+*Unit:* milliseconds
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -615,21 +555,19 @@ Interval (in milliseconds) for consumer heartbeats.
 
 ---
 
-=== consumer_rebalance_timeout
+=== consumer_rebalance_timeout_ms
 
 Timeout (in milliseconds) for consumer rebalance.
 
-*Units*: milliseconds
+*Unit:* milliseconds
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `200`
+*Default:* `2000`
 
 ---
 
@@ -637,11 +575,9 @@ Timeout (in milliseconds) for consumer rebalance.
 
 Maximum bytes to fetch per request.
 
-*Units*: bytes
+*Unit:* bytes
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -655,11 +591,9 @@ Maximum bytes to fetch per request.
 
 Minimum bytes to fetch per request.
 
-*Units*: bytes
+*Unit:* bytes
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -669,15 +603,13 @@ Minimum bytes to fetch per request.
 
 ---
 
-=== consumer_request_timeout
+=== consumer_request_timeout_ms
 
 Interval (in milliseconds) for consumer request timeout.
 
-*Units*: milliseconds
+*Unit:* milliseconds
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -687,15 +619,13 @@ Interval (in milliseconds) for consumer request timeout.
 
 ---
 
-=== consumer_session_timeout
+=== consumer_session_timeout_ms
 
 Timeout (in milliseconds) for consumer session.
 
-*Units*: milliseconds
+*Unit:* milliseconds
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -709,9 +639,7 @@ Timeout (in milliseconds) for consumer session.
 
 Number of acknowledgments the producer requires the leader to have received before considering a request complete.
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -721,15 +649,13 @@ Number of acknowledgments the producer requires the leader to have received befo
 
 ---
 
-=== produce_batch_delay
+=== produce_batch_delay_ms
 
 Delay (in milliseconds) to wait before sending batch.
 
-*Units*: milliseconds
+*Unit:* milliseconds
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -743,9 +669,7 @@ Delay (in milliseconds) to wait before sending batch.
 
 Number of records to batch before sending to broker.
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -759,11 +683,9 @@ Number of records to batch before sending to broker.
 
 Number of bytes to batch before sending to broker.
 
-*Units*: bytes
+*Unit:* bytes
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -777,27 +699,21 @@ Number of bytes to batch before sending to broker.
 
 Enable or disable compression by the Kafka client. Specify `none` to disable compression or one of the supported types [gzip, snappy, lz4, zstd].
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* string
-
-*Accepted values:* `gzip`, `snappy`, `lz4`, `zstd`
 
 *Default:* `none`
 
 ---
 
-=== produce_shutdown_delay
+=== produce_shutdown_delay_ms
 
 Delay (in milliseconds) to allow for final flush of buffers before shutting down.
 
-*Units*: milliseconds
+*Unit:* milliseconds
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -811,9 +727,7 @@ Delay (in milliseconds) to allow for final flush of buffers before shutting down
 
 Number of times to retry a request to a broker.
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -821,15 +735,13 @@ Number of times to retry a request to a broker.
 
 ---
 
-=== retry_base_backoff
+=== retry_base_backoff_ms
 
 Delay (in milliseconds) for initial retry backoff.
 
-*Units*: milliseconds
+*Unit:* milliseconds
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -843,9 +755,7 @@ Delay (in milliseconds) for initial retry backoff.
 
 The SASL mechanism to use when connecting.
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* string
 
@@ -857,9 +767,7 @@ The SASL mechanism to use when connecting.
 
 Password to use for SCRAM authentication mechanisms.
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* string
 
@@ -871,9 +779,7 @@ Password to use for SCRAM authentication mechanisms.
 
 Username to use for SCRAM authentication mechanisms.
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* string
 

--- a/modules/reference/pages/properties/broker-properties.adoc
+++ b/modules/reference/pages/properties/broker-properties.adoc
@@ -14,8 +14,6 @@ NOTE: All broker properties require that you restart Redpanda for any update to 
 
 Network address for the glossterm:Admin API[] server.
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Default:* `127.0.0.1:9644`
@@ -58,8 +56,6 @@ The crash-tracking logic is reset (to zero consecutive crashes) by any of the fo
 * The `startup_log` file in the broker's <<data_directory,data_directory>> is manually deleted.
 
 *Unit*: number of consecutive crashes of a broker
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -117,8 +113,6 @@ Controls how a new cluster is formed. All brokers in a cluster must have the sam
 
 TIP: For backward compatibility, `true` is the default. Redpanda recommends using `false` in production environments to prevent accidental cluster formation.
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -136,8 +130,6 @@ Controls whether Redpanda starts in FIPS mode.  This property allows for three v
 * Permissive - Redpanda performs the same check as enabled, but a warning is logged, and Redpanda continues to run. Redpanda loads the OpenSSL FIPS provider into the OpenSSL library. After this completes, Redpanda is operating in FIPS mode, which means that the TLS cipher suites available to users are limited to the TLSv1.2 and TLSv1.3 NIST-approved cryptographic methods.
 
 * Enabled - Redpanda verifies that the operating system is enabled for FIPS by checking `/proc/sys/crypto/fips_enabled`. If the file does not exist or does not return `1`, Redpanda immediately exits.
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -289,8 +281,6 @@ Only one broker, the designated cluster root, should have an empty `seed_servers
 ====
 The `seed_servers` list must be consistent across all seed brokers to prevent cluster fragmentation and ensure stable cluster formation.
 ====
-
-*Optional:* Yes
 
 *Visibility:* `user`
 

--- a/modules/reference/pages/properties/broker-properties.adoc
+++ b/modules/reference/pages/properties/broker-properties.adoc
@@ -188,18 +188,6 @@ CAUTION: The `node_id` property must not be changed after a broker joins the clu
 
 ---
 
-=== node_id_overrides
-
-List of node ID and UUID overrides to be applied at broker startup. Each entry includes the current UUID and desired ID and UUID. Each entry applies to a given node if and only if 'current' matches that node's current UUID.
-
-*Visibility:* `user`
-
-*Type:* array
-
-*Default:* `null`
-
----
-
 === openssl_config_file
 
 Path to the configuration file used by OpenSSL to properly load the FIPS-compliant module.

--- a/modules/reference/pages/properties/broker-properties.adoc
+++ b/modules/reference/pages/properties/broker-properties.adoc
@@ -475,7 +475,7 @@ How long to wait for an idle consumer before removing it. A consumer is consider
 
 === pandaproxy_api
 
-Rest API listen address and port.
+Rest API listener address and port.
 
 *Visibility:* `user`
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -898,13 +898,25 @@ Default quota tracking window size in milliseconds.
 
 ---
 
+=== development_enable_cloud_topics
+
+Enable cloud topics.
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
 === disable_batch_cache
 
 Disable batch cache in log manager.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -916,7 +928,9 @@ Disable batch cache in log manager.
 
 === disable_cluster_recovery_loop_for_tests
 
-Disables the cluster recovery loop. This property is used to simplify testing and should not be set in production.
+include::reference:partial$internal-use-property.adoc[]
+
+Disables the cluster recovery loop.
 
 *Requires restart:* No
 
@@ -1019,7 +1033,7 @@ Enable idempotent producers.
 
 === enable_leader_balancer
 
-Enable automatic leadership rebalancing. Mode is set by <<leader_balancer_mode,`leader_balancer_mode`>>.
+Enable automatic leadership rebalancing.
 
 *Requires restart:* No
 
@@ -1118,8 +1132,6 @@ Mode to enable server-side schema ID validation.
 * xref:manage:schema-reg/schema-id-validation.adoc[Server-Side Schema ID Validation]
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -1278,8 +1290,6 @@ The strategy used to fulfill fetch requests.
 * `non_polling_with_debounce`: This option behaves like `non_polling`, but it includes a debounce mechanism with a fixed delay specified by <<fetch_reads_debounce_timeout,`fetch_reads_debounce_timeout`>> at the start of each fetch. By introducing this delay, Redpanda can accumulate more data before processing, leading to fewer fetch operations and returning larger amounts of data. Enabling this option reduces reactor utilization, but it may also increase end-to-end latency.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -1617,6 +1627,22 @@ Time between cluster join retries in milliseconds.
 
 ---
 
+=== kafka_admin_topic_api_rate
+
+Target quota rate (partition mutations per default_window_sec).
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `4294967295`]
+
+*Default:* `null`
+
+---
+
 === kafka_batch_max_bytes
 
 Maximum size of a batch processed by the server. If the batch is compressed, the limit applies to the compressed batch size.
@@ -1635,15 +1661,33 @@ Maximum size of a batch processed by the server. If the batch is compressed, the
 
 ---
 
+=== kafka_client_group_byte_rate_quota
+
+Per-group target produce quota byte rate (bytes per second). Client is considered part of the group if client_id contains clients_prefix.
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Default:* `null`
+
+---
+
+=== kafka_client_group_fetch_byte_rate_quota
+
+Per-group target fetch quota byte rate (bytes per second). Client is considered part of the group if client_id contains clients_prefix.
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Default:* `null`
+
+---
+
 === kafka_connection_rate_limit
 
 Maximum connections per second for one core. If `null` (the default), then the number of connections per second is unlimited.
-
-*Unit*: number of connections per second, per core
-
-*Related topics*:
-
-* xref:manage:cluster-maintenance/configure-availability.adoc#limit-client-connections[Limit client connections]
 
 *Requires restart:* No
 
@@ -1740,8 +1784,6 @@ Maximum number of Kafka client connections per IP address, per broker. If `null`
 Flag to require authorization for Kafka connections. If `null`, the property is disabled, and authorization is instead enabled by <<enable_sasl,`enable_sasl`>>.
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -2481,27 +2523,6 @@ Leadership rebalancing idle timeout.
 
 ---
 
-=== leader_balancer_mode
-
-Mode of the leader balancer for optimizing movements of leadership between shards (logical CPU cores). Enabled by <<enable_leader_balancer,`enable_leader_balancer`>>.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `user`
-
-*Type:* `string`
-
-*Accepted Values*:
-
-* `random_hill_climbing`: a shard is randomly chosen and leadership is moved to it if the load on the original shard is reduced.
-* `greedy_balanced_shards`: leadership movement is based on a greedy heuristic of moving leaders from the most loaded shard to the least loaded shard.
-
-*Default:* `random_hill_climbing`
-
----
-
 === leader_balancer_mute_timeout
 
 Leadership rebalancing mute timeout.
@@ -2609,8 +2630,6 @@ Default cleanup policy for topic logs.
 The topic property xref:./topic-properties.adoc#cleanuppolicy[`cleanup.policy`] overrides the value of `log_cleanup_policy` at the topic level.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -2726,8 +2745,6 @@ The topic property xref:./topic-properties.adoc#messagetimestamptype[`message.ti
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Accepted Values:* `CreateTime`, `LogAppendTime`.
@@ -2743,8 +2760,6 @@ The amount of time to keep a log file before deleting it (in milliseconds). If s
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -3365,8 +3380,6 @@ Mode of xref:manage:cluster-maintenance/cluster-balancing.adoc[partition balanci
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Accepted values:* 
@@ -3710,6 +3723,24 @@ Disables cross shard sharing used to throttle recovery traffic. Should only be u
 *Type:* boolean
 
 *Default:* `false`
+
+---
+
+=== raft_replica_max_flush_delay_ms
+
+Maximum delay between two subsequent flushes. After this delay, the log is automatically force flushed.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `100`
 
 ---
 
@@ -4369,8 +4400,6 @@ Rules for mapping Kerberos principal names to Redpanda user principals.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* string array
@@ -4384,8 +4413,6 @@ Rules for mapping Kerberos principal names to Redpanda user principals.
 A list of supported SASL mechanisms. 
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -4454,6 +4481,20 @@ Option to explicitly disable automatic disk space management. If this property w
 *Type:* boolean
 
 *Default:* `true`
+
+---
+
+=== space_management_enable_override
+
+Enable automatic space management. This option is ignored and deprecated in versions >= v23.3.
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* boolean
+
+*Default:* `false`
 
 ---
 
@@ -4572,8 +4613,6 @@ To figure out whether to set `storage_ignore_timestamps_in_future_sec` for your 
 *Unit*: seconds
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `tunable`
 
@@ -4743,13 +4782,43 @@ List of superuser usernames.
 
 ---
 
+=== target_fetch_quota_byte_rate
+
+Target fetch size quota byte rate (bytes per second) - disabled default.
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `4294967295`]
+
+*Default:* `null`
+
+---
+
+=== target_quota_byte_rate
+
+Target request size quota byte rate (bytes per second).
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `4294967295`]
+
+*Default:* `target_produce_quota_byte_rate_default`
+
+---
+
 === tls_min_version
 
 The minimum TLS version that Redpanda clusters support. This property prevents client applications from negotiating a downgrade to the TLS version when they make a connection to a Redpanda cluster.
 
 *Requires restart:* Yes
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -5065,8 +5134,6 @@ Timeout to wait for leadership in metadata cache.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -5084,8 +5151,6 @@ The default write caching mode to apply to user topics. Write caching acknowledg
 The `write_caching_default` cluster property can be overridden with the xref:topic-properties.adoc#writecaching[`write.caching`] topic property.
 
 *Requires restart:* no
-
-*Optional:* No
 
 *Type*: string
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -14,7 +14,7 @@ NOTE: Some cluster properties require that you restart the cluster for any updat
 
 Capacity (in number of txns) of an abort index segment.
 
-Each partition tracks the aborted transaction offset ranges to help service client requests. If the number transactions increase beyond this threshold, they are flushed to disk to easy memory pressure. Then they're loaded on demand. This configuration controls the maximum number of aborted transactions before they are flushed to disk.
+Each partition tracks the aborted transaction offset ranges to help service client requests. If the number of transactions increases beyond this threshold, they are flushed to disk to ease memory pressure. Then they're loaded on demand. This configuration controls the maximum number of aborted transactions before they are flushed to disk.
 
 *Requires restart:* Yes
 
@@ -470,7 +470,7 @@ Maximum capacity of rate limit accumulation in controller node management operat
 
 === controller_log_accummulation_rps_capacity_topic_operations
 
-Maximum capacity of rate limit accumulationin controller topic operations limit.
+Maximum capacity of rate limit accumulation in controller topic operations limit.
 
 *Requires restart:* No
 
@@ -1514,7 +1514,7 @@ A list of supported HTTP authentication mechanisms.
 
 === iceberg_enabled
 
-Enables the translation of topic data into Iceberg tables. Setting iceberg_enabled to true activates the feature at the cluster level, but each topic must also set the redpanda.iceberg.enabled topic-level property to true to use it. If iceberg_enabled is set to false, the feature is disabled for all topics in the cluster, overriding any topic-level settings.
+Enables the translation of topic data into Iceberg tables. Setting `iceberg_enabled` to `true` activates the feature at the cluster level, but each topic must also set the `redpanda.iceberg.enabled` topic-level property to `true` to use it. If `iceberg_enabled` is set to `false`, then the feature is disabled for all topics in the cluster, overriding any topic-level settings.
 
 *Requires restart:* Yes
 
@@ -2385,9 +2385,9 @@ List of Kafka API keys that are subject to cluster-wide and node-wide throughput
 
 *Visibility:* `user`
 
-*Type:* array
+*Type:* list<string>
 
-*Default:* `[produce, fetch]`
+*Default:* `["produce", "fetch"]`
 
 ---
 
@@ -2926,7 +2926,7 @@ Maximum compacted segment size after consolidation.
 
 === max_concurrent_producer_ids
 
-Maximum number of the active producers sessions. When the threshold is passed, Redpanda terminates old sessions. When an idle producer corresponding to the terminated session wakes up and produces, its message batches are rejected, and an out of order sequence error is emitted. Consumers don't affect this setting.
+Maximum number of active producer sessions. When the threshold is passed, Redpanda terminates old sessions. When an idle producer corresponding to the terminated session wakes up and produces, its message batches are rejected, and an out of order sequence error is emitted. Consumers don't affect this setting.
 
 *Requires restart:* No
 
@@ -3056,7 +3056,7 @@ Interval for metadata dissemination batching.
 
 === metadata_dissemination_retries
 
-Number of attempts to look up a topic's metadata-like shard before a request fails. This configuration controls the number of retries that request handlers perform when internal topic metadata (for topics like tx, consumer offsets, etc) is missing. These topics are usually created on demand when users try to use the cluster for the first time and it may take some time for the creation to happen and the metadata to propagate to all the brokers (particularly the broker handling the request). In the mean time Redpanda waits and retry. This configuration controls the number retries.
+Number of attempts to look up a topic's metadata-like shard before a request fails. This configuration controls the number of retries that request handlers perform when internal topic metadata (for topics like tx, consumer offsets, etc) is missing. These topics are usually created on demand when users try to use the cluster for the first time and it may take some time for the creation to happen and the metadata to propagate to all the brokers (particularly the broker handling the request). In the meantime Redpanda waits and retries. This configuration controls the number retries.
 
 *Requires restart:* Yes
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -14,11 +14,9 @@ NOTE: Some cluster properties require that you restart the cluster for any updat
 
 Capacity (in number of txns) of an abort index segment.
 
-Each partition tracks the aborted transaction offset ranges to help service client requests. If the number transactions increase beyond this threshold, they are flushed to disk to easy memory pressure. Then they're loaded on demand. This configuration controls the maximum number of aborted transactions  before they are flushed to disk.
+Each partition tracks the aborted transaction offset ranges to help service client requests. If the number transactions increase beyond this threshold, they are flushed to disk to easy memory pressure. Then they're loaded on demand. This configuration controls the maximum number of aborted transactions before they are flushed to disk.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -36,9 +34,7 @@ Interval, in milliseconds, at which Redpanda looks for inactive transactions and
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -56,8 +52,6 @@ Whether Admin API clients must provide HTTP basic authentication headers.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -72,9 +66,7 @@ Enable aggregation of metrics returned by the xref:reference:internal-metrics-re
 
 *Requires restart:* No
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* boolean
 
@@ -89,8 +81,6 @@ The amount of time since the last broker status heartbeat. After this time, a br
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Nullable:* No
 
 *Visibility:* `tunable`
 
@@ -110,8 +100,6 @@ The duration, in milliseconds, that Redpanda waits for the replication of entrie
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -126,9 +114,7 @@ The duration, in milliseconds, that Redpanda waits for the replication of entrie
 
 Size of direct write operations to disk in bytes. A larger chunk size can improve performance for write-heavy workloads, but increase latency for these writes as more data is collected before each write operation. A smaller chunk size can decrease write latency, but potentially increase the number of disk I/O operations.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -144,8 +130,6 @@ Defines the number of bytes allocated by the internal audit client for audit mes
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -159,8 +143,6 @@ Defines the number of bytes allocated by the internal audit client for audit mes
 Enables or disables audit logging. When you set this to true, Redpanda checks for an existing topic named `_redpanda.audit_log`. If none is found, Redpanda automatically creates one for you.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -176,8 +158,6 @@ List of strings in JSON style identifying the event types to include in the audi
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* array
@@ -191,8 +171,6 @@ List of strings in JSON style identifying the event types to include in the audi
 List of user principals to exclude from auditing.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -208,8 +186,6 @@ List of topics to exclude from auditing.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* array
@@ -222,9 +198,9 @@ List of topics to exclude from auditing.
 
 Defines the number of partitions used by a newly-created audit topic. This configuration applies only to the audit log topic and may be different from the cluster or other topic configurations. This cannot be altered for existing audit log topics.
 
-*Requires restart:* No
+*Unit:* number of partitions per topic
 
-*Optional:* Yes
+*Requires restart:* No
 
 *Visibility:* `user`
 
@@ -241,8 +217,6 @@ Defines the number of partitions used by a newly-created audit topic. This confi
 Defines the replication factor for a newly-created audit log topic. This configuration applies only to the audit log topic and may be different from the cluster or other topic configurations. This cannot be altered for existing audit log topics. Setting this value is optional. If a value is not provided, Redpanda will use the value specified for `internal_topic_replication_factor`.
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -262,8 +236,6 @@ Interval, in milliseconds, at which Redpanda flushes the queued audit log messag
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -279,8 +251,6 @@ Interval, in milliseconds, at which Redpanda flushes the queued audit log messag
 Defines the maximum amount of memory in bytes used by the audit buffer in each shard. Once this size is reached, requests to log additional audit messages will return a non-retryable error. Limiting the buffer size per shard helps prevent any single shard from consuming excessive memory due to audit log messages.
 
 *Requires restart:* Yes
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -298,8 +268,6 @@ If you produce to a topic that doesn't exist, the topic will be created with def
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -314,9 +282,7 @@ Cluster identifier.
 
 *Requires restart:* No
 
-*Optional:* No
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* string
 
@@ -330,8 +296,6 @@ Size (in bytes) for each compacted log segment.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -344,11 +308,9 @@ Size (in bytes) for each compacted log segment.
 
 === compaction_ctrl_backlog_size
 
-Target backlog size for compaction controller. If not set the max backlog size is configured to 80% of total disk space available. 
+Target backlog size for compaction controller. If not set the max backlog size is configured to 80% of total disk space available.
 
-*Requires restart:* No
-
-*Optional:* No
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -362,9 +324,7 @@ Target backlog size for compaction controller. If not set the max backlog size i
 
 Derivative coefficient for compaction PID controller.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -378,9 +338,7 @@ Derivative coefficient for compaction PID controller.
 
 Integral coefficient for compaction PID controller.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -394,9 +352,7 @@ Integral coefficient for compaction PID controller.
 
 Maximum number of I/O and CPU shares that compaction process can use.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -412,9 +368,7 @@ Maximum number of I/O and CPU shares that compaction process can use.
 
 Minimum number of I/O and CPU shares that compaction process can use.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -430,9 +384,7 @@ Minimum number of I/O and CPU shares that compaction process can use.
 
 Proportional coefficient for compaction PID controller. This must be negative, because the compaction backlog should decrease when the number of compaction shares increases.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -450,8 +402,6 @@ Interval between iterations of controller backend housekeeping loop.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -468,8 +418,6 @@ Maximum capacity of rate limit accumulation in controller ACLs and users operati
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -483,8 +431,6 @@ Maximum capacity of rate limit accumulation in controller ACLs and users operati
 Maximum capacity of rate limit accumulation in controller configuration operations limit.
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `tunable`
 
@@ -500,8 +446,6 @@ Maximum capacity of rate limit accumulation in controller move operations limit.
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -516,8 +460,6 @@ Maximum capacity of rate limit accumulation in controller node management operat
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -528,11 +470,9 @@ Maximum capacity of rate limit accumulation in controller node management operat
 
 === controller_log_accummulation_rps_capacity_topic_operations
 
-Maximum capacity of rate limit accumulation in controller topic operations limit.
+Maximum capacity of rate limit accumulationin controller topic operations limit.
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `tunable`
 
@@ -546,11 +486,9 @@ Maximum capacity of rate limit accumulation in controller topic operations limit
 
 Maximum amount of time before Redpanda attempts to create a controller snapshot after a new controller command appears.
 
-*Unit*: seconds
+*Unit:* seconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -568,8 +506,6 @@ If set to `true`, move partitions between cores in runtime to maintain balanced 
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -586,15 +522,13 @@ Interval, in milliseconds, between trigger and invocation of core balancing.
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `10000`
+*Default:* `10000` (10s)
 
 ---
 
@@ -603,8 +537,6 @@ Interval, in milliseconds, between trigger and invocation of core balancing.
 If set to `true`, and if after a restart the number of cores changes, Redpanda will move partitions between cores to maintain balanced partition distribution.
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -619,8 +551,6 @@ If set to `true`, and if after a restart the number of cores changes, Redpanda w
 Enables CPU profiling for Redpanda.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -637,8 +567,6 @@ The sample period for the CPU profiler.
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -658,8 +586,6 @@ Timeout, in milliseconds, to wait for new topic creation.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -675,8 +601,6 @@ Timeout, in milliseconds, to wait for new topic creation.
 The maximum size for a deployable WebAssembly binary that the broker can store.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -694,8 +618,6 @@ The commit interval at which data transforms progress.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -712,8 +634,6 @@ Enables WebAssembly-powered data transforms directly in the broker. When `data_t
 
 *Requires restart:* Yes
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -726,9 +646,9 @@ Enables WebAssembly-powered data transforms directly in the broker. When `data_t
 
 Buffer capacity for transform logs, per shard. Buffer occupancy is calculated as the total size of buffered log messages; that is, logs emitted but not yet produced.
 
-*Requires restart:* Yes
+*Unit:* bytes
 
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -745,8 +665,6 @@ Flush interval for transform logs. When a timer expires, pending logs are collec
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -766,8 +684,6 @@ Transform log lines truncate to this length. Truncation occurs after any charact
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -782,8 +698,6 @@ The amount of memory to reserve per core for data transform (Wasm) virtual machi
 
 *Requires restart:* Yes
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -797,8 +711,6 @@ The amount of memory to reserve per core for data transform (Wasm) virtual machi
 The amount of memory to give an instance of a data transform (Wasm) virtual machine. The maximum number of functions that can be deployed to a cluster is equal to `data_transforms_per_core_memory_reservation` / `data_transforms_per_function_memory_limit`.
 
 *Requires restart:* Yes
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -816,8 +728,6 @@ The percentage of available memory in the transform subsystem to use for read bu
 
 *Requires restart:* Yes
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -833,8 +743,6 @@ The maximum amount of runtime to start up a data transform, and the time it take
 *Unit:* milliseconds
 
 *Requires restart:* Yes
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -854,8 +762,6 @@ The percentage of available memory in the transform subsystem to use for write b
 
 *Requires restart:* Yes
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -869,8 +775,6 @@ The percentage of available memory in the transform subsystem to use for write b
 The recursion depth after which debug logging is enabled automatically for the log reader.
 
 *Requires restart:* No
-
-*Nullable:* Yes
 
 *Visibility:* `tunable`
 
@@ -888,8 +792,6 @@ Default number of quota tracking windows.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -904,11 +806,9 @@ Default number of quota tracking windows.
 
 Default number of partitions per topic.
 
-*Unit*: number of partitions per topic
+*Unit:* number of partitions per topic
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -925,8 +825,6 @@ Default number of partitions per topic.
 Default replication factor for new topics.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -945,8 +843,6 @@ Default quota tracking window size in milliseconds.
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -980,8 +876,6 @@ Disables the cluster recovery loop. This property is used to simplify testing an
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -994,11 +888,9 @@ Disables the cluster recovery loop. This property is used to simplify testing an
 
 Disable registering the metrics exposed on the internal `/metrics` endpoint.
 
-*Requires restart:* No
+*Requires restart:* Yes
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* boolean
 
@@ -1010,11 +902,9 @@ Disable registering the metrics exposed on the internal `/metrics` endpoint.
 
 Disable registering the metrics exposed on the `/public_metrics` endpoint.
 
-*Requires restart:* No
+*Requires restart:* Yes
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* boolean
 
@@ -1033,8 +923,6 @@ It is recommended to not run disks near capacity to avoid blocking I/O due to lo
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* number
@@ -1048,8 +936,6 @@ It is recommended to not run disks near capacity to avoid blocking I/O due to lo
 Enables cluster metadata uploads. Required for xref:manage:whole-cluster-restore.adoc[whole cluster restore].
 
 *Requires restart:* Yes
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -1065,8 +951,6 @@ Limits the write rate for the controller log.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -1079,9 +963,7 @@ Limits the write rate for the controller log.
 
 Enable idempotent producers.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -1096,8 +978,6 @@ Enable idempotent producers.
 Enable automatic leadership rebalancing. Mode is set by <<leader_balancer_mode,`leader_balancer_mode`>>.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -1121,8 +1001,6 @@ The cluster metrics of the metrics reporter are different from xref:manage:monit
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -1137,8 +1015,6 @@ Enable Redpanda extensions for MPX.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -1151,9 +1027,7 @@ Enable Redpanda extensions for MPX.
 
 Enable PID file. You should not need to change.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1169,8 +1043,6 @@ Enable rack-aware replica assignment.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -1184,8 +1056,6 @@ Enable rack-aware replica assignment.
 Enable SASL authentication for Kafka connections. Authorization is required to modify this property. See also <<kafka_enable_authorization,`kafka_enable_authorization`>>.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -1223,9 +1093,7 @@ Mode to enable server-side schema ID validation.
 
 Enable transactions (atomic writes).
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -1241,8 +1109,6 @@ Enables the usage tracking mechanism, storing windowed history of kafka/cloud_st
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -1257,8 +1123,6 @@ Whether new feature flags auto-activate after upgrades (true) or must wait for m
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -1271,11 +1135,9 @@ Whether new feature flags auto-activate after upgrades (true) or must wait for m
 
 Maximum number of bytes returned in a fetch request.
 
-*Unit*: bytes
+*Unit:* bytes
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -1315,8 +1177,6 @@ Time to wait for the next read in fetch requests when the requested minimum byte
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1333,9 +1193,7 @@ Time duration after which the inactive fetch session is removed from the fetch s
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1355,8 +1213,6 @@ Delay added to the rebalance phase to wait for new members.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1371,13 +1227,11 @@ Delay added to the rebalance phase to wait for new members.
 
 The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -1391,13 +1245,11 @@ The maximum allowed session timeout for registered consumers. Longer timeouts gi
 
 The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -1414,8 +1266,6 @@ Timeout for new member joins.
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -1435,8 +1285,6 @@ Frequency rate at which the system should check for expired group offsets.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1455,8 +1303,6 @@ Consumer group offset retention seconds. To disable offset retention, set this t
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1471,9 +1317,9 @@ Consumer group offset retention seconds. To disable offset retention, set this t
 
 Number of partitions in the internal group membership topic.
 
-*Requires restart:* No
+*Unit:* number of partitions per topic
 
-*Optional:* Yes
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -1490,10 +1336,7 @@ Number of partitions in the internal group membership topic.
 How often the health manager runs.
 
 *Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1513,8 +1356,6 @@ Maximum age of the metadata cached in the health monitor of a non-controller bro
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1531,8 +1372,6 @@ A list of supported HTTP authentication mechanisms.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* array
@@ -1547,9 +1386,7 @@ A list of supported HTTP authentication mechanisms.
 
 The ID allocator allocates messages in batches (each batch is a one log record) and then serves requests from memory without touching the log until the batch is exhausted.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1565,9 +1402,7 @@ The ID allocator allocates messages in batches (each batch is a one log record) 
 
 Capacity of the `id_allocator` log in number of batches. After it reaches `id_allocator_stm`, it truncates the log's prefix.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1587,8 +1422,6 @@ Initial local retention size target for partitions of topics with xref:manage:ti
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -1605,8 +1438,6 @@ Initial local retention time target for partitions of topics with xref:manage:ti
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -1622,10 +1453,7 @@ Initial local retention time target for partitions of topics with xref:manage:ti
 Target replication factor for internal topics.
 
 *Unit*: number of replicas per topic.
-
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -1643,9 +1471,7 @@ Time between cluster join retries in milliseconds.
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1661,9 +1487,9 @@ Time between cluster join retries in milliseconds.
 
 Maximum size of a batch processed by the server. If the batch is compressed, the limit applies to the compressed batch size.
 
-*Requires restart:* No
+*Unit:* bytes
 
-*Optional:* Yes
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -1687,8 +1513,6 @@ Maximum connections per second for one core. If `null` (the default), then the n
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -1709,8 +1533,6 @@ Overrides the maximum connections per second for one core for the specified IP a
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* array
@@ -1729,8 +1551,6 @@ Maximum number of Kafka client connections per broker. If `null`, the property i
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -1745,11 +1565,9 @@ Maximum number of Kafka client connections per broker. If `null`, the property i
 
 === kafka_connections_max_overrides
 
-A list of IP addresses for which Kafka client connection limits are overridden and don't apply. For example, `(['127.0.0.1:90', '50.20.1.1:40']).`
+A list of IP addresses for which Kafka client connection limits are overridden and don't apply. For example, `(['127.0.0.1:90', '50.20.1.1:40']).`.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -1768,8 +1586,6 @@ A list of IP addresses for which Kafka client connection limits are overridden a
 Maximum number of Kafka client connections per IP address, per broker. If `null`, the property is disabled.
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -1818,8 +1634,6 @@ Whether to include Tiered Storage as a special remote:// directory in `DescribeL
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -1834,8 +1648,6 @@ Enable the Kafka partition reassignment API.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -1848,11 +1660,9 @@ Enable the Kafka partition reassignment API.
 
 Kafka group recovery timeout.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -1870,8 +1680,6 @@ Limit fetch responses to this many bytes, even if the total of partition bytes l
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1885,8 +1693,6 @@ Limit fetch responses to this many bytes, even if the total of partition bytes l
 The size of the batch used to estimate memory consumption for fetch requests, in bytes. Smaller sizes allow more concurrent fetch requests per shard. Larger sizes prevent running out of memory because of too many concurrent fetch requests.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -1902,8 +1708,6 @@ The share of Kafka subsystem memory that can be used for fetch read buffers, as 
 
 *Requires restart:* Yes
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* number
@@ -1918,8 +1722,6 @@ Principal mapping rules for mTLS authentication on the Kafka API. If `null`, the
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Type:* array
@@ -1933,8 +1735,6 @@ Principal mapping rules for mTLS authentication on the Kafka API. If `null`, the
 A list of topics that are protected from deletion and configuration changes by Kafka clients. Set by default to a list of Redpanda internal topics.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -1955,8 +1755,6 @@ A list of topics that are protected from being produced to by Kafka clients. Set
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* array
@@ -1969,9 +1767,7 @@ A list of topics that are protected from being produced to by Kafka clients. Set
 
 Smoothing factor for Kafka queue depth control depth tracking.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1987,9 +1783,7 @@ Update frequency for Kafka queue depth control.
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -2007,8 +1801,6 @@ Enable Kafka queue depth control.
 
 *Requires restart:* Yes
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -2021,9 +1813,7 @@ Enable Kafka queue depth control.
 
 Queue depth when idleness is detected in Kafka queue depth control.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -2037,9 +1827,7 @@ Queue depth when idleness is detected in Kafka queue depth control.
 
 Smoothing parameter for Kafka queue depth control latency tracking.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -2053,9 +1841,7 @@ Smoothing parameter for Kafka queue depth control latency tracking.
 
 Maximum queue depth used in Kafka queue depth control.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -2069,11 +1855,9 @@ Maximum queue depth used in Kafka queue depth control.
 
 Maximum latency threshold for Kafka queue depth control depth tracking.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -2089,9 +1873,7 @@ Maximum latency threshold for Kafka queue depth control depth tracking.
 
 Minimum queue depth used in Kafka queue depth control.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -2105,9 +1887,7 @@ Minimum queue depth used in Kafka queue depth control.
 
 Number of windows used in Kafka queue depth control latency tracking.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -2123,9 +1903,7 @@ Window size for Kafka queue depth control latency tracking.
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -2155,8 +1933,6 @@ If set to `0`, no minimum is enforced.
 * xref:manage:cluster-maintenance/manage-throughput.adoc#node-wide-throughput-limits[Node-wide throughput limits]
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -2188,8 +1964,6 @@ If set to `0.0`, the minimum is disabled. If set to `1.0`, the balancer won't be
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* number
@@ -2202,15 +1976,13 @@ If set to `0.0`, the minimum is disabled. If set to `1.0`, the balancer won't be
 
 ---
 
-=== kafka_quota_balancer_node_period
+=== kafka_quota_balancer_node_period_ms
 
 Intra-node throughput quota balancer invocation period, in milliseconds. When set to 0, the balancer is disabled and makes all the throughput quotas immutable.
 
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -2222,15 +1994,13 @@ Intra-node throughput quota balancer invocation period, in milliseconds. When se
 
 ---
 
-=== kafka_quota_balancer_window
+=== kafka_quota_balancer_window_ms
 
 Time window used to average current throughput measurement for quota balancer, in milliseconds.
 
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -2246,9 +2016,9 @@ Time window used to average current throughput measurement for quota balancer, i
 
 Maximum size of a single request processed using the Kafka API.
 
-*Requires restart:* No
+*Unit:* bytes
 
-*Optional:* Yes
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -2264,9 +2034,9 @@ Maximum size of a single request processed using the Kafka API.
 
 Maximum size of the user-space receive buffer. If `null`, this limit is not applied.
 
-*Requires restart:* No
+*Unit:* bytes
 
-*Optional:* No
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -2280,17 +2050,15 @@ Maximum size of the user-space receive buffer. If `null`, this limit is not appl
 
 Size of the Kafka server TCP receive buffer. If `null`, the property is disabled.
 
-*Unit*: bytes
+*Unit:* bytes
 
-*Requires restart:* No
+*Requires restart:* Yes
 
-*Optional:* No
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
-*Accepted values:* [`-2147483648`, `2147483647`] aligned to 4096 bytes
+*Accepted values:* [`-2147483648`, `2147483647`]
 
 *Default:* `null`
 
@@ -2300,13 +2068,11 @@ Size of the Kafka server TCP receive buffer. If `null`, the property is disabled
 
 Size of the Kafka server TCP transmit buffer. If `null`, the property is disabled.
 
-*Unit*: bytes
+*Unit:* bytes
 
-*Requires restart:* No
+*Requires restart:* Yes
 
-*Optional:* No
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -2326,8 +2092,6 @@ IMPORTANT: If this property is not set (or set to `null`), session expiry is dis
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -2344,8 +2108,6 @@ Per-shard capacity of the cache for validating schema IDs.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -2354,15 +2116,13 @@ Per-shard capacity of the cache for validating schema IDs.
 
 ---
 
-=== kafka_tcp_keepalive_idle_timeout_seconds
+=== kafka_tcp_keepalive_timeout
 
 TCP keepalive idle timeout in seconds for Kafka connections. This describes the timeout between TCP keepalive probes that the remote site successfully acknowledged. Refers to the TCP_KEEPIDLE socket option. When changed, applies to new connections only.
 
 *Unit:* seconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -2382,8 +2142,6 @@ TCP keepalive probe interval in seconds for Kafka connections. This describes th
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -2399,8 +2157,6 @@ TCP keepalive probe interval in seconds for Kafka connections. This describes th
 TCP keepalive unacknowledged probes until the connection is considered dead for Kafka connections. Refers to the TCP_KEEPCNT socket option. When changed, applies to new connections only.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -2431,8 +2187,6 @@ A connection is assigned the first matching group and is then excluded from thro
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* string array
@@ -2453,27 +2207,21 @@ List of Kafka API keys that are subject to cluster-wide and node-wide throughput
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
-*Type:* list<string>
+*Type:* array
 
-*Default:* `["produce", "fetch"]`
+*Default:* `[produce, fetch]`
 
 ---
 
 === kafka_throughput_limit_node_in_bps
 
-The maximum rate of all ingress Kafka API traffic for a node. Includes all Kafka API traffic (requests, responses, headers, fetched data, produced data, etc.).
+The maximum rate of all ingress Kafka API traffic for a node. Includes all Kafka API traffic (requests, responses, headers, fetched data, produced data, etc.). If `null`, the property is disabled, and traffic is not limited.
 
-If `null`, the property is disabled, and traffic is not limited.
-
-*Unit*: bytes per second
+*Unit:* bytes per second
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -2491,15 +2239,11 @@ If `null`, the property is disabled, and traffic is not limited.
 
 === kafka_throughput_limit_node_out_bps
 
-The maximum rate of all egress Kafka traffic for a node. Includes all Kafka API traffic (requests, responses, headers, fetched data, produced data, etc.).
+The maximum rate of all egress Kafka traffic for a node. Includes all Kafka API traffic (requests, responses, headers, fetched data, produced data, etc.). If `null`, the property is disabled, and traffic is not limited.
 
-If `null`, the property is disabled, and traffic is not limited.
-
-*Unit*: bytes per second
+*Unit:* bytes per second
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -2523,8 +2267,6 @@ This threshold is evaluated with each request for data. When the number of token
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -2547,8 +2289,6 @@ WARNING: Disabling this property is not recommended. It causes your Redpanda clu
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -2565,8 +2305,6 @@ Key-value store flush interval (in milliseconds).
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -2581,9 +2319,7 @@ Key-value store flush interval (in milliseconds).
 
 Key-value maximum segment size (in bytes).
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -2600,8 +2336,6 @@ Leadership rebalancing idle timeout.
 *Unit*: milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -2642,8 +2376,6 @@ Leadership rebalancing mute timeout.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -2654,15 +2386,13 @@ Leadership rebalancing mute timeout.
 
 ---
 
-=== leader_balancer_node_mute_timeout
+=== leader_balancer_mute_timeout
 
 Leadership rebalancing node mute timeout.
 
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -2680,8 +2410,6 @@ Per shard limit for in-progress leadership transfers.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -2696,8 +2424,6 @@ Group offset retention is enabled by default starting in Redpanda version 23.1. 
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -2708,13 +2434,9 @@ Group offset retention is enabled by default starting in Redpanda version 23.1. 
 
 === legacy_permit_unsafe_log_operation
 
-Flag to enable a Redpanda cluster operator to use unsafe control characters within strings, such as consumer group names or user names.
-
-This flag applies only for Redpanda clusters that were originally on version 23.1 or earlier and have been upgraded to version 23.2 or later. Starting in version 23.2, newly-created Redpanda clusters ignore this property.
+Flag to enable a Redpanda cluster operator to use unsafe control characters within strings, such as consumer group names or user names. This flag applies only for Redpanda clusters that were originally on version 23.1 or earlier and have been upgraded to version 23.2 or later. Starting in version 23.2, newly-created Redpanda clusters ignore this property.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -2728,15 +2450,11 @@ This flag applies only for Redpanda clusters that were originally on version 23.
 
 === legacy_unsafe_log_warning_interval_sec
 
-Period at which to log a warning about using unsafe strings containing control characters.
+Period at which to log a warning about using unsafe strings containing control characters. If unsafe strings are permitted by `legacy_permit_unsafe_log_operation`, a warning will be logged at an interval specified by this property.
 
-If unsafe strings are permitted by <<legacy_permit_unsafe_log_operation,`legacy_permit_unsafe_log_operation`>>, a warning will be logged at an interval specified by this property.
-
-*Unit*: seconds
+*Unit:* seconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -2772,11 +2490,9 @@ The topic property xref:./topic-properties.adoc#cleanuppolicy[`cleanup.policy`] 
 
 How often to trigger background compaction.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -2794,8 +2510,6 @@ Use sliding window compaction.
 
 *Requires restart:* Yes
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -2812,8 +2526,6 @@ The topic property xref:./topic-properties.adoc#compressiontype[`compression.typ
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Accepted Values:* `gzip`, `snappy`, `lz4`, `zstd`, `producer`, `none`.
@@ -2824,13 +2536,9 @@ The topic property xref:./topic-properties.adoc#compressiontype[`compression.typ
 
 === log_disable_housekeeping_for_tests
 
-Disables the housekeeping loop for local storage. 
-
-IMPORTANT: This property is used to simplify testing, and should not be set in production.
+Disables the housekeeping loop for local storage. This property is used to simplify testing, and should not be set in production.
 
 *Requires restart:* Yes
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -2847,8 +2555,6 @@ Threshold in milliseconds for alerting on messages with a timestamp after the br
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -2867,8 +2573,6 @@ Threshold in milliseconds for alerting on messages with a timestamp before the b
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `tunable`
 
@@ -2902,7 +2606,7 @@ The topic property xref:./topic-properties.adoc#messagetimestamptype[`message.ti
 
 The amount of time to keep a log file before deleting it (in milliseconds). If set to `-1`, no time limit is applied. This is a cluster-wide default when a topic does not set or disable xref:./topic-properties.adoc#retentionms[`retention.ms`].
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
 
@@ -2922,11 +2626,9 @@ Default lifetime of log segments. If `null`, the property is disabled, and no de
 
 The topic property xref:./topic-properties.adoc#segmentms[`segment.ms`] overrides the value of `log_segment_ms` at the topic level.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -2951,8 +2653,6 @@ Upper bound on topic `segment.ms`: higher values will be clamped to this value.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -2971,8 +2671,6 @@ Lower bound on topic `segment.ms`: lower values will be clamped to this value.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -2989,8 +2687,6 @@ Default log segment size in bytes for topics which do not set `segment.bytes`.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -3005,9 +2701,9 @@ Default log segment size in bytes for topics which do not set `segment.bytes`.
 
 Random variation to the segment size limit used for each partition.
 
-*Requires restart:* Yes
+*Unit:* percent
 
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -3025,8 +2721,6 @@ Upper bound on topic `segment.bytes`: higher values will be clamped to this limi
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -3042,8 +2736,6 @@ Upper bound on topic `segment.bytes`: higher values will be clamped to this limi
 Lower bound on topic `segment.bytes`: lower values will be clamped to this limit.
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `tunable`
 
@@ -3061,8 +2753,6 @@ Disable reusable preallocated buffers for LZ4 decompression.
 
 *Requires restart:* Yes
 
-*Nullable:* No
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -3077,8 +2767,6 @@ Maximum compacted segment size after consolidation.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -3089,11 +2777,9 @@ Maximum compacted segment size after consolidation.
 
 === max_concurrent_producer_ids
 
-Maximum number of the active producers sessions. When the threshold is passed, Redpanda terminates old sessions. When an idle producer corresponding to the terminated session wakes up and produces, its message batches are rejected, and an out of order sequence error is emitted. Consumers don't affect this setting. 
+Maximum number of the active producers sessions. When the threshold is passed, Redpanda terminates old sessions. When an idle producer corresponding to the terminated session wakes up and produces, its message batches are rejected, and an out of order sequence error is emitted. Consumers don't affect this setting.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3111,8 +2797,6 @@ Maximum number of in-flight HTTP requests to HTTP Proxy permitted per shard.  An
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -3126,8 +2810,6 @@ Maximum number of in-flight HTTP requests to HTTP Proxy permitted per shard.  An
 Maximum number of in-flight HTTP requests to Schema Registry permitted per shard.  Any additional requests above this limit will be rejected with a 429 error.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3144,8 +2826,6 @@ Fail-safe maximum throttle delay on Kafka requests.
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3165,8 +2845,6 @@ For details, see xref:develop:transactions#transaction-usage-tips[Transaction us
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -3183,9 +2861,7 @@ Time between members backend reconciliation loop retries.
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -3203,8 +2879,6 @@ If `true`, the Redpanda process will terminate immediately when an allocation ca
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -3217,11 +2891,9 @@ If `true`, the Redpanda process will terminate immediately when an allocation ca
 
 Interval for metadata dissemination batching.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -3235,13 +2907,9 @@ Interval for metadata dissemination batching.
 
 === metadata_dissemination_retries
 
-Number of attempts to look up a topic's metadata-like shard before a request fails.
+Number of attempts to look up a topic's metadata-like shard before a request fails. This configuration controls the number of retries that request handlers perform when internal topic metadata (for topics like tx, consumer offsets, etc) is missing. These topics are usually created on demand when users try to use the cluster for the first time and it may take some time for the creation to happen and the metadata to propagate to all the brokers (particularly the broker handling the request). In the mean time Redpanda waits and retry. This configuration controls the number retries.
 
-This configuration controls the number of retries that request handlers perform when internal topic metadata (for topics like tx, consumer offsets, etc) is missing. These topics are usually created on demand when users try to use the cluster for the first time and it may take some time for the creation to happen and the metadata to propagate to all the brokers (particularly the broker handling the request). In the mean time Redpanda waits and retry. This configuration controls the number retries.
-
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -3259,9 +2927,7 @@ Delay before retrying a topic lookup in a shard or other meta tables.
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -3279,9 +2945,7 @@ Maximum time to wait in metadata request for cluster health to be refreshed.
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -3298,10 +2962,7 @@ Maximum time to wait in metadata request for cluster health to be refreshed.
 Cluster metrics reporter report interval.
 
 *Unit:* milliseconds
-
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3321,8 +2982,6 @@ Cluster metrics reporter tick interval.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -3338,8 +2997,6 @@ Cluster metrics reporter tick interval.
 URL of the cluster metrics reporter.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3359,8 +3016,6 @@ If you change the `minimum_topic_replications` setting, the replication factor o
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -3376,8 +3031,6 @@ If you change the `minimum_topic_replications` setting, the replication factor o
 How long after the last heartbeat request a node will wait before considering itself to be isolated.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3395,9 +3048,7 @@ Timeout for executing node management operations.
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -3414,10 +3065,7 @@ Timeout for executing node management operations.
 Time interval between two node status messages. Node status messages establish liveness status outside of the Raft protocol.
 
 *Unit:* milliseconds
-
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3437,8 +3085,6 @@ Maximum backoff (in milliseconds) to reconnect to an unresponsive peer during no
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -3457,8 +3103,6 @@ The amount of time (in seconds) to allow for when validating the expiry claim in
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -3474,8 +3118,6 @@ The amount of time (in seconds) to allow for when validating the expiry claim in
 The URL pointing to the well-known discovery endpoint for the OIDC provider.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -3493,8 +3135,6 @@ The frequency of refreshing the JSON Web Keys (JWKS) used to validate access tok
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -3511,8 +3151,6 @@ Rule for mapping JWT payload claim to a Redpanda user principal.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* string
@@ -3527,8 +3165,6 @@ A string representing the intended recipient of the token.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* string
@@ -3542,8 +3178,6 @@ A string representing the intended recipient of the token.
 Number of partitions that can be reassigned at once.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3562,8 +3196,6 @@ When the disk usage of a node exceeds this threshold, it triggers Redpanda to mo
 *Unit*: percent of disk used
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -3584,8 +3216,6 @@ When the disk usage of a node exceeds this threshold, it triggers Redpanda to mo
 Minimum size of partition that is going to be prioritized when rebalancing a cluster due to the disk size threshold being breached. This value is calculated automatically by default.
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `tunable`
 
@@ -3625,11 +3255,9 @@ NOTE: This property applies only when <<partition_autobalancing_mode,`partition_
 
 When a node is unavailable for at least this timeout duration, it triggers Redpanda to move partitions off of the node.
 
-*Unit*: seconds
+*Unit:* seconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -3649,11 +3277,9 @@ When a node is unavailable for at least this timeout duration, it triggers Redpa
 
 Partition autobalancer tick interval.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3671,8 +3297,6 @@ If the number of scheduled tick moves drops by this ratio, a new tick is schedul
 
 *Requires restart:* No
 
-*Nullable:* No
-
 *Visibility:* `tunable`
 
 *Type:* number
@@ -3685,9 +3309,9 @@ If the number of scheduled tick moves drops by this ratio, a new tick is schedul
 
 If `true`, Redpanda prioritizes balancing a topic’s partition replica count evenly across all brokers while it’s balancing the cluster’s overall partition count. Because different topics in a cluster can have vastly different load profiles, this better distributes the workload of the most heavily-used topics evenly across brokers.
 
-*Requires restart:* no
+*Requires restart:* No
 
-*Optional:* Yes
+*Visibility:* `user`
 
 *Type:* boolean
 
@@ -3707,8 +3331,6 @@ A threshold value to detect partitions which might have been stuck while shuttin
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -3727,8 +3349,6 @@ See https://docs.seastar.io/master/[Seastar documentation^]
 
 *Requires restart:* Yes
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -3743,11 +3363,9 @@ See https://docs.seastar.io/master/[Seastar documentation^]
 
 Quota manager GC frequency in milliseconds.
 
-*Unit*: milliseconds
+*Unit:* seconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -3755,39 +3373,17 @@ Quota manager GC frequency in milliseconds.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `30000` (30s)
+*Default:* `30.0`
 
 ---
 
-=== raft_replica_max_flush_delay_ms
-
-Maximum delay between two subsequent flushes. After this delay, the log is automatically force flushed.
-
-*Unit*: milliseconds
-
-*Requires restart:* No
-
-*Nullable:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `100`
-
----
-
-=== raft_election_timeout_ms
+=== election_timeout_ms
 
 Election timeout expressed in milliseconds.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3805,8 +3401,6 @@ Enables an additional step in leader election where a candidate is allowed to wa
 
 *Requires restart:* No
 
-*Nullable:* No
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -3821,8 +3415,6 @@ Enables Raft optimization of heartbeats.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -3835,9 +3427,7 @@ Enables Raft optimization of heartbeats.
 
 The number of failed heartbeats after which an unresponsive TCP connection is forcibly closed. To disable forced disconnection, set to 0.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -3851,11 +3441,9 @@ The number of failed heartbeats after which an unresponsive TCP connection is fo
 
 Number of milliseconds for Raft leader heartbeats.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3869,15 +3457,11 @@ Number of milliseconds for Raft leader heartbeats.
 
 === raft_heartbeat_timeout_ms
 
-Raft heartbeat RPC (remote procedure call) timeout.
+Raft heartbeat RPC (remote procedure call) timeout. Raft uses a heartbeat mechanism to maintain leadership authority and to trigger leader elections. The `raft_heartbeat_interval_ms` is a periodic heartbeat sent by the partition leader to all followers to declare its leadership. If a follower does not receive a heartbeat within the `raft_heartbeat_timeout_ms`, then it triggers an election to choose a new partition leader.
 
-Raft uses a heartbeat mechanism to maintain leadership authority and to trigger leader elections. The `raft_heartbeat_interval_ms` is a periodic heartbeat sent by the partition leader to all followers to assert its leadership. If a follower does not receive a heartbeat within the `raft_heartbeat_timeout_ms`, then it triggers an election to choose a new partition leader. 
-
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3893,11 +3477,9 @@ Raft uses a heartbeat mechanism to maintain leadership authority and to trigger 
 
 Raft I/O timeout.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3911,15 +3493,9 @@ Raft I/O timeout.
 
 === raft_learner_recovery_rate
 
-Raft learner recovery rate limit. Throttles the rate of data communicated to nodes (learners) that need to catch up to leaders.
-
-This rate limit is placed on a node sending data to a recovering node. Each sending node is limited to this rate. The recovering node accepts data as fast as possible according to the combined limits of all healthy nodes in the cluster. For example, if two nodes are sending data to the recovering node, and `raft_learner_recovery_rate` is 100 MB/sec, then the recovering node will recover at a rate of 200 MB/sec.
-
-*Unit*: bytes per second.
+Raft learner recovery rate limit. Throttles the rate of data communicated to nodes (learners) that need to catch up to leaders. This rate limit is placed on a node sending data to a recovering node. Each sending node is limited to this rate. The recovering node accepts data as fast as possible according to the combined limits of all healthy nodes in the cluster. For example, if two nodes are sending data to the recovering node, and `raft_learner_recovery_rate` is 100 MB/sec, then the recovering node will recover at a rate of 200 MB/sec.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -3933,9 +3509,7 @@ This rate limit is placed on a node sending data to a recovering node. Each send
 
 Maximum number of concurrent append entry requests sent by the leader to one follower.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -3953,8 +3527,6 @@ Maximum memory that can be used for reads in Raft recovery process by default 15
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -3969,8 +3541,6 @@ Number of partitions that may simultaneously recover data to a particular shard.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -3984,8 +3554,6 @@ Number of partitions that may simultaneously recover data to a particular shard.
 Specifies the default size of a read issued during Raft follower recovery.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -4003,8 +3571,6 @@ Disables cross shard sharing used to throttle recovery traffic. Should only be u
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -4017,9 +3583,9 @@ Disables cross shard sharing used to throttle recovery traffic. Should only be u
 
 Maximum number of bytes that are not flushed per partition. If the configured threshold is reached, the log is automatically flushed even if it has not been explicitly requested.
 
-*Requires restart:* No
+*Unit:* bytes
 
-*Optional:* No
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -4033,9 +3599,7 @@ Maximum number of bytes that are not flushed per partition. If the configured th
 
 Maximum size of requests cached for replication.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -4050,10 +3614,7 @@ Maximum size of requests cached for replication.
 Maximum number of Cross-core(Inter-shard communication) requests pending in Raft seastar::smp group. For details, refer to the `seastar::smp_service_group` documentation).
 
 See https://docs.seastar.io/master/[Seastar documentation^]
-
-*Requires restart:* No
-
-*Optional:* No
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -4073,8 +3634,6 @@ Timeout for Raft's timeout_now RPC. This RPC is used to force a follower to disp
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4093,8 +3652,6 @@ Follower recovery timeout waiting period when transferring leadership.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4111,9 +3668,7 @@ Duration after which inactive readers are evicted from cache.
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -4131,8 +3686,6 @@ Maximum desired number of readers cached per NTP. This a soft limit, meaning tha
 
 *Requires restart:* No
 
-*Nullable:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4145,9 +3698,7 @@ Maximum desired number of readers cached per NTP. This a soft limit, meaning tha
 
 Minimum amount of free memory maintained by the batch cache background reclaimer.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -4163,9 +3714,7 @@ Starting from the last point in time when memory was reclaimed from the batch ca
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -4181,9 +3730,7 @@ Starting from the last point in time when memory was reclaimed from the batch ca
 
 Maximum batch cache reclaim size.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -4197,9 +3744,7 @@ Maximum batch cache reclaim size.
 
 Minimum batch cache reclaim size.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -4215,9 +3760,7 @@ If the duration since the last time memory was reclaimed is longer than the amou
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -4235,9 +3778,7 @@ Timeout for append entry requests issued while updating a stale follower.
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -4255,8 +3796,6 @@ Flag for specifying whether or not to release cache when a full segment is rolle
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -4269,9 +3808,9 @@ Flag for specifying whether or not to release cache when a full segment is rolle
 
 Timeout for append entry requests issued while replicating entries.
 
-*Requires restart:* No
+*Unit:* milliseconds
 
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -4279,7 +3818,7 @@ Timeout for append entry requests issued while replicating entries.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `300`
+*Default:* `3000`
 
 ---
 
@@ -4293,8 +3832,6 @@ The topic property xref:./topic-properties.adoc#retentionbytes[`retention.bytes`
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -4305,13 +3842,9 @@ The topic property xref:./topic-properties.adoc#retentionbytes[`retention.bytes`
 
 === retention_local_strict
 
-Flag to allow Tiered Storage topics to expand to consumable retention policy limits.
-
-When this flag is enabled, non-local retention settings are used, and local retention settings are used to inform data removal policies in low-disk space scenarios.
+Flag to allow Tiered Storage topics to expand to consumable retention policy limits. When this flag is enabled, non-local retention settings are used, and local retention settings are used to inform data removal policies in low-disk space scenarios.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -4326,8 +3859,6 @@ When this flag is enabled, non-local retention settings are used, and local rete
 Trim log data when a cloud topic reaches its local retention limit. When this option is disabled Redpanda will allow partitions to grow past the local retention limit, and will be trimmed automatically as storage reaches the configured target size.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -4353,8 +3884,6 @@ NOTE: Both `retention_local_target_bytes_default` and `retention_local_target_ms
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -4372,8 +3901,6 @@ NOTE: Redpanda Data recommends setting only one of <<retention_local_target_capa
 *Unit*: percentage of total disk size
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -4394,8 +3921,6 @@ NOTE: Redpanda Data recommends setting only one of <<retention_local_target_capa
 *Unit*: percentage of total disk size
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -4421,8 +3946,6 @@ NOTE: Both <<retention_local_target_bytes_default,`retention_local_target_bytes_
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* integer
@@ -4441,8 +3964,6 @@ The period during which disk usage is checked for disk pressure, and data is opt
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4459,8 +3980,6 @@ The space management control loop reclaims the overage multiplied by this this c
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* number
@@ -4473,11 +3992,9 @@ The space management control loop reclaims the overage multiplied by this this c
 
 Resource manager's synchronization timeout. Specifies the maximum time for this node to wait for the internal state machine to catch up with all events written by previous leaders before rejecting a request.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -4493,11 +4010,9 @@ Resource manager's synchronization timeout. Specifies the maximum time for this 
 
 The maximum number of connections a broker will open to each of its peers.
 
-*Requires restart:* No
+*Requires restart:* Yes
 
-*Optional:* Yes
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -4513,8 +4028,6 @@ Enable compression for internal RPC (remote procedure call) server replies.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -4528,10 +4041,7 @@ Enable compression for internal RPC (remote procedure call) server replies.
 Maximum TCP connection queue length for Kafka server and internal RPC server. If `null` (the default value), no queue length is set.
 
 *Unit*: number of queue entries
-
-*Requires restart:* No
-
-*Optional:* No
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -4547,13 +4057,11 @@ Maximum TCP connection queue length for Kafka server and internal RPC server. If
 
 Internal RPC TCP receive buffer size. If `null` (the default value), no buffer size is set by Redpanda.
 
-*Unit*: bytes
+*Unit:* bytes
 
-*Requires restart:* No
+*Requires restart:* Yes
 
-*Optional:* No
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -4567,13 +4075,11 @@ Internal RPC TCP receive buffer size. If `null` (the default value), no buffer s
 
 Internal RPC TCP send buffer size. If `null` (the default value), then no buffer size is set by Redpanda.
 
-*Unit*: bytes
+*Unit:* bytes
 
-*Requires restart:* No
+*Requires restart:* Yes
 
-*Optional:* No
-
-*Visibility:* `None`
+*Visibility:* `user`
 
 *Type:* integer
 
@@ -4589,8 +4095,6 @@ Rate limit for controller ACLs and user's operations.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4604,8 +4108,6 @@ Rate limit for controller ACLs and user's operations.
 Rate limit for controller configuration operations.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -4621,8 +4123,6 @@ Rate limit for controller move operations.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4636,8 +4136,6 @@ Rate limit for controller move operations.
 Rate limit for controller node management operations.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -4653,8 +4151,6 @@ Rate limit for controller topic operations.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4663,13 +4159,11 @@ Rate limit for controller topic operations.
 
 ---
 
-=== sampled_memory_profile
+=== memory_enable_memory_sampling
 
 When `true`, memory allocations are sampled and tracked. A sampled live set of allocations can then be retrieved from the Admin API. Additionally, Redpanda will periodically log the top-n allocation sites.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -4685,8 +4179,6 @@ The location of the Kerberos `krb5.conf` file for Redpanda.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* string
@@ -4699,13 +4191,11 @@ The location of the Kerberos `krb5.conf` file for Redpanda.
 
 The location of the Kerberos keytab file for Redpanda.
 
-*Type*: string
-
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
+
+*Type:* string
 
 *Default:* `/var/lib/redpanda/redpanda.keytab`
 
@@ -4716,8 +4206,6 @@ The location of the Kerberos keytab file for Redpanda.
 The primary of the Kerberos Service Principal Name (SPN) for Redpanda.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -4767,8 +4255,6 @@ Normalize schemas as they are read from the topic on startup.
 
 *Requires restart:* Yes
 
-*Optional:* No
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -4784,8 +4270,6 @@ Maximum delay until buffered data is written.
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -4803,8 +4287,6 @@ Size for segments fallocation.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4819,8 +4301,6 @@ Option to explicitly disable automatic disk space management. If this property w
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -4834,8 +4314,6 @@ Option to explicitly disable automatic disk space management. If this property w
 Maximum parallel logs inspected during space management process.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -4853,8 +4331,6 @@ Maximum parallel segments inspected during space management process.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4871,8 +4347,6 @@ Maximum number of bytes that may be used on each shard by compaction index write
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4888,8 +4362,6 @@ Maximum number of bytes that may be used on each shard by compaction index write
 Maximum number of bytes that may be used on each shard by compaction key-offset maps. Only applies when <<log_compaction_use_sliding_window,`log_compaction_use_sliding_window`>> is set to `true`.
 
 *Requires restart:* Yes
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -4909,8 +4381,6 @@ NOTE: Memory per shard is computed after <<data_transforms_per_core_memory_reser
 
 *Requires restart:* Yes
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* number
@@ -4924,8 +4394,6 @@ NOTE: Memory per shard is computed after <<data_transforms_per_core_memory_reser
 When set, cstore hints are ignored and not used for data access (but are otherwise generated).
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -4975,8 +4443,6 @@ Maximum number of partitions' logs that will be replayed concurrently at startup
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -4991,9 +4457,9 @@ Maximum number of partitions' logs that will be replayed concurrently at startup
 
 Threshold of minimum bytes free space before rejecting producers.
 
-*Requires restart:* No
+*Unit:* bytes
 
-*Optional:* Yes
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -5009,8 +4475,6 @@ Size of each read buffer (one per in-flight read, per log segment).
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -5024,8 +4488,6 @@ Size of each read buffer (one per in-flight read, per log segment).
 How many additional reads to issue ahead of current read location.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -5043,8 +4505,6 @@ The number of segments per partition that the system will attempt to reserve dis
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -5059,9 +4519,9 @@ The number of segments per partition that the system will attempt to reserve dis
 
 Threshold of minimum bytes free space before setting storage space alert.
 
-*Requires restart:* No
+*Unit:* bytes
 
-*Optional:* Yes
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -5075,9 +4535,9 @@ Threshold of minimum bytes free space before setting storage space alert.
 
 Threshold of minimum percent free space before setting storage space alert.
 
-*Requires restart:* No
+*Unit:* percent
 
-*Optional:* Yes
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -5095,8 +4555,6 @@ Requires that an empty file named `.redpanda_data_dir` be present in the xref:re
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -5109,9 +4567,9 @@ Requires that an empty file named `.redpanda_data_dir` be present in the xref:re
 
 Target bytes to replay from disk on startup after clean shutdown: controls frequency of snapshots and checkpoints.
 
-*Requires restart:* No
+*Unit:* bytes
 
-*Optional:* Yes
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -5128,8 +4586,6 @@ Target bytes to replay from disk on startup after clean shutdown: controls frequ
 List of superuser usernames.
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -5161,11 +4617,9 @@ The minimum TLS version that Redpanda clusters support. This property prevents c
 
 Transaction manager's synchronization timeout. Maximum time to wait for internal state machine to catch up before rejecting a request.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -5183,8 +4637,6 @@ Required file handles per partition when creating topics.
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -5201,8 +4653,6 @@ Required memory per partition when creating topics.
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -5216,8 +4666,6 @@ Required memory per partition when creating topics.
 Maximum number of partitions which may be allocated to one shard (CPU core).
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -5235,8 +4683,6 @@ Reserved partition slots on shard (CPU core) 0 on each node.  If this is greater
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -5253,8 +4699,6 @@ Cleanup policy for a transaction coordinator topic.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `user`
 
 *Type:* string array
@@ -5269,11 +4713,9 @@ Cleanup policy for a transaction coordinator topic.
 
 Delete segments older than this age. To ensure transaction state is retained as long as the longest-running transaction, make sure this is no less than <<transactional_id_expiration_ms,`transactional_id_expiration_ms`>>.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -5289,11 +4731,7 @@ Delete segments older than this age. To ensure transaction state is retained as 
 
 The size (in bytes) each log segment should be.
 
-*Unit:* bytes
-
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -5309,9 +4747,9 @@ The size (in bytes) each log segment should be.
 
 Number of partitions for transactions coordinator.
 
-*Requires restart:* No
+*Unit:* number of partitions per topic
 
-*Optional:* Yes
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -5331,8 +4769,6 @@ The maximum allowed timeout for transactions. If a client-requested transaction 
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -5347,11 +4783,9 @@ The maximum allowed timeout for transactions. If a client-requested transaction 
 
 Expiration time of producer IDs. Measured starting from the time of the last write until now for a given ID.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `user`
 
@@ -5367,11 +4801,9 @@ Expiration time of producer IDs. Measured starting from the time of the last wri
 
 Delay before scheduling the next check for timed out transactions.
 
-*Unit*: milliseconds
+*Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -5389,8 +4821,6 @@ Enables delete retention of consumer offsets topic. This is an internal-only con
 
 *Requires restart:* Yes
 
-*Nullable:* No
-
 *Visibility:* `user`
 
 *Type:* boolean
@@ -5406,8 +4836,6 @@ The interval in which all usage stats are written to disk.
 *Unit:* seconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -5425,8 +4853,6 @@ The number of windows to persist in memory and disk.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -5442,8 +4868,6 @@ The width of a usage window, tracking cloud and kafka ingress/egress traffic eac
 *Unit:* seconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -5461,8 +4885,6 @@ Use a separate scheduler group for fetch processing.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* boolean
@@ -5476,8 +4898,6 @@ Use a separate scheduler group for fetch processing.
 Minimum number of active producers per virtual cluster.
 
 *Requires restart:* No
-
-*Nullable:* No
 
 *Visibility:* `tunable`
 
@@ -5539,9 +4959,9 @@ The `write_caching_default` cluster property can be overridden with the xref:top
 
 Size of the zstd decompression workspace.
 
-*Requires restart:* No
+*Unit:* bytes
 
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -5550,3 +4970,4 @@ Size of the zstd decompression workspace.
 *Default:* `8388608`
 
 ---
+

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -770,6 +770,38 @@ The percentage of available memory in the transform subsystem to use for write b
 
 ---
 
+=== debug_bundle_auto_removal_seconds
+
+If set, how long debug bundles are kept in the debug bundle storage directory after they are created. If not set, debug bundles are kept indefinitely.
+
+*Unit:* seconds
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`-17179869184`, `17179869183`]
+
+*Default:* `null`
+
+---
+
+=== debug_bundle_storage_dir
+
+Path to the debug bundle storage directory. Note: Changing this path does not clean up existing debug bundles. If not set, the debug bundle is stored in the Redpanda data directory specified in the redpanda.yaml broker configuration file.
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
+
+---
+
 === debug_load_slice_warning_depth
 
 The recursion depth after which debug logging is enabled automatically for the log reader.
@@ -783,6 +815,18 @@ The recursion depth after which debug logging is enabled automatically for the l
 *Accepted values:* [`0`, `4294967295`]
 
 *Default:* `null`
+
+---
+
+=== default_leaders_preference
+
+Default settings for preferred location of topic partition leaders. It can be either "none" (no preference), or "racks:<rack1>,<rack2>,..." (prefer brokers with rack id from the list).
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Default:* `none`
 
 ---
 
@@ -1147,6 +1191,82 @@ Maximum number of bytes returned in a fetch request.
 
 ---
 
+=== fetch_pid_d_coeff
+
+Derivative coefficient for fetch PID controller.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `0.0`
+
+---
+
+=== fetch_pid_i_coeff
+
+Integral coefficient for fetch PID controller.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `0.01`
+
+---
+
+=== fetch_pid_max_debounce_ms
+
+The maximum debounce time the fetch PID controller will apply, in milliseconds.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `100`
+
+---
+
+=== fetch_pid_p_coeff
+
+Proportional coefficient for fetch PID controller.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `100.0`
+
+---
+
+=== fetch_pid_target_utilization_fraction
+
+A fraction, between 0 and 1, for the target reactor utilization of the fetch scheduling group.
+
+*Unit:* fraction
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `0.2`
+
+---
+
 === fetch_read_strategy
 
 The strategy used to fulfill fetch requests.
@@ -1379,6 +1499,20 @@ A list of supported HTTP authentication mechanisms.
 *Accepted Values:* `BASIC`, `OIDC`
 
 *Default:* `[basic]`
+
+---
+
+=== iceberg_enabled
+
+Enables the translation of topic data into Iceberg tables. Setting iceberg_enabled to true activates the feature at the cluster level, but each topic must also set the redpanda.iceberg.enabled topic-level property to true to use it. If iceberg_enabled is set to false, the feature is disabled for all topics in the cluster, overriding any topic-level settings.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Type:* boolean
+
+*Default:* `false`
 
 ---
 
@@ -4086,6 +4220,20 @@ Internal RPC TCP send buffer size. If `null` (the default value), then no buffer
 *Accepted values:* [`-2147483648`, `2147483647`]
 
 *Default:* `null`
+
+---
+
+=== rpk_path
+
+Path to RPK binary.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* string
+
+*Default:* `/usr/bin/rpk`
 
 ---
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -11,13 +11,11 @@ Object storage properties should only be set if you enable xref:manage:tiered-st
 
 === cloud_storage_access_key
 
-AWS or GCP access key. This access key is part of the credentials that Redpanda requires to authenticate with object storage services for Tiered Storage. This access key is used with the <<cloud_storage_secret_key>> to form the complete credentials required for authentication.
+AWS or GCP access key. This access key is part of the credentials that Redpanda requires to authenticate with object storage services for Tiered Storage. This access key is used with the <<cloud_storage_secret_key,`cloud_storage_secret_key`>> to form the complete credentials required for authentication.
 
-To authenticate using IAM roles, see <<cloud_storage_credentials_source>>.
+To authenticate using IAM roles, see <<cloud_storage_credentials_source,`cloud_storage_credentials_source`>>.
 
 *Requires restart:* Yes
-
-*Optional:* No
 
 *Visibility:* `user`
 
@@ -51,9 +49,7 @@ Optional API endpoint. The only instance in which you must set this value is whe
 
 TLS port override.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -65,13 +61,27 @@ TLS port override.
 
 ---
 
-=== cloud_storage_bucket
+=== cloud_storage_attempt_cluster_restore_on_bootstrap
 
-AWS or GCP bucket that should be used to store data.
+When set to `true`, Redpanda automatically retrieves cluster metadata from a specified object storage bucket at the cluster's first startup. This option is ideal for orchestrated deployments, such as Kubernetes. Ensure any previous cluster linked to the bucket is fully decommissioned to prevent conflicts between Tiered Storage subsystems.
 
-*Requires restart:* No
+*Requires restart:* Yes
 
-*Optional:* No
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_azure_adls_endpoint
+
+Azure Data Lake Storage v2 endpoint override. Use when hierarchical namespaces are enabled on your storage account and you have set up a custom endpoint.
+
+If not set, this is automatically generated using `dfs.core.windows.net` and <<cloud_storage_azure_storage_account,`cloud_storage_azure_storage_account`>>.
+
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -81,18 +91,235 @@ AWS or GCP bucket that should be used to store data.
 
 ---
 
+=== cloud_storage_azure_adls_port
 
-=== cloud_storage_cache_size
+Azure Data Lake Storage v2 port override. See also: <<cloud_storage_azure_adls_endpoint,`cloud_storage_azure_adls_endpoint`>>. Use when hierarchical namespaces are enabled on your storage account and you have set up a custom endpoint.
 
-Maximum size of object storage cache.
+*Requires restart:* Yes
 
-If both this property and <<cloud_storage_cache_size_percent>> are set, Redpanda uses the minimum of the two.
+*Visibility:* `user`
 
-*Units*: bytes
+*Type:* integer
+
+*Accepted values:* [`0`, `65535`]
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_azure_container
+
+The name of the Azure container to use with Tiered Storage. If `null`, the property is disabled.
+
+NOTE: The container must belong to <<cloud_storage_azure_storage_account,`cloud_storage_azure_storage_account`>>.
+
+*Type*: string
+
+*Default*: null
+
+*Restart required*: yes
+
+*Supported versions*: Redpanda v23.1 or later
+
+---
+
+=== cloud_storage_azure_hierarchical_namespace_enabled
+
+Force Redpanda to use or not use an Azure Data Lake Storage (ADLS) Gen2 hierarchical namespace-compliant client in <<cloud_storage_azure_storage_account,`cloud_storage_azure_storage_account`>>. 
+
+When this property is not set, <<cloud_storage_azure_shared_key,`cloud_storage_azure_shared_key`>> must be set, and each broker checks at startup if a hierarchical namespace is enabled. 
+
+When set to `true`, this property disables the check and assumes a hierarchical namespace is enabled. 
+
+When set to `false`, this property disables the check and assumes a hierarchical namespace is not enabled. 
+
+This setting should be used only in emergencies where Redpanda fails to detect the correct a hierarchical namespace status.
+
+*Requires restart:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_azure_managed_identity_id
+
+The managed identity ID to use for access to the Azure storage account. To use Azure managed identities, you must set <<cloud_storage_credentials_source,`cloud_storage_credentials_source`>> to `azure_vm_instance_metadata`. See xref:manage:security/iam-roles.adoc[IAM Roles] for more information on managed identities.
+
+*Type*: string
+
+*Default*: null
+
+*Restart required*: no
+
+*Supported versions*: Redpanda v24.1 or later
+
+---
+
+=== cloud_storage_azure_shared_key
+
+The account access key to be used for Azure Shared Key authentication with the Azure storage account configured by <<cloud_storage_azure_storage_account,`cloud_storage_azure_storage_account`>>.  If `null`, the property is disabled.
+
+NOTE: Redpanda expects this key string to be Base64 encoded.
+
+*Type*: string
+
+*Default*: null
+
+*Restart required*: yes
+
+*Supported versions*: Redpanda v23.1 or later
+
+---
+
+=== cloud_storage_azure_storage_account
+
+The name of the Azure storage account to use with Tiered Storage. If `null`, the property is disabled.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_backend
+
+Optional object storage backend variant used to select API capabilities. If not supplied, this will be inferred from other configuration properties.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Accepted values:* [`unknown`, `aws`, `google_s3_compat`, `azure`, `minio`]
+
+*Default:* `unknown`
+
+---
+
+=== cloud_storage_background_jobs_quota
+
+The total number of requests the object storage background jobs can make during one background housekeeping run. This is a per-shard limit. Adjusting this limit can optimize object storage traffic and impact shard performance.
 
 *Requires restart:* No
 
-*Optional:* Yes
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-2147483648`, `2147483647`]
+
+*Default:* `5000`
+
+---
+
+=== cloud_storage_bucket
+
+AWS or GCP bucket or container that should be used to store data.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_cache_check_interval
+
+Minimum interval between Tiered Storage cache trims, measured in milliseconds. This setting dictates the cooldown period after a cache trim operation before another trim can occur. If a cache fetch operation requests a trim but the interval since the last trim has not yet passed, the trim will be postponed until this cooldown expires. Adjusting this interval helps manage the balance between cache size and retrieval performance.
+
+*Unit:* milliseconds
+
+*Requires restart:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `5000`
+
+---
+
+=== cloud_storage_cache_chunk_size
+
+Size of chunks of segments downloaded into object storage cache. Reduces space usage by only downloading the necessary chunk from a segment.
+
+*Unit:* bytes
+
+*Requires restart:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `18446744073709551615`]
+
+*Default:* `16777216`
+
+---
+
+=== cloud_storage_cache_directory
+
+The directory where the cache archive is stored. This property is mandatory when <<cloud_storage_enabled,`cloud_storage_enabled`>> is set to `true`.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_cache_max_objects
+
+Maximum number of objects that may be held in the Tiered Storage cache.  This applies simultaneously with <<cloud_storage_cache_size,`cloud_storage_cache_size`>>, and whichever limit is hit first will trigger trimming of the cache.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `4294967295`]
+
+*Default:* `100000`
+
+---
+
+=== cloud_storage_cache_num_buckets
+
+Divide the object storage cache across the specified number of buckets. This only works for objects with randomized prefixes. The names are not changed when the value is set to zero.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `4294967295`]
+
+*Default:* `0`
+
+---
+
+=== cloud_storage_cache_size
+
+Maximum size of object storage cache. If both this property and <<cloud_storage_cache_size_percent,cloud_storage_cache_size_percent>> are set, Redpanda uses the minimum of the two.
+
+*Requires restart:* No
 
 *Visibility:* `user`
 
@@ -102,18 +329,139 @@ If both this property and <<cloud_storage_cache_size_percent>> are set, Redpanda
 
 *Default:* `0`
 
-
 ---
 
-=== cloud_storage_cluster_metadata_upload_interval_ms
+=== cloud_storage_cache_size_percent
 
-Time interval to wait between cluster metadata uploads.
+Maximum size of the cloud cache as a percentage of unreserved disk space disk_reservation_percent. The default value for this option is tuned for a shared disk configuration. Consider increasing the value if using a dedicated cache disk. The property <<cloud_storage_cache_size,`cloud_storage_cache_size`>> controls the same limit expressed as a fixed number of bytes. If both `cloud_storage_cache_size` and `cloud_storage_cache_size_percent` are set, Redpanda uses the minimum of the two.
 
-*Units*: milliseconds
+*Unit:* percent
 
 *Requires restart:* No
 
-*Optional:* Yes
+*Visibility:* `user`
+
+*Type:* number
+
+*Default:* `20.0`
+
+---
+
+=== cloud_storage_cache_trim_threshold_percent_objects
+
+Introduced in 24.1.10.
+
+Cache trimming is triggered when the number of objects in the cache reaches this percentage relative to its maximum object count. If unset, the default behavior is to start trimming when the cache is full.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_cache_trim_threshold_percent_size
+
+Introduced in 24.1.10.
+
+Cache trimming is triggered when the cache size reaches this percentage relative to its maximum capacity. If unset, the default behavior is to start trimming when the cache is full.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_cache_trim_walk_concurrency
+
+The maximum number of concurrent tasks launched for traversing the directory structure during cache trimming. A higher number allows cache trimming to run faster but can cause latency spikes due to increased pressure on I/O subsystem and syscall threads.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `65535`]
+
+*Default:* `1`
+
+---
+
+=== cloud_storage_chunk_eviction_strategy
+
+Selects a strategy for evicting unused cache chunks.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Accepted values:* [`eager`, `capped`, `predictive`]
+
+*Default:* `eager`
+
+---
+
+=== cloud_storage_chunk_prefetch
+
+Number of chunks to prefetch ahead of every downloaded chunk. Prefetching additional chunks can enhance read performance by reducing wait times for sequential data access. A value of `0` disables prefetching, relying solely on on-demand downloads. Adjusting this property allows for tuning the balance between improved read performance and increased network and storage I/O.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `65535`]
+
+*Default:* `0`
+
+---
+
+=== cloud_storage_cluster_metadata_num_consumer_groups_per_upload
+
+Number of groups to upload in a single snapshot object during consumer offsets upload. Setting a lower value will mean a larger number of smaller snapshots are uploaded.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Default:* `1000`
+
+---
+
+=== cloud_storage_cluster_metadata_retries
+
+Number of attempts metadata operations may be retried.
+
+*Requires restart:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-32768`, `32767`]
+
+*Default:* `5`
+
+---
+
+=== cloud_storage_cluster_metadata_upload_timeout_ms
+
+Timeout for cluster metadata uploads.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -121,36 +469,368 @@ Time interval to wait between cluster metadata uploads.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `3600000` (1 hour)
+*Default:* `60000`
 
 ---
 
-=== cloud_storage_credentials_source
+=== cloud_storage_credentials_host
 
-The source of credentials used to authenticate to object storage services.
-Required for AWS or GCP authentication with IAM roles.
-
-To authenticate using access keys, see <<cloud_storage_access_key,`cloud_storage_access_key`>>.
-
-*Accepted values*: `config_file`, `aws_instance_metadata`, `sts, gcp_instance_metadata`, `azure_vm_instance_metadata`, `azure_aks_oidc_federation`
+The hostname to connect to for retrieving role based credentials. Derived from <<cloud_storage_credentials_source,`cloud_storage_credentials_source`>> if not set. Only required when using IAM role based access. To authenticate using access keys, see <<cloud_storage_access_key,`cloud_storage_access_key`>>.
 
 *Requires restart:* Yes
 
-*Optional:* Yes
+*Visibility:* `tunable`
 
-*Visibility:* `user`
+*Type:* 
+
+*Accepted values:* [`config_file`, `aws_instance_metadata`, `sts`, `gcp_instance_metadata`, `azure_aks_oidc_federation`, `azure_vm_instance_metadata`]
 
 *Default:* `config_file`
 
 ---
 
-=== cloud_storage_crl_file
+=== cloud_storage_disable_chunk_reads
 
-Path to certificate revocation list for <<cloud_storage_trust_file, `cloud_storage_trust_file`>>.
+Disable chunk reads and switch back to legacy mode where full segments are downloaded. When set to `true`, this option disables the more efficient chunk-based reads, causing Redpanda to download entire segments. This legacy behavior might be useful in specific scenarios where chunk-based fetching is not optimal.
 
 *Requires restart:* No
 
-*Optional:* Yes
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_disable_metadata_consistency_checks
+
+Disable all metadata consistency checks to allow Redpanda to replay logs with inconsistent Tiered Storage metadata. This option should generally remain disabled, except for new clusters.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `true`
+
+---
+
+=== cloud_storage_disable_read_replica_loop_for_tests
+
+Begins the read replica sync loop in topic partitions with Tiered Storage enabled. The property exists to simplify testing and shouldn't be set in production.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_disable_remote_labels_for_tests
+
+If `true`, Redpanda disables remote labels and falls back on the hash-based object naming scheme for new topics. 
+
+CAUTION: This property exists to simplify testing and shouldn't be set in production.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_disable_upload_consistency_checks
+
+Disable all upload consistency checks to allow Redpanda to upload logs with gaps and replicate metadata with consistency violations. Normally, this option should be disabled.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_disable_upload_loop_for_tests
+
+Begins the upload loop in topic partitions with Tiered Storage enabled. The property exists to simplify testing and shouldn't be set in production.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_enable_compacted_topic_reupload
+
+Enable re-uploading data for compacted topics.
+When set to `true`, Redpanda can re-upload data for compacted topics to object storage, ensuring that the most current state of compacted topics is available in the cloud. Disabling this property (`false`) may reduce storage and network overhead but at the risk of not having the latest compacted data state in object storage.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `true`
+
+---
+
+=== cloud_storage_enable_remote_read
+
+Default remote read config value for new topics.
+When set to `true`, new topics are by default configured to allow reading data directly from object storage, facilitating access to older data that might have been offloaded as part of Tiered Storage. With the default set to `false`, remote reads must be explicitly enabled at the topic level.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_enable_remote_write
+
+Default remote write value for new topics.
+When set to `true`, new topics are by default configured to upload data to object storage. With the default set to `false`, remote write must be explicitly enabled at the topic level.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_enable_scrubbing
+
+Enable routine checks (scrubbing) of object storage partitions. The scrubber validates the integrity of data and metadata uploaded to object storage.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_enable_segment_merging
+
+Enables adjacent segment merging. The segments are reuploaded if there is an opportunity for that and if it will improve the performance of Tiered Storage.
+
+*Related topics*: 
+
+* xref:manage:tiered-storage.adoc#object-storage-housekeeping[Object storage housekeeping]
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `true`
+
+---
+
+=== cloud_storage_full_scrub_interval_ms
+
+Interval, in milliseconds, between a final scrub and the next scrub.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `43200000` (12h)
+
+---
+
+=== cloud_storage_garbage_collect_timeout_ms
+
+Timeout for running the cloud storage garbage collection, in milliseconds.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `30000`
+
+---
+
+=== cloud_storage_graceful_transfer_timeout_ms
+
+Time limit on waiting for uploads to complete before a leadership transfer.  If this is `null`, leadership transfers proceed without waiting.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `5000`
+
+---
+
+=== cloud_storage_housekeeping_interval_ms
+
+Interval, in milliseconds, between object storage housekeeping tasks.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `300000`
+
+---
+
+=== cloud_storage_hydrated_chunks_per_segment_ratio
+
+The maximum number of chunks per segment that can be hydrated at a time. Above this number, unused chunks are trimmed.
+
+A segment is divided into chunks. Chunk hydration means downloading the chunk (which is a small part of a full segment) from cloud storage and placing it in the local disk cache. Redpanda periodically removes old, unused chunks from your local disk. This process is called chunk eviction. This property  controls how many chunks can be present for a given segment in local disk at a time, before eviction is triggered, removing the oldest ones from disk. Note that this property is not used for the default eviction strategy which simply removes all unused chunks.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Accepted values:* [`0`, `1`]
+
+*Default:* `0.7`
+
+---
+
+=== cloud_storage_hydration_timeout_ms
+
+Time to wait for a hydration request to be fulfilled. If hydration is not completed within this time, the consumer is notified with a timeout error.
+
+Negative doesn't make sense, but it may not be checked-for/enforced. Large is subjective, but a huge timeout also doesn't make sense. This particular config doesn't have a min/max bounds control, but it probably should to avoid mistakes.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `17592186044415`]
+
+*Default:* `600000`
+
+---
+
+=== cloud_storage_idle_threshold_rps
+
+The object storage request rate threshold for idle state detection. If the average request rate for the configured period is lower than this threshold, the object storage is considered idle.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* number
+
+*Default:* `10.0`
+
+---
+
+=== cloud_storage_idle_timeout_ms
+
+The timeout, in milliseconds, used to detect the idle state of the object storage API. If the average object storage request rate is below this threshold for a configured amount of time, the object storage is considered idle and the housekeeping jobs are started.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `10000`
+
+---
+
+=== cloud_storage_initial_backoff_ms
+
+Initial backoff time for exponential backoff algorithm (ms).
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `100`
+
+---
+
+=== cloud_storage_inventory_based_scrub_enabled
+
+Scrubber uses the latest cloud storage inventory report, if available, to check if the required objects exist in the bucket or container.
+
+*Requires restart:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_inventory_hash_path_directory
+
+Directory to store inventory report hashes for use by cloud storage scrubber.
+
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -160,43 +840,77 @@ Path to certificate revocation list for <<cloud_storage_trust_file, `cloud_stora
 
 ---
 
-=== cloud_storage_disable_archiver_manager
+=== cloud_storage_inventory_id
 
-Use legacy upload mode and do not start archiver_manager.
+The name of the scheduled inventory job created by Redpanda to generate bucket or container inventory reports.
 
 *Requires restart:* Yes
 
-*Optional:* No
+*Visibility:* `tunable`
 
-*Visibility:* `user`
+*Type:* string
 
-*Type:* boolean
-
-*Default:* `true`
+*Default:* `redpanda_scrubber_inventory`
 
 ---
 
-=== cloud_storage_disable_tls
+=== cloud_storage_inventory_max_hash_size_during_parse
 
-Disable TLS for all object storage connections.
+Maximum bytes of hashes held in memory before writing data to disk during inventory report parsing. This affects the number of files written to disk during inventory report parsing. When this limit is reached, new files are written to disk.
 
-*Type*: boolean
-
-*Default*: false
-
-*Restart required*: yes
-
----
-
-=== cloud_storage_enabled
-
-Enable object storage. Must be set to `true` to use Tiered Storage or Remote Read Replicas.
+*Unit:* bytes
 
 *Requires restart:* No
 
-*Optional:* Yes
+*Visibility:* `tunable`
 
-*Visibility:* `user`
+*Type:* integer
+
+*Accepted values:* [`0`, `18446744073709551615`]
+
+*Default:* `67108864`
+
+---
+
+=== cloud_storage_inventory_report_check_interval_ms
+
+Time interval between checks for a new inventory report in the cloud storage bucket or container.
+
+*Unit:* milliseconds
+
+*Requires restart:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `21600000` (6h)
+
+---
+
+=== cloud_storage_inventory_reports_prefix
+
+The prefix to the path in the cloud storage bucket or container where inventory reports will be placed.
+
+*Requires restart:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* string
+
+*Default:* `redpanda_scrubber_inventory`
+
+---
+
+=== cloud_storage_inventory_self_managed_report_config
+
+If enabled, Redpanda will not attempt to create the scheduled report configuration using cloud storage APIs. The scrubbing process will look for reports in the expected paths in the bucket or container, and use the latest report found. Primarily intended for use in testing and on backends where scheduled inventory reports are not supported.
+
+*Requires restart:* Yes
+
+*Visibility:* `tunable`
 
 *Type:* boolean
 
@@ -204,23 +918,256 @@ Enable object storage. Must be set to `true` to use Tiered Storage or Remote Rea
 
 ---
 
-=== cloud_storage_max_connections
+=== cloud_storage_manifest_cache_size
 
-Maximum simultaneous object storage connections per shard, applicable to upload and download activities.
+Amount of memory that can be used to handle Tiered Storage metadata.
 
-*Units*: number of simultaneous connections
+*Unit:* bytes
 
 *Requires restart:* No
 
-*Optional:* Yes
-
-*Visibility:* `user`
+*Visibility:* `tunable`
 
 *Type:* integer
 
-*Accepted values:* [`-32768`, `32767`]
+*Default:* `1048576`
 
-*Default:* `20`
+---
+
+=== cloud_storage_materialized_manifest_ttl_ms
+
+The interval, in milliseconds, determines how long the materialized manifest can stay in the cache under contention. This setting is used for performance tuning. When the spillover manifest is materialized and stored in the cache, and the cache needs to evict it, it uses this value as a timeout. The cursor that uses the spillover manifest uses this value as a TTL interval, after which it stops referencing the manifest making it available for eviction. This only affects spillover manifests under contention.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `10000`
+
+---
+
+=== cloud_storage_manifest_max_upload_interval_sec
+
+Minimum interval, in seconds, between partition manifest uploads. Actual time between uploads may be greater than this interval. If this is `null`, metadata is updated after each segment upload.
+
+*Unit:* seconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17179869184`, `17179869183`]
+
+*Default:* `60`
+
+---
+
+=== cloud_storage_manifest_upload_timeout_ms
+
+Manifest upload timeout, in milliseconds.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `10000`
+
+---
+
+=== cloud_storage_max_concurrent_hydrations_per_shard
+
+Maximum concurrent segment hydrations of remote data per CPU core.  If unset, value of `cloud_storage_max_connections / 2` is used, which means that half of available object storage bandwidth could be used to download data from object storage. If the cloud storage cache is empty every new segment reader will require a download. This will lead to 1:1 mapping between number of partitions scanned by the fetch request and number of parallel downloads. If this value is too large the downloads can affect other workloads. In case of any problem caused by the tiered-storage reads this value can be lowered. This will only affect segment hydrations (downloads) but won't affect cached segments. If fetch request is reading from the tiered-storage cache its concurrency will only be limited by available memory.
+
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `4294967295`]
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_max_connection_idle_time_ms
+
+Defines the maximum duration an HTTPS connection to object storage can stay idle, in milliseconds, before being terminated.
+This setting reduces resource utilization by closing inactive connections. Adjust this property to balance keeping connections ready for subsequent requests and freeing resources associated with idle connections. 
+
+*Unit:* milliseconds
+
+*Requires restart:* Yes
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `5000`
+
+---
+
+=== cloud_storage_max_segment_readers_per_shard
+
+Maximum concurrent I/O cursors of materialized remote segments per CPU core.  If unset, the value of `topic_partitions_per_shard` is used, where one segment reader per partition is used if the shard is at its maximum partition capacity.  These readers are cached across Kafka consume requests and store a readahead buffer.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `4294967295`]
+
+*Default:* `null`
+
+---
+
+=== cloud_storage_max_segments_pending_deletion_per_partition
+
+The per-partition limit for the number of segments pending deletion from the cloud. Segments can be deleted due to retention or compaction. If this limit is breached and deletion fails, then segments are orphaned in the cloud and must be removed manually.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Default:* `5000`
+
+---
+
+=== cloud_storage_max_throughput_per_shard
+
+Maximum bandwidth allocated to Tiered Storage operations per shard, in bytes per second.
+This setting limits the Tiered Storage subsystem's throughput per shard, facilitating precise control over bandwidth usage in testing scenarios. In production environments, use `cloud_storage_throughput_limit_percent` for more dynamic throughput management based on actual storage capabilities.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Default:* `1073741824`
+
+---
+
+=== cloud_storage_metadata_sync_timeout_ms
+
+Timeout for xref:manage:tiered-storage.adoc[] metadata synchronization.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `10000`
+
+---
+
+=== cloud_storage_min_chunks_per_segment_threshold
+
+The minimum number of chunks per segment for trimming to be enabled. If the number of chunks in a segment is below this threshold, the segment is small enough that all chunks in it can be hydrated at any given time.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `18446744073709551615`]
+
+*Default:* `5`
+
+---
+
+=== cloud_storage_partial_scrub_interval_ms
+
+Time interval between two partial scrubs of the same partition.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `3600000` (1h)
+
+---
+
+=== cloud_storage_readreplica_manifest_sync_timeout_ms
+
+Timeout to check if new data is available for partitions in object storage for read replicas.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `30000`
+
+---
+
+=== cloud_storage_recovery_temporary_retention_bytes_default
+
+Retention in bytes for topics created during automated recovery.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Default:* `1073741824`
+
+---
+
+=== cloud_storage_recovery_topic_validation_depth
+
+Number of metadata segments to validate, from newest to oldest, when <<cloud_storage_recovery_topic_validation_mode,`cloud_storage_recovery_topic_validation_mode`>> is set to `check_manifest_and_segment_metadata`.
+
+*Requires restart:* No
+
+*Required:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `4294967295`]
+
+*Default:* `10`
 
 ---
 
@@ -269,1268 +1216,27 @@ ERROR ... ... - Stopping recovery of {<namespace/topic>} due to validation error
 
 ---
 
-=== cloud_storage_recovery_topic_validation_depth
-
-Number of metadata segments to validate, from newest to oldest, when <<cloud_storage_recovery_topic_validation_mode,`cloud_storage_recovery_topic_validation_mode`>> is set to `check_manifest_and_segment_metadata`.
-
-*Requires restart:* No
-
-*Required:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `4294967295`]
-
-*Default:* `10`
-
----
-
 === cloud_storage_region
 
-AWS or GCP region that houses the bucket or container used for storage.
+Cloud provider region that houses the bucket or container used for storage.
 
-*Requires restart:* No
-
-*Optional:* No
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
 *Type:* string
 
 *Default:* `null`
-
----
-
-=== cloud_storage_secret_key
-
-AWS or GCP secret key.
-
-*Requires restart:* Yes
-
-*Optional:* No
-
-*Visibility:* `user`
-
-*Type:* string
-
-*Default:* `null`
-
----
-
-=== cloud_storage_trust_file
-
-Path to certificate that should be used to validate server certificate during TLS handshake.
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `user`
-
-*Type:* string
-
-*Default:* `null`
-
----
-
-=== cloud_storage_attempt_cluster_restore_on_bootstrap
-
-When set to `true`, Redpanda automatically retrieves cluster metadata from a specified object storage bucket at the cluster's first startup. This option is ideal for orchestrated deployments, such as Kubernetes. Ensure any previous cluster linked to the bucket is fully decommissioned to prevent conflicts between Tiered Storage subsystems.
-
-*Requires restart:* Yes
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_azure_adls_endpoint
-
-Azure Data Lake Storage v2 endpoint override. Use when hierarchical namespaces are enabled on your storage account and you have set up a custom endpoint.
-
-If not set, this is automatically generated using `dfs.core.windows.net` and <<cloud_storage_azure_storage_account,`cloud_storage_azure_storage_account`>>.
-
-*Requires restart:* Yes
-
-*Optional:* Yes (if not using a custom domain)
-
-*Visibility:* `user`
-
-*Type:* string
-
-*Default:* `null`
-
----
-
-=== cloud_storage_azure_adls_port
-
-Azure Data Lake Storage v2 port override. See also: <<cloud_storage_azure_adls_endpoint,`cloud_storage_azure_adls_endpoint`>>. Use when hierarchical namespaces are enabled on your storage account and you have set up a custom endpoint.
-
-*Requires restart:* Yes
-
-*Optional:* No
-
-*Visibility:* `user`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `65535`]
-
-*Default:* `null`
-
----
-
-=== cloud_storage_azure_container
-
-The name of the Azure container to use with Tiered Storage. If `null`, the property is disabled.
-
-NOTE: The container must belong to <<cloud_storage_azure_storage_account,`cloud_storage_azure_storage_account`>>.
-
-*Type*: string
-
-*Default*: null
-
-*Restart required*: yes
-
-*Supported versions*: Redpanda v23.1 or later
-
----
-
-=== cloud_storage_azure_hierarchical_namespace_enabled
-
-Force Redpanda to use or not use an Azure Data Lake Storage (ADLS) Gen2 hierarchical namespace-compliant client in <<cloud_storage_azure_storage_account,`cloud_storage_azure_storage_account`>>. 
-
-When this property is not set, <<cloud_storage_azure_shared_key,`cloud_storage_azure_shared_key`>> must be set, and each broker checks at startup if a hierarchical namespace is enabled. 
-
-When set to `true`, this property disables the check and assumes a hierarchical namespace is enabled. 
-
-When set to `false`, this property disables the check and assumes a hierarchical namespace is not enabled. 
-
-This setting should be used only in emergencies where Redpanda fails to detect the correct a hierarchical namespace status.
-
-*Requires restart:* Yes
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `null`
-
----
-
-=== cloud_storage_azure_managed_identity_id
-
-The managed identity ID to use for access to the Azure storage account. To use Azure managed identities, you must set <<cloud_storage_credentials_source,`cloud_storage_credentials_source`>> to `azure_vm_instance_metadata`. See xref:manage:security/iam-roles.adoc[IAM Roles] for more information on managed identities.
-
-*Type*: string
-
-*Default*: null
-
-*Restart required*: no
-
-*Supported versions*: Redpanda v24.1 or later
-
----
-
-=== cloud_storage_azure_shared_key
-
-The account access key to be used for Azure Shared Key authentication with the Azure storage account configured by <<cloud_storage_azure_storage_account,`cloud_storage_azure_storage_account`>>.  If `null`, the property is disabled.
-
-NOTE: Redpanda expects this key string to be Base64 encoded.
-
-*Type*: string
-
-*Default*: null
-
-*Restart required*: yes
-
-*Supported versions*: Redpanda v23.1 or later
-
----
-
-=== cloud_storage_azure_storage_account
-
-The name of the Azure storage account to use with Tiered Storage. If `null`, the property is disabled.
-
-*Requires restart:* Yes
-
-*Optional:* No
-
-*Visibility:* `user`
-
-*Type:* string
-
-*Default:* `null`
-
----
-
-=== cloud_storage_backend
-
-Optional object storage backend variant used to select API capabilities. If not supplied, this will be inferred from other configuration properties.
-
-*Requires restart:* Yes
-
-*Optional:* Yes
-
-*Visibility:* `user`
-
-*Accepted values:* [`unknown`, `aws`, `google_s3_compat`, `azure`, `minio`]
-
-*Default:* `unknown`
-
----
-
-=== cloud_storage_background_jobs_quota
-
-The total number of requests the object storage background jobs can make during one background housekeeping run. This is a per-shard limit. Adjusting this limit can optimize object storage traffic and impact shard performance.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-2147483648`, `2147483647`]
-
-*Default:* `5000`
-
----
-
-=== cloud_storage_cache_check_interval_ms
-
-Minimum interval between Tiered Storage cache trims, measured in milliseconds.
-This setting dictates the cooldown period after a cache trim operation before another trim can occur. If a cache fetch operation requests a trim but the interval since the last trim has not yet passed, the trim will be postponed until this cooldown expires. Adjusting this interval helps manage the balance between cache size and retrieval performance.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `5000`
-
----
-
-=== cloud_storage_cache_chunk_size
-
-Size of chunks of segments downloaded into object storage cache. Reduces space usage by only downloading the necessary chunk from a segment.
-
-*Unit:* bytes
-
-*Requires restart:* Yes
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `18446744073709551615`]
-
-*Default:* `16777216`
-
----
-
-=== cloud_storage_cache_directory
-
-The directory where the cache archive is stored. This property is mandatory when <<cloud_storage_enabled,`cloud_storage_enabled`>> is set to `true`.
-
-*Requires restart:* Yes
-
-*Optional:* No
-
-*Visibility:* `user`
-
-*Type:* string
-
-*Default:* `null`
-
----
-
-=== cloud_storage_cache_max_objects
-
-Maximum number of objects that may be held in the Tiered Storage cache.  This applies simultaneously with <<cloud_storage_cache_size>>, and whichever limit is hit first will trigger trimming of the cache.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `4294967295`]
-
-*Default:* `100000`
-
----
-
-=== cloud_storage_cache_num_buckets
-
-Divide the object storage cache across the specified number of buckets. This only works for objects with randomized prefixes. The names are not changed when the value is set to zero.
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `4294967295`]
-
-*Default:* `0`
-
----
-
-=== cloud_storage_cache_size_percent
-
-Maximum size of the cloud cache as a percentage of unreserved disk space (see config_ref:disk_reservation_percent,true,cluster-properties[]). The default value for this option is tuned for a shared disk configuration. Consider increasing the value if using a dedicated cache disk.
-
-The property <<cloud_storage_cache_size,`cloud_storage_cache_size`>> controls the same limit expressed as a fixed number of bytes. If both `cloud_storage_cache_size` and `cloud_storage_cache_size_percent` are set, Redpanda uses the minimum of the two.
-
-*Units*: percentage of total disk size.
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `user`
-
-*Type:* number
-
-*Default:* `20.0`
-
----
-
-=== cloud_storage_cache_trim_threshold_percent_objects
-
-Introduced in 24.1.10.
-
-Cache trimming is triggered when the number of objects in the cache reaches this percentage relative to its maximum object count. If unset, the default behavior is to start trimming when the cache is full.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* number
-
-*Default:* `null`
-
----
-
-=== cloud_storage_cache_trim_threshold_percent_size
-
-Introduced in 24.1.10.
-
-Cache trimming is triggered when the cache size reaches this percentage relative to its maximum capacity. If unset, the default behavior is to start trimming when the cache is full.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* number
-
-*Default:* `null`
-
----
-
-=== cloud_storage_cache_trim_walk_concurrency
-
-The maximum number of concurrent tasks launched for traversing the directory structure during cache trimming. A higher number allows cache trimming to run faster but can cause latency spikes due to increased pressure on I/O subsystem and syscall threads.
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `65535`]
-
-*Default:* `1`
-
----
-
-=== cloud_storage_chunk_eviction_strategy
-
-Selects a strategy for evicting unused cache chunks.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Accepted values:* [`eager`, `capped`, `predictive`]
-
-*Default:* `eager`
-
----
-
-=== cloud_storage_chunk_prefetch
-
-Number of chunks to prefetch ahead of every downloaded chunk. Prefetching additional chunks can enhance read performance by reducing wait times for sequential data access. A value of `0` disables prefetching, relying solely on on-demand downloads. Adjusting this property allows for tuning the balance between improved read performance and increased network and storage I/O.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `65535`]
-
-*Default:* `0`
-
----
-
-=== cloud_storage_cluster_metadata_num_consumer_groups_per_upload
-
-Number of groups to upload in a single snapshot object during consumer offsets upload. Setting a lower value means a larger number of smaller snapshots are uploaded.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Default:* `1000`
-
----
-
-=== cloud_storage_cluster_metadata_retries
-
-Number of attempts metadata operations may be retried.
-
-*Requires restart:* Yes
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-32768`, `32767`]
-
-*Default:* `5`
-
----
-
-=== cloud_storage_cluster_metadata_upload_timeout_ms
-
-Timeout for cluster metadata uploads.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `60000`
-
----
-
-=== cloud_storage_credentials_host
-
-The hostname to connect to for retrieving role based credentials. Derived from <<cloud_storage_credentials_source>> if not set. Only required when using IAM role-based access.
-
-*Requires restart:* Yes
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* 
-
-*Accepted values:* [`config_file`, `aws_instance_metadata`, `sts`, `gcp_instance_metadata`, `azure_aks_oidc_federation`, `azure_vm_instance_metadata`]
-
-*Default:* `config_file`
-
----
-
-=== cloud_storage_disable_chunk_reads
-
-Disable chunk reads and switch back to legacy mode where full segments are downloaded. When set to `true`, this option disables the more efficient chunk-based reads, causing Redpanda to download entire segments. This legacy behavior might be useful in specific scenarios where chunk-based fetching is not optimal.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_disable_metadata_consistency_checks
-
-Disable all metadata consistency checks to allow Redpanda to replay logs with inconsistent Tiered Storage metadata. This option should generally remain disabled, except for new clusters.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `true`
-
----
-
-=== cloud_storage_disable_read_replica_loop_for_tests
-
-Begins the read replica sync loop in topic partitions with Tiered Storage enabled. The property exists to simplify testing and shouldn't be set in production.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_disable_remote_labels_for_tests
-
-If `true`, Redpanda disables remote labels and falls back on the hash-based object naming scheme for new topics. 
-
-CAUTION: This property exists to simplify testing and shouldn't be set in production.
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_disable_upload_consistency_checks
-
-Disable all upload consistency checks to allow Redpanda to upload logs with gaps and replicate metadata with consistency violations. Normally, this option should be disabled.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_disable_upload_loop_for_tests
-
-Begins the upload loop in topic partitions with Tiered Storage enabled. The property exists to simplify testing and shouldn't be set in production.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_enable_compacted_topic_reupload
-
-Enable re-uploading data for compacted topics.
-When set to `true`, Redpanda can re-upload data for compacted topics to object storage, ensuring that the most current state of compacted topics is available in the cloud. Disabling this property (`false`) may reduce storage and network overhead but at the risk of not having the latest compacted data state in object storage.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `true`
-
----
-
-=== cloud_storage_enable_remote_read
-
-Default remote read config value for new topics.
-When set to `true`, new topics are by default configured to allow reading data directly from object storage, facilitating access to older data that might have been offloaded as part of Tiered Storage. With the default set to `false`, remote reads must be explicitly enabled at the topic level.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_enable_remote_write
-
-Default remote write value for new topics.
-When set to `true`, new topics are by default configured to upload data to object storage. With the default set to `false`, remote write must be explicitly enabled at the topic level.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_enable_scrubbing
-
-Enable routine checks (scrubbing) of object storage partitions. The scrubber validates the integrity of data and metadata uploaded to object storage.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_enable_segment_merging
-
-Enables adjacent segment merging. The segments are reuploaded if there is an opportunity for that and if it will improve the performance of Tiered Storage.
-
-*Related topics*: 
-
-* xref:manage:tiered-storage.adoc#object-storage-housekeeping[Object storage housekeeping]
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `true`
-
----
-
-=== cloud_storage_full_scrub_interval_ms
-
-Interval, in milliseconds, between a final scrub and the next scrub.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `4320000000` (12h)
-
----
-
-=== cloud_storage_garbage_collect_timeout_ms
-
-Timeout for running the cloud storage garbage collection, in milliseconds.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `30000`
-
----
-
-=== cloud_storage_graceful_transfer_timeout_ms
-
-Time limit on waiting for uploads to complete before a leadership transfer.  If this is `null`, leadership transfers proceed without waiting.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `5000`
-
----
-
-=== cloud_storage_housekeeping_interval_ms
-
-Interval, in milliseconds, between object storage housekeeping tasks.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `5000`
-
----
-
-=== cloud_storage_hydrated_chunks_per_segment_ratio
-
-The maximum number of chunks per segment that can be hydrated at a time. Above this number, unused chunks are trimmed.
-
-A segment is divided into chunks. Chunk hydration means downloading the chunk (which is a small part of a full segment) from cloud storage and placing it in the local disk cache. Redpanda periodically removes old, unused chunks from your local disk. This process is called chunk eviction. This property  controls how many chunks can be present for a given segment in local disk at a time, before eviction is triggered, removing the oldest ones from disk. Note that this property is not used for the default eviction strategy which simply removes all unused chunks.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* number
-
-*Accepted values:* [`0`, `1`]
-
-*Default:* `0.7`
-
----
-
-=== cloud_storage_hydration_timeout_ms
-
-Time to wait for a hydration request to be fulfilled. If hydration is not completed within this time, the consumer is notified with a timeout error.
-
-Negative doesn't make sense, but it may not be checked-for/enforced. Large is subjective, but a huge timeout also doesn't make sense. This particular config doesn't have a min/max bounds control, but it probably should to avoid mistakes.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `17592186044415`]
-
-*Default:* `600000`
-
----
-
-=== cloud_storage_idle_threshold_rps
-
-The object storage request rate threshold for idle state detection. If the average request rate for the configured period is lower than this threshold, the object storage is considered idle.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* number
-
-*Default:* `10.0`
-
----
-
-=== cloud_storage_idle_timeout_ms
-
-The timeout, in milliseconds, used to detect the idle state of the object storage API. If the average object storage request rate is below this threshold for a configured amount of time, the object storage is considered idle and the housekeeping jobs are started.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `10000`
-
----
-
-=== cloud_storage_initial_backoff_ms
-
-Initial backoff time for exponential backoff algorithm (ms).
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `100`
-
----
-
-=== cloud_storage_inventory_based_scrub_enabled
-
-Scrubber uses the latest cloud storage inventory report, if available, to check if the required objects exist in the bucket or container.
-
-*Requires restart:* Yes
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_inventory_hash_store
-
-Directory to store inventory report hashes for use by cloud storage scrubber.
-
-*Requires restart:* Yes
-
-*Optional:* Yes
-
-*Visibility:* `user`
-
-*Type:* string
-
-*Default:* `null`
-
----
-
-=== cloud_storage_inventory_id
-
-The name of the scheduled inventory job created by Redpanda to generate bucket or container inventory reports.
-
-*Requires restart:* Yes
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* string
-
-*Default:* `redpanda_scrubber_inventory`
-
----
-
-=== cloud_storage_inventory_max_hash_size_during_parse
-
-Maximum bytes of hashes held in memory before writing data to disk during inventory report parsing. This affects the number of files written to disk during inventory report parsing. When this limit is reached, new files are written to disk.
-
-*Unit:* bytes
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `18446744073709551615`]
-
-*Default:* `67108864`
-
----
-
-=== cloud_storage_inventory_report_check_interval_ms
-
-Time interval between checks for a new inventory report in the cloud storage bucket or container.
-
-*Requires restart:* Yes
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `21600000` (6h)
-
----
-
-=== cloud_storage_inventory_reports_prefix
-
-The prefix to the path in the cloud storage bucket or container where inventory reports will be placed.
-
-*Requires restart:* Yes
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* string
-
-*Default:* `redpanda_scrubber_inventory`
-
----
-
-=== cloud_storage_inventory_self_managed_report_config
-
-If enabled, Redpanda will not attempt to create the scheduled report configuration using cloud storage APIs. The scrubbing process will look for reports in the expected paths in the bucket or container, and use the latest report found. Primarily intended for use in testing and on backends where scheduled inventory reports are not supported.
-
-*Requires restart:* Yes
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* boolean
-
-*Default:* `false`
-
----
-
-=== cloud_storage_manifest_cache_size
-
-Amount of memory that can be used to handle Tiered Storage metadata.
-
-*Unit:* bytes
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Default:* `1048576`
-
----
-
-=== cloud_storage_manifest_cache_ttl_ms
-
-The interval, in milliseconds, determines how long the materialized manifest can stay in the cache under contention. This setting is used for performance tuning. When the spillover manifest is materialized and stored in the cache, and the cache needs to evict it, it uses this value as a timeout. The cursor that uses the spillover manifest uses this value as a TTL interval, after which it stops referencing the manifest making it available for eviction. This only affects spillover manifests under contention.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `10000`
-
----
-
-=== cloud_storage_manifest_max_upload_interval_sec
-
-Minimum interval, in seconds, between partition manifest uploads. Actual time between uploads may be greater than this interval. If this is `null`, metadata is updated after each segment upload.
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17179869184`, `17179869183`]
-
-*Default:* `60`
-
----
-
-=== cloud_storage_manifest_upload_timeout_ms
-
-Manifest upload timeout, in milliseconds.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `10000`
-
----
-
-=== cloud_storage_max_concurrent_hydrations_per_shard
-
-Maximum concurrent segment hydrations of remote data per CPU core.  If unset, value of `cloud_storage_max_connections / 2` is used, which means that half of available object storage bandwidth could be used to download data from object storage. If the cloud storage cache is empty every new segment reader will require a download. This will lead to 1:1 mapping between number of partitions scanned by the fetch request and number of parallel downloads. If this value is too large the downloads can affect other workloads. In case of any problem caused by the tiered-storage reads this value can be lowered. This will only affect segment hydrations (downloads) but won't affect cached segments. If fetch request is reading from the tiered-storage cache its concurrency will only be limited by available memory.
-
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `4294967295`]
-
-*Default:* `null`
-
----
-
-=== cloud_storage_max_connection_idle_time_ms
-
-Defines the maximum duration an HTTPS connection to object storage can stay idle, in milliseconds, before being terminated.
-This setting reduces resource utilization by closing inactive connections. Adjust this property to balance keeping connections ready for subsequent requests and freeing resources associated with idle connections. 
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `5000`
-
----
-
-=== cloud_storage_max_segment_readers_per_shard
-
-Maximum concurrent I/O cursors of materialized remote segments per CPU core.  If unset, the value of `topic_partitions_per_shard` is used, where one segment reader per partition is used if the shard is at its maximum partition capacity.  These readers are cached across Kafka consume requests and store a readahead buffer.
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `4294967295`]
-
-*Default:* `null`
-
----
-
-=== cloud_storage_max_segments_pending_deletion_per_partition
-
-The per-partition limit for the number of segments pending deletion from the cloud. Segments can be deleted due to retention or compaction. If this limit is breached and deletion fails, then segments are orphaned in the cloud and must be removed manually.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Default:* `5000`
-
----
-
-=== cloud_storage_max_throughput_per_shard
-
-Maximum bandwidth allocated to Tiered Storage operations per shard, in bytes per second.
-This setting limits the Tiered Storage subsystem's throughput per shard, facilitating precise control over bandwidth usage in testing scenarios. In production environments, use `cloud_storage_throughput_limit_percent` for more dynamic throughput management based on actual storage capabilities.
-
-*Requires restart:* No
-
-*Optional:* No
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Default:* `1073741824`
-
----
-
-=== cloud_storage_metadata_sync_timeout_ms
-
-Timeout for xref:manage:tiered-storage.adoc[] metadata synchronization.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `10000`
-
----
-
-=== cloud_storage_min_chunks_per_segment_threshold
-
-The minimum number of chunks per segment for trimming to be enabled. If the number of chunks in a segment is below this threshold, the segment is small enough that all chunks in it can be hydrated at any given time.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `18446744073709551615`]
-
-*Default:* `5`
-
----
-
-=== cloud_storage_partial_scrub_interval_ms
-
-Time interval between two partial scrubs of the same partition.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `3600000` (1h)
-
----
-
-=== cloud_storage_readreplica_manifest_sync_timeout_ms
-
-Timeout to check if new data is available for partitions in object storage for read replicas.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Accepted values:* [`-17592186044416`, `17592186044415`]
-
-*Default:* `30000`
-
----
-
-=== cloud_storage_recovery_temporary_retention_bytes_default
-
-Retention in bytes for topics created during automated recovery.
-
-*Requires restart:* No
-
-*Optional:* Yes
-
-*Visibility:* `tunable`
-
-*Type:* integer
-
-*Default:* `1073741824`
 
 ---
 
 === cloud_storage_roles_operation_timeout_ms
 
-Timeout for IAM role related operations, in milliseconds.
+Timeout for IAM role related operations (ms).
 
 *Unit:* milliseconds
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1550,8 +1256,6 @@ Jitter applied to the object storage scrubbing interval.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1566,9 +1270,9 @@ Jitter applied to the object storage scrubbing interval.
 
 Time that a segment can be kept locally without uploading it to the object storage, in seconds.
 
-*Requires restart:* No
+*Unit:* seconds
 
-*Optional:* No
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -1586,8 +1290,6 @@ Smallest acceptable segment size in the object storage. Default: `cloud_storage_
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1603,8 +1305,6 @@ Smallest acceptable segment size in the object storage. Default: `cloud_storage_
 Desired segment size in the object storage. The default is set in the topic-level `segment.bytes` property.
 
 *Requires restart:* No
-
-*Optional:* No
 
 *Visibility:* `tunable`
 
@@ -1622,8 +1322,6 @@ Log segment upload timeout, in milliseconds.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1640,8 +1338,6 @@ Maximum number of segments in the spillover manifest that can be offloaded to th
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1656,8 +1352,6 @@ The size of the manifest which can be offloaded to the cloud. If the size of the
 
 *Requires restart:* No
 
-*Optional:* No
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1670,9 +1364,9 @@ The size of the manifest which can be offloaded to the cloud. If the size of the
 
 Maximum throughput used by Tiered Storage per broker expressed as a percentage of the disk bandwidth. If the server has several disks, Redpanda uses the one that stores the Tiered Storage cache. Even if Tiered Storage is allowed to use the full bandwidth of the disk (100%), it won't necessarily use it in full. The actual usage depends on your workload and the state of the Tiered Storage cache. This setting is a safeguard that prevents Tiered Storage from using too many system resources: it is not a performance tuning knob.
 
-*Requires restart:* No
+*Unit:* percent
 
-*Optional:* No
+*Requires restart:* No
 
 *Visibility:* `tunable`
 
@@ -1690,8 +1384,6 @@ Grace period during which the purger refuses to purge the topic.
 
 *Requires restart:* No
 
-*Optional:* Yes
-
 *Visibility:* `tunable`
 
 *Type:* integer
@@ -1706,9 +1398,7 @@ Grace period during which the purger refuses to purge the topic.
 
 Derivative coefficient for upload PID controller.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1722,9 +1412,7 @@ Derivative coefficient for upload PID controller.
 
 Maximum number of I/O and CPU shares that archival upload can use.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1740,9 +1428,7 @@ Maximum number of I/O and CPU shares that archival upload can use.
 
 Minimum number of I/O and CPU shares that archival upload can use.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1758,9 +1444,7 @@ Minimum number of I/O and CPU shares that archival upload can use.
 
 Proportional coefficient for upload PID controller.
 
-*Requires restart:* No
-
-*Optional:* Yes
+*Requires restart:* Yes
 
 *Visibility:* `tunable`
 
@@ -1777,8 +1461,6 @@ Initial backoff interval when there is nothing to upload for a partition, in mil
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -1797,8 +1479,6 @@ Maximum backoff interval when there is nothing to upload for a partition, in mil
 *Unit:* milliseconds
 
 *Requires restart:* No
-
-*Optional:* Yes
 
 *Visibility:* `tunable`
 
@@ -1821,8 +1501,6 @@ If the initial request fails, the client automatically tries the `path` style.
 If neither addressing style works, Redpanda terminates the startup, requiring manual configuration to proceed.
 
 *Requires restart:* Yes
-
-*Optional:* Yes
 
 *Visibility:* `user`
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -455,6 +455,24 @@ Number of attempts metadata operations may be retried.
 
 ---
 
+=== cloud_storage_cluster_metadata_upload_interval_ms
+
+Time interval to wait between cluster metadata uploads.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* integer
+
+*Accepted values:* [`-17592186044416`, `17592186044415`]
+
+*Default:* `3600000`
+
+---
+
 === cloud_storage_cluster_metadata_upload_timeout_ms
 
 Timeout for cluster metadata uploads.
@@ -486,6 +504,37 @@ The hostname to connect to for retrieving role based credentials. Derived from <
 *Accepted values:* [`config_file`, `aws_instance_metadata`, `sts`, `gcp_instance_metadata`, `azure_aks_oidc_federation`, `azure_vm_instance_metadata`]
 
 *Default:* `config_file`
+
+---
+
+=== cloud_storage_credentials_source
+
+The source of credentials used to authenticate to object storage services.
+Required for AWS or GCP authentication with IAM roles.
+
+To authenticate using access keys, see <<cloud_storage_access_key,`cloud_storage_access_key`>>.
+
+*Accepted values*: `config_file`, `aws_instance_metadata`, `sts, gcp_instance_metadata`, `azure_vm_instance_metadata`, `azure_aks_oidc_federation`
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Default:* `config_file`
+
+---
+
+=== cloud_storage_crl_file
+
+Path to certificate revocation list for <<cloud_storage_trust_file, `cloud_storage_trust_file`>>.
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
 
 ---
 
@@ -540,6 +589,20 @@ CAUTION: This property exists to simplify testing and shouldn't be set in produc
 *Requires restart:* No
 
 *Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
+=== cloud_storage_disable_tls
+
+Disable TLS for all object storage connections.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
 
 *Type:* boolean
 
@@ -649,6 +712,20 @@ Enables adjacent segment merging. The segments are reuploaded if there is an opp
 *Type:* boolean
 
 *Default:* `true`
+
+---
+
+=== cloud_storage_enabled
+
+Enable object storage. Must be set to `true` to use Tiered Storage or Remote Read Replicas.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Type:* boolean
+
+*Default:* `false`
 
 ---
 
@@ -1024,6 +1101,22 @@ This setting reduces resource utilization by closing inactive connections. Adjus
 
 ---
 
+=== cloud_storage_max_connections
+
+Maximum simultaneous object storage connections per shard, applicable to upload and download activities.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`-32768`, `32767`]
+
+*Default:* `20`
+
+---
+
 === cloud_storage_max_segment_readers_per_shard
 
 Maximum concurrent I/O cursors of materialized remote segments per CPU core.  If unset, the value of `topic_partitions_per_shard` is used, where one segment reader per partition is used if the shard is at its maximum partition capacity.  These readers are cached across Kafka consume requests and store a readahead buffer.
@@ -1262,7 +1355,21 @@ Jitter applied to the object storage scrubbing interval.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `600000` (10min)
+*Default:* `600000`
+
+---
+
+=== cloud_storage_secret_key
+
+Cloud provider secret key.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
 
 ---
 
@@ -1391,6 +1498,20 @@ Grace period during which the purger refuses to purge the topic.
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
 *Default:* `30000`
+
+---
+
+=== cloud_storage_trust_file
+
+Path to certificate that should be used to validate server certificate during TLS handshake.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
 
 ---
 


### PR DESCRIPTION
## Changelog

### New cluster properties

- debug_bundle_auto_removal_seconds
- debug_bundle_storage_dir
- default_leaders_preference
- fetch_pid_d_coeff (internal)
- fetch_pid_i_coeff (internal)
- fetch_pid_max_debounce_ms (internal)
- fetch_pid_p_coeff (internal)
- fetch_pid_target_utilization_fraction (internal)
- iceberg_enabled
- rpk_path


## Page previews

https://deploy-preview-822--redpanda-docs-preview.netlify.app/24.3/reference/properties/cluster-properties/

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)