### PR TITLE
Fix typo in authentication.adoc

### DIFF
--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1096,7 +1096,7 @@ To configure Kerberos authentication, use a keytab, which contains credentials f
 .. Ensure that host names are fully qualified domain names (FQDN).
 .. Ensure that each broker has a http://web.mit.edu/Kerberos/krb5-latest/doc/admin/conf_files/krb5_conf.html[Kerberos configuration file^] (`krb5.conf`) set to use Active Directory or another corporate key distribution center (KDC). The default is at `/etc/krb5.conf`.
 .. Ensure that the KDC has a valid Kerberos service principal name (SPN) for each broker in the form `primary/<FQDN>@<REALM>`.
-.. Ensure that each broker has a keytab containing the SPN for that broker. This must be located at an identical file path on each Redpanda broker. The dfault is `/var/lib/redpanda/redpanda.keytab`.
+.. Ensure that each broker has a keytab containing the SPN for that broker. This must be located at an identical file path on each Redpanda broker. The default is `/var/lib/redpanda/redpanda.keytab`.
 
 . <<enable-authentication, Enable SASL authentication>> if it's not already enabled.
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)