### PR TITLE
DOC-760 Add extra filters to command that fetches loadbalancer addresses

### DIFF
--- a/modules/manage/pages/kubernetes/networking/external/k-loadbalancer.adoc
+++ b/modules/manage/pages/kubernetes/networking/external/k-loadbalancer.adoc
@@ -516,7 +516,15 @@ Helm::
 +
 --
 ```bash
-helm upgrade redpanda redpanda/redpanda --namespace <namespace> --set $(kubectl get svc --namespace <namespace> -o jsonpath='{"external.addresses={"}{ range .items[*]}{.status.loadBalancer.ingress[0].ip }{.status.loadBalancer.ingress[0].hostname}{","}{ end }{"}\n"}') --reuse-values --wait
+helm upgrade redpanda redpanda/redpanda \
+  --namespace <namespace> \
+  --set $(
+  kubectl get svc \
+    --namespace <namespace> \
+    --selector "app.kubernetes.io/name=redpanda,app.kubernetes.io/instance=redpanda" \
+    -o jsonpath='{"external.addresses={"}{ range .items[*]}{.status.loadBalancer.ingress[0].ip }{.status.loadBalancer.ingress[0].hostname}{","}{ end }{"}\n"}') \
+  --reuse-values \
+  --wait
 ```
 --
 ======


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 17 Jan

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)