### PR TITLE
Let users know a restart is reqd when enabling TS for clusters

### DIFF
--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -857,7 +857,7 @@ To enable Tiered Storage for a cluster (in addition to setting `cloud_storage_en
 * config_ref:cloud_storage_enable_remote_write,true,properties/object-storage-properties[]
 * config_ref:cloud_storage_enable_remote_read,true,properties/object-storage-properties[]
 
-When you enable Tiered Storage for a cluster, you enable it for all existing topics in the cluster. When cluster-level properties are changed, the changes apply only to new topics, not existing topics.
+When you enable Tiered Storage for a cluster, you enable it for all existing topics in the cluster. When cluster-level properties are changed, the changes apply only to new topics, not existing topics. You must restart your cluster after enabling Tiered Storage.
 
 NOTE: The `cloud_storage_enable_remote_write` and `cloud_storage_enable_remote_read` cluster-level properties are essentially creation-time defaults for the `redpanda.remote.write` and `redpanda.remote.read` topic-level properties.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-795
Review deadline: **Dec 4**

[Preview](https://deploy-preview-890--redpanda-docs-preview.netlify.app/current/manage/tiered-storage/#enable-tiered-storage-for-a-cluster)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X ] Content gap
- [ ] Support Follow-up
- [ X] Small fix (typos, links, copyedits, etc)