### PR TITLE
DOC-836 Add link to apply license key

### DIFF
--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -159,6 +159,10 @@ Redpanda Console offers two methods for applying or updating a license, dependin
 
 - If Redpanda Console is connected to a Redpanda cluster, you can xref:console:ui/add-license.adoc[upload a license through the Redpanda Console UI]. This method allows you to manage and update licenses for both Redpanda Console and the connected Redpanda cluster.
 
+== Manage licenses for Redpanda Connect
+
+Redpanda offers multiple ways to apply or update your license. See xref:redpanda-connect:get-started:licensing.adoc[Enterprise Licensing].
+
 == Next steps
 
 - xref:get-started:licensing/add-license-redpanda/index.adoc[]

--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -161,7 +161,7 @@ Redpanda Console offers two methods for applying or updating a license, dependin
 
 == Manage licenses for Redpanda Connect
 
-Redpanda offers multiple ways to apply or update your license. See xref:redpanda-connect:get-started:licensing.adoc[Enterprise Licensing].
+Redpanda Connect offers multiple ways to apply or update your license. See xref:redpanda-connect:get-started:licensing.adoc[Enterprise Licensing].
 
 == Next steps
 

--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -161,7 +161,7 @@ Redpanda Console offers two methods for applying or updating a license, dependin
 
 == Manage licenses for Redpanda Connect
 
-Redpanda Connect offers multiple ways to apply or update your license. See xref:redpanda-connect:get-started:licensing.adoc[Enterprise Licensing].
+Redpanda Connect offers multiple ways to apply or update your license. See xref:redpanda-connect:get-started:licensing.adoc#apply-a-license-key-to-redpanda-connect[Apply a license key to Redpanda Connect].
 
 == Next steps
 

--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -38,7 +38,7 @@ To get a trial license key or extend your trial period, https://redpanda.com/try
 
 [IMPORTANT]
 ====
-Redpanda Connect does not accept trial license keys. To use enterprise features of Redpanda Connect, https://redpanda.com/upgrade[upgrade to Redpanda Enterprise^]
+Redpanda Connect does not accept trial license keys. To use enterprise features of Redpanda Connect, https://redpanda.com/upgrade[upgrade to Redpanda Enterprise^] and then xref:redpanda-connect:get-started:licensing.adoc[apply your license key].
 ====
 
 [NOTE]
@@ -133,7 +133,7 @@ The following enterprise features for Redpanda Console are activated with a vali
 [[connect]]
 === Redpanda Connect enterprise features
 
-The Enterprise Edition of Redpanda Connect includes additional connectors. An Enterprise Edition license is required to enable them.
+The Enterprise Edition of Redpanda Connect includes additional connectors. An xref:redpanda-connect:get-started:licensing.adoc[Enterprise Edition license] is required to enable them.
 
 For all available connectors, see xref:redpanda-connect:components:catalog.adoc[].
 
@@ -142,7 +142,7 @@ For all available connectors, see xref:redpanda-connect:components:catalog.adoc[
 
 [IMPORTANT]
 ====
-Redpanda Connect does not accept trial license keys. To use enterprise features of Redpanda Connect, https://redpanda.com/upgrade[upgrade to Redpanda Enterprise^]
+Redpanda Connect does not accept trial license keys. To use enterprise features of Redpanda Connect, https://redpanda.com/upgrade[upgrade to Redpanda Enterprise^] and then xref:redpanda-connect:get-started:licensing.adoc[apply your license key].
 ====
 
 == Manage licenses for Redpanda


### PR DESCRIPTION
## Description

Resolves [DOC-836](https://redpandadata.atlassian.net/browse/DOC-836)
Review deadline: 6 December

Missing link to apply license key

## Page previews

https://deploy-preview-897--redpanda-docs-preview.netlify.app/current/get-started/licensing/overview/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-836]: https://redpandadata.atlassian.net/browse/DOC-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ