### PR TITLE
Update install-beta.adoc - add in certmanager

### DIFF
--- a/modules/get-started/pages/install-beta.adoc
+++ b/modules/get-started/pages/install-beta.adoc
@@ -156,7 +156,9 @@ Install Redpanda with Helm from the RC build in https://hub.docker.com/r/redpand
 [source,bash,subs="attributes+"]
 ----
 helm repo add redpanda https://charts.redpanda.com
+helm repo add jetstack https://charts.jetstack.io
 helm repo update
+helm install cert-manager jetstack/cert-manager --set crds.enabled=true --namespace cert-manager --create-namespace
 helm install redpanda redpanda/redpanda \
   --namespace <namespace> \
   --create-namespace --set image.repository=docker.redpanda.com/redpandadata/redpanda-unstable --set image.tag={redpanda-beta-tag}


### PR DESCRIPTION
## Description

Without cert-manager beta Helm only installations of 25.2-rc2 will fail. 

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
