### PR TITLE
Hard-code link to cloud repo

### DIFF
--- a/.github/workflows/get-cloud-api-spec.yml
+++ b/.github/workflows/get-cloud-api-spec.yml
@@ -38,7 +38,7 @@ jobs:
         id: commit-info
         run: |
           COMMIT_SHA="${{ github.event.client_payload.commit_sha }}"
-          COMMIT_URL="https://github.com/${{ github.event.repository.full_name }}/commit/${COMMIT_SHA}"
+          COMMIT_URL="https://github.com/redpanda-data/cloudv2/commit/${COMMIT_SHA}"
           echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_ENV
           echo "COMMIT_URL=${COMMIT_URL}" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Description

The `repository.full_name` string refers to the current repo. As a workaround, this PR hardcodes the repo link to go to the `cloudv2` repo.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)