### PR TITLE
Update kubernetes.adoc - Update update license key steps

### DIFF
--- a/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
+++ b/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
@@ -226,9 +226,11 @@ spec:
 ----
 
 . Apply the changes to the Cluster CRD, which should update the license without restarting the Repanda broker.
-```bash
++
+[,bash]
+---
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
-```
+---
 
 . Check the status of new license to make sure it was successfully applied:
 +

--- a/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
+++ b/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
@@ -231,6 +231,8 @@ spec:
 ---
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
 ---
++
+The Redpanda Operator updates the license without restarting the Repanda broker.
 
 . Check the status of new license to make sure it was successfully applied:
 +

--- a/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
+++ b/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
@@ -198,7 +198,7 @@ If the license is provided through a Kubernetes Secret, follow these steps to up
 kubectl delete secret redpanda-license --namespace <namespace>
 ----
 
-. Create a new Secret with a **new secret name** that contains the contents of the updated license:
+. Create a new Secret with a **new name** that contains the contents of the updated license:
 +
 [,bash]
 ----

--- a/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
+++ b/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
@@ -198,15 +198,37 @@ If the license is provided through a Kubernetes Secret, follow these steps to up
 kubectl delete secret redpanda-license --namespace <namespace>
 ----
 
-. Create a new Secret with the updated license:
+. Create a new Secret with a **new secret name** that contains the contents of the updated license:
 +
 [,bash]
 ----
-kubectl create secret generic redpanda-license \
+kubectl create secret generic redpanda-license-updated \
   --from-file=license=./redpanda.license \
   --namespace <namespace>
 ----
 +
+
+. Update the Cluster CRD to use the new secret name 
+.`redpanda-cluster.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  chartRef: {}
+  clusterSpec:
+    enterprise:
+      licenseSecretRef:
+        name: redpanda-license-updated
+        key: license
+----
+
+. Apply the changes to the Cluster CRD, which should update the license without restarting the Repanda broker.
+```bash
+kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
+```
 
 . Check the status of new license to make sure it was successfully applied:
 +

--- a/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
+++ b/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
@@ -225,7 +225,7 @@ spec:
         key: license
 ----
 
-. Apply the changes to the Cluster CRD, which should update the license without restarting the Repanda broker.
+. Apply the changes to the Redpanda CRD:
 +
 [,bash]
 ---

--- a/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
+++ b/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
@@ -208,7 +208,7 @@ kubectl create secret generic redpanda-license-updated \
 ----
 +
 
-. Update the Cluster CRD to use the new secret name 
+. Update the Redpanda CRD to use the new Secret.
 .`redpanda-cluster.yaml`
 [,yaml]
 ----


### PR DESCRIPTION
## Description

Updates the steps to update the license key which will allow the license key to be properly updated on Kubernetes. Previously license key changes were not applied, since we do not pick up license key changes upon creation or modification of K8s secrets (which we will likely provide in the future). 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)