### PR TITLE
Fix link to download crd-ref-docs

### DIFF
--- a/.github/workflows/generate-crd.yml
+++ b/.github/workflows/generate-crd.yml
@@ -39,7 +39,8 @@ jobs:
       # Download crd-ref-docs utility for doc generation.
       - name: Download crd-ref-docs
         run: |
-          curl -fLO https://github.com/elastic/crd-ref-docs/releases/download/v0.1.0/crd-ref-docs
+          curl -fLO https://github.com/elastic/crd-ref-docs/releases/download/v0.1.0/crd-ref-docs_0.1.0_Linux_x86_64.tar.gz
+          tar -xzf crd-ref-docs_0.1.0_Linux_x86_64.tar.gz
           chmod +x crd-ref-docs
           sudo mv crd-ref-docs /usr/local/bin/
       # Generate Operator CRD documentation.


### PR DESCRIPTION
This workflow has been failing for a while because the binary we downloaded is no longer available. This PR updates the workflow to download an available file.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)