### PR TITLE
Configure beta release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@
 name: Build Production Site
 on:
   push:
-    branches: [main, 'v/*', shared, api, site-search, 'v-WIP/*']
+    branches: [main, 'v/*', shared, api, site-search, beta]
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/antora.yml
+++ b/antora.yml
@@ -17,7 +17,7 @@ asciidoc:
     # Name of the Redpanda UI used in single-sourced content with Redpanda Cloud.
     ui: Redpanda Console@
     # Fallback versions
-    # We try to fetch the latest from GitHub at build time
+    # We try to fetch the latest versions from GitHub at build time
     # --
     full-version: 24.3.1
     latest-redpanda-tag: 'v24.3.1'

--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,8 @@
 name: ROOT
 title: Self-Managed
-version: 24.3
+version: 25.1
+display_version: '25.1 Beta'
+prerelease: true
 start_page: home:index.adoc
 nav:
 - modules/ROOT/nav.adoc
@@ -12,7 +14,7 @@ asciidoc:
     page-header-data:
       order: 2
       color: '#107569'
-    # Name of the Redpanda UI used in content that is single-sourced with Redpanda Cloud.
+    # Name of the Redpanda UI used in single-sourced content with Redpanda Cloud.
     ui: Redpanda Console@
     # Fallback versions
     # We try to fetch the latest from GitHub at build time

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
+    branches: [main, v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
     branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs


### PR DESCRIPTION
## Description

Prepares the beta release branch for 25.1.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)