### PR TITLE
Cloud min replication factor

### DIFF
--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -15,7 +15,15 @@ Creating a topic can be as simple as specifying a name for your topic on the com
 rpk topic create xyz
 ----
 
-This command creates a topic named `xyz` with one partition and one replica, because these are the default values set in the cluster configuration file.
+ifndef::env-cloud[]
+This command creates a topic named `xyz` with one partition and one replica, because these are the default values set in the cluster configuration file. Replicas are copies of partitions that are distributed across different brokers, so if one broker goes down, other brokers still have a copy of the data. 
+
+endif::[]
+
+ifdef::env-cloud[]
+This command creates a topic named `xyz` with one partition and three replicas, because these are the default values set in the cluster configuration file. Replicas are copies of partitions that are distributed across different brokers, so if one broker goes down, other brokers still have a copy of the data. 
+
+endif::[]
 
 This section shows how to change default settings for a topic.
 
@@ -35,9 +43,7 @@ rpk topic create xyz -p 10
 ifndef::env-cloud[]
 === Choose the replication factor
 
-Replicas are copies of partitions that are distributed across different brokers, so if one broker goes down, other brokers still have a copy of the data. The default replication factor in the cluster configuration is set to 1.
-
-By choosing a replication factor greater than 1, you ensure that each partition has a copy of its data on at least one other broker. One replica acts as the leader, and the other replicas are followers.
+The default replication factor in the cluster configuration is set to 1. By choosing a replication factor greater than 1, you ensure that each partition has a copy of its data on at least one other broker. One replica acts as the leader, and the other replicas are followers.
 
 To specify a replication factor of 3 for topic `xyz`, run:
 

--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -164,6 +164,7 @@ The `-c` flag limits the command output to just the topic configurations. This c
 
 The following command output displays after running `rpk topic describe test-topic`, where `test-topic` was created with default settings:
 
+ifndef::env-cloud[]
 [,bash]
 ----
 rpk topic describe test_topic
@@ -201,6 +202,38 @@ NAME        test_topic
 PARTITIONS  3
 REPLICAS    3
 ----
+
+endif::[]
+
+ifdef::env-cloud[]
+[,bash]
+----
+rpk topic describe test_topic
+SUMMARY
+=======
+NAME        test_topic
+PARTITIONS  1
+REPLICAS    3
+
+CONFIGS
+=======
+KEY                           VALUE                          SOURCE
+cleanup.policy                delete                         DYNAMIC_TOPIC_CONFIG
+compression.type              producer                       DEFAULT_CONFIG
+max.message.bytes             1048576                        DEFAULT_CONFIG
+message.timestamp.type        CreateTime                     DEFAULT_CONFIG
+redpanda.datapolicy           function_name:  script_name:   DEFAULT_CONFIG
+redpanda.remote.delete        true                           DEFAULT_CONFIG
+redpanda.remote.read          false                          DEFAULT_CONFIG
+redpanda.remote.write         false                          DEFAULT_CONFIG
+retention.bytes               -1                             DEFAULT_CONFIG
+retention.local.target.bytes  -1                             DEFAULT_CONFIG
+retention.local.target.ms     86400000                       DEFAULT_CONFIG
+retention.ms                  604800000                      DEFAULT_CONFIG
+segment.bytes                 1073741824                     DEFAULT_CONFIG
+----
+
+endif::[]
 
 == Delete a topic
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -936,6 +936,8 @@ Default replication factor for new topics.
 
 *Default:* `1`
 
+NOTE: In Redpanda Cloud, all new topics are created with a replication factor of 3. 
+
 ---
 
 === default_window_sec

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-create.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-create.adoc
@@ -33,7 +33,7 @@ create topics.
 defaults to the cluster property `default_topic_partitions` (default `-1`).
 
 |-r, --replicas |int16 |Replication factor (must be odd); -1 defaults to
-the cluster's default_topic_replications (default -1).
+the cluster's default_topic_replications (default -1). In Redpanda Cloud, the replication factor is set to 3. 
 
 |-c, --topic-config |string (repeatable) |Topic properties can be set by using `<key>=<value>`. For example `-c cleanup.policy=compact`. This flag is repeatable, so you can set multiple parameters in a single command. 
 


### PR DESCRIPTION
## Description
Documents the new RF=3 enforcement in Redpanda Cloud. This goes along with https://github.com/redpanda-data/cloud-docs/pull/115

Resolves https://redpandadata.atlassian.net/browse/DOC-290
Review deadline: Monday Nov 11

## Page previews

- [Manage topics (Cloud)](https://deploy-preview-840--redpanda-docs-preview.netlify.app/redpanda-cloud/get-started/config-topics/) vs [(Self-Managed)](https://deploy-preview-840--redpanda-docs-preview.netlify.app/current/develop/config-topics/#create-a-topic)
- [List topic configuration settings (Cloud)](https://deploy-preview-840--redpanda-docs-preview.netlify.app/redpanda-cloud/get-started/config-topics/#list-topic-configuration-settings) vs [(Self-Managed)](https://deploy-preview-840--redpanda-docs-preview.netlify.app/current/develop/config-topics/#list-topic-configuration-settings)
- [rpk topic create (SM & Cloud)](https://deploy-preview-840--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-topic/rpk-topic-create/)
- [`default_topic_replications` cluster property (only appears in SM docs)](https://deploy-preview-840--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/#default_topic_replications)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)