### PR TITLE
Broker restart resets counters to 0

### DIFF
--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -2,7 +2,17 @@
 
 This section provides guidelines and example queries using Redpanda's public metrics to optimize your system's performance and monitor its health.
 
-TIP: To help detect and mitigate anomalous system behaviors, capture baseline metrics of your healthy system at different stages (at start-up, under high load, in steady state) so you can set thresholds and alerts according to those baselines.
+To help detect and mitigate anomalous system behaviors, capture baseline metrics of your healthy system at different stages (at start-up, under high load, in steady state) so you can set thresholds and alerts according to those baselines.
+
+[TIP]
+====
+For counter type metrics, a broker restart causes the count in tools such as Prometheus and Grafana to reset to zero. Redpanda recommends wrapping counter metrics in a rate query to account for broker restarts, for example:
+
+[,promql]
+----
+rate(redpanda_kafka_records_produced_total[5m])
+----
+====
 
 === Redpanda architecture
 

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -6,7 +6,7 @@ To help detect and mitigate anomalous system behaviors, capture baseline metrics
 
 [TIP]
 ====
-For counter type metrics, a broker restart causes the count in tools such as Prometheus and Grafana to reset to zero. Redpanda recommends wrapping counter metrics in a rate query to account for broker restarts, for example:
+For counter type metrics, a broker restart causes the count to reset to zero in tools like Prometheus and Grafana. Redpanda recommends wrapping counter metrics in a rate query to account for broker restarts, for example:
 
 [,promql]
 ----

--- a/modules/manage/partials/monitor-redpanda.adoc
+++ b/modules/manage/partials/monitor-redpanda.adoc
@@ -1,8 +1,8 @@
-Redpanda exports metrics through two Prometheus endpoints on the Admin API port (default: 9644) for you to monitor system health and optimize system performance.
-
-The xref:reference:internal-metrics-reference.adoc[`/metrics`] is a legacy endpoint that includes many internal metrics that are unnecessary for a typical Redpanda user to monitor. The `/metrics` endpoint is also referred to as the 'internal metrics' endpoint, and Redpanda recommends that you use it for development, testing, and analysis. Alternatively, the xref:reference:public-metrics-reference.adoc[`/public_metrics`] endpoint provides a smaller set of important metrics that can be queried and ingested more quickly and inexpensively. 
+Redpanda exports metrics through two endpoints on the Admin API port (default: 9644) for you to monitor system health and optimize system performance.
 
 include::shared:partial$metrics-usage-tip.adoc[]
+
+The xref:reference:internal-metrics-reference.adoc[`/metrics`] is a legacy endpoint that includes many internal metrics that are unnecessary for a typical Redpanda user to monitor. The `/metrics` endpoint is also referred to as the 'internal metrics' endpoint, and Redpanda recommends that you use it for development, testing, and analysis. Alternatively, the xref:reference:public-metrics-reference.adoc[`/public_metrics`] endpoint provides a smaller set of important metrics that can be queried and ingested more quickly and inexpensively. 
 
 [NOTE]
 ====

--- a/modules/manage/partials/monitor-redpanda.adoc
+++ b/modules/manage/partials/monitor-redpanda.adoc
@@ -2,7 +2,7 @@ Redpanda exports metrics through two endpoints on the Admin API port (default: 9
 
 include::shared:partial$metrics-usage-tip.adoc[]
 
-The xref:reference:internal-metrics-reference.adoc[`/metrics`] is a legacy endpoint that includes many internal metrics that are unnecessary for a typical Redpanda user to monitor. The `/metrics` endpoint is also referred to as the 'internal metrics' endpoint, and Redpanda recommends that you use it for development, testing, and analysis. Alternatively, the xref:reference:public-metrics-reference.adoc[`/public_metrics`] endpoint provides a smaller set of important metrics that can be queried and ingested more quickly and inexpensively. 
+The xref:reference:internal-metrics-reference.adoc[`/metrics`] endpoint is a legacy endpoint that includes many internal metrics that are unnecessary for a typical Redpanda user to monitor. The `/metrics` endpoint is also referred to as the 'internal metrics' endpoint, and Redpanda recommends that you use it for development, testing, and analysis. Alternatively, the xref:reference:public-metrics-reference.adoc[`/public_metrics`] endpoint provides a smaller set of important metrics that can be queried and ingested more quickly and inexpensively. 
 
 [NOTE]
 ====

--- a/modules/manage/partials/monitor-redpanda.adoc
+++ b/modules/manage/partials/monitor-redpanda.adoc
@@ -1,8 +1,6 @@
-Redpanda exports metrics through Prometheus endpoints for you to monitor system health and optimize system performance.
+Redpanda exports metrics through two Prometheus endpoints on the Admin API port (default: 9644) for you to monitor system health and optimize system performance.
 
-A Redpanda broker exports public metrics from the xref:reference:public-metrics-reference.adoc[`/public_metrics`] endpoint through the Admin API port (default: 9644).
-
-Before v22.2, a Redpanda broker provided metrics only through the xref:reference:internal-metrics-reference.adoc[`/metrics`] endpoint through the Admin API port. While Redpanda still provides this endpoint, it includes many internal metrics that are unnecessary for a typical Redpanda user to monitor. Consequently, the `/public_metrics` endpoint was added to provide a smaller set of important metrics that can be queried and ingested more quickly and inexpensively. The `/metrics` endpoint is now referred to as the 'internal metrics' endpoint, and Redpanda recommends that you use it for development, testing, and analysis.
+The xref:reference:internal-metrics-reference.adoc[`/metrics`] is a legacy endpoint that includes many internal metrics that are unnecessary for a typical Redpanda user to monitor. The `/metrics` endpoint is also referred to as the 'internal metrics' endpoint, and Redpanda recommends that you use it for development, testing, and analysis. Alternatively, the xref:reference:public-metrics-reference.adoc[`/public_metrics`] endpoint provides a smaller set of important metrics that can be queried and ingested more quickly and inexpensively. 
 
 include::shared:partial$metrics-usage-tip.adoc[]
 
@@ -24,8 +22,6 @@ This topic covers the following about monitoring Redpanda metrics:
 == Configure Prometheus
 
 https://prometheus.io/[Prometheus^] is a system monitoring and alerting tool. It collects and stores metrics as time-series data identified by a metric name and key/value pairs.
-
-NOTE: Redpanda Data recommends creating monitoring dashboards with `/public_metrics`.
 
 ifdef::env-kubernetes[]
 

--- a/modules/shared/partials/metrics-usage-tip.adoc
+++ b/modules/shared/partials/metrics-usage-tip.adoc
@@ -1,6 +1,6 @@
 [TIP]
 ====
-Use xref:reference:public-metrics-reference.adoc[/public_metrics] for your primary dashboards for system health.
+Use xref:reference:public-metrics-reference.adoc[/public_metrics] for your primary dashboards for monitoring system health.
 
 Use xref:reference:internal-metrics-reference.adoc[/metrics] for detailed analysis and debugging.
 ====


### PR DESCRIPTION
## Description

- Also includes some minor reworking of the Monitor Redpanda doc overview

Resolves https://github.com/redpanda-data/documentation-private/issues/2452
Review deadline: 12 Dec 2024

## Page previews

[Monitor Redpanda > Monitor for performance and health](https://deploy-preview-913--redpanda-docs-preview.netlify.app/current/manage/monitoring/#monitor-for-performance-and-health)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)