### PR TITLE
Fix TLS configs in K8s

### DIFF
--- a/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
@@ -4,11 +4,11 @@
 :page-categories: Management, Security
 :env-kubernetes: true
 
-When using glossterm:cert-manager[] for TLS certificate management, you have the option to use a self-signed certificate or a certificate signed by a trusted certificate authority (CA). This topic provides instructions for each option.
+When using glossterm:cert-manager[] for TLS certificate management, you can use a self-signed certificate or a certificate signed by a trusted certificate authority (CA). This topic provides instructions for each option.
 
 Redpanda supports both TLS and mTLS:
 
-- TLS, previously SSL, provides encryption for client-server communication. A server certificate prevents third parties from accessing data transferred between the client and server.
+- TLS, previously SSL, provides encryption for client-server communication. A server certificate prevents third parties from accessing data transferred between the client and the server.
 
 - mTLS, or mutual TLS, is a protocol that authenticates both the server and the client. In addition to the server certificate required in TLS, mTLS also requires the client to give a certificate. mTLS is useful for environments that require additional security and only have a small number of verified clients.
 
@@ -44,7 +44,7 @@ By default, the Redpanda Helm chart uses cert-manager to generate four Certifica
 
 |===
 
-For each Certificate resource, a corresponding Secret resource exists, which contains the TLS files.
+A corresponding Secret resource exists for each Certificate resource, which contains the TLS files.
 
 Having separate self-signed certificates for internal and external connections provides security isolation.
 If an external certificate or its corresponding private key is compromised,
@@ -271,7 +271,7 @@ Helm::
 tls:
   enabled: true
   certs:
-    default:
+    external:
       issuerRef:
         name: <issuer-name>
         kind: <issuer>
@@ -290,9 +290,9 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 ```bash
 helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
   --set tls.enabled=true \
-  --set tls.certs.default.issuerRef.name=<issuer-name> \
-  --set tls.certs.default.issuerRef.kind=<issuer> \
-  --set tls.certs.default.caEnabled=false \
+  --set tls.certs.external.issuerRef.name=<issuer-name> \
+  --set tls.certs.external.issuerRef.kind=<issuer> \
+  --set tls.certs.external.caEnabled=false \
   --set external.domain=<custom-domain>
 ```
 ====

--- a/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
@@ -44,7 +44,7 @@ By default, the Redpanda Helm chart uses cert-manager to generate four Certifica
 
 |===
 
-A corresponding Secret resource exists for each Certificate resource, which contains the TLS files.
+A corresponding Secret resource exists for each Certificate resource. The Secret contains the TLS files.
 
 Having separate self-signed certificates for internal and external connections provides security isolation.
 If an external certificate or its corresponding private key is compromised,


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)