### PR TITLE
remove rpk links from cloud

### DIFF
--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-mount.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-mount.adoc
@@ -9,7 +9,9 @@ You can optionally rename the topic using the `--to` flag.
 
 Requirements:
 
+ifndef::env-cloud[]
 - xref:manage:tiered-storage.adoc#enable-tiered-storage[Tiered Storage must be enabled].
+endif::[]
 
 - Log segments for the topic must be available in Tiered Storage.
 

--- a/modules/reference/pages/rpk/rpk-transform/rpk-transform-deploy.adoc
+++ b/modules/reference/pages/rpk/rpk-transform/rpk-transform-deploy.adoc
@@ -92,9 +92,11 @@ Configure this at deployment using `rpk` with the `--compression` flag:
 rpk transform deploy --compression <compression_type>
 ----
 
+ifndef::env-cloud[]
 Enabling compression may increase computation costs and could impact latency at the output topic.
 
 For more details, see xref:deploy:deployment-option/self-hosted/manual/sizing.adoc[].
+endif::[]
 
 
 // end::single-source[]


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)