### PR TITLE
DOC-1068 add glossterms for beta and LA

### DIFF
--- a/modules/terms/partials/LA.adoc
+++ b/modules/terms/partials/LA.adoc
@@ -1,0 +1,4 @@
+=== limited availability
+:term-name: LA
+:hover-text: Features in limited availability (LA) are production-ready and are covered by Redpanda Support for early adopters.
+:category: Redpanda Cloud

--- a/modules/terms/partials/beta.adoc
+++ b/modules/terms/partials/beta.adoc
@@ -1,0 +1,4 @@
+=== beta
+:term-name: beta
+:hover-text: Features in beta are available for testing and feedback. They are not covered by Redpanda Support and should not be used in production environments. 
+:category: Redpanda Cloud

--- a/modules/terms/partials/beta.adoc
+++ b/modules/terms/partials/beta.adoc
@@ -1,4 +1,4 @@
 === beta
 :term-name: beta
-:hover-text: Features in beta are available for testing and feedback. They are not covered by Redpanda Support and should not be used in production environments. 
+:hover-text: Features in beta are available for testing and feedback. They are not supported by Redpanda and should not be used in production environments. 
 :category: Redpanda Cloud


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1068
Review deadline: Feb 27

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)