### PR TITLE
Point helm-spec generator at `redpanda-operator` repo

### DIFF
--- a/.github/workflows/generate-helm-spec.yml
+++ b/.github/workflows/generate-helm-spec.yml
@@ -29,11 +29,10 @@ jobs:
         run: |
           echo "helm-docs" >> $GITHUB_PATH
           sudo mv helm-docs /usr/local/bin/
-      # Checkout the main branch of the helm-charts repository.
-      - name: Checkout helm-charts repository
+      - name: Checkout redpanda-operator repository
         uses: actions/checkout@v4
         with:
-          repository: redpanda-data/helm-charts
+          repository: redpanda-data/redpanda-operator
           ref: main
           path: helm-charts
           token: ${{ env.ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
We are moving the `connectors`, `console`, `redpanda`, and `operator` charts to the `redpanda-operator` repo. This PR updates our CI workflow to pull from that repo when generating the Helm spec docs.

## Description

Review deadline: 25 Jan

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)