### PR TITLE
DOC-688 Fix typo in rpk flags

### DIFF
--- a/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
@@ -84,9 +84,9 @@ producer
 
 Use the `export` option to save the current cluster configuration to a file. You can then copy this file to other clusters, so they can use the same configuration.
 
-. Export the current configuration settings to a YAML file by running `rpk cluster config export -filename <filename>.yaml`. To store the configuration file outside your current working directory, use the full pathname for `-filename`; otherwise, supply the filename to store the file in your current working directory.
+. Export the current configuration settings to a YAML file by running `rpk cluster config export --filename <filename>.yaml`. To store the configuration file outside your current working directory, use the full pathname for `--filename`; otherwise, supply the filename to store the file in your current working directory.
 . Copy `<filename>.yaml` to the other cluster.
-. Log in to the other cluster, and import the file with the saved configuration by running `rpk cluster config import -filename <filename>.yaml`. This command applies the property settings in `<filename>.yaml` to all nodes in the cluster.
+. Log in to the other cluster, and import the file with the saved configuration by running `rpk cluster config import --filename <filename>.yaml`. This command applies the property settings in `<filename>.yaml` to all nodes in the cluster.
 
 CAUTION: Redpanda does not support importing cluster-specific identification (such as `cluster_id`) with this command.
 
@@ -103,4 +103,5 @@ This avoids the issue of referring to a previous version or custom configuration
 
 include::shared:partial$suggested-reading.adoc[]
 
+* xref:reference:rpk/rpk-cluster/rpk-cluster-config.adoc[]
 * https://redpanda.com/blog/raft-centralized-cluster-configuration-improvements/[Using Raft to centralize cluster configuration in Redpanda^]


### PR DESCRIPTION
## Description

`-filename` changed to `--filename`. Also added a link to the `rpk cluster config` reference in suggested reading so that users can find it without searching.

## Page previews

[Preview](https://deploy-preview-831--redpanda-docs-preview.netlify.app/current/manage/cluster-maintenance/cluster-property-configuration/#copy-configurations-to-other-clusters)

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)