### PR TITLE
Add link to Jira in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Description
 
-Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
+Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
 Review deadline:
 
 ## Page previews


### PR DESCRIPTION
## Description

We no longer use GitHub for our docs issues. This PR replaces the placeholder link to GitHub issues in our PR templates with a link to Jira.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)