### PR TITLE
Fix error in Admin API spec

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -39,8 +39,6 @@ paths:
 
         For the broker configuration properties of the latest Redpanda version, see [Broker Configuration Properties](https://docs.redpanda.com/docs/reference/broker-properties/).
       operationId: get_node_config
-      externalDocs:
-        url: https://docs.redpanda.com/docs/reference/broker-properties/
       responses:
         200:
           description: Brokers' configurations response
@@ -574,9 +572,6 @@ paths:
       operationId: get_enterprise_license_status
       tags:
         - Licenses and Features
-      externalDocs:
-        description: See the Redpanda Licensing guide for more information.
-        url: https://docs.redpanda.com/docs/get-started/licenses/
       responses:
         '200':
           description: The status of the Enterprise Edition license and details about Enterprise features that are in-use in the cluster.

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -867,7 +867,9 @@ paths:
           content: 
             application/json:
               schema:
-                $ref: '#/components/schemas/ntp_with_majority_loss'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ntp_with_majority_loss'
       parameters:
         - name: dead_nodes
           in: query

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -37,13 +37,13 @@ paths:
       description: |
         List the configuration properties of all brokers (nodes) in the cluster.
 
-        For the node configuration properties of the latest Redpanda version, see [Node Configuration Properties](https://docs.redpanda.com/docs/reference/node-properties/).
+        For the broker configuration properties of the latest Redpanda version, see [Broker Configuration Properties](https://docs.redpanda.com/docs/reference/broker-properties/).
       operationId: get_node_config
+      externalDocs:
+        url: https://docs.redpanda.com/docs/reference/broker-properties/
       responses:
         200:
           description: Brokers' configurations response
-          externalDocs:
-            url: https://docs.redpanda.com/docs/reference/node-properties/
           content:
             application/json:
               schema:
@@ -574,11 +574,11 @@ paths:
       operationId: get_enterprise_license_status
       tags:
         - Licenses and Features
+      externalDocs:
+        url: https://docs.redpanda.com/docs/get-started/licenses/
       responses:
         '200':
           description: The status of the Enterprise Edition license and details about Enterprise features that are in-use in the cluster.
-          externalDocs:
-            url: https://docs.redpanda.com/docs/get-started/licenses/
           content:
             application/json:
               schema:

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -863,6 +863,7 @@ paths:
       operationId: majority_lost
       responses: 
         200:
+          description: List of partitions
           content: 
             application/json:
               schema:

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -575,6 +575,7 @@ paths:
       tags:
         - Licenses and Features
       externalDocs:
+        description: See the Redpanda Licensing guide for more information.
         url: https://docs.redpanda.com/docs/get-started/licenses/
       responses:
         '200':


### PR DESCRIPTION
## Description

Fixes error `Property externalDocs is not allowed.`

Resolves https://github.com/redpanda-data/documentation-private/issues/2367
Review deadline: 25 Oct

## Page previews

[Get license and feature status](https://deploy-preview-824--redpanda-docs-preview.netlify.app/api/admin-api/#get-/v1/features/enterprise)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)