### PR TITLE
Release 24.3

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,8 +1,6 @@
 name: ROOT
 title: Self-Managed
 version: 24.3
-display_version: '24.3 Beta'
-prerelease: true
 start_page: home:index.adoc
 nav:
 - modules/ROOT/nav.adoc
@@ -20,7 +18,7 @@ asciidoc:
     full-version: 24.3.1
     latest-redpanda-tag: 'v24.3.1'
     latest-console-tag: 'v2.7.2'
-    latest-release-commit: '72ba3d3'
+    latest-release-commit: 'afe1a3f'
     latest-operator-version: 'v2.2.0-24.2.2'
     latest-redpanda-helm-chart-version: 5.8.3
     redpanda-beta-version: '24.3.1-rc2'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [main,v/*, api, shared, site-search,'!v-end-of-life/*']
+    branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
     branches: main
   - url: https://github.com/redpanda-data/redpanda-labs


### PR DESCRIPTION
## Description

This PR updates the Antora atributtes ahead of the release.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)