### PR TITLE
Update fips-compliance.adoc to call out limitation for Console

### DIFF
--- a/modules/manage/pages/security/fips-compliance.adoc
+++ b/modules/manage/pages/security/fips-compliance.adoc
@@ -23,6 +23,7 @@ Before configuring brokers to run in FIPS compliance mode (FIPS mode), check to 
 == Limitations
 
 - Redpanda is not fully FIPS-compliant when used with the Redpanda Helm chart and Operator in a Kubernetes deployment.
+- Redpanda Console is not FIPS-compliant.
 - PKCS#12 keys for xref:manage:security/encryption.adoc[TLS encryption] are not supported when FIPS mode is enabled in Redpanda. The PKCS12KDF algorithm used in PKCS#12 is not FIPS-compliant. To use Redpanda in FIPS mode with TLS enabled, configure your certificates and keys in PEM format instead.
 
 == Configure FIPS mode


### PR DESCRIPTION
Added limitation that Console is not currently FIPS compliant.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)