### PR TITLE
Doc-24 Minor clarification about cluster versions in migration doc

### DIFF
--- a/modules/upgrade/pages/migrate/data-migration.adoc
+++ b/modules/upgrade/pages/migrate/data-migration.adoc
@@ -14,7 +14,7 @@ See the https://kafka.apache.org/downloads[Kafka downloads page^] for download i
 
 To set up the replication, you need:
 
-* 2 Redpanda clusters - You can set up these clusters in any deployment you like, including xref:deploy:deployment-option/self-hosted/kubernetes/get-started-dev.adoc[Kubernetes], xref:get-started:quick-start.adoc[Docker], and xref:deploy:deployment-option/self-hosted/manual/index.adoc[Linux].
+* 2 Redpanda clusters - Redpanda's migration mechanism is independent of the underlying cluster version or cluster platform, so you can set up these clusters in any deployment you like, including xref:deploy:deployment-option/self-hosted/kubernetes/get-started-dev.adoc[Kubernetes], xref:get-started:quick-start.adoc[Docker], and xref:deploy:deployment-option/self-hosted/manual/index.adoc[Linux].
 * MirrorMaker 2 host - You install MirrorMaker 2 on a separate system or on one of the Redpanda clusters, as long as the IP addresses and ports on each cluster are accessible from the MirrorMaker 2 host.
 You must install the https://docs.oracle.com/javase/10/install/toc.htm[Java Runtime Engine (JRE)^] on the MirrorMaker 2 host.
 

--- a/modules/upgrade/pages/migrate/data-migration.adoc
+++ b/modules/upgrade/pages/migrate/data-migration.adoc
@@ -14,7 +14,7 @@ See the https://kafka.apache.org/downloads[Kafka downloads page^] for download i
 
 To set up the replication, you need:
 
-* 2 Redpanda clusters - Redpanda's migration mechanism is independent of the underlying cluster version or cluster platform, so you can set up these clusters in any deployment you like, including xref:deploy:deployment-option/self-hosted/kubernetes/get-started-dev.adoc[Kubernetes], xref:get-started:quick-start.adoc[Docker], and xref:deploy:deployment-option/self-hosted/manual/index.adoc[Linux].
+* 2 Redpanda clusters - Redpanda's migration mechanism is independent of the underlying cluster version or cluster platform, so you can set up these clusters in any deployment you like, including xref:deploy:deployment-option/self-hosted/kubernetes/get-started-dev.adoc[Kubernetes], and xref:deploy:deployment-option/self-hosted/manual/index.adoc[Linux].
 * MirrorMaker 2 host - You install MirrorMaker 2 on a separate system or on one of the Redpanda clusters, as long as the IP addresses and ports on each cluster are accessible from the MirrorMaker 2 host.
 You must install the https://docs.oracle.com/javase/10/install/toc.htm[Java Runtime Engine (JRE)^] on the MirrorMaker 2 host.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-24
Review deadline: **Dec 9**

@c4milo I ran this by @hcoyote, so feeling pretty confident this is the only update to make in response to your question for this ticket.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)