### PR TITLE
Update name of redpanda_pandaproxy_request_latency_seconds

### DIFF
--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -340,7 +340,7 @@ Number of timed out node status RPCs from a node.
 
 == Service metrics
 
-=== redpanda_pandaproxy_request_latency_seconds
+=== redpanda_rest_proxy_request_latency_seconds
 
 Latency in seconds of the request indicated by the label in HTTP Proxy. The measurement includes the time spent waiting for resources to become available, processing the request, and dispatching the response.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-966
Review deadline: **Jan 30**

## Page previews
[redpanda_rest_proxy_request_latency_seconds](https://deploy-preview-971--redpanda-docs-preview.netlify.app/current/reference/public-metrics-reference/#redpanda_rest_proxy_request_latency_seconds)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X ] Small fix (typos, links, copyedits, etc)