### PR TITLE
add note that command only supported in Serverless

### DIFF
--- a/modules/reference/pages/rpk/rpk-generate/rpk-generate-app.adoc
+++ b/modules/reference/pages/rpk/rpk-generate/rpk-generate-app.adoc
@@ -1,23 +1,31 @@
 = rpk generate app
 // tag::single-source[]
 
+ifdef::env-cloud[]
+NOTE: This command is only supported in Serverless clusters.
+
+endif::[]
+
 Generate a sample application to connect with Redpanda.
 
 This command generates a starter application to produce and consume from the
 settings defined in the `rpk profile`. Its goal is to get you producing and
 consuming quickly with Redpanda in a language that is familiar to you.
 
-By default, this will run interactively, prompting you to select a language and
+By default, this runs interactively, prompting you to select a language and
 a user with which to create your application. To use this without interactivity,
-specify how you would like your application to be created using flags.
+specify how you want your application to be created using flags.
 
-The `--language` option allows you to specify the language. There is no default.
+The `--language` flag lets you specify the language. There is no default.
 
-The `--new-sasl--user` flag allows you to generate a new SASL user
+The `--new-sasl--user` flag lets you generate a new SASL user
 with admin ACLs. If you don't want to use your current profile user or don't want to create a
 new one, you can use the `--no-user` flag to generate the starter app without the user.
 
+ifndef::env-cloud[]
 If you are having trouble connecting to your cluster, you can use the common xref:reference:rpk/rpk-x-options.adoc#adminhosts[`-X admin.hosts=<host:ports>`] flag to pass a specific Admin API address.
+
+endif::[]
 
 == Examples
 

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-create.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-create.adoc
@@ -2,6 +2,11 @@
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-create.adoc, reference:rpk/rpk-security/rpk-security-acl-user-create.adoc
 // tag::single-source[]
 
+ifdef::env-cloud[]
+NOTE: This command is only supported in Serverless clusters.
+
+endif::[]
+
 Create a SASL user.
 
 This command creates a single SASL user with the given password, optionally

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-delete.adoc
@@ -2,6 +2,11 @@
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-delete.adoc, reference:rpk/rpk-security/rpk-security-acl-user-delete.adoc
 // tag::single-source[]
 
+ifdef::env-cloud[]
+NOTE: This command is only supported in Serverless clusters.
+
+endif::[]
+
 Delete a SASL user.
 
 This command deletes the specified SASL account from Redpanda. This does not

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-list.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-list.adoc
@@ -2,6 +2,11 @@
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-list.adoc, reference:rpk/rpk-security/rpk-security-acl-user-list.adoc
 // tag::single-source[]
 
+ifdef::env-cloud[]
+NOTE: This command is only supported in Serverless clusters.
+
+endif::[]
+
 List SASL users.
 
 == Usage

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc
@@ -2,6 +2,11 @@
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-update.adoc, reference:rpk/rpk-security/rpk-security-acl-user-update.adoc
 // tag::single-source[]
 
+ifdef::env-cloud[]
+NOTE: This command is only supported in Serverless clusters.
+
+endif::[]
+
 Update SASL user credentials
 
 CAUTION: The default value for the `--mechanism` flag is `SCRAM-SHA-256`. Set the flag when using a different mechanism to avoid unexpected changes.

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user.adoc
@@ -2,6 +2,11 @@
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user.adoc, reference:rpk/rpk-security/rpk-security-acl-user.adoc
 // tag::single-source[]
 
+ifdef::env-cloud[]
+NOTE: This command is only supported in Serverless clusters.
+
+endif::[]
+
 Manage SCRAM users.
 
 If SCRAM is enabled, a SCRAM user is what you use to talk to Redpanda, and ACLs

--- a/modules/reference/pages/rpk/rpk-security/rpk-security.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security.adoc
@@ -2,7 +2,15 @@
 // tag::single-source[]
 :description: These commands let you create SASL users and create, list, and delete ACLs and RBAC.
 
-Manage Redpanda security.
+ifdef::env-cloud[]
+NOTE: This command is only supported in Serverless clusters.
+
+endif::[]
+
+ifdef::env-cloud[]
+NOTE: This command is only supported in Serverless clusters.
+
+endif::[]
 
 == Usage
 


### PR DESCRIPTION
## Description

This adds a conditionalized-for-Cloud note in the `docs` repo for commands only available in Serverless. 

This is related to https://redpandadata.atlassian.net/browse/DOC-756 (https://github.com/redpanda-data/cloud-docs/pull/128) in the `cloud-docs` repo, which removes rpk commands from Cloud docs that don't make sense for Cloud users.

## Page previews

- https://deploy-preview-868--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-generate/rpk-generate-app/
- https://deploy-preview-868--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-security/rpk-security-user/
- https://deploy-preview-868--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-security/rpk-security-user-create/
- https://deploy-preview-868--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-security/rpk-security-user-delete/
- https://deploy-preview-868--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-security/rpk-security-user-update/
- https://deploy-preview-868--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-security/rpk-security-user-list/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)