### PR TITLE
DOC-797 Add end-of-life banner to 23.3 docs

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -6,6 +6,7 @@ nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
+    page-eol: true
     # Only used in the main branch (latest version)
     page-header-data:
       order: 2


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)