### PR TITLE
Schema Registry API - support for `?verbose` with compatibility check

### DIFF
--- a/modules/ROOT/attachments/pandaproxy-schema-registry.json
+++ b/modules/ROOT/attachments/pandaproxy-schema-registry.json
@@ -1159,6 +1159,13 @@
             "schema": {
               "$ref": "#/definitions/schema_def"
             }
+          },
+          {
+            "name": "verbose",
+            "in": "query",
+            "description": "If true, includes more verbose information about the compatibility check, for example the reason the check failed.",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "produces": [
@@ -1318,6 +1325,12 @@
       "properties": {
         "is_compatible": {
           "type": "boolean"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

- Add verbose and messages field definitions

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: Nov 11

## Page previews

Schema Registry API reference > [Test compatibility of a schema for the subject and version.](https://deploy-preview-839--redpanda-docs-preview.netlify.app/api/pandaproxy-schema-registry/#post-/compatibility/subjects/-subject-/versions/-version-)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)