### PR TITLE
cloud replication factor update for glossterm

### DIFF
--- a/modules/terms/partials/rf.adoc
+++ b/modules/terms/partials/rf.adoc
@@ -1,6 +1,4 @@
 === replication factor
 :term-name: replication factor
-:hover-text: The number of copies of partitions in a cluster. With a replication factor greater than 1, you ensure that each partition has a copy of its data on at least one other broker. One replica acts as the leader, and the other replicas are followers. 
+:hover-text: The number of copies of partitions in a cluster. This is set to 3 in Redpanda Cloud deployments and 1 (no replication) in Self-Managed deployments. A replication factor greater than 1 ensures that each partition has a copy of its data on at least one other broker. One replica acts as the leader, and the other replicas are followers. 
 :category: Redpanda core
-
-By default, `replication.factor` is set to 1 (no replication) in Redpanda Self-Managed deployments and set to 3 in Redpanda Cloud deployments.

--- a/modules/terms/partials/rf.adoc
+++ b/modules/terms/partials/rf.adoc
@@ -1,4 +1,4 @@
 === replication factor
 :term-name: replication factor
-:hover-text: The number of copies of partitions in a cluster. This is set to 3 in Redpanda Cloud deployments and 1 (no replication) in Self-Managed deployments. A replication factor greater than 1 ensures that each partition has a copy of its data on at least one other broker. One replica acts as the leader, and the other replicas are followers. 
+:hover-text: The number of partition copies in a cluster. This is set to 3 in Redpanda Cloud deployments and 1 (no replication) in Self-Managed deployments. A replication factor greater than 1 ensures that each partition has a copy of its data on at least one other broker. One replica acts as the leader, and the other replicas are followers. 
 :category: Redpanda core

--- a/modules/terms/partials/rf.adoc
+++ b/modules/terms/partials/rf.adoc
@@ -1,4 +1,4 @@
 === replication factor
 :term-name: replication factor
-:hover-text: The number of partition copies in a cluster. This is set to 3 in Redpanda Cloud deployments and 1 (no replication) in Self-Managed deployments. A replication factor greater than 1 ensures that each partition has a copy of its data on at least one other broker. One replica acts as the leader, and the other replicas are followers. 
+:hover-text: The number of partition copies in a cluster. This is set to 3 in Redpanda Cloud deployments and 1 (no replication) in Self-Managed deployments. A replication factor of at least 3 ensures that each partition has a copy of its data on at least one other broker. One replica acts as the leader, and the other replicas are followers. 
 :category: Redpanda core


### PR DESCRIPTION
## Description
Edits the glossterm for replication factor for better readability for difference in RP Cloud. 

Resolves https://redpandadata.atlassian.net/browse/DOC-290
Review deadline: Monday Nov 11

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)