### PR TITLE
DOC-1098 remove admonition in rpk security user

### DIFF
--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-create.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-create.adoc
@@ -2,11 +2,6 @@
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-create.adoc, reference:rpk/rpk-security/rpk-security-acl-user-create.adoc
 // tag::single-source[]
 
-ifdef::env-cloud[]
-NOTE: This command is only supported in Serverless clusters.
-
-endif::[]
-
 Create a SASL user.
 
 This command creates a single SASL user with the given password, optionally

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-delete.adoc
@@ -2,11 +2,6 @@
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-delete.adoc, reference:rpk/rpk-security/rpk-security-acl-user-delete.adoc
 // tag::single-source[]
 
-ifdef::env-cloud[]
-NOTE: This command is only supported in Serverless clusters.
-
-endif::[]
-
 Delete a SASL user.
 
 This command deletes the specified SASL account from Redpanda. This does not

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-list.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-list.adoc
@@ -2,11 +2,6 @@
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-list.adoc, reference:rpk/rpk-security/rpk-security-acl-user-list.adoc
 // tag::single-source[]
 
-ifdef::env-cloud[]
-NOTE: This command is only supported in Serverless clusters.
-
-endif::[]
-
 List SASL users.
 
 == Usage

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc
@@ -2,11 +2,6 @@
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-update.adoc, reference:rpk/rpk-security/rpk-security-acl-user-update.adoc
 // tag::single-source[]
 
-ifdef::env-cloud[]
-NOTE: This command is only supported in Serverless clusters.
-
-endif::[]
-
 Update SASL user credentials
 
 CAUTION: The default value for the `--mechanism` flag is `SCRAM-SHA-256`. Set the flag when using a different mechanism to avoid unexpected changes.

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user.adoc
@@ -2,11 +2,6 @@
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user.adoc, reference:rpk/rpk-security/rpk-security-acl-user.adoc
 // tag::single-source[]
 
-ifdef::env-cloud[]
-NOTE: This command is only supported in Serverless clusters.
-
-endif::[]
-
 Manage SCRAM users.
 
 If SCRAM is enabled, a SCRAM user is what you use to talk to Redpanda, and ACLs

--- a/modules/reference/pages/rpk/rpk-security/rpk-security.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security.adoc
@@ -2,16 +2,6 @@
 // tag::single-source[]
 :description: These commands let you create SASL users and create, list, and delete ACLs and RBAC.
 
-ifdef::env-cloud[]
-NOTE: This command is only supported in Serverless clusters.
-
-endif::[]
-
-ifdef::env-cloud[]
-NOTE: This command is only supported in Serverless clusters.
-
-endif::[]
-
 == Usage
 
 [,bash]


### PR DESCRIPTION
## Description
This removes notes that indicated certain commands were only supported in Serverless clusters. 

* [`modules/reference/pages/rpk/rpk-security/rpk-security-user-create.adoc`](diffhunk://#diff-f0fad087792233dc95017a4fafb8f0c0a53d50df0ead496f03e0b158a6bda508L5-L9): Removed the note stating that the command is only supported in Serverless clusters.
* [`modules/reference/pages/rpk/rpk-security/rpk-security-user-delete.adoc`](diffhunk://#diff-a064fc4d41810e4aa4e262b9e22ebb714f9fae647ce97eb68328153cd3246cdeL5-L9): Removed the note stating that the command is only supported in Serverless clusters.
* [`modules/reference/pages/rpk/rpk-security/rpk-security-user-list.adoc`](diffhunk://#diff-e37ab12925ca116bc01e46c37f1ae85bfefc8222b70663b2f5fef4dee1228d05L5-L9): Removed the note stating that the command is only supported in Serverless clusters.
* [`modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc`](diffhunk://#diff-f96cf4bb43f5dc9736eb0dc2c77da3b769f4c4382d03f84d6b1fe911ed146eb8L5-L9): Removed the note stating that the command is only supported in Serverless clusters.
* [`modules/reference/pages/rpk/rpk-security/rpk-security.adoc`](diffhunk://#diff-27cc3a1468a23499e3374e9121ad8e7fa7aca6df385b5bb53da6bcfdae084d04L5-L14): Removed multiple instances of the note stating that commands are only supported in Serverless clusters.

Resolves https://redpandadata.atlassian.net/browse/DOC-1098
Review deadline:

## Page previews
[rpk security user](https://deploy-preview-1004--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-security/rpk-security/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
