### PR TITLE
Tombstone retention

### DIFF
--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -54,7 +54,6 @@ ifdef::env-cloud[]
 endif::[]
 ifndef::env-cloud[]
 +
-* The `delete.retention.ms` topic configuration in Kafka is not supported. Tombstone markers are not removed for topics with a `compact` xref:develop:config-topics.adoc#change-the-cleanup-policy[cleanup policy]. Redpanda only deletes tombstone markers when topics with a cleanup policy of `compact,delete` have reached their xref:manage:cluster-maintenance/disk-utilization.adoc#configure-message-retention[retention limits].
 * Quotas per user for bandwidth and API request rates. However, xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[quotas per client and per client group] using AlterClientQuotas and DescribeClientQuotas APIs are supported.
 endif::[]
 

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -7,6 +7,10 @@ This topic includes new content added in version {page-component-version}. For a
 * xref:redpanda-cloud:get-started:whats-new-cloud.adoc[] 
 * xref:redpanda-cloud:get-started:cloud-overview.adoc#redpanda-cloud-vs-self-managed-feature-compatibility[Redpanda Cloud vs Self-Managed feature compatibility]
 
+== Tombstone removal 
+
+Redpanda now supports the Kafka `delete.retention.ms` topic configuration. You can specify how long Redpanda keeps xref:manage:cluster-maintenance.adoc#tombstone-record-removal[tombstone records] for compacted topics by setting `delete.retention.ms` on the topic level, or `tombstone_retention_ms` on the cluster level.
+
 == Mountable topics
 
 For topics with Tiered Storage enabled, you can unmount a topic to safely detach it from a cluster and keep the topic data in the cluster's object storage bucket or container. You can mount the detached topic to either the same origin cluster, or a different one. This allows you to hibernate a topic and free up system resources taken up by the topic, or migrate a topic to a different cluster. See xref:manage:mountable-topics.adoc[Mountable topics] for details.

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -58,3 +58,4 @@ The following cluster properties are new in this version:
 
 * xref:reference:properties/cluster-properties.adoc#default_leaders_preference[`default_leaders_preference`]
 * xref:reference:properties/cluster-properties.adoc#rpk_path[`rpk_path`]
+* xref:reference:properties/cluster-properties.adoc#tombstone_retention_ms[`tombstone_retention_ms`]

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -9,7 +9,7 @@ This topic includes new content added in version {page-component-version}. For a
 
 == Tombstone removal 
 
-Redpanda now supports the Kafka `delete.retention.ms` topic configuration. You can specify how long Redpanda keeps xref:manage:cluster-maintenance.adoc#tombstone-record-removal[tombstone records] for compacted topics by setting `delete.retention.ms` on the topic level, or `tombstone_retention_ms` on the cluster level.
+Redpanda now supports the Kafka `delete.retention.ms` topic configuration. You can specify how long Redpanda keeps xref:manage:cluster-maintenance.adoc#tombstone-record-removal[tombstone records] for compacted topics by setting `delete.retention.ms` at the topic level, or `tombstone_retention_ms` at the cluster level.
 
 == Mountable topics
 

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -9,7 +9,7 @@ This topic includes new content added in version {page-component-version}. For a
 
 == Tombstone removal 
 
-Redpanda now supports the Kafka `delete.retention.ms` topic configuration. You can specify how long Redpanda keeps xref:manage:cluster-maintenance.adoc#tombstone-record-removal[tombstone records] for compacted topics by setting `delete.retention.ms` at the topic level, or `tombstone_retention_ms` at the cluster level.
+Redpanda now supports the Kafka `delete.retention.ms` topic configuration. You can specify how long Redpanda keeps xref:manage:cluster-maintenance/compaction-settings.adoc#tombstone-record-removal[tombstone records] for compacted topics by setting `delete.retention.ms` at the topic level, or `tombstone_retention_ms` at the cluster level.
 
 == Mountable topics
 

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -6,15 +6,15 @@ Configure compaction for your cluster to optimize storage utilization.
 
 == Redpanda compaction overview
 
-Compaction is an optional mechanism intended to reduce the storage needs of Redpanda topics. You can enable compaction through configuration of a cluster or topic's cleanup policy. When compaction is enabled as part of the cleanup policy, a background process executes on a pre-set interval to perform compaction operations. When triggered for a partition, the process purges older versions of messages for a given key and only retains the most recent message in that partition. This is done by analyzing closed segments in the partition, copying the most recent messages for each key into a new segment, then deleting the source segments.
+Compaction is an optional mechanism intended to reduce the storage needs of Redpanda topics. You can enable compaction through configuration of a cluster or topic's cleanup policy. When compaction is enabled as part of the cleanup policy, a background process executes on a pre-set interval to perform compaction operations. When triggered for a partition, the process purges older versions of records for a given key and only retains the most recent record in that partition. This is done by analyzing closed segments in the partition, copying the most recent records for each key into a new segment, then deleting the source segments.
 
 image::shared:compaction-example.png[Example of topic compaction]
 
-This diagram provides an illustration of a compacted topic. Imagine a remote sensor network that uses image recognition to track appearances of red pandas in a geographic area. The sensor network employs special devices that send messages to a topic when they detect one. You might enable compaction to reduce topic storage while still maintaining a record in the topic of the last time each device saw a red panda, perhaps to see if they stop frequenting a given area. The left side of the diagram shows all messages sent across the topic. The right side illustrates the results of compaction; older messages for certain keys are deleted from the message log.
+This diagram provides an illustration of a compacted topic. Imagine a remote sensor network that uses image recognition to track appearances of red pandas in a geographic area. The sensor network employs special devices that send records to a topic when they detect one. You might enable compaction to reduce topic storage while still maintaining a record in the topic of the last time each device saw a red panda, perhaps to see if they stop frequenting a given area. The left side of the diagram shows all records sent across the topic. The right side illustrates the results of compaction; older records for certain keys are deleted from the log.
 
-NOTE: If your application requires consuming every message for a given key, consider using the `delete` xref:develop:config-topics#change-the-cleanup-policy.adoc[cleanup policy] instead.
+NOTE: If your application requires consuming every record for a given key, consider using the `delete` xref:develop:config-topics#change-the-cleanup-policy.adoc[cleanup policy] instead.
 
-IMPORTANT:  When using xref:manage:tiered-storage.adoc[Tiered Storage], compaction functions at the local storage level. As long as a segment remains in local storage, its messages are eligible for compaction. Once a segment is uploaded to object storage and removed from local storage it is not retrieved for further compaction operations. A key may therefore appear in multiple segments between Tiered Storage and local storage.
+IMPORTANT:  When using xref:manage:tiered-storage.adoc[Tiered Storage], compaction functions at the local storage level. As long as a segment remains in local storage, its records are eligible for compaction. Once a segment is uploaded to object storage and removed from local storage it is not retrieved for further compaction operations. A key may therefore appear in multiple segments between Tiered Storage and local storage.
 
 While compaction reduces storage needs, Redpanda's compaction (just like Kafka's) does not guarantee perfect de-duplication of a topic. It represents a best effort mechanism to reduce storage needs but duplicates of a key may still exist within a topic. Compaction is not a complete topic operation, either, since it operates on subsets of each partition within the topic.
 
@@ -22,9 +22,9 @@ While compaction reduces storage needs, Redpanda's compaction (just like Kafka's
 
 Compaction policy may be applied to a cluster or to an individual topic. If both are set, the topic-level policy overrides the cluster-level policy. The cluster-level xref:reference:cluster-properties.adoc#log_cleanup_policy[`log_cleanup_policy`] and the topic-level xref:reference:topic-properties.adoc#cleanuppolicy[`cleanup.policy`] support the following three options:
 
-* `delete`: Messages are deleted from the topic once the specified retention period (time and/or size allocations) is exceeded. This is the default mechanism and is analogous to disabling compaction.
-* `compact`: This triggers only cleanup of messages with multiple versions. A message that represents the only version for a given key is not deleted.
-* `compact,delete`: This combines both policies, deleting messages exceeding the retention period while compacting multiple versions of messages.
+* `delete`: Records are deleted from the topic once the specified retention period (time and/or size allocations) is exceeded. This is the default mechanism and is analogous to disabling compaction.
+* `compact`: This triggers only cleanup of records with multiple versions. A record that represents the only version for a given key is not deleted.
+* `compact,delete`: This combines both policies, deleting records exceeding the retention period while compacting multiple versions of records.
 
 == Tombstone record removal
 

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -10,7 +10,7 @@ Compaction is an optional mechanism intended to reduce the storage needs of Redp
 
 image::shared:compaction-example.png[Example of topic compaction]
 
-This diagram provides an illustration of a compacted topic. Imagine a remote sensor network that uses image recognition to track appearances of red pandas in a geographic area. The sensor network employs special devices that send records to a topic when they detect one. You might enable compaction to reduce topic storage while still maintaining a record in the topic of the last time each device saw a red panda, perhaps to see if they stop frequenting a given area. The left side of the diagram shows all records sent across the topic. The right side illustrates the results of compaction; older records for certain keys are deleted from the log.
+This diagram illustrates a compacted topic. Imagine a remote sensor network that uses image recognition to track appearances of red pandas in a geographic area. The sensor network employs special devices that send records to a topic when they detect one. You might enable compaction to reduce topic storage while still maintaining a record in the topic of the last time each device saw a red panda, perhaps to see if they stop frequenting a given area. The left side of the diagram shows all records sent across the topic. The right side illustrates the results of compaction; older records for certain keys are deleted from the log.
 
 NOTE: If your application requires consuming every record for a given key, consider using the `delete` xref:develop:config-topics#change-the-cleanup-policy.adoc[cleanup policy] instead.
 

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -76,7 +76,7 @@ Redpanda removes tombstones as follows:
 
 If obtaining a complete snapshot of the log, including tombstone records, is important to your consumers, set the tombstone retention value such that consumers have enough time for their reads to complete before tombstones are removed. Consumers may not see tombstones if their reads take longer than `delete.retention.ms` and `tombstone_retention_ms`. The trade-offs to ensuring tombstone visibility to consumers are increased disk usage and potentially slower compaction. 
 
-On the other hand, if more frequent cleanup of tombstones is important for optimizing workloads and space management, consider setting a shorter tombstone retention, for example the typical default of 24 hours (86400000 ms). Consequently, if you set tombstone retention limits that are too low, it could cause more data inconsistencies.
+On the other hand, if more frequent cleanup of tombstones is important for optimizing workloads and space management, consider setting a shorter tombstone retention, for example the typical default of 24 hours (86400000 ms).
 
 == Compaction policy settings
 

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -30,7 +30,7 @@ Compaction policy may be applied to a cluster or to an individual topic. If both
 
 Compaction also enables deletion of existing records through tombstones. For example, as data is deleted from a source system, clients produce a tombstone record to the log. A tombstone record contains the key and the value `null`. Tombstones signal to brokers and consumers that records with the same key prior to it in the log should be deleted. 
 
-You can specify how long Redpanda keeps these tombstones for compacted topics using both a cluster configuration property `tombstone_retention_ms` and a topic configuration property xref:reference:properties/topic-properties.adoc#deleteretentionms[`delete.retention.ms`]. If both are set, the topic-level tombstone retention policy overrides the cluster-level policy.
+You can specify how long Redpanda keeps these tombstones for compacted topics using both a cluster configuration property config_ref:tombstone_retention_ms,true,properties/cluster-properties[] and a topic configuration property xref:reference:properties/topic-properties.adoc#deleteretentionms[`delete.retention.ms`]. If both are set, the topic-level tombstone retention policy overrides the cluster-level policy.
 
 [NOTE]
 ====

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -34,7 +34,7 @@ You can specify how long Redpanda keeps these tombstones for compacted topics us
 
 [NOTE]
 ====
-Redpanda does not remove tombstone records for compacted topics with Tiered Storage enabled. 
+Redpanda does not currently remove tombstone records for compacted topics with Tiered Storage enabled. 
 
 You cannot enable `tombstone_retention_ms` if you have enabled any of the Tiered Storage cluster properties `cloud_storage_enabled`, `cloud_storage_enable_remote_read`, and `cloud_storage_enable_remote_write`.
 
@@ -71,8 +71,10 @@ rpk topic alter-config <topic-name> --set delete.retention.ms=-1
 
 Redpanda removes tombstones as follows:
 
-* For topics with a `compact,delete` cleanup policy: the standard garbage collection process, per the tombstone retention limit.
-* For topics with a `compact` only cleanup policy: tombstones must be seen at least twice by the compaction scheduler before they are removed. The `delete.retention.ms` or `tombstone_retention_ms` value sets the retention time for a tombstone, and in effect sets the time bound that a consumer has to read from the message log before they see an incomplete view of the log because tombstones were removed. 
+* For topics with a `compact,delete` cleanup policy: the standard garbage collection process, per the topic retention limit.
+* For topics with a `compact` only cleanup policy: The `delete.retention.ms` or `tombstone_retention_ms` value sets the time bound that a consumer has in order to see a complete view of the log with tombstones present before they are removed. 
+
+If obtaining a complete snapshot of the log, including tombstone records, is important to your consumers, set the tombstone retention value such that consumers have enough time for their reads to complete before tombstones are removed. If managing local disk space is a higher priority, consider setting the tombstone retention to a lower value, for example, less than 24 hours (86400000 ms).
 
 == Compaction policy settings
 

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -26,6 +26,13 @@ Compaction policy may be applied to a cluster or to an individual topic. If both
 * `compact`: This triggers only cleanup of messages with multiple versions. A message that represents the only version for a given key is not deleted.
 * `compact,delete`: This combines both policies, deleting messages exceeding the retention period while compacting multiple versions of messages.
 
+== Tombstone marker removal
+
+When all messages for a given key are deleted, the topic partition keeps one message, called a tombstone, that contains the key, and a null value. A tombstone indicates to clients that the messages have been deleted. How long Redpanda keeps these tombstones depends on the topic cleanup policy:
+
+* For topics with a `compact,delete` policy, Redpanda deletes the tombstones when a topic reaches its retention limits.
+* For topics with a `compact` policy, Redpanda deletes the tombstones based on the specified tombstone retention policy. This retention policy is set with the `delete.retention.ms` topic configuration property. 
+
 == Compaction policy settings
 
 The various cleanup policy settings rely on proper tuning of a cluster's compaction and retention policy options. The applicable settings are:

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -69,10 +69,10 @@ To disable tombstone removal for a specific topic:
 rpk topic alter-config <topic-name> --set delete.retention.ms=-1
 ----
 
-Redpanda removes tombstones through the following:
+Redpanda removes tombstones as follows:
 
-* Garbage collection in a `compact,delete` cleanup policy, per the topic retention limits.
-* For topics with a `compact` only cleanup policy, tombstones must be seen at least twice by the compaction scheduler before they are removed. The `delete.retention.ms` value sets the retention time for a tombstone, and therefore the bound on the time a consumer has to read from the log before they see an incomplete view due to tombstone removal. This prevents race conditions between consumers and tombstone removal. 
+* For topics with a `compact,delete` cleanup policy: the standard garbage collection process, per the tombstone retention limit.
+* For topics with a `compact` only cleanup policy: tombstones must be seen at least twice by the compaction scheduler before they are removed. The `delete.retention.ms` or `tombstone_retention_ms` value sets the retention time for a tombstone, and in effect sets the time bound that a consumer has to read from the message log before they see an incomplete view of the log because tombstones were removed. 
 
 == Compaction policy settings
 

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -28,7 +28,9 @@ Compaction policy may be applied to a cluster or to an individual topic. If both
 
 == Tombstone record removal
 
-When all messages for a given key are deleted, the topic partition keeps one message, called a tombstone, that contains the key, and a null value. A tombstone record indicates to clients that the messages have been deleted. You can specify how long Redpanda retains these tombstones for compacted topics using both a cluster configuration property `tombstone_retention_ms` and a topic configuration property xref:reference:properties/topic-properties.adoc#deleteretentionms[`delete.retention.ms`]. If both are set, the topic-level tombstone retention policy overrides the cluster-level policy.
+When a topic's messages should be deleted, for example as data is deleted from a source system, clients add a tombstone record to the message log. A tombstone contains the message key, and the value `null`. Tombstones signal to brokers and consumers that records with the same key prior to it in the log should be deleted. 
+
+You can specify how long Redpanda keeps these tombstones for compacted topics using both a cluster configuration property `tombstone_retention_ms` and a topic configuration property xref:reference:properties/topic-properties.adoc#deleteretentionms[`delete.retention.ms`]. If both are set, the topic-level tombstone retention policy overrides the cluster-level policy.
 
 [NOTE]
 ====
@@ -46,7 +48,7 @@ To set the cluster-level tombstone retention policy, run the command:
 rpk cluster config set tombstone_retention_ms=100
 ----
 
-You can set the tombstone retention for a topic so that it inherits the cluster-wide default:
+You can unset the tombstone retention policy for a topic so it inherits the cluster-wide default policy:
 
 [,bash]
 ----
@@ -66,6 +68,11 @@ To disable tombstone removal for a specific topic:
 ----
 rpk topic alter-config <topic-name> --set delete.retention.ms=-1
 ----
+
+Redpanda removes tombstones through the following:
+
+* Garbage collection in a `compact,delete` cleanup policy, per the topic retention limits.
+* For topics with a `compact` only cleanup policy, tombstones must be seen at least twice by the compaction scheduler before they are removed. The `delete.retention.ms` value sets the retention time for a tombstone, and therefore the bound on the time a consumer has to read from the log before they see an incomplete view due to tombstone removal. This prevents race conditions between consumers and tombstone removal. 
 
 == Compaction policy settings
 

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -28,7 +28,7 @@ Compaction policy may be applied to a cluster or to an individual topic. If both
 
 == Tombstone record removal
 
-Compaction also enables deletion of existing records through tombstones. For example, as data is deleted from a source system, clients produce a tombstone record to the log. A tombstone record contains the key and the value `null`. Tombstones signal to brokers and consumers that records with the same key prior to it in the log should be deleted. 
+Compaction also enables deletion of existing records through tombstones. For example, as data is deleted from a source system, clients produce a tombstone record to the log. A tombstone contains a key and the value `null`. Tombstones signal to brokers and consumers that records with the same key prior to it in the log should be deleted. 
 
 You can specify how long Redpanda keeps these tombstones for compacted topics using both a cluster configuration property config_ref:tombstone_retention_ms,true,properties/cluster-properties[] and a topic configuration property xref:reference:properties/topic-properties.adoc#deleteretentionms[`delete.retention.ms`]. If both are set, the topic-level tombstone retention policy overrides the cluster-level policy.
 

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -28,10 +28,42 @@ Compaction policy may be applied to a cluster or to an individual topic. If both
 
 == Tombstone marker removal
 
-When all messages for a given key are deleted, the topic partition keeps one message, called a tombstone, that contains the key, and a null value. A tombstone indicates to clients that the messages have been deleted. How long Redpanda keeps these tombstones depends on the topic cleanup policy:
+When all messages for a given key are deleted, the topic partition keeps one message, called a tombstone, that contains the key, and a null value. A tombstone indicates to clients that the messages have been deleted. You can specify how long Redpanda keeps these tombstones using both a cluster configuration property `tombstone_retention_ms` and a topic configuration property `delete.retention.ms`. If both are set, the topic-level tombstone retention policy overrides the cluster-level policy.
 
-* For topics with a `compact,delete` policy, Redpanda deletes the tombstones when a topic reaches its retention limits.
-* For topics with a `compact` policy, Redpanda deletes the tombstones based on the specified tombstone retention policy. This retention policy is set with the `delete.retention.ms` topic configuration property. 
+[NOTE]
+====
+You cannot enable `tombstone_retention_ms` if you have enabled any of the Tiered Storage cluster properties `cloud_storage_enabled`, `cloud_storage_enable_remote_read`, and `cloud_storage_enable_remote_write`.
+
+On the topic level, you cannot enable `delete.retention.ms` at the same time as the Tiered Storage topic configuration properties `redpanda.remote.read` and `redpanda.remote.write`.
+====
+
+To set the cluster-level tombstone retention policy, run the command:
+
+[,bash]
+----
+rpk cluster config set tombstone_retention_ms=100
+----
+
+You can set the tombstone retention for a topic so that it inherits the cluster-wide default:
+
+[,bash]
+----
+rpk topic alter-config <topic-name> --delete delete.retention.ms
+----
+
+To override the cluster-wide default for a specific topic:
+
+[,bash]
+----
+rpk topic alter-config <topic-name> --set delete.retention.ms=5
+----
+
+To disable tombstone retention for a specific topic:
+
+[,bash]
+----
+rpk topic alter-config <topic-name> --set delete.retention.ms=-1
+----
 
 == Compaction policy settings
 

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -14,7 +14,7 @@ This diagram provides an illustration of a compacted topic. Imagine a remote sen
 
 NOTE: If your application requires consuming every message for a given key, consider using the `delete` xref:develop:config-topics#change-the-cleanup-policy.adoc[cleanup policy] instead.
 
-IMPORTANT:  When using Tiered Storage, compaction functions at the local storage level. As long as a segment remains in local storage, its messages are eligible for compaction. Once a segment is uploaded to tiered storage and removed from local storage it is not retrieved for further compaction operations. A key may therefore appear in multiple segments between Tiered Storage and local storage.
+IMPORTANT:  When using xref:manage:tiered-storage.adoc[Tiered Storage], compaction functions at the local storage level. As long as a segment remains in local storage, its messages are eligible for compaction. Once a segment is uploaded to object storage and removed from local storage it is not retrieved for further compaction operations. A key may therefore appear in multiple segments between Tiered Storage and local storage.
 
 While compaction reduces storage needs, Redpanda's compaction (just like Kafka's) does not guarantee perfect de-duplication of a topic. It represents a best effort mechanism to reduce storage needs but duplicates of a key may still exist within a topic. Compaction is not a complete topic operation, either, since it operates on subsets of each partition within the topic.
 
@@ -26,12 +26,14 @@ Compaction policy may be applied to a cluster or to an individual topic. If both
 * `compact`: This triggers only cleanup of messages with multiple versions. A message that represents the only version for a given key is not deleted.
 * `compact,delete`: This combines both policies, deleting messages exceeding the retention period while compacting multiple versions of messages.
 
-== Tombstone marker removal
+== Tombstone record removal
 
-When all messages for a given key are deleted, the topic partition keeps one message, called a tombstone, that contains the key, and a null value. A tombstone indicates to clients that the messages have been deleted. You can specify how long Redpanda keeps these tombstones using both a cluster configuration property `tombstone_retention_ms` and a topic configuration property `delete.retention.ms`. If both are set, the topic-level tombstone retention policy overrides the cluster-level policy.
+When all messages for a given key are deleted, the topic partition keeps one message, called a tombstone, that contains the key, and a null value. A tombstone record indicates to clients that the messages have been deleted. You can specify how long Redpanda retains these tombstones for compacted topics using both a cluster configuration property `tombstone_retention_ms` and a topic configuration property xref:reference:properties/topic-properties.adoc#deleteretentionms[`delete.retention.ms`]. If both are set, the topic-level tombstone retention policy overrides the cluster-level policy.
 
 [NOTE]
 ====
+Redpanda does not remove tombstone records for compacted topics with Tiered Storage enabled. 
+
 You cannot enable `tombstone_retention_ms` if you have enabled any of the Tiered Storage cluster properties `cloud_storage_enabled`, `cloud_storage_enable_remote_read`, and `cloud_storage_enable_remote_write`.
 
 On the topic level, you cannot enable `delete.retention.ms` at the same time as the Tiered Storage topic configuration properties `redpanda.remote.read` and `redpanda.remote.write`.
@@ -58,7 +60,7 @@ To override the cluster-wide default for a specific topic:
 rpk topic alter-config <topic-name> --set delete.retention.ms=5
 ----
 
-To disable tombstone retention for a specific topic:
+To disable tombstone removal for a specific topic:
 
 [,bash]
 ----

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -28,7 +28,7 @@ Compaction policy may be applied to a cluster or to an individual topic. If both
 
 == Tombstone record removal
 
-When a topic's messages should be deleted, for example as data is deleted from a source system, clients add a tombstone record to the message log. A tombstone contains the message key, and the value `null`. Tombstones signal to brokers and consumers that records with the same key prior to it in the log should be deleted. 
+Compaction also enables deletion of existing records through tombstones. For example, as data is deleted from a source system, clients produce a tombstone record to the log. A tombstone record contains the key and the value `null`. Tombstones signal to brokers and consumers that records with the same key prior to it in the log should be deleted. 
 
 You can specify how long Redpanda keeps these tombstones for compacted topics using both a cluster configuration property `tombstone_retention_ms` and a topic configuration property xref:reference:properties/topic-properties.adoc#deleteretentionms[`delete.retention.ms`]. If both are set, the topic-level tombstone retention policy overrides the cluster-level policy.
 
@@ -71,10 +71,12 @@ rpk topic alter-config <topic-name> --set delete.retention.ms=-1
 
 Redpanda removes tombstones as follows:
 
-* For topics with a `compact,delete` cleanup policy: the standard garbage collection process, per the topic retention limit.
-* For topics with a `compact` only cleanup policy: The `delete.retention.ms` or `tombstone_retention_ms` value sets the time bound that a consumer has in order to see a complete view of the log with tombstones present before they are removed. 
+* For topics with a `compact` only cleanup policy: Tombstones are removed when the topic exceeds the tombstone retention limit. The `delete.retention.ms` or `tombstone_retention_ms` values therefore also set the time bound that a consumer has in order to see a complete view of the log with tombstones present before they are removed.
+* For topics with a `compact,delete` cleanup policy: Both the tombstone retention policy and standard garbage collection can remove tombstone records.
 
-If obtaining a complete snapshot of the log, including tombstone records, is important to your consumers, set the tombstone retention value such that consumers have enough time for their reads to complete before tombstones are removed. If managing local disk space is a higher priority, consider setting the tombstone retention to a lower value, for example, less than 24 hours (86400000 ms).
+If obtaining a complete snapshot of the log, including tombstone records, is important to your consumers, set the tombstone retention value such that consumers have enough time for their reads to complete before tombstones are removed. Consumers may not see tombstones if their reads take longer than `delete.retention.ms` and `tombstone_retention_ms`. The trade-offs to ensuring tombstone visibility to consumers are increased disk usage and potentially slower compaction. 
+
+On the other hand, if more frequent cleanup of tombstones is important for optimizing workloads and space management, consider setting a shorter tombstone retention, for example the typical default of 24 hours (86400000 ms). Consequently, if you set tombstone retention limits that are too low, it could cause more data inconsistencies.
 
 == Compaction policy settings
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -550,11 +550,13 @@ NOTE: Although `replication.factor` isn't returned or displayed by xref:referenc
 [[deleteretentionms]]
 ==== delete.retention.ms
 
-The retention time (in ms) for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
+The retention time for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
 
 If you have enabled Tiered Storage and set <<redpandaremoteread,`redpanda.remote.read`>> or <<redpandaremotewrite,`redpanda.remote.write`>> for the topic, you cannot enable tombstone removal. 
 
 If both `delete.retention.ms` and the cluster property config_ref:tombstone_retention_ms,true,properties/cluster-properties[] are set, `delete.retention.ms` overrides the cluster level tombstone retention for an individual topic.
+
+*Unit:* milliseconds
 
 **Default**: null
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -547,6 +547,23 @@ NOTE: Although `replication.factor` isn't returned or displayed by xref:referenc
 
 ---
 
+[[deleteretentionms]]
+==== delete.retention.ms
+
+The retention time for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
+
+If you have enabled Tiered Storage and set <<redpandaremoteread,`redpanda.remote.read`>> or <<redpandaremotewrite,`redpanda.remote.write`>> for the topic, you cannot enable tombstone removal. 
+
+If both `delete.retention.ms` and the cluster property `tombstone_retention_ms` are set, `delete.retention.ms` overrides the cluster level tombstone retention for an individual topic.
+
+**Default**: null
+
+**Related topics**:
+
+- xref:manage:cluster-maintenance/compaction-settings.adoc#tombstone-record-removal[Tombstone record removal]
+
+---
+
 == Related topics
 
 - xref:develop:produce-data/configure-producers.adoc[Configure Producers]

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -554,7 +554,7 @@ The retention time (in ms) for tombstone records in a compacted topic. Redpanda 
 
 If you have enabled Tiered Storage and set <<redpandaremoteread,`redpanda.remote.read`>> or <<redpandaremotewrite,`redpanda.remote.write`>> for the topic, you cannot enable tombstone removal. 
 
-If both `delete.retention.ms` and the cluster property `tombstone_retention_ms` are set, `delete.retention.ms` overrides the cluster level tombstone retention for an individual topic.
+If both `delete.retention.ms` and the cluster property config_ref:tombstone_retention_ms,true,properties/cluster-properties[] are set, `delete.retention.ms` overrides the cluster level tombstone retention for an individual topic.
 
 **Default**: null
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -550,7 +550,7 @@ NOTE: Although `replication.factor` isn't returned or displayed by xref:referenc
 [[deleteretentionms]]
 ==== delete.retention.ms
 
-The retention time for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
+The retention time (in ms) for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
 
 If you have enabled Tiered Storage and set <<redpandaremoteread,`redpanda.remote.read`>> or <<redpandaremotewrite,`redpanda.remote.write`>> for the topic, you cannot enable tombstone removal. 
 


### PR DESCRIPTION
## Description

Support for topic level `delete.retention.ms` and cluster level `tombstone_retention_ms` properties, which define the retention limit for tombstone records in compacted topics.

TODO:
- A separate PR will add the `tombstone_retention_ms` reference entry: https://github.com/redpanda-data/docs/pull/847
- We will also have to update https://docs.redpanda.com/current/develop/kafka-clients/#unsupported-kafka-features when this is available.

Resolves https://github.com/redpanda-data/documentation-private/issues/2600
Review deadline: Nov 12

## Page previews

24.3 Beta > [Compaction settings > Tombstone record removal](https://deploy-preview-829--redpanda-docs-preview.netlify.app/24.3/manage/cluster-maintenance/compaction-settings/#tombstone-record-removal)
Topic properties > [delete.retention.ms](https://deploy-preview-829--redpanda-docs-preview.netlify.app/24.3/reference/properties/topic-properties/#deleteretentionms)
[What's new](https://deploy-preview-829--redpanda-docs-preview.netlify.app/24.3/get-started/whats-new/#tombstone-removal)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)