### PR TITLE
Doc-578 Fix incorrect curl commands

### DIFF
--- a/modules/manage/partials/recovery-mode.adoc
+++ b/modules/manage/partials/recovery-mode.adoc
@@ -271,7 +271,7 @@ Curl::
 +
 --
 ```bash
-curl -X POST -d '{"disabled": true}' http://localhost:9644/cluster/partitions/<partition-namespace>/<topic-name>/<partition-id>
+curl -X POST -d '{"disabled": true}' http://localhost:9644/v1/cluster/partitions/<partition-namespace>/<topic-name>/<partition-id>
 ```
 --
 ====
@@ -291,7 +291,7 @@ Curl::
 +
 --
 ```bash
-curl -X POST -d '{"disabled": false}' http://localhost:9644/cluster/partitions/<partition-namespace>/<topic-name>/<partition-id>
+curl -X POST -d '{"disabled": false}' http://localhost:9644/v1/cluster/partitions/<partition-namespace>/<topic-name>/<partition-id>
 ```
 --
 ====
@@ -311,7 +311,7 @@ Curl::
 +
 --
 ```bash
-curl -X POST -d '{"disabled": true}' http://localhost:9644/cluster/partitions/<partition-namespace>/<topic-name>
+curl -X POST -d '{"disabled": true}' http://localhost:9644/v1/cluster/partitions/<partition-namespace>/<topic-name>
 ```
 --
 ====
@@ -331,7 +331,7 @@ Curl::
 +
 --
 ```bash
-curl -X POST -d '{"disabled": false}' http://localhost:9644/cluster/partitions/<partition-namespace>/<topic-name>
+curl -X POST -d '{"disabled": false}' http://localhost:9644/v1/cluster/partitions/<partition-namespace>/<topic-name>
 ```
 --
 ====
@@ -351,7 +351,7 @@ Curl::
 +
 --
 ```bash
-curl http://localhost:9644/cluster/partitions?disabled=true
+curl http://localhost:9644/v1/cluster/partitions?disabled=true
 ```
 --
 ====
@@ -371,7 +371,7 @@ Curl::
 +
 --
 ```bash
-curl http://localhost:9644/cluster/partitions/<partition-namespace>/<topic-name>?disabled=true
+curl http://localhost:9644/v1/cluster/partitions/<partition-namespace>/<topic-name>?disabled=true
 ```
 --
 ====


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-578
Review deadline: **Dec 9**

## Page previews
https://deploy-preview-899--redpanda-docs-preview.netlify.app/current/manage/recovery-mode/?tab=tabs-3-curl
<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)