### PR TITLE
DOC-755 Add link to commit that triggered the Cloud API spec update

### DIFF
--- a/.github/workflows/get-cloud-api-spec.yml
+++ b/.github/workflows/get-cloud-api-spec.yml
@@ -34,6 +34,14 @@ jobs:
           path: redpanda-docs
           token: ${{ env.ACTIONS_BOT_TOKEN }}
 
+      - name: Get commit SHA and build URL
+        id: commit-info
+        run: |
+          COMMIT_SHA="${{ github.event.client_payload.commit_sha }}"
+          COMMIT_URL="https://github.com/${{ github.event.repository.full_name }}/commit/${COMMIT_SHA}"
+          echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_ENV
+          echo "COMMIT_URL=${COMMIT_URL}" >> $GITHUB_ENV
+
       - name: Install dependencies
         run: |
           cd ./redpanda-docs/scripts/fetch-from-github
@@ -53,6 +61,8 @@ jobs:
           path: redpanda-docs
           branch: update-branch-api
           title: "auto-docs: Update Cloud API spec"
-          body: "This PR updates the OpenAPI spec file for the Cloud API."
+          body: |
+            This PR updates the OpenAPI spec file for the Cloud API.
+            Triggered by commit: [${{ env.COMMIT_SHA }}](${{ env.COMMIT_URL }})
           labels: auto-docs
           reviewers: JakeSCahill, kbatuigas


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)