### PR TITLE
Explicit callout for loading license into Console from Redpanda

### DIFF
--- a/modules/console/pages/config/enterprise-license.adoc
+++ b/modules/console/pages/config/enterprise-license.adoc
@@ -3,8 +3,6 @@
 
 To enable xref:get-started:licensing/overview.adoc#console[enterprise features for Redpanda Console], you must have an Enterprise Edition license to load at startup. This guide explains how to configure Redpanda Console to load the license key from its local configuration.
 
-TIP: Redpanda Console can also load the license key from a connected Redpanda cluster. To add a license key to Redpanda, see xref:get-started:licensing/add-license-redpanda/index.adoc[].
-
 == Prerequisites
 
 You must have an Enterprise Edition license. To get a trial license key or extend your trial period, https://redpanda.com/try-enterprise[generate a new trial license key^]. To purchase a license, contact https://redpanda.com/upgrade[Redpanda Sales^].
@@ -13,10 +11,11 @@ If Redpanda Console has enterprise features enabled and cannot find a valid lice
 
 == Add a new license to Redpanda Console
 
-To add a new license to Redpanda Console, you have two options:
+To add a new license to Redpanda Console, choose an option:
 
 - <<file, Provide the path to the license file>>.
 - <<inline, Provide the license key contents directly>>.
+- <<redpanda, Load the license from the connected Redpanda cluster>>.
 
 [[file]]
 === Use a license file
@@ -50,6 +49,11 @@ license: <license-key-contents>
 ```yaml
 export REDPANDA_LICENSE=<license-key-contents>
 ```
+
+[[redpanda]]
+=== Load the license from the connected Redpanda cluster
+
+If Redpanda Console is not configured with a license and it is connected to a Redpanda cluster that has a license, it can load the license key from a connected Redpanda cluster. To add a license key to Redpanda, see xref:get-started:licensing/add-license-redpanda/index.adoc[].
 
 == Update an existing license
 

--- a/modules/console/pages/config/enterprise-license.adoc
+++ b/modules/console/pages/config/enterprise-license.adoc
@@ -53,7 +53,9 @@ export REDPANDA_LICENSE=<license-key-contents>
 [[redpanda]]
 === Load the license from the connected Redpanda cluster
 
-If Redpanda Console is not configured with a license and it is connected to a Redpanda cluster that has a license, it can load the license key from a connected Redpanda cluster. To add a license key to Redpanda, see xref:get-started:licensing/add-license-redpanda/index.adoc[].
+If Redpanda Console is not configured with a license and is xref:console:config/connect-to-redpanda.adoc[connected to a Redpanda cluster] that has a license, it can load the license key from a connected Redpanda cluster.
+
+To add a license key to Redpanda, see xref:get-started:licensing/add-license-redpanda/index.adoc[].
 
 == Update an existing license
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

During an internal discussion, we discovered that the callout about Redpanda Console loading licenses from Redpanda could be missed when scanning for all options. https://redpandadata.slack.com/archives/C07LMK6GRDE/p1738689131122689

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)