### PR TITLE
Sleep between calls of K8s compatibility script

### DIFF
--- a/.github/workflows/generate-kubernetes-compatibility.yml
+++ b/.github/workflows/generate-kubernetes-compatibility.yml
@@ -40,17 +40,26 @@ jobs:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
       - name: Install dependencies
         run: cd scripts/generate-k8s-compatibility-matrix && npm install
-      - name: Run script to generate compatibility matrix
+      - name: Run script to generate compatibility matrix for Redpanda
         run: |
           node scripts/generate-k8s-compatibility-matrix/generate-rp-matrix.js \
             ${{ github.event.inputs.min_rp_version }} redpanda \
             > ./redpanda-docs/modules/upgrade/partials/k-redpanda-compatibility-matrix.adoc
+          sleep 50
+        
+      - name: Run script to generate compatibility matrix for Console
+        run: |
           node scripts/generate-k8s-compatibility-matrix/generate-rp-matrix.js \
             ${{ github.event.inputs.min_rp_version }} console \
             > ./redpanda-docs/modules/upgrade/partials/k-redpanda-console-chart-dependencies.adoc
+          sleep 50
+        
+      - name: Run script to generate compatibility matrix for Operator
+        run: |
           node scripts/generate-k8s-compatibility-matrix/generate-rp-matrix.js \
             ${{ github.event.inputs.min_rp_version }} operator \
             > ./redpanda-docs/modules/upgrade/partials/k-operator-compatibility-matrix.adoc
+
       # Check for any changes made in the documentation.
       - name: Check if changes were made
         id: check_changes


### PR DESCRIPTION
We see 429 (rate limiting) errors when running the script. The ArtifactHub docs don't publish their rate-limiting rules. So, this adds a pause between each run to reduce the likelihood of getting these errors.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)