### PR TITLE
Doc-918 Remove client quota cluster config properties

### DIFF
--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -24,3 +24,15 @@ You now can configure Kafka clients to authenticate using xref:manage:security/a
 The following cluster properties are new in this version:
 
 * `iceberg_invalid_record_action`
+
+== Client quota properties removed
+
+The following client configuration properties were deprecated in version 24.2.1, and have been removed in this release:
+
+* `kafka_client_group_byte_rate_quota`
+* `kafka_client_group_fetch_byte_rate_quota`
+* `target_quota_byte_rate`
+* `target_fetch_quota_byte_rate`
+* `kafka_admin_topic_api_rate`
+
+Use xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`] to manage xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[client throughput limits] based on the Kafka API.

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -1,6 +1,7 @@
 = Manage Throughput
 :description: Manage the throughput of Kafka traffic with configurable properties.
 :page-categories: Management, Networking
+:page-aliases: reference:properties/cluster-properties#kafka_client_group_byte_rate_quota, reference:properties/cluster-properties/#kafka_client_group_fetch_byte_rate_quota.adoc, reference:properties/cluster-properties/#target_quota_byte_rate.adoc, reference:properties/cluster-properties#/#target_fetch_quota_byte_rate.adoc, reference:properties/cluster-properties.adoc#kafka_admin_topic_api_rate
 
 Redpanda supports applying throughput throttling on both ingress and egress independently, and allows configuration at the broker and client levels. The purpose of this is to prevent unbounded network and disk usage of the broker by clients. Broker-wide limits apply to all clients connected to the broker and restrict total traffic on the broker. Client limits apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker.
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -1,7 +1,6 @@
 = Manage Throughput
 :description: Manage the throughput of Kafka traffic with configurable properties.
 :page-categories: Management, Networking
-:page-aliases: reference:properties/cluster-properties#kafka_client_group_byte_rate_quota, reference:properties/cluster-properties/#kafka_client_group_fetch_byte_rate_quota.adoc, reference:properties/cluster-properties/#target_quota_byte_rate.adoc, reference:properties/cluster-properties/#target_fetch_quota_byte_rate.adoc, reference:properties/cluster-properties.adoc#kafka_admin_topic_api_rate
 
 Redpanda supports applying throughput throttling on both ingress and egress independently, and allows configuration at the broker and client levels. The purpose of this is to prevent unbounded network and disk usage of the broker by clients. Broker-wide limits apply to all clients connected to the broker and restrict total traffic on the broker. Client limits apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker.
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -1,7 +1,7 @@
 = Manage Throughput
 :description: Manage the throughput of Kafka traffic with configurable properties.
 :page-categories: Management, Networking
-:page-aliases: reference:properties/cluster-properties#kafka_client_group_byte_rate_quota, reference:properties/cluster-properties/#kafka_client_group_fetch_byte_rate_quota.adoc, reference:properties/cluster-properties/#target_quota_byte_rate.adoc, reference:properties/cluster-properties#/#target_fetch_quota_byte_rate.adoc, reference:properties/cluster-properties.adoc#kafka_admin_topic_api_rate
+:page-aliases: reference:properties/cluster-properties#kafka_client_group_byte_rate_quota, reference:properties/cluster-properties/#kafka_client_group_fetch_byte_rate_quota.adoc, reference:properties/cluster-properties/#target_quota_byte_rate.adoc, reference:properties/cluster-properties/#target_fetch_quota_byte_rate.adoc, reference:properties/cluster-properties.adoc#kafka_admin_topic_api_rate
 
 Redpanda supports applying throughput throttling on both ingress and egress independently, and allows configuration at the broker and client levels. The purpose of this is to prevent unbounded network and disk usage of the broker by clients. Broker-wide limits apply to all clients connected to the broker and restrict total traffic on the broker. Client limits apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker.
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -1851,22 +1851,6 @@ Time between cluster join retries in milliseconds.
 
 ---
 
-=== kafka_admin_topic_api_rate
-
-Target quota rate (partition mutations per default_window_sec).
-
-*Requires restart:* No
-
-*Visibility:* `user`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `4294967295`]
-
-*Default:* `null`
-
----
-
 === kafka_batch_max_bytes
 
 Maximum size of a batch processed by the server. If the batch is compressed, the limit applies to the compressed batch size.
@@ -1882,30 +1866,6 @@ Maximum size of a batch processed by the server. If the batch is compressed, the
 *Accepted values:* [`0`, `4294967295`]
 
 *Default:* `1048576`
-
----
-
-=== kafka_client_group_byte_rate_quota
-
-Per-group target produce quota byte rate (bytes per second). Client is considered part of the group if client_id contains clients_prefix.
-
-*Requires restart:* No
-
-*Visibility:* `user`
-
-*Default:* `null`
-
----
-
-=== kafka_client_group_fetch_byte_rate_quota
-
-Per-group target fetch quota byte rate (bytes per second). Client is considered part of the group if client_id contains clients_prefix.
-
-*Requires restart:* No
-
-*Visibility:* `user`
-
-*Default:* `null`
 
 ---
 
@@ -5031,38 +4991,6 @@ List of superuser usernames.
 *Type:* string
 
 *Default:* `null`
-
----
-
-=== target_fetch_quota_byte_rate
-
-Target fetch size quota byte rate (bytes per second) - disabled default.
-
-*Requires restart:* No
-
-*Visibility:* `user`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `4294967295`]
-
-*Default:* `null`
-
----
-
-=== target_quota_byte_rate
-
-Target request size quota byte rate (bytes per second).
-
-*Requires restart:* No
-
-*Visibility:* `user`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `4294967295`]
-
-*Default:* `target_produce_quota_byte_rate_default`
 
 ---
 

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -11,13 +11,13 @@ This index helps you to identify deprecated features in Redpanda releases and pl
 | Deprecated in  | Feature | Details
 
 | 24.2.1
-| Client throughput quota cluster configuration:
+a| Client throughput quota cluster configuration:
 
-- `kafka_client_group_byte_rate_quota`
-- `kafka_client_group_fetch_byte_rate_quota`
-- `target_quota_byte_rate`
-- `target_fetch_quota_byte_rate`
-- `kafka_admin_topic_api_rate`
+* `kafka_client_group_byte_rate_quota`
+* `kafka_client_group_fetch_byte_rate_quota`
+* `target_quota_byte_rate`
+* `target_fetch_quota_byte_rate`
+* `kafka_admin_topic_api_rate`
 | Use xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`] to manage xref:manage:cluster-maintenance/manage-throughput.adoc#client-throughput-limits[client throughput limits] based on the Kafka API.
 
 | 24.1.1


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-918
Review deadline: **Tuesday March 11**

This pull request remove five client quota properties in Redpanda. The changes include updates to the "What's New",  and "Cluster Properties" sections, as well as the "Deprecated Features" (updated tagging error I found there) index.

The following client configuration properties, which were deprecated in version 24.2.1, have been removed in this release:

```
kafka_client_group_byte_rate_quota
kafka_client_group_fetch_byte_rate_quota
target_quota_byte_rate
target_fetch_quota_byte_rate
kafka_admin_topic_api_rate
```

Updated Files and Previews

Beta: 
What's New
[Preview](https://github.com/redpanda-data/docs/blob/26c14352c49bee282a3fe5fb905c90b748402b06/modules/get-started/pages/whats-new.adoc)

[Preview](https://github.com/redpanda-data/docs/blob/26c14352c49bee282a3fe5fb905c90b748402b06/modules/reference/pages/properties/cluster-properties.adoc)

Deprecated Features Index
[Preview](https://github.com/redpanda-data/docs/blob/26c14352c49bee282a3fe5fb905c90b748402b06/modules/upgrade/pages/deprecated/index.adoc)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
