### PR TITLE
Define useFlux: false as in beta

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-deployment-overview.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-deployment-overview.adoc
@@ -49,7 +49,7 @@ The Redpanda Helm chart provides all the manifest files required to deploy Redpa
 
 The Redpanda Operator provides two deployment modes controlled by the `useFlux` flag. The modes differ in how reconciliation is handled.
 
-IMPORTANT: The `useFlux: false` configuration is in beta. It is not supported for production deployments. Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback].
+IMPORTANT: The `useFlux: false` configuration is in beta. It is not supported for production deployments. Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback^].
 
 - *Flux-managed mode (`useFlux: true`)*:
 When `useFlux` is set to `true` (default), the Redpanda Operator delegates reconciliation to https://fluxcd.io/flux/concepts/[Flux^] controllers. The workflow is as follows:

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-deployment-overview.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-deployment-overview.adoc
@@ -47,7 +47,9 @@ The Redpanda Helm chart provides all the manifest files required to deploy Redpa
 [[helm-and-redpanda-operator]]
 === Redpanda Operator
 
-The Redpanda Operator provides two deployment modes controlled by the `useFlux` flag. The modes differ in how reconciliation is handled:
+The Redpanda Operator provides two deployment modes controlled by the `useFlux` flag. The modes differ in how reconciliation is handled.
+
+IMPORTANT: The `useFlux: false` configuration is in beta. It is not supported for production deployments. Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback].
 
 - *Flux-managed mode (`useFlux: true`)*:
 When `useFlux` is set to `true` (default), the Redpanda Operator delegates reconciliation to https://fluxcd.io/flux/concepts/[Flux^] controllers. The workflow is as follows:

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -102,7 +102,6 @@ metadata:
 spec:
   chartRef:
     chartVersion: {latest-redpanda-helm-chart-version}
-    #useFlux: true
   clusterSpec:
     #enterprise:
       #licenseSecretRef:
@@ -124,7 +123,6 @@ spec:
 - xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-api-redpanda-v1alpha2-chartref[`spec.chartRef`]: Information about the Helm chart that will be used to deploy Redpanda.
 - `spec.chartRef.chartVersion`: This field specifies the exact version of the Redpanda Helm chart to use for deployment. By setting this value, you <<version-pinning, pin the chart to a specific version>>, which prevents automatic updates that might introduce breaking changes or new features that have not been tested in your environment.
 - xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-api-redpanda-v1alpha2-redpandaclusterspec[`spec.clusterSpec`]: This is where you can override default values in the Redpanda Helm chart. Here, you mount the <<prerequisites, I/O configuration file>> to the Pods that run Redpanda. For other configuration details, see <<Production considerations>>.
-- `spec.chartRef.useFlux`: By default, the Redpanda Operator uses Flux controllers to deploy and manage the Redpanda resource. Set this to `false` to disable Flux and instead use the Redpanda Operator controllers.
 - `spec.clusterSpec.enterprise`: If you want to use enterprise features in Redpanda, uncomment this section and add the details of a Secret that stores your Enterprise Edition license key. For details, see xref:get-started:licenses.adoc[].
 - `spec.clusterSpec.statefulset`: Here, you mount the <<prerequisites, I/O configuration file>> to the Pods that run Redpanda. For other configuration details, see <<Production considerations>>.
 

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -90,7 +90,7 @@ The Redpanda Operator now supports the `useFlux` flag, giving you control over r
 - `useFlux: true` (default): Delegates Redpanda resource management to Flux controllers through HelmRelease resources.
 - `useFlux: false`: Directly manages resources within the Redpanda Operator, bypassing Flux.
 +
-IMPORTANT: The `useFlux:false` configuration is in beta. It is not supported for production deployments. Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback].
+IMPORTANT: The `useFlux:false` configuration is in beta. It is not supported for production deployments. Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback^].
 
 Example:
 

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -83,12 +83,14 @@ The Redpanda Operator now supports declarative schema management using the Schem
 
 To learn more, see the xref:manage:kubernetes/k-schema-controller.adoc[Schema custom resource documentation].
 
-=== Use Redpanda Operator without Flux
+=== Use Redpanda Operator without Flux (beta)
 
 The Redpanda Operator now supports the `useFlux` flag, giving you control over resource management, starting in version v2.3.0-24.3.1:
 
 - `useFlux: true` (default): Delegates Redpanda resource management to Flux controllers through HelmRelease resources.
 - `useFlux: false`: Directly manages resources within the Redpanda Operator, bypassing Flux.
++
+IMPORTANT: The `useFlux:false` configuration is in beta. It is not supported for production deployments. Beta features are available for users to test and https://redpandacommunity.slack.com/[provide feedback].
 
 Example:
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2806
Review deadline: 13 December

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)