### PR TITLE
Add redirect for Console quickstart

### DIFF
--- a/modules/console/pages/quickstart.adoc
+++ b/modules/console/pages/quickstart.adoc
@@ -1,6 +1,7 @@
 = Redpanda Console Quickstart
 :description: Learn how to use Redpanda Console to manage and monitor your Redpanda clusters.
 :page-categories: Redpanda Console
+:page-aliases: manage:console/quickstart.adoc
 // ========================AUTOMATED TESTS===================================
 // The comments in this file are used to run automated tests of all the documented steps. Tests are run on each pull request to the upstream repository using GitHub Actions. For more details about the testing tool we use, see https://doc-detective.com/.
 


### PR DESCRIPTION
Been seeing a few hits for this URL in our 404 channel. I think I may have forgotten to add the alias when we moved this page: https://redpandadata.slack.com/archives/C04TJ532U87/p1734017153846889

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)