### PR TITLE
Update GitHub Action to match `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,25 @@
+---
 # This workflow triggers a build of the production docs site
 
 name: Build Production Site
-
 on:
   push:
-    branches: [ main, 'v/*', shared, api, site-search, 'v-WIP/*' ]
-
+    branches: [main, 'v/*', shared, api, site-search, 'v-WIP/*']
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-    - name: Trigger build
-      env:
-        BUILD_HOOK: ${{ secrets.BUILD_HOOK }}
-      run: curl -X POST -d {} $BUILD_HOOK
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/docs_netlify_build_hook
+          parse-json-secrets: true
+      - name: Trigger build
+        run: curl -X POST -d {} "${{ env.DOCS_NETLIFY_BUILD_HOOK }}"


### PR DESCRIPTION
## Description

On pushes to the `v/23.3` branch, our Action to trigger a build on the production site no longer works because it's using an old secret that we no longer store in GitHub: https://github.com/redpanda-data/docs/actions/runs/11610090885

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)