### PR TITLE
DOC-800 add enterprise properties to reference

### DIFF
--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -140,6 +140,8 @@ Defines the number of bytes allocated by the internal audit client for audit mes
 
 === audit_enabled
 
+include::reference:partial$enterprise-licensed-property.adoc[]
+
 Enables or disables audit logging. When you set this to true, Redpanda checks for an existing topic named `_redpanda.audit_log`. If none is found, Redpanda automatically creates one for you.
 
 *Requires restart:* No
@@ -147,6 +149,8 @@ Enables or disables audit logging. When you set this to true, Redpanda checks fo
 *Visibility:* `user`
 
 *Type:* boolean
+
+*Enterprise license required*: `true`
 
 *Default:* `false`
 
@@ -502,6 +506,8 @@ Maximum amount of time before Redpanda attempts to create a controller snapshot 
 
 === core_balancing_continuous
 
+include::reference:partial$enterprise-licensed-property.adoc[]
+
 If set to `true`, move partitions between cores in runtime to maintain balanced partition distribution.
 
 *Requires restart:* No
@@ -509,6 +515,8 @@ If set to `true`, move partitions between cores in runtime to maintain balanced 
 *Visibility:* `user`
 
 *Type:* boolean
+
+*Enterprise license required*: `true`
 
 *Default:* `false`
 
@@ -838,6 +846,8 @@ The recursion depth after which debug logging is enabled automatically for the l
 
 === default_leaders_preference
 
+include::reference:partial$enterprise-licensed-property.adoc[]
+
 Default settings for preferred location of topic partition leaders. It can be either "none" (no preference), or "racks:<rack1>,<rack2>,..." (prefer brokers with rack ID from the list).
 
 The list can contain one or more rack IDs. If you specify multiple IDs, Redpanda tries to distribute the partition leader locations equally across brokers in these racks.
@@ -847,6 +857,8 @@ If config_ref:enable_rack_awareness,true,properties/cluster-properties[] is set 
 *Requires restart:* No
 
 *Visibility:* `user`
+
+*Enterprise license required*: Any value other than the default `none`
 
 *Default:* `none`
 
@@ -1153,6 +1165,8 @@ Enable SASL authentication for Kafka connections. Authorization is required to m
 
 === enable_schema_id_validation
 
+include::reference:partial$enterprise-licensed-property.adoc[]
+
 Mode to enable server-side schema ID validation.
 
 *Related topics*:
@@ -1168,6 +1182,8 @@ Mode to enable server-side schema ID validation.
 * `none`: Schema validation is disabled (no schema ID checks are done). Associated topic properties cannot be modified.
 * `redpanda`: Schema validation is enabled. Only Redpanda topic properties are accepted.
 * `compat`: Schema validation is enabled. Both Redpanda and compatible topic properties are accepted.
+
+*Enterprise license required*: `compat` , `redpanda`
 
 *Default:* `none`
 
@@ -1526,6 +1542,8 @@ Maximum age of the metadata cached in the health monitor of a non-controller bro
 
 === http_authentication
 
+include::reference:partial$enterprise-licensed-property.adoc[]
+
 A list of supported HTTP authentication mechanisms. 
 
 *Requires restart:* No
@@ -1535,6 +1553,8 @@ A list of supported HTTP authentication mechanisms.
 *Type:* array
 
 *Accepted Values:* `BASIC`, `OIDC`
+
+*Enterprise license required*: `OIDC`
 
 *Default:* `[basic]`
 
@@ -1602,6 +1622,8 @@ Default value for the `redpanda.iceberg.delete` topic property that determines i
 
 === iceberg_enabled
 
+include::reference:partial$enterprise-licensed-property.adoc[]
+
 Enables the translation of topic data into Iceberg tables. Setting `iceberg_enabled` to `true` activates the feature at the cluster level, but each topic must also set the `redpanda.iceberg.enabled` topic-level property to `true` to use it. If `iceberg_enabled` is set to `false`, then the feature is disabled for all topics in the cluster, overriding any topic-level settings.
 
 *Requires restart:* Yes
@@ -1609,6 +1631,8 @@ Enables the translation of topic data into Iceberg tables. Setting `iceberg_enab
 *Visibility:* `user`
 
 *Type:* boolean
+
+*Enterprise license required*: `true`
 
 *Default:* `false`
 
@@ -3580,6 +3604,8 @@ Minimum size of partition that is going to be prioritized when rebalancing a clu
 
 === partition_autobalancing_mode
 
+include::reference:partial$enterprise-licensed-property.adoc[]
+
 Mode of xref:manage:cluster-maintenance/cluster-balancing.adoc[partition balancing] for a cluster.
 
 *Requires restart:* No
@@ -3591,6 +3617,8 @@ Mode of xref:manage:cluster-maintenance/cluster-balancing.adoc[partition balanci
 * `continuous`: partition balancing happens automatically to maintain optimal performance and availability, based on continuous monitoring for node changes (same as `node_add`) and also high disk usage. This option requires an xref:get-started:licenses.adoc[enterprise license], and it is customized by <<partition_autobalancing_node_availability_timeout_sec,`partition_autobalancing_node_availability_timeout_sec`>> and <<partition_autobalancing_max_disk_usage_percent,`partition_autobalancing_max_disk_usage_percent`>> properties.
 * `node_add`: partition balancing happens when a node is added.
 * `off`: partition balancing is disabled. This option is not recommended for production clusters.
+
+*Enterprise license required*: `continuous`
 
 *Default:* `node_add`
 
@@ -4634,6 +4662,8 @@ Rules for mapping Kerberos principal names to Redpanda user principals.
 
 === sasl_mechanisms
 
+include::reference:partial$enterprise-licensed-property.adoc[]
+
 A list of supported SASL mechanisms. 
 
 *Requires restart:* No
@@ -4642,7 +4672,9 @@ A list of supported SASL mechanisms.
 
 *Type:* string array
 
-*Accepted values*: `SCRAM`, `GSSAPI`, `OAUTHBEARER`.
+*Accepted values*: `SCRAM`, `GSSAPI`, `OAUTHBEARER`
+
+*Enterprise license required*:  `GSSAPI`, `OAUTHBEARER`
 
 *Default:* `[SCRAM]`
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -717,6 +717,8 @@ Enables adjacent segment merging. The segments are reuploaded if there is an opp
 
 === cloud_storage_enabled
 
+include::reference:partial$enterprise-licensed-property.adoc[]
+
 Enable object storage. Must be set to `true` to use Tiered Storage or Remote Read Replicas.
 
 *Requires restart:* Yes
@@ -724,6 +726,8 @@ Enable object storage. Must be set to `true` to use Tiered Storage or Remote Rea
 *Visibility:* `user`
 
 *Type:* boolean
+
+*Enterprise license required*: `true`
 
 *Default:* `false`
 

--- a/modules/reference/partials/enterprise-licensed-property.adoc
+++ b/modules/reference/partials/enterprise-licensed-property.adoc
@@ -1,1 +1,1 @@
-NOTE: This property requires a license when used with certain values.  Check the field *Enterprise license required*. For license details, see xref:get-started:licenses.adoc[].
+NOTE: Some values for this property require an Enterprise license. Refer to the *Enterprise license required* field for specific requirements. For license details, see xref:get-started:licenses.adoc[].

--- a/modules/reference/partials/enterprise-licensed-property.adoc
+++ b/modules/reference/partials/enterprise-licensed-property.adoc
@@ -1,0 +1,1 @@
+NOTE: This property requires a license when used with certain values.  Check the field *Enterprise license required*. For license details, see xref:get-started:licenses.adoc[].


### PR DESCRIPTION
## Description

Review deadline: Dec 11th

## Page previews

https://deploy-preview-904--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/
https://deploy-preview-904--redpanda-docs-preview.netlify.app/current/reference/properties/object-storage-properties/

CTRL+F for

audit_enabled
cloud_storage_enabled
core_balancing_continuous
default_leaders_preference
enable_schema_id_validation
http_authentication
iceberg_enabled (still the case in 24.3.1) 
partition_autobalancing_mode
sasl_mechanisms


## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)