### PR TITLE
DOC-1074 update superuser in Cloud

### DIFF
--- a/modules/manage/pages/security/authorization/acl.adoc
+++ b/modules/manage/pages/security/authorization/acl.adoc
@@ -10,9 +10,9 @@ Access control lists (ACLs) provide a way to configure fine-grained access to pr
 
 Use access control lists (ACLs) to manage user permissions. ACLs are assigned principals, which then access resources within Redpanda. Redpanda stores ACLs internally, replicated with glossterm:Raft[] to provide the same consensus guarantees as your data. 
 
+ifndef::env-cloud[]
 After you enable authorization, by default, only superusers have access to the resources. Redpanda recommends creating other users to effectively use Redpanda and then, create ACLs for them. You can manage ACLs with `rpk security acl`.
 
-ifndef::env-cloud[]
 For complex organizational hierarchies or large numbers of users, consider using xref:manage:security/authorization/rbac.adoc[role-based access control] for a more flexible and efficient way to manage user permissions. 
 
 endif::[]

--- a/modules/manage/partials/rbac-dp.adoc
+++ b/modules/manage/partials/rbac-dp.adoc
@@ -22,7 +22,7 @@ endif::[]
 A role is a named collection of ACLs which may have users (security principals) assigned to it. You can assign any number of roles to a given user. When installing a new Redpanda cluster, no roles are provisioned by default. 
 
 ifndef::env-cloud[]
-If you want to use RBAC, you need to create your first roles using your `superuser` account. You need to use your `superuser` account to create additional roles and assign appropriate ACLs as necessary. See xref:security/authentication.adoc#create_superusers[configure authentication] for more information on creating and managing superusers.
+If you want to use RBAC, you must create your first roles using your `superuser` account, which enables you to create additional roles and assign appropriate ACLs as necessary. See xref:security/authentication.adoc#create_superusers[configure authentication] for more information on creating and managing superusers.
 
 endif::[]
 

--- a/modules/manage/partials/rbac-dp.adoc
+++ b/modules/manage/partials/rbac-dp.adoc
@@ -19,14 +19,14 @@ endif::[]
 
 ==== Roles
 
-A role is a named collection of ACLs which may have users (security principals) assigned to it. You can assign any number of roles to a given user. When installing a new Redpanda cluster, no roles are provisioned by default. If you want to use RBAC, you need to create your first roles using your `superuser` account.
+A role is a named collection of ACLs which may have users (security principals) assigned to it. You can assign any number of roles to a given user. When installing a new Redpanda cluster, no roles are provisioned by default. 
 
 ifndef::env-cloud[]
-See xref:security/authentication.adoc#create_superusers[configure authentication] for more information on creating and managing superusers.
+If you want to use RBAC, you need to create your first roles using your `superuser` account. You need to use your `superuser` account to create additional roles and assign appropriate ACLs as necessary. See xref:security/authentication.adoc#create_superusers[configure authentication] for more information on creating and managing superusers.
 
 endif::[]
 
-When performing an upgrade from older versions of Redpanda, all existing SASL/SCRAM users are assigned to the placeholder `Users` role to help you more readily migrate away from pure ACLs. As a security measure, this default role has no assigned ACLs. You need to use your `superuser` account to create additional roles and assign appropriate ACLs as necessary.
+When performing an upgrade from older versions of Redpanda, all existing SASL/SCRAM users are assigned to the placeholder `Users` role to help you more readily migrate away from pure ACLs. As a security measure, this default role has no assigned ACLs. 
 
 ==== Policy conflicts
 


### PR DESCRIPTION
## Description
This PR conditionalizes the requirement around superusers with ACLs, so the requirement appears in self-managed docs, but it does not appear (since it's not necessary) in Cloud docs.

Resolves https://redpandadata.atlassian.net/browse/DOC-1074
Review deadline:

## Page previews
**Self-managed** [RBAC](https://deploy-preview-995--redpanda-docs-preview.netlify.app/current/manage/security/authorization/rbac/#roles) and [ACLs](https://deploy-preview-995--redpanda-docs-preview.netlify.app/current/manage/security/authorization/acl/)
**Cloud** [RBAC in Data Plane](https://deploy-preview-995--redpanda-docs-preview.netlify.app/redpanda-cloud/security/authorization/rbac/rbac_dp/#roles) and [ACLs](https://deploy-preview-995--redpanda-docs-preview.netlify.app/redpanda-cloud/security/authorization/rbac/acl/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)