### PR TITLE
Clarify the behavior of the wait=false flag with kubectl delete

### DIFF
--- a/modules/upgrade/pages/k-upgrade-kubernetes.adoc
+++ b/modules/upgrade/pages/k-upgrade-kubernetes.adoc
@@ -378,7 +378,7 @@ kubectl get pvc --namespace <namespace>
 kubectl delete pvc <pvc-name> --namespace <namespace> --wait=false
 ----
 +
-NOTE: Deleting the PVC sets a deletion timestamp. The actual removal occurs when the Pod terminates. The `--wait=false` flag ensures the associated PersistentVolume is not deleted until the associated Pod is deleted so that the Redpanda broker can shut down cleanly.
+NOTE: The `--wait=false` flag makes `kubectl` return immediately after setting a deletion timestamp for the PVC. The actual removal happens when the associated Pod terminates, allowing the Redpanda broker to shut down cleanly.
 
 .. Delete the Pod to trigger rescheduling on the new node pool:
 +


### PR DESCRIPTION
## Description

See internal discussion https://redpandadata.slack.com/archives/C01H6JRQX1S/p1741138166763289

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
