### PR TITLE
Update with latest rpk commands from v0.0.0-20241104git4a0f859

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -283,6 +283,7 @@
 ***** rpk cluster storage mount/unmount
 ****** xref:reference:rpk/rpk-cluster/rpk-cluster-storage-cancel-mount.adoc[]
 ****** xref:reference:rpk/rpk-cluster/rpk-cluster-storage-list-mount.adoc[]
+****** xref:reference:rpk/rpk-cluster/rpk-cluster-storage-list-mountable.adoc[]
 ****** xref:reference:rpk/rpk-cluster/rpk-cluster-storage-mount.adoc[]
 ****** xref:reference:rpk/rpk-cluster/rpk-cluster-storage-status-mount.adoc[]
 ****** xref:reference:rpk/rpk-cluster/rpk-cluster-storage-unmount.adoc[]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-license-info.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-license-info.adoc
@@ -2,13 +2,11 @@
 
 Retrieve license information:
 
-----
-Organization:    Organization the license was generated for.
-Type:            Type of license: free, enterprise, etc.
-Expires:         Expiration date of the license.
-License Status:  Status of the loaded license (valid, expired, not_present).
-Violation:       Whether the cluster is using enterprise features without a valid license.
-----
+- Organization:    Organization the license was generated for.
+- Type:            Type of license (free, enterprise, etc).
+- Expires:         Expiration date of the license.
+- License Status:  Status of the loaded license (valid, expired, not_present).
+- Violation:       Whether the cluster is using enterprise features without a valid license.
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-list-mountable.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-list-mountable.adoc
@@ -1,29 +1,24 @@
-= rpk cluster license info
+= rpk cluster storage list-mountable
 
-Retrieve license information:
+List topics that are available to mount from object storage.
 
-----
-Organization:    Organization the license was generated for.
-Type:            Type of license: free, enterprise, etc.
-Expires:         Expiration date of the license.
-License Status:  Status of the loaded license (valid, expired, not_present).
-Violation:       Whether the cluster is using enterprise features without a valid license.
-----
+This command displays topics that exist in object storage and can be mounted to your Redpanda cluster. Each topic includes its location in object storage and namespace information if applicable.
 
 == Usage
 
 [,bash]
 ----
-rpk cluster license info [flags]
+rpk cluster storage list-mountable [flags]
 ----
 
-== Aliases
+== Examples
+
+List all mountable topics:
 
 [,bash]
 ----
-info, status
+rpk cluster storage list-mountable
 ----
-
 
 == Flags
 
@@ -31,9 +26,9 @@ info, status
 |===
 |*Value* |*Type* |*Description*
 
-|--format |string |Output format. Possible values: `json`, `yaml`, `text`, `wide`, `help`. Default: `text`.
+|-h, --help |- |Help for list-mountable.
 
-|-h, --help |- |Help for info.
+|--format |string |Output format. Possible values: `json`, `yaml`, `text`, `wide`, `help`. Default: `text`.
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 
@@ -43,4 +38,3 @@ info, status
 
 |-v, --verbose |- |Enable verbose logging.
 |===
-

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-list.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-list.adoc
@@ -41,6 +41,8 @@ list, ls
 
 |-d, --detailed |- |Print per-partition information for topics.
 
+|--format |string |Output format. Possible values: `json`, `yaml`, `text`, `wide`, `help`. Default: `text`.
+
 |-h, --help |- |Help for list.
 
 |-i, --internal |- |Print internal topics.

--- a/modules/reference/pages/rpk/rpk-version.adoc
+++ b/modules/reference/pages/rpk/rpk-version.adoc
@@ -6,6 +6,8 @@ Prints the current `rpk` and Redpanda version and allows you to list the Redpand
 
 To list the Redpanda version of each broker in your cluster you may pass the Admin API hosts via flags, profile, or environment variables.
 
+To get only the rpk version, use `rpk --version`.
+
 == Usage
 
 [,bash]


### PR DESCRIPTION
## Changelog

### New commands
rpk-cluster-storage-list-mountable

### Description changes
rpk-cluster-license-info
rpk-cluster-storage-list-mountable
rpk-version

### New flags
rpk-topic-list

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)