### PR TITLE
Remove topic-aware balancing from 23.3 what's new

### DIFF
--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -23,16 +23,14 @@ Redpanda's xref:manage:audit-logging.adoc[audit logging] supports fine-grained r
 * Any time a topic is written to or read from (requires explicit opt-in)
 * HTTP requests for the Schema Registry, HTTP Proxy, and Admin APIs
 
+Auditing events can be stored in a topic, ensuring their retention for a specified period. They are protected against removal by all users, including Redpanda administrators. Auditing is compatible with the Open Cybersecurity Schema Framework (OCSF) and works with industry-standard tools, such as Splunk, Sumo Logic, and AWS.
+
 == Enhanced cache trimming
 
 From 23.3.17, Redpanda has two new properties that provide finer control over cache management. These settings allow you to define specific thresholds for triggering xref:manage:tiered-storage.adoc#cache-trimming[cache trimming] based on cache size and the number of objects, helping to optimize performance and prevent slow reads.
 
 - config_ref:cloud_storage_cache_trim_threshold_percent_size,true,cluster-properties[]
 - config_ref:cloud_storage_cache_trim_threshold_percent_objects,true,cluster-properties[]
-
-== Topic-aware partition balancing 
-
-Auditing events can be stored in a topic, ensuring their retention for a specified period. They are protected against removal by all users, including Redpanda administrators. Auditing is compatible with the Open Cybersecurity Schema Framework (OCSF) and works with industry-standard tools, such as Splunk, Sumo Logic, and AWS.
 
 == Whole cluster restore
 


### PR DESCRIPTION
## Description

This was introduced by mistake during a backport: https://github.com/redpanda-data/docs/commit/86223310df7ca50c2aee9e41823039de8be4e3e8

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)