### PR TITLE
Add 24.3 to K8s compatibility doc

### DIFF
--- a/modules/upgrade/partials/k-redpanda-compatibility-matrix.adoc
+++ b/modules/upgrade/partials/k-redpanda-compatibility-matrix.adoc
@@ -2,7 +2,7 @@
 | Redpanda Helm Chart |Supported Redpanda Versions|Minimum Kubernetes Version|Minimum Helm Version
 
 | link:https://artifacthub.io/packages/helm/redpanda-data/redpanda/5.9.6[5.9.x]
-| link:https://github.com/redpanda-data/redpanda/releases/[24.2.x], link:https://github.com/redpanda-data/redpanda/releases/[24.1.x], link:https://github.com/redpanda-data/redpanda/releases/[23.3.x]
+| link:https://github.com/redpanda-data/redpanda/releases/[24.3.x], link:https://github.com/redpanda-data/redpanda/releases/[24.2.x], link:https://github.com/redpanda-data/redpanda/releases/[24.1.x], link:https://github.com/redpanda-data/redpanda/releases/[23.3.x]
 | {supported-kubernetes-version}
 | 3.10.0
 
@@ -12,44 +12,9 @@
 | 3.10.0
 
 | link:https://artifacthub.io/packages/helm/redpanda-data/redpanda/5.7.41[5.7.x]
-| link:https://github.com/redpanda-data/redpanda/releases/[23.3.x], link:https://github.com/redpanda-data/redpanda/releases/[23.2.x]
+| link:https://github.com/redpanda-data/redpanda/releases/[23.3.x]
 | 1.21.0-0
 | 3.10.0
-
-| link:https://artifacthub.io/packages/helm/redpanda-data/redpanda/5.6.66[5.6.x]
-| link:https://github.com/redpanda-data/redpanda/releases/[23.2.x]
-| 1.21.0-0
-| 3.8.0
-
-| link:https://artifacthub.io/packages/helm/redpanda-data/redpanda/5.5.4[5.5.x]
-| link:https://github.com/redpanda-data/redpanda/releases/[23.2.x]
-| 1.21.0-0
-| 3.6.0
-
-| link:https://artifacthub.io/packages/helm/redpanda-data/redpanda/5.4.13[5.4.x]
-| link:https://github.com/redpanda-data/redpanda/releases/[23.2.x]
-| 1.21.0-0
-| 3.6.0
-
-| link:https://artifacthub.io/packages/helm/redpanda-data/redpanda/5.3.4[5.3.x]
-| link:https://github.com/redpanda-data/redpanda/releases/[23.2.x]
-| 1.21.0-0
-| 3.6.0
-
-| link:https://artifacthub.io/packages/helm/redpanda-data/redpanda/5.2.0[5.2.x]
-| link:https://github.com/redpanda-data/redpanda/releases/[23.2.x]
-| 1.21.0-0
-| 3.6.0
-
-| link:https://artifacthub.io/packages/helm/redpanda-data/redpanda/5.1.8[5.1.x]
-| link:https://github.com/redpanda-data/redpanda/releases/[23.2.x]
-| 1.21.0-0
-| 3.6.0
-
-| link:https://artifacthub.io/packages/helm/redpanda-data/redpanda/5.0.10[5.0.x]
-| link:https://github.com/redpanda-data/redpanda/releases/[23.2.x]
-| 1.21.0-0
-| 3.6.0
 
 |===
 


### PR DESCRIPTION
## Description

Manually updates the compatibility matrix until we can merge https://github.com/redpanda-data/docs/pull/919

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)