### PR TITLE
Point config at the redpanda-operator repo

### DIFF
--- a/.github/workflows/generate-crd.yml
+++ b/.github/workflows/generate-crd.yml
@@ -50,7 +50,7 @@ jobs:
             --source-path=./redpanda/operator/api/redpanda/v1alpha2 \
             --max-depth=10 \
             --templates-dir=./redpanda-docs/.github/crd-config/templates/asciidoctor/operator \
-            --config=./redpanda-docs/.github/crd-config/config.yaml \
+            --config=./redpanda/operator/crd-ref-docs-config.yaml \
             --renderer=asciidoctor \
             --output-path=./redpanda-docs/modules/reference/pages/k-crd.adoc
       # Check for any changes made in the documentation.


### PR DESCRIPTION
## Description

Review deadline: 21 Jan

We now host the config for the `crd-ref-docs` tool in the `redpanda-operator` repo so that the K8s team can manage it: https://github.com/redpanda-data/redpanda-operator/pull/396/files#diff-0cb4f1303ff20a2dac37c99d821bff1eded9843e59401d605c4c8314d8762c3e

## Page previews

https://deploy-preview-956--redpanda-docs-preview.netlify.app/current/reference/k-crd/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)