### PR TITLE
Fix misplacing of useFlux key on "What's new"."Use Redpanda Operator without Flux (beta)" page

### DIFF
--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -97,7 +97,7 @@ Example:
 [,yaml]
 ----
 spec:
-  clusterSpec:
+  chartRef:
     useFlux: false
 ----
 


### PR DESCRIPTION
## Description

Based on CRD reference `useFlux` key must be in `chartRef` block

Link to:
- [CRD reference in docs](https://github.com/redpanda-data/docs/blob/609f22a12ea7919f9318dd5b9f31eb347b27ac67/modules/reference/pages/k-crd.adoc#chartref)
- [Deployment overview doc](https://github.com/redpanda-data/docs/blob/609f22a12ea7919f9318dd5b9f31eb347b27ac67/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-deployment-overview.adoc#redpanda-operator)

## Page previews

https://deploy-preview-1008--redpanda-docs-preview.netlify.app/current/get-started/whats-new/

## Checks

- [x] Small fix (typos, links, copyedits, etc)
