### PR TITLE
Change clusterSpec to chartRef in Redpanda spec for useFlux option

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-deployment-overview.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-deployment-overview.adoc
@@ -74,7 +74,7 @@ kind: Redpanda
 metadata:
   name: redpanda
 spec:
-  clusterSpec:
+  chartRef:
     useFlux: true  # or false, depending on your desired deployment mode
 ----
 

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -102,8 +102,8 @@ metadata:
 spec:
   chartRef:
     chartVersion: {latest-redpanda-helm-chart-version}
-  clusterSpec:
     #useFlux: true
+  clusterSpec:
     #enterprise:
       #licenseSecretRef:
         #name: <secret-name>
@@ -124,7 +124,7 @@ spec:
 - xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-api-redpanda-v1alpha2-chartref[`spec.chartRef`]: Information about the Helm chart that will be used to deploy Redpanda.
 - `spec.chartRef.chartVersion`: This field specifies the exact version of the Redpanda Helm chart to use for deployment. By setting this value, you <<version-pinning, pin the chart to a specific version>>, which prevents automatic updates that might introduce breaking changes or new features that have not been tested in your environment.
 - xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-api-redpanda-v1alpha2-redpandaclusterspec[`spec.clusterSpec`]: This is where you can override default values in the Redpanda Helm chart. Here, you mount the <<prerequisites, I/O configuration file>> to the Pods that run Redpanda. For other configuration details, see <<Production considerations>>.
-- `spec.clusterSpec.useFlux`: By default, the Redpanda Operator uses Flux controllers to deploy and manage the Redpanda resource. Set this to `false` to disable Flux and instead use the Redpanda Operator controllers.
+- `spec.chartRef.useFlux`: By default, the Redpanda Operator uses Flux controllers to deploy and manage the Redpanda resource. Set this to `false` to disable Flux and instead use the Redpanda Operator controllers.
 - `spec.clusterSpec.enterprise`: If you want to use enterprise features in Redpanda, uncomment this section and add the details of a Secret that stores your Enterprise Edition license key. For details, see xref:get-started:licenses.adoc[].
 - `spec.clusterSpec.statefulset`: Here, you mount the <<prerequisites, I/O configuration file>> to the Pods that run Redpanda. For other configuration details, see <<Production considerations>>.
 


### PR DESCRIPTION
## Description

The `useFlux` is available under `chartRef` not `clusterSpec`

https://github.com/redpanda-data/redpanda-operator/blob/43c3dd0e59539bfbc30faacc53e430f5217a6216/operator/api/redpanda/v1alpha2/redpanda_types.go#L75

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)