### PR TITLE
rpk: update -X flag list.

### DIFF
--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -52,7 +52,7 @@ A boolean that disables `rpk` from verifying the broker's certificate chain.
 
 === tls.ca
 
-A filepath to a PEM encoded CA certificate file to talk to your broker's Kafka API listeners with mTLS.
+A filepath to a PEM-encoded CA certificate file to talk to your broker's Kafka API listeners with mTLS.
 
 You may need this option if your listeners are using a certificate by a well known authority that is not bundled with your operating system.
 
@@ -62,7 +62,7 @@ You may need this option if your listeners are using a certificate by a well kno
 
 === tls.cert
 
-A filepath to a PEM encoded client certificate file to talk to your broker's Kafka API listeners with mTLS.
+A filepath to a PEM-encoded client certificate file to talk to your broker's Kafka API listeners with mTLS.
 
 *Example*: `tls.cert=/path/to/cert.pem`
 
@@ -70,7 +70,7 @@ A filepath to a PEM encoded client certificate file to talk to your broker's Kaf
 
 === tls.key
 
-A filepath to a PEM encoded client key file to talk to your broker's Kafka API listeners with mTLS.
+A filepath to a PEM-encoded client key file to talk to your broker's Kafka API listeners with mTLS.
 
 *Example*: `tls.key=/path/to/key.pem`
 
@@ -130,7 +130,7 @@ A boolean that disables `rpk` from verifying the broker's certificate chain.
 
 === admin.tls.ca
 
-A filepath to a PEM encoded CA certificate file to talk to your broker's Admin API listeners with mTLS. You may also need this if your listeners are using a certificate by a well known authority that is not yet bundled with your operating system.
+A filepath to a PEM-encoded CA certificate file to talk to your broker's Admin API listeners with mTLS. You may also need this if your listeners are using a certificate by a well known authority that is not yet bundled with your operating system.
 
 *Example*: `admin.tls.ca=/path/to/ca.pem`
 
@@ -138,7 +138,7 @@ A filepath to a PEM encoded CA certificate file to talk to your broker's Admin A
 
 === admin.tls.cert
 
-A filepath to a PEM encoded client certificate file to talk to your broker's Admin API listeners with mTLS.
+A filepath to a PEM-encoded client certificate file to talk to your broker's Admin API listeners with mTLS.
 
 *Example*: `admin.tls.cert=/path/to/cert.pem`
 
@@ -146,7 +146,7 @@ A filepath to a PEM encoded client certificate file to talk to your broker's Adm
 
 === admin.tls.key
 
-A filepath to a PEM encoded client key file to talk to your broker's Admin API listeners with mTLS.
+A filepath to a PEM-encoded client key file to talk to your broker's Admin API listeners with mTLS.
 
 *Example*: `admin.tls.key=/path/to/key.pem`
 

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -154,7 +154,7 @@ A filepath to a PEM encoded client key file to talk to your broker's Admin API l
 
 === registry.hosts
 
-A comma separated list of `host:ports` that `rpk` communicates with for the schema registry API. By default, this option is set to `127.0.0.1:8081`.
+A comma-separated list of `host:ports` that `rpk` communicates with for the Schema Registry API. By default, this option is set to `127.0.0.1:8081`.
 
 *Example*: `registry.hosts=localhost:8081,rp.example.com:8081`
 
@@ -162,9 +162,9 @@ A comma separated list of `host:ports` that `rpk` communicates with for the sche
 
 === registry.tls.enabled
 
-A boolean that enables `rpk` to speak TLS to your broker's schema registry API listeners.
+A boolean that enables `rpk` to use TLS with your broker's Schema Registry API listeners.
 
-You can use this if you have well known certificates set up on your schema registry API. If you use mTLS, specifying mTLS certificate filepaths automatically opts into `registry.tls.enabled`.
+You can use this if you have well known certificates set up on your Schema Registry API. If you use mTLS, specifying mTLS certificate filepaths automatically opts into `registry.tls.enabled`.
 
 *Example*: `registry.tls.enabled=false`
 
@@ -180,7 +180,7 @@ A boolean that disables `rpk` from verifying the broker's certificate chain.
 
 === registry.tls.ca
 
-A filepath to a PEM encoded CA certificate file to talk to your broker's schema registry API listeners with mTLS.
+A filepath to a PEM-encoded CA certificate file to talk to your broker's Schema Registry API listeners with mTLS.
 
 *Example*: `registry.tls.ca=/path/to/ca.pem`
 
@@ -188,7 +188,7 @@ A filepath to a PEM encoded CA certificate file to talk to your broker's schema 
 
 === registry.tls.cert
 
-A filepath to a PEM encoded client certificate file to talk to your broker's schema registry API listeners with mTLS.
+A filepath to a PEM-encoded client certificate file to talk to your broker's Schema Registry API listeners with mTLS.
 
 *Example*: `registry.tls.cert=/path/to/cert.pem`
 
@@ -196,7 +196,7 @@ A filepath to a PEM encoded client certificate file to talk to your broker's sch
 
 === registry.tls.key
 
-A filepath to a PEM encoded client key file to talk to your broker's schema registry API listeners with mTLS.
+A filepath to a PEM-encoded client key file to talk to your broker's Schema Registry API listeners with mTLS.
 
 *Example*: `registry.tls.key=/path/to/key.pem`
 

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -42,6 +42,14 @@ You can use this if you have well known certificates set up on your Kafka API. I
 
 '''
 
+=== tls.insecure_skip_verify
+
+A boolean that disables `rpk` from verifying the broker's certificate chain.
+
+*Example*: `tls.insecure_skip_verify=true`
+
+'''
+
 === tls.ca
 
 A filepath to a PEM encoded CA certificate file to talk to your broker's Kafka API listeners with mTLS.
@@ -112,6 +120,14 @@ You can use this if you have well known certificates set up on your Admin API. I
 
 '''
 
+=== admin.tls.insecure_skip_verify
+
+A boolean that disables `rpk` from verifying the broker's certificate chain.
+
+*Example*: `admin.tls.insecure_skip_verify=true`
+
+'''
+
 === admin.tls.ca
 
 A filepath to a PEM encoded CA certificate file to talk to your broker's Admin API listeners with mTLS. You may also need this if your listeners are using a certificate by a well known authority that is not yet bundled with your operating system.
@@ -136,6 +152,56 @@ A filepath to a PEM encoded client key file to talk to your broker's Admin API l
 
 '''
 
+=== registry.hosts
+
+A comma separated list of `host:ports` that `rpk` communicates with for the schema registry API. By default, this option is set to `127.0.0.1:8081`.
+
+*Example*: `registry.hosts=localhost:8081,rp.example.com:8081`
+
+'''
+
+=== registry.tls.enabled
+
+A boolean that enables `rpk` to speak TLS to your broker's schema registry API listeners.
+
+You can use this if you have well known certificates set up on your schema registry API. If you use mTLS, specifying mTLS certificate filepaths automatically opts into `registry.tls.enabled`.
+
+*Example*: `registry.tls.enabled=false`
+
+'''
+
+=== registry.tls.insecure_skip_verify
+
+A boolean that disables `rpk` from verifying the broker's certificate chain.
+
+*Example*: `registry.tls.insecure_skip_verify=false`
+
+'''
+
+=== registry.tls.ca
+
+A filepath to a PEM encoded CA certificate file to talk to your broker's schema registry API listeners with mTLS.
+
+*Example*: `registry.tls.ca=/path/to/ca.pem`
+
+'''
+
+=== registry.tls.cert
+
+A filepath to a PEM encoded client certificate file to talk to your broker's schema registry API listeners with mTLS.
+
+*Example*: `registry.tls.cert=/path/to/cert.pem`
+
+'''
+
+=== registry.tls.key
+
+A filepath to a PEM encoded client key file to talk to your broker's schema registry API listeners with mTLS.
+
+*Example*: `registry.tls.key=/path/to/key.pem`
+
+'''
+
 === cloud.client_id
 
 An OAuth client ID to use for authenticating with the Redpanda Cloud API.
@@ -152,46 +218,54 @@ An OAuth client secret to use for authenticating with the Redpanda Cloud API.
 
 '''
 
-=== defaults.prompt
+=== globals.prompt
 
 A format string to use for the default prompt. See xref:./rpk-profile/rpk-profile-prompt.adoc[`rpk profile prompt`] for more information.
 
-*Example*: `defaults.prompt="%n"`
+*Example*: `globals.prompt="%n"`
 
 '''
 
-=== defaults.no_default_cluster
+=== globals.no_default_cluster
 
 A boolean that disables `rpk` from communicating to `localhost:9092` if no other cluster is specified.
 
-*Example*: `defaults.no_default_cluster=false`
+*Example*: `globals.no_default_cluster=false`
 
 '''
 
-=== defaults.dial_timeout
+=== globals.command_timeout
+
+A duration that `rpk` will wait for a command to complete before timing out, for certain commands.
+
+*Example*: `globals.command_timeout=30s`
+
+'''
+
+=== globals.dial_timeout
 
 A duration that `rpk` will wait for a connection to be established before timing out.
 
-*Example*: `defaults.dial_timeout=3s`
+*Example*: `globals.dial_timeout=3s`
 
 '''
 
-=== defaults.request_timeout_overhead
+=== globals.request_timeout_overhead
 
 A duration that limits how long `rpk` waits for responses.
 
 [NOTE]
 ====
-`defaults.request_timeout_overhead` applies in addition to any request-internal timeout.
+`globals.request_timeout_overhead` applies in addition to any request-internal timeout.
 
 For example, `ListOffsets` has no `Timeout` field, so `rpk` will wait `request_timeout_overhead` for a response. However, `JoinGroup` has a `RebalanceTimeoutMillis` field, so `request_timeout_overhead` is applied on top of the rebalance timeout.
 ====
 
-*Example*: `defaults.request_timeout_overhead=10s`
+*Example*: `globals.request_timeout_overhead=5s`
 
 '''
 
-=== defaults.retry_timeout
+=== globals.retry_timeout
 
 This timeout specifies how long `rpk` will retry Kafka API requests.
 
@@ -201,22 +275,22 @@ This timeout is evaluated before any backoff:
  ** If the retry timeout has elapsed, `rpk` stops retrying.
  ** Otherwise, `rpk` waits for the backoff and then retries.
 
-*Example*: `defaults.retry_timeout=30s`
+*Example*: `globals.retry_timeout=11s`
 
 '''
 
-=== defaults.fetch_max_wait
+=== globals.fetch_max_wait
 
 This timeout specifies the maximum duration that brokers will wait before replying to a fetch request with available data.
 
-*Example*: `defaults.fetch_max_wait=5s`
+*Example*: `globals.fetch_max_wait=5s`
 
 '''
 
-=== defaults.redpanda_client_id
+=== globals.kafka_protocol_request_client_id
 
 This string value is the client ID that `rpk` uses when issuing Kafka protocol requests to Redpanda. This client ID shows up in Redpanda logs and metrics. Changing it can be useful if you want to have your own `rpk` client stand out from others that are also interacting with the cluster.
 
-*Example*: `defaults.redpanda_client_id=rpk`
+*Example*: `globals.kafka_protocol_request_client_id=rpk`
 
 // end::single-source[]


### PR DESCRIPTION
## Description

Added new flag options (such as `registry`) and updated `defaults` to `globals`

Fixes #DOC-908

Review deadline:

## Page previews

https://deploy-preview-1009--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-x-options/
<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
