### PR TITLE
Doc-439 - Note about not using SELinux in deployments due to latency

### DIFF
--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -9,6 +9,8 @@ endif::[]
 
 - Minimum version required of Ubuntu: {supported-ubuntu-required}. *Recommended*: {supported-ubuntu-recommended}
 
+NOTE: Enabling SELinux (Security-Enhanced Linux) can result in latency issues. If you wish to avoid such latency issues, do not use this mechanism.
+
 *Recommendation*: Linux kernel 4.19 or later for better performance.
 
 ifdef::env-kubernetes[]


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-439
Review deadline: **Nov 9**

## Page previews
https://deploy-preview-903--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/manual/production/requirements/#operating-system

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)