### PR TITLE
DOC-798 Add date of first release

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -6,6 +6,8 @@ nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
+    # Date of release in the format YYYY-MM-DD
+    page-release-date: 2024-12-03
     # Only used in the main branch (latest version)
     page-header-data:
       order: 2


### PR DESCRIPTION
## Description

Review deadline: 16 Jan

Adds the release date according to https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions

This release date will be used by our end-of-life extension to display banners on docs versions that will soon reach their end-of-life.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)