### PR TITLE
add tabs for linux | arm64 vs. amd64

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
@@ -501,7 +501,7 @@ kubectl --namespace <namespace> get secret redpanda-external-root-certificate -o
 +
 --
 [loweralpha]
-include::get-started:partial$install-rpk-linux.adoc[]
+include::get-started:partial$install-rpk-linux.adoc[tags=latest]
 --
 
 . Configure `rpk` to connect to your cluster using the xref:manage:kubernetes/networking/k-connect-to-redpanda.adoc#rpk-profile[pre-configured profile]:

--- a/modules/deploy/partials/kubernetes/guides/external-access-steps.adoc
+++ b/modules/deploy/partials/kubernetes/guides/external-access-steps.adoc
@@ -27,7 +27,7 @@ Linux::
 +
 --
 [loweralpha]
-include::get-started:partial$install-rpk-linux.adoc[]
+include::get-started:partial$install-rpk-linux.adoc[tags=latest]
 
 --
 macOS::

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -198,9 +198,8 @@ NOTE: The `rpk` binary is not supported on Windows.
 Linux::
 +
 --
-
 [loweralpha]
-include::get-started:partial$install-rpk-linux.adoc[]
+include::get-started:partial$install-rpk-linux.adoc[tags=latest]
 --
 macOS::
 +

--- a/modules/get-started/partials/install-rpk-linux.adoc
+++ b/modules/get-started/partials/install-rpk-linux.adoc
@@ -1,8 +1,10 @@
 To install, or update to, the latest version of `rpk` for Linux, run:
 
 [tabs]
-====
+======
 amd64::
++
+--
 [,bash]
 ----
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-amd64.zip &&
@@ -10,7 +12,11 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
 ----
+--
+
 arm64::
++
+--
 [,bash]
 ----
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-arm64.zip &&
@@ -18,14 +24,17 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
 ----
-====
+--
+======
 
 ifndef::env-cloud[]
 To install, or update to, a version other than the latest, run:
 
 [tabs]
-====
+======
 amd64::
++
+--
 [,bash]
 ----
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-linux-amd64.zip &&
@@ -33,7 +42,11 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
 ----
+--
+
 arm64::
++
+--
 [,bash]
 ----
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-linux-arm64.zip &&
@@ -41,7 +54,8 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
 ----
-====
+--
+======
 
 
 endif::[]

--- a/modules/get-started/partials/install-rpk-linux.adoc
+++ b/modules/get-started/partials/install-rpk-linux.adoc
@@ -1,19 +1,47 @@
 To install, or update to, the latest version of `rpk` for Linux, run:
 
-```bash
+[tabs]
+====
+amd64::
+[,bash]
+----
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-amd64.zip &&
   mkdir -p ~/.local/bin &&
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
-```
+----
+arm64::
+[,bash]
+----
+curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-arm64.zip &&
+  mkdir -p ~/.local/bin &&
+  export PATH="~/.local/bin:$PATH" &&
+  unzip rpk-linux-amd64.zip -d ~/.local/bin/
+----
+====
 
 ifndef::env-cloud[]
 To install, or update to, a version other than the latest, run:
 
-```bash
+[tabs]
+====
+amd64::
+[,bash]
+----
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-linux-amd64.zip &&
   mkdir -p ~/.local/bin &&
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
-```
+----
+arm64::
+[,bash]
+----
+curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-linux-arm64.zip &&
+  mkdir -p ~/.local/bin &&
+  export PATH="~/.local/bin:$PATH" &&
+  unzip rpk-linux-amd64.zip -d ~/.local/bin/
+----
+====
+
+
 endif::[]

--- a/modules/get-started/partials/install-rpk-linux.adoc
+++ b/modules/get-started/partials/install-rpk-linux.adoc
@@ -1,10 +1,10 @@
 To install, or update to, the latest version of `rpk` for Linux, run:
 
+// tag::latest[]
 [tabs]
-======
+====
 amd64::
 +
---
 [,bash]
 ----
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-amd64.zip &&
@@ -12,11 +12,8 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
 ----
---
-
 arm64::
 +
---
 [,bash]
 ----
 curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-arm64.zip &&
@@ -24,17 +21,16 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
 ----
---
-======
+====
+// end::latest[]
 
 ifndef::env-cloud[]
 To install, or update to, a version other than the latest, run:
 
 [tabs]
-======
+====
 amd64::
 +
---
 [,bash]
 ----
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-linux-amd64.zip &&
@@ -42,11 +38,8 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
 ----
---
-
 arm64::
 +
---
 [,bash]
 ----
 curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/rpk-linux-arm64.zip &&
@@ -54,8 +47,5 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/download/v<version>/
   export PATH="~/.local/bin:$PATH" &&
   unzip rpk-linux-amd64.zip -d ~/.local/bin/
 ----
---
-======
-
-
+====
 endif::[]

--- a/modules/get-started/partials/install-rpk-macos.adoc
+++ b/modules/get-started/partials/install-rpk-macos.adoc
@@ -8,7 +8,7 @@ include::get-started:partial$install-rpk-homebrew.adoc[]
 Manual Download::
 +
 --
-To install or update `rpk` through a manual download, choose the option for your system architecture. For example, if you have an M1 or M2 chip, select *Apple Silicon*.
+To install or update `rpk` through a manual download, choose the option for your system architecture. For example, if you have an M1 or newer chip, select *Apple Silicon*.
 
 [tabs]
 ====

--- a/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
@@ -179,7 +179,7 @@ Linux::
 +
 --
 [loweralpha]
-include::get-started:partial$install-rpk-linux.adoc[]
+include::get-started:partial$install-rpk-linux.adoc[tags=latest]
 
 --
 macOS::
@@ -356,7 +356,7 @@ Linux::
 +
 --
 [loweralpha]
-include::get-started:partial$install-rpk-linux.adoc[]
+include::get-started:partial$install-rpk-linux.adoc[tags=latest]
 
 --
 macOS::

--- a/modules/manage/pages/kubernetes/security/tls/k-secrets.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-secrets.adoc
@@ -241,7 +241,7 @@ Linux::
 +
 --
 [loweralpha]
-include::get-started:partial$install-rpk-linux.adoc[]
+include::get-started:partial$install-rpk-linux.adoc[tags=latest]
 
 --
 macOS::


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

https://deploy-preview-826--redpanda-docs-preview.netlify.app/current/get-started/quick-start/?tab=tabs-3-amd64
https://deploy-preview-826--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/kubernetes/local-guide/?tab=tabs-5-amd64
https://deploy-preview-826--redpanda-docs-preview.netlify.app/current/manage/kubernetes/security/tls/k-cert-manager/?tab=tabs-3-linux
https://deploy-preview-826--redpanda-docs-preview.netlify.app/current/manage/kubernetes/security/tls/k-secrets/?tab=tabs-3-linux

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)