### PR TITLE
DOC-1075 update KafkaJS compatibility

### DIFF
--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -30,9 +30,6 @@ The following clients have been validated with Redpanda.
 | Python
 | https://pypi.org/project/kafka-python-ng[kafka-python-ng^]
 
-| Node.js
-| https://kafka.js.org[KafkaJS^]
-
 | Rust
 | https://github.com/kafka-rust/kafka-rust[kafka-rust^]
 |===

--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -36,7 +36,7 @@ The following clients have been validated with Redpanda.
 | Node.js
 | https://kafka.js.org[KafkaJS^] 
 
-Note: Working with the Schema Registry is not possible with the current KafkaJS version.
+Note: Redpanda has known issues with confluent-kafka-javascript when interacting with the Schema Registry.
 |===
 
 Clients that have not been validated by Redpanda Data, but use the Kafka protocol, remain compatible with Redpanda subject to the limitations below (particularly those based on librdkafka, such as confluent-kafka-dotnet or confluent-python).

--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -36,7 +36,7 @@ The following clients have been validated with Redpanda.
 | Node.js
 | https://kafka.js.org[KafkaJS^] 
 
-Note: Redpanda has known issues with confluent-kafka-javascript when interacting with the Schema Registry.
+Note: Redpanda has known issues interacting with the Schema Registry with https://www.confluent.io/blog/introducing-confluent-kafka-javascript/[confluent-kafka-javascript^].
 |===
 
 Clients that have not been validated by Redpanda Data, but use the Kafka protocol, remain compatible with Redpanda subject to the limitations below (particularly those based on librdkafka, such as confluent-kafka-dotnet or confluent-python).

--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -32,6 +32,11 @@ The following clients have been validated with Redpanda.
 
 | Rust
 | https://github.com/kafka-rust/kafka-rust[kafka-rust^]
+
+| Node.js
+| https://kafka.js.org[KafkaJS^] 
+
+Note: Working with the Schema Registry is not possible with the current KafkaJS version.
 |===
 
 Clients that have not been validated by Redpanda Data, but use the Kafka protocol, remain compatible with Redpanda subject to the limitations below (particularly those based on librdkafka, such as confluent-kafka-dotnet or confluent-python).


### PR DESCRIPTION
## Description
This pull request includes a minor update to the `kafka-clients.adoc` file to add a note regarding the Schema Registry compatibility with KafkaJS.

Resolves https://redpandadata.atlassian.net/browse/DOC-1075
Review deadline: Feb 28

## Page previews
[Kafka Compatibility](https://deploy-preview-993--redpanda-docs-preview.netlify.app/current/develop/kafka-clients/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)