### PR TITLE
Update auth server for data plane doc

### DIFF
--- a/modules/ROOT/attachments/cloud-dataplane-api.yaml
+++ b/modules/ROOT/attachments/cloud-dataplane-api.yaml
@@ -1661,7 +1661,7 @@ components:
       description: RedpandaCloud
       flows:
         implicit:
-          authorizationUrl: https://prod-cloudv2.us.auth0.com/oauth/authorize
+          authorizationUrl: https://auth.prd.cloud.redpanda.com/oauth/authorize
           scopes: {}
           x-client-id: dQjapNIAHhF7EQqQToRla3yEII9sUSap
       type: oauth2


### PR DESCRIPTION
## Description

We need to update the auth URL server in the data plane API spec so that it makes the correct call for Get Token (for trying requests in the browser).

See https://redpandadata.slack.com/archives/C058KAULETE/p1738614418180469?thread_ts=1738610193.029789&cid=C058KAULETE

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

[Data Plane APIs > Authentication ](https://deploy-preview-974--redpanda-docs-preview.netlify.app/api/cloud-dataplane-api/#auth)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)