### PR TITLE
DOC-1005 [24.3.3] Update rpk command flag (debug remote-bundle)

### DIFF
--- a/modules/reference/pages/rpk/rpk-debug/rpk-debug-remote-bundle-start.adoc
+++ b/modules/reference/pages/rpk/rpk-debug/rpk-debug-remote-bundle-start.adoc
@@ -27,7 +27,7 @@ rpk debug remote-bundle start [flags]
 
 |-h, --help |- |Help for start.
 
-|--job-id |string |ID of the job to start debug bundle in.
+|--job-id |string |Custom UUID to assign to the job that generates the debug bundle.
 
 |-l, --label-selector |stringArray |(K8s only) Comma-separated label selectors to filter your resources. For example: `<label>=<value>,<label>=<value>`  (default `[app.kubernetes.io/name=redpanda]`).
 

--- a/modules/reference/pages/rpk/rpk-debug/rpk-debug-remote-bundle-start.adoc
+++ b/modules/reference/pages/rpk/rpk-debug/rpk-debug-remote-bundle-start.adoc
@@ -27,7 +27,7 @@ rpk debug remote-bundle start [flags]
 
 |-h, --help |- |Help for start.
 
-|--job-id |string |Custom UUID to assign to the job that generates the debug bundle.
+|--job-id |string |Custom UUID assigned to the job that generates the debug bundle.
 
 |-l, --label-selector |stringArray |(K8s only) Comma-separated label selectors to filter your resources. For example: `<label>=<value>,<label>=<value>`  (default `[app.kubernetes.io/name=redpanda]`).
 


### PR DESCRIPTION
## Description

Updates the description of the `--job-id` flag for `rpk debug remote-bundle start`.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 30 Jan

## Page previews

[rpk debug remote-bundle start](https://deploy-preview-969--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-debug/rpk-debug-remote-bundle-start/#flags)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)