### PR TITLE
Update GH Actions: Fetch split spec files

### DIFF
--- a/.github/workflows/get-cloud-api-spec.yml
+++ b/.github/workflows/get-cloud-api-spec.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Run the script and save the output
         run: |
           cd ./redpanda-docs/scripts/fetch-from-github
-          node fetch.js redpanda-data cloudv2 proto/gen/openapi/openapi.prod.yaml ../../modules/ROOT/attachments cloud-api.yaml
+          node fetch.js redpanda-data cloudv2 proto/gen/openapi/openapi.controlplane.prod.yaml ../../modules/ROOT/attachments cloud-controlplane-api.yaml
+          node fetch.js redpanda-data cloudv2 proto/gen/openapi/openapi.dataplane.prod.yaml ../../modules/ROOT/attachments cloud-dataplane-api.yaml
         env:
           VBOT_GITHUB_API_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
       - name: Create pull request


### PR DESCRIPTION
## Description

Result of workflow adds cloud-controlplane-api.yaml and cloud-dataplane-api.yaml commits in `update-branch-api` (example: https://github.com/redpanda-data/docs/commit/ee4272ab37fe3118c847ebc12d4cc6fc5228d2e3)

Related: 
https://github.com/redpanda-data/docs/pull/929 (must be merged first)
https://github.com/redpanda-data/cloud-docs/pull/185

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 30 Jan

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)