### PR TITLE
DOC-920 update glossary for Serverless

### DIFF
--- a/modules/terms/partials/redpanda-cloud.adoc
+++ b/modules/terms/partials/redpanda-cloud.adoc
@@ -1,4 +1,4 @@
 === Redpanda Cloud
 :term-name: Redpanda Cloud
-:hover-text: A fully-managed data streaming service deployed with Redpanda Console. It includes automated upgrades and patching, backup and recovery, data and partition balancing, and built-in connectors. It is available in Serverless, Dedicated, and Bring Your Own Cloud (BYOC) deployment options to suit different data sovereignty and infrastructure requirements.
+:hover-text: A fully-managed data streaming service deployed with Redpanda Console. It includes automated upgrades and patching, backup and recovery, data and partition balancing, and built-in connectors. It is available in Serverless Standard, Serverless Pro, Dedicated, and Bring Your Own Cloud (BYOC) deployment options to suit different data sovereignty and infrastructure requirements.
 :category: Redpanda Cloud

--- a/modules/terms/partials/serverless.adoc
+++ b/modules/terms/partials/serverless.adoc
@@ -1,4 +1,6 @@
 === Serverless
 :term-name: Serverless
-:hover-text: Serverless is a fully-managed Redpanda Cloud deployment where you host your data in Redpanda's VPC, and Redpanda handles automatic scaling, provisioning, operations, and maintenance. A cluster is available instantly, there is no base cost, and you only pay for what you consume.
+:hover-text: Serverless is the fastest and easiest way to start data streaming. You host your data in Redpanda's VPC, and Redpanda handles automatic scaling, provisioning, operations, and maintenance. 
+
+Serverless Pro is the enterprise version of Serverless Standard. It includes higher usage limits and dedicated support. 
 :category: Redpanda Cloud

--- a/modules/terms/partials/serverless.adoc
+++ b/modules/terms/partials/serverless.adoc
@@ -1,6 +1,4 @@
 === Serverless
 :term-name: Serverless
-:hover-text: Serverless is the fastest and easiest way to start data streaming. You host your data in Redpanda's VPC, and Redpanda handles automatic scaling, provisioning, operations, and maintenance. 
-
-Serverless Pro is the enterprise version of Serverless Standard. It includes higher usage limits and dedicated support. 
+:hover-text: Serverless is the fastest and easiest way to start data streaming. You host your data in Redpanda's VPC, and Redpanda handles automatic scaling, provisioning, operations, and maintenance. Serverless Pro is the enterprise version of Serverless Standard. It includes higher usage limits and dedicated support. 
 :category: Redpanda Cloud


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-920
Review deadline: Jan 14

## Page previews
[Serverless](https://deploy-preview-945--redpanda-docs-preview.netlify.app/24.2/reference/glossary#serverless)
[Redpanda Cloud](https://deploy-preview-945--redpanda-docs-preview.netlify.app/24.2/reference/glossary#redpanda-cloud)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)