### PR TITLE
DOC-1099 remove rpk from RBAC in DP

### DIFF
--- a/modules/manage/partials/rbac-assign-role.adoc
+++ b/modules/manage/partials/rbac-assign-role.adoc
@@ -1,0 +1,27 @@
+There are two ways to add a role to a principal:
+
+Option 1, using the `Edit Role` view:
+
+1. Select `Security` from the left navigation menu.
+
+2. Select the `Roles` tab.
+
+3. Find the role you want to assign to one or more principals and then click on the role name.
+
+4. Click *Edit*.
+
+5. Below the list of permissions, find the `Principals` section. You can add any number of principals to the role at a time.
+
+6. After you have listed all new principals, click *Update*.
+
+Option 2, using the `Edit User` view:
+
+1. Select `Security` from the left navigation menu.
+
+2. Select the `Users` tab.
+
+3. Find the user you want to assign one or more roles to then click the user's name.
+
+4. Using the `Assign Roles` input field, list the roles you want to add to this user.
+
+5. After you have added all roles, click *Update*.

--- a/modules/manage/partials/rbac-create-role.adoc
+++ b/modules/manage/partials/rbac-create-role.adoc
@@ -8,7 +8,7 @@ To create a new role:
 
 4. In the `Create Role` view, provide a name for the role and an optional origin host for users to connect from.
 
-5. Define the permissions (ACLs) for the role. You can create ACLs for topics, consumer groups, and transactional IDs.
+5. Define the permissions (access control lists, ACLs) for the role. You can create ACLs for topics, consumer groups, and transactional IDs.
 
 6. __(Optional)__ You can assign one or more principals (users) to the role when creating it.
 

--- a/modules/manage/partials/rbac-create-role.adoc
+++ b/modules/manage/partials/rbac-create-role.adoc
@@ -10,6 +10,6 @@ To create a new role:
 
 5. Define the permissions (ACLs) for the role. You can create ACLs for topics, consumer groups, and transactional IDs.
 
-6. __(Optional)__ You can assign one or more principals (users) to the role as part of creating it.
+6. __(Optional)__ You can assign one or more principals (users) to the role when creating it.
 
 7. Click *Create*.

--- a/modules/manage/partials/rbac-create-role.adoc
+++ b/modules/manage/partials/rbac-create-role.adoc
@@ -4,9 +4,9 @@ To create a new role:
 
 2. Select the `Roles` tab.
 
-3. Click *Create Role*.
+3. Click *Create role*.
 
-4. In the `Create Role` view, provide a name for the role and an optional origin host for users to connect from.
+4. In the `Create role` view, provide a name for the role and an optional origin host for users to connect from.
 
 5. Define the permissions (access control lists, ACLs) for the role. You can create ACLs for topics, consumer groups, and transactional IDs.
 

--- a/modules/manage/partials/rbac-create-role.adoc
+++ b/modules/manage/partials/rbac-create-role.adoc
@@ -1,0 +1,15 @@
+To create a new role:
+
+1. Select `Security` from the left navigation menu.
+
+2. Select the `Roles` tab.
+
+3. Click *Create Role*.
+
+4. In the `Create Role` view, provide a name for the role and an optional origin host for users to connect from.
+
+5. Define the permissions (ACLs) for the role. You can create ACLs for topics, consumer groups, and transactional IDs.
+
+6. __(Optional)__ You can assign one or more principals (users) to the role as part of creating it.
+
+7. Click *Create*.

--- a/modules/manage/partials/rbac-delete-role.adoc
+++ b/modules/manage/partials/rbac-delete-role.adoc
@@ -1,0 +1,11 @@
+To delete an existing role:
+
+1. Select `Security` from the left navigation menu.
+
+2. Click the role you want to delete. This shows all currently assigned permissions (ACLs) and principals (users).
+
+3. Click *Delete*.
+
+4. {ui} displays a prompt asking you to confirm deletion of the role. The prompt differs based on whether you have principals assigned to the role or not. If you have principals assigned to the role, you must type the role name in the input field where prompted before you can continue.
+
+5. Click *Delete*.

--- a/modules/manage/partials/rbac-delete-role.adoc
+++ b/modules/manage/partials/rbac-delete-role.adoc
@@ -6,6 +6,6 @@ To delete an existing role:
 
 3. Click *Delete*.
 
-4. {ui} displays a prompt asking you to confirm deletion of the role. The prompt differs based on whether you have principals assigned to the role or not. If you have principals assigned to the role, you must type the role name in the input field where prompted before you can continue.
+4. {ui} displays a prompt asking you to confirm deletion of the role. The prompt differs based on whether there are  principals assigned to the role or not. If there are principals assigned to the role, you must type the role name in the input field when prompted before you can continue.
 
 5. Click *Delete*.

--- a/modules/manage/partials/rbac-describe-role.adoc
+++ b/modules/manage/partials/rbac-describe-role.adoc
@@ -1,0 +1,9 @@
+To view details of an existing role:
+
+1. Select `Security` from the left navigation menu.
+
+2. Select the `Roles` tab.
+
+3. Find the role you want to view and click the role name.
+
+All roles are listed in a paginated view. You can also filter the view using the input field at the top of the list.

--- a/modules/manage/partials/rbac-dp.adoc
+++ b/modules/manage/partials/rbac-dp.adoc
@@ -35,6 +35,7 @@ You can assign a combination of ACLs and roles to any given principal. ACLs allo
 * There does not exist a DENY permission matching the operation.
 * There exists an ALLOW permission matching the operation.
 
+ifndef::env-cloud[]
 === RBAC example
 
 Consider a scenario where your software engineers use a set of private topics to publish application update information to users. All your private topics begin with the prefix `private-`. You might create a new `SoftwareEng` role to represent the software engineers with write access to these private topics. You would then assign the `SoftwareEng` role as the allowed role for a new ACL specifying read and write permissions to `private-*`. Using a wildcard includes all existing private topics and any new ones you might create later. You then assign the new role to John and Jane, your two software engineers who will write messages to this topic. The `rpk` commands to accomplish this are:
@@ -57,6 +58,8 @@ Consider the situation where you want to create a new topic, `private-software-v
 rpk security acl create --operation write --topic private-software-versions --allow-role User
 ----
 
+endif::[]
+
 == Manage users and roles
 
 ifndef::env-cloud[]
@@ -65,7 +68,7 @@ Administrators can manage RBAC configurations with `rpk`, the Redpanda Admin API
 endif::[]
 
 ifdef::env-cloud[]
-Administrators can manage RBAC configurations with `rpk` or {ui}. 
+Administrators can manage RBAC configurations with {ui}. 
 
 endif::[]
 
@@ -73,6 +76,7 @@ endif::[]
 
 Creating a new role is a two-step process. First you define the role, giving it a unique and descriptive name. Second, you assign one or more ACLs to allow or deny access for the new role. This defines the permissions that are inherited by all users assigned to the role. It is possible to have an empty role with no ACLs assigned.
 
+ifndef::env-cloud[]
 [tabs]
 =====
 rpk::
@@ -106,23 +110,16 @@ Successfully created role "red"
 {ui}::
 +
 --
-To create a new role:
-
-1. Select `Security` from the left navigation menu.
-
-2. Select the `Roles` tab.
-
-3. Click *Create Role*.
-
-4. In the `Create Role` view, provide a name for the role and an optional origin host for users to connect from.
-
-5. Define the permissions (ACLs) for the role. You can create ACLs for topics, consumer groups, and transactional IDs.
-
-6. __(Optional)__ You can assign one or more principals (users) to the role as part of creating it.
-
-7. Click *Create*.
+include::manage:partial$rbac-create-role.adoc[]
 --
 =====
+
+endif::[]
+
+ifdef::env-cloud[]
+include::manage:partial$rbac-create-role.adoc[]
+
+endif::[]
 
 === Delete a role
 
@@ -133,6 +130,7 @@ When a role is deleted, Redpanda carries out the following actions automatically
 
 Redpanda lists all impacted ACLs and role assignments when running this command. You receive a prompt to confirm the deletion action. The delete operation is irreversible.
 
+ifndef::env-cloud[]
 [tabs]
 ====
 rpk::
@@ -170,24 +168,22 @@ Successfully deleted role "red"
 {ui}::
 +
 --
-To delete an existing role:
-
-1. Select `Security` from the left navigation menu.
-
-2. Click the role you want to delete. This shows all currently assigned permissions (ACLs) and principals (users).
-
-3. Click *Delete*.
-
-4. {ui} displays a prompt asking you to confirm deletion of the role. The prompt differs based on whether you have principals assigned to the role or not. If you have principals assigned to the role, you must type the role name in the input field where prompted before you can continue.
-
-5. Click *Delete*.
+include::manage:partial$rbac-delete-role.adoc[]
 --
 ====
+
+endif::[]
+
+ifdef::env-cloud[]
+include::manage:partial$rbac-delete-role.adoc[]
+
+endif::[]
 
 === Assign a role
 
 You can assign a role to any security principal. Principals are referred to using the format: `Type:Name`. Redpanda currently supports only the `User` type. If you omit the type, Redpanda assumes the `User` type by default. With this command, you can assign the role to multiple principals at the same time by using a comma separator between each principal.
 
+ifndef::env-cloud[]
 [tabs]
 ====
 rpk::
@@ -217,40 +213,22 @@ panda  User
 {ui}::
 +
 --
-There are two ways to add a role to a principal:
-
-Option 1, using the `Edit Role` view:
-
-1. Select `Security` from the left navigation menu.
-
-2. Select the `Roles` tab.
-
-3. Find the role you want to assign to one or more principals and then click on the role name.
-
-4. Click *Edit*.
-
-5. Below the list of permissions, find the `Principals` section. You can add any number of principals to the role at a time.
-
-6. After you have listed all new principals, click *Update*.
-
-Option 2, using the `Edit User` view:
-
-1. Select `Security` from the left navigation menu.
-
-2. Select the `Users` tab.
-
-3. Find the user you want to assign one or more roles to then click the user's name.
-
-4. Using the `Assign Roles` input field, list the roles you want to add to this user.
-
-5. After you have added all roles, click *Update*.
+include::manage:partial$rbac-assign-role.adoc[]
 --
 ====
+
+endif::[]
+
+ifdef::env-cloud[]
+include::manage:partial$rbac-assign-role.adoc[]
+
+endif::[]
 
 === Unassign a role
 
 You can remove a role assignment from a security principal without deleting the role. Principals are referred to using the format: `Type:Name`. Redpanda currently supports only the `User` type. If you omit the type, Redpanda assumes the `User` type by default. With this command, you can remove the role from multiple principals at the same time by using a comma separator between each principal.
 
+ifndef::env-cloud[]
 [tabs]
 ====
 rpk::
@@ -279,40 +257,22 @@ panda  User
 {ui}::
 +
 --
-There are two ways to remove a role from a principal:
-
-Option 1, using the `Edit Role` view:
-
-1. Select `Security` from the left navigation menu.
-
-2. Select the `Roles` tab.
-
-3. Find the role you want to assign to one or more principals and then click on the role name.
-
-4. Click *Edit*.
-
-5. Below the list of permissions, find the `Principals` section. Click *x* beside the name of any principals you want to remove from the role.
-
-6. After you have removed all needed principals, click *Update*.
-
-Option 2, using the `Edit User` view:
-
-1. Select `Security` from the left navigation menu.
-
-2. Select the `Users` tab.
-
-3. Find the user you want to remove from one or more roles and then click the user's name.
-
-4. Click *x* beside the name of any roles you want to remove this user from.
-
-5. After you have removed the user from all roles, click *Update*.
+include::manage:partial$rbac-unassign-role.adoc[]
 --
 ====
+
+endif::[]
+
+ifdef::env-cloud[]
+include::manage:partial$rbac-unassign-role.adoc[]
+
+endif::[]
 
 === Edit role permissions
 
 You can add or remove ACLs from any of the roles you have previously created.
 
+ifndef::env-cloud[]
 [tabs]
 ====
 rpk::
@@ -347,7 +307,6 @@ To list all the ACLs associated with a role, run:
 rpk security acl list --allow-role <role_name> --deny-role <role_name>
 ----
 
-ifndef::env-cloud[]
 See also:
 
 * xref:security/authorization/acl.adoc[Access Control Lists] for more information on defining and using ACLs.
@@ -355,34 +314,26 @@ See also:
 * xref:reference:rpk/rpk-acl/rpk-acl-delete.adoc[]
 * xref:reference:rpk/rpk-acl/rpk-acl-list.adoc[]
 
-endif::[]
-
 --
 {ui}::
 +
 --
-To edit the ACLs for an existing role:
-
-1. Select `Security` from the left navigation menu.
-
-2. Select the `Roles` tab.
-
-3. Find the role you want to assign to one or more principals and then click on the role name.
-
-4. Click *Edit*.
-
-5. In the `Edit Role` view, you can update the optional origin host for users to connect from.
-
-6. You can add or remove existing (ACLs) for the role. As when creating a new role, you can create or modify ACLs for topics, consumer groups, and transactional IDs.
-
-7. After making all changes, click *Update*.
+include::manage:partial$rbac-edit-role.adoc[]
 --
 ====
+
+endif::[]
+
+ifdef::env-cloud[]
+include::manage:partial$rbac-edit-role.adoc[]
+
+endif::[]
 
 === List all roles
 
 Redpanda lets you view a list of all existing roles.
 
+ifndef::env-cloud[]
 [tabs]
 ====
 rpk::
@@ -410,20 +361,22 @@ red
 {ui}::
 +
 --
-To view all existing roles:
-
-1. Select `Security` from the left navigation menu.
-
-2. Select the `Roles` tab.
-
-All roles are listed in a paginated view. You can also filter the view using the input field at the top of the list.
+include::manage:partial$rbac-list-role.adoc[]
 --
 ====
+
+endif::[]
+
+ifdef::env-cloud[]
+include::manage:partial$rbac-list-role.adoc[]
+
+endif::[]
 
 === Describe a role
 
 When managing roles, you may need to review the ACLs the role grants or the list of principals assigned to the role.
 
+ifndef::env-cloud[]
 [tabs]
 ====
 rpk::
@@ -459,16 +412,15 @@ panda User
 {ui}::
 +
 --
-To view details of an existing role:
-
-1. Select `Security` from the left navigation menu.
-
-2. Select the `Roles` tab.
-
-3. Find the role you want to view and click the role name.
-
-All roles are listed in a paginated view. You can also filter the view using the input field at the top of the list.
+include::manage:partial$rbac-describe-role.adoc[]
 --
 ====
+
+endif::[]
+
+ifdef::env-cloud[]
+include::manage:partial$rbac-describe-role.adoc[]
+
+endif::[]
 
 // end::single-source[]

--- a/modules/manage/partials/rbac-edit-role.adoc
+++ b/modules/manage/partials/rbac-edit-role.adoc
@@ -1,0 +1,15 @@
+To edit the ACLs for an existing role:
+
+1. Select `Security` from the left navigation menu.
+
+2. Select the `Roles` tab.
+
+3. Find the role you want to assign to one or more principals and then click on the role name.
+
+4. Click *Edit*.
+
+5. In the `Edit Role` view, you can update the optional origin host for users to connect from.
+
+6. You can add or remove existing (ACLs) for the role. As when creating a new role, you can create or modify ACLs for topics, consumer groups, and transactional IDs.
+
+7. After making all changes, click *Update*.

--- a/modules/manage/partials/rbac-list-role.adoc
+++ b/modules/manage/partials/rbac-list-role.adoc
@@ -1,0 +1,7 @@
+To view all existing roles:
+
+1. Select `Security` from the left navigation menu.
+
+2. Select the `Roles` tab.
+
+All roles are listed in a paginated view. You can also filter the view using the input field at the top of the list.

--- a/modules/manage/partials/rbac-unassign-role.adoc
+++ b/modules/manage/partials/rbac-unassign-role.adoc
@@ -6,7 +6,7 @@ Option 1, using the `Edit Role` view:
 
 2. Select the `Roles` tab.
 
-3. Find the role you want to assign to one or more principals and then click on the role name.
+3. Find the role you want to remove from one or more principals and then click on the role name.
 
 4. Click *Edit*.
 

--- a/modules/manage/partials/rbac-unassign-role.adoc
+++ b/modules/manage/partials/rbac-unassign-role.adoc
@@ -1,0 +1,27 @@
+There are two ways to remove a role from a principal:
+
+Option 1, using the `Edit Role` view:
+
+1. Select `Security` from the left navigation menu.
+
+2. Select the `Roles` tab.
+
+3. Find the role you want to assign to one or more principals and then click on the role name.
+
+4. Click *Edit*.
+
+5. Below the list of permissions, find the `Principals` section. Click *x* beside the name of any principals you want to remove from the role.
+
+6. After you have removed all needed principals, click *Update*.
+
+Option 2, using the `Edit User` view:
+
+1. Select `Security` from the left navigation menu.
+
+2. Select the `Users` tab.
+
+3. Find the user you want to remove from one or more roles and then click the user's name.
+
+4. Click *x* beside the name of any roles you want to remove this user from.
+
+5. After you have removed the user from all roles, click *Update*.


### PR DESCRIPTION
## Description
This conditionalizes out rpk steps for Cloud docs. 

Resolves https://redpandadata.atlassian.net/browse/DOC-1099
Review deadline: Mar 10

## Page previews
[Cloud docs](https://deploy-preview-1007--redpanda-docs-preview.netlify.app/redpanda-cloud/security/authorization/rbac/rbac_dp/#manage-users-and-roles)
[Self-Managed docs](https://deploy-preview-1007--redpanda-docs-preview.netlify.app/current/manage/security/authorization/rbac/#manage-users-and-roles)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
