### PR TITLE
Michele rp patch 1

### DIFF
--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -15,10 +15,6 @@ For topics with Tiered Storage enabled, you can unmount a topic to safely detach
 
 For a Redpanda cluster deployed across multiple availability zones (AZs), xref:develop:produce-data/leader-pinning.adoc[leader pinning] ensures that a topic's partition leaders are geographically closer to clients. Leader pinning can lower networking costs and help guarantee lower latency by routing produce and consume requests to brokers located in certain AZs.
 
-== Debug bundles in Redpanda Console
-
-You can now xref:troubleshoot:debug-bundle/index.adoc[generate a debug bundle] in Redpanda Console for comprehensive diagnostics. A debug bundle can help debug and diagnose issues with a Redpanda cluster, a broker, or the machines on which the brokers are running. You can use this file to debug issues yourself, or you can send it to the Redpanda support team to help resolve your issue.
-
 == Declarative user and ACL management in Kubernetes
 
 Redpanda now supports declarative management of users and access control lists (ACLs) using the new User custom resource with the Redpanda Operator. This feature allows you to:


### PR DESCRIPTION
## Description

Remove debug bundle blurb from What's New

## Page previews
[What's New](https://deploy-preview-837--redpanda-docs-preview.netlify.app/24.3/get-started/whats-new/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)