### PR TITLE
Clarify support for cross region Tiered Storage / RRR

### DIFF
--- a/modules/manage/partials/remote-read-replicas.adoc
+++ b/modules/manage/partials/remote-read-replicas.adoc
@@ -36,7 +36,10 @@ You need the following:
 
 * An origin cluster with xref:{tiered-storage-link}#set-up-tiered-storage[Tiered Storage] set up. Note that multi-region buckets or containers are not supported.
 * A topic on the origin cluster, which you can use as a Remote Read Replica topic on the remote cluster.
-* A separate remote cluster. This cluster can be in the same or a different region as the bucket or container used for the origin cluster.
+* A separate remote cluster. 
+** AWS: The remote cluster must be in the same region as the origin cluster.
+** GCP: The remote cluster can be in the same or a different region as the origin cluster.
+** Azure: Remote read replicas are not supported. 
 
 include::shared:partial$enterprise-license.adoc[]
 

--- a/modules/manage/partials/remote-read-replicas.adoc
+++ b/modules/manage/partials/remote-read-replicas.adoc
@@ -21,9 +21,8 @@ You can create Remote Read Replica topics in a Redpanda cluster that directly ac
 
 [IMPORTANT]
 ====
-- The Remote Read Replica cluster must run on the same version of Redpanda as the origin cluster, or just one feature release ahead of the origin cluster. For example, if the origin cluster is version 23.1, the Remote Read Replica cluster can be 23.2, but not 23.4. It cannot skip feature releases.
+- The Remote Read Replica cluster must run on the same version of Redpanda as the origin cluster, or just one feature release ahead of the origin cluster. For example, if the origin cluster is version 24.1, the Remote Read Replica cluster can be 24.2, but not 24.3. It cannot skip feature releases.
 - When upgrading, upgrade the Remote Read Replica cluster before upgrading the origin cluster.
-- When upgrading to Redpanda 23.2, metadata from object storage is not synchronized until all brokers in the cluster are upgraded. If you need to force a mixed-version cluster to sync read replicas, move partition leadership to brokers running the original version.
 ====
 
 ifdef::env-kubernetes[]
@@ -37,8 +36,8 @@ You need the following:
 * An origin cluster with xref:{tiered-storage-link}#set-up-tiered-storage[Tiered Storage] set up. Multi-region buckets or containers are not supported.
 * A topic on the origin cluster, which you can use as a Remote Read Replica topic on the remote cluster.
 * A separate remote cluster. 
-** AWS: The remote cluster must be in the same region as the origin cluster.
-** GCP: The remote cluster can be in the same or a different region as the origin cluster.
+** AWS: The remote cluster must be in the same region as the origin cluster's storage bucket/container.
+** GCP: The remote cluster can be in the same or a different region as the bucket/container.
 ** Azure: Remote read replicas are not supported. 
 
 include::shared:partial$enterprise-license.adoc[]
@@ -57,7 +56,7 @@ You must configure access to the same object storage as the origin cluster.
 ifndef::env-kubernetes[]
 To set up a Remote Read Replica topic on a separate remote cluster:
 
-. Create a remote cluster for the Remote Read Replica topic. The remote cluster can be in the same or a different region as the bucket/container.
+. Create a remote cluster for the Remote Read Replica topic. For AWS, the remote cluster must be in the same region as the origin cluster's storage bucket/container. For GCP, the remote cluster can be in the same or a different region as the bucket/container.
 . Run `rpk cluster config edit`, and then specify properties specific to your object storage provider (your cluster will require a restart after any changes to these properties):
 +
 |===

--- a/modules/manage/partials/remote-read-replicas.adoc
+++ b/modules/manage/partials/remote-read-replicas.adoc
@@ -26,8 +26,6 @@ You can create Remote Read Replica topics in a Redpanda cluster that directly ac
 - When upgrading to Redpanda 23.2, metadata from object storage is not synchronized until all brokers in the cluster are upgraded. If you need to force a mixed-version cluster to sync read replicas, move partition leadership to brokers running the original version.
 ====
 
-TIP: To create a Remote Read Replica topic in another region, consider using a https://aws.amazon.com/s3/features/multi-region-access-points/[multi-region bucket^] to simplify deployment and optimize performance.
-
 ifdef::env-kubernetes[]
 helm_ref:storage.tiered.config[]
 endif::[]
@@ -38,9 +36,7 @@ You need the following:
 
 * An origin cluster with xref:{tiered-storage-link}#set-up-tiered-storage[Tiered Storage] set up.
 * A topic on the origin cluster, which you can use as a Remote Read Replica topic on the remote cluster.
-* A separate remote cluster in the same region as the bucket or container used for the origin cluster.
-** If you use a multi-region bucket/container, you can create the read replica cluster in any region that has that bucket/container.
-** If you use a single-region bucket/container, the remote cluster must be in the same region as the bucket/container.
+* A separate remote cluster. This cluster can be in the same or a different region as the bucket or container used for the origin cluster.
 
 include::shared:partial$enterprise-license.adoc[]
 
@@ -58,9 +54,7 @@ You must configure access to the same object storage as the origin cluster.
 ifndef::env-kubernetes[]
 To set up a Remote Read Replica topic on a separate remote cluster:
 
-. Create a remote cluster for the Remote Read Replica topic.
-* If that's a multi-region bucket/container, you can create the read replica cluster in any region that has that bucket/container.
-* If that's a single-region bucket/container, the remote cluster must be in the same region as the bucket/container.
+. Create a remote cluster for the Remote Read Replica topic. The remote cluster can be in the same or a different region as the bucket/container.
 . Run `rpk cluster config edit`, and then specify properties specific to your object storage provider (your cluster will require a restart after any changes to these properties):
 +
 |===

--- a/modules/manage/partials/remote-read-replicas.adoc
+++ b/modules/manage/partials/remote-read-replicas.adoc
@@ -34,7 +34,7 @@ endif::[]
 
 You need the following:
 
-* An origin cluster with xref:{tiered-storage-link}#set-up-tiered-storage[Tiered Storage] set up.
+* An origin cluster with xref:{tiered-storage-link}#set-up-tiered-storage[Tiered Storage] set up. Note that multi-region buckets or containers are not supported.
 * A topic on the origin cluster, which you can use as a Remote Read Replica topic on the remote cluster.
 * A separate remote cluster. This cluster can be in the same or a different region as the bucket or container used for the origin cluster.
 

--- a/modules/manage/partials/remote-read-replicas.adoc
+++ b/modules/manage/partials/remote-read-replicas.adoc
@@ -34,7 +34,7 @@ endif::[]
 
 You need the following:
 
-* An origin cluster with xref:{tiered-storage-link}#set-up-tiered-storage[Tiered Storage] set up. Note that multi-region buckets or containers are not supported.
+* An origin cluster with xref:{tiered-storage-link}#set-up-tiered-storage[Tiered Storage] set up. Multi-region buckets or containers are not supported.
 * A topic on the origin cluster, which you can use as a Remote Read Replica topic on the remote cluster.
 * A separate remote cluster. 
 ** AWS: The remote cluster must be in the same region as the origin cluster.

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -36,6 +36,7 @@ rpk cluster license info
 
 - Migrating topics from one object storage provider to another is not supported.
 - Migrating topics from one bucket or container to another is not supported.
+- Multi-region buckets or containers are not supported.
 
 CAUTION: Redpanda strongly recommends that you do not re-enable Tiered Storage after previously enabling and disabling it. Re-enabling Tiered Storage can result in inconsistent data and data gaps in Tiered Storage for a topic.
 


### PR DESCRIPTION
## Description

Based on [this discussion](https://redpandadata.slack.com/archives/C02BDN76HUK/p1733154105000019), we should
- explicitly state that multi-region buckets are not supported,
- cross-region RRR (where the remote cluster accessing the RRR topic is in a different region as the source topic's bucket).

TODO

- [x] Confirm what update the Cloud doc [Create Remote Read Replicas](https://deploy-preview-942--redpanda-docs-preview.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/remote-read-replicas/#prerequisites) needs

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 10 Jan

## Page previews

[Remote Read Replicas](https://deploy-preview-942--redpanda-docs-preview.netlify.app/current/manage/remote-read-replicas/)
[Tiered Storage > Limitations](https://deploy-preview-942--redpanda-docs-preview.netlify.app/current/manage/tiered-storage/#limitations)


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)