### PR TITLE
Doc-851 Persistent Stacktrace Logging

### DIFF
--- a/modules/troubleshoot/pages/debug-bundle/overview.adoc
+++ b/modules/troubleshoot/pages/debug-bundle/overview.adoc
@@ -38,6 +38,14 @@ include::reference:partial$bundle-contents.adoc[]
 --
 ====
 
+In addition to the preceding files and directories, the debug bundle also includes 
+all stack traces from the root cause of a crash loop for up to 50 crashes in FIFO order. Logs include:
+
+- Cluster UUID
+- Node ID
+- Timestamp
+- Stack trace logs
+
 == Next steps
 
 - xref:troubleshoot:debug-bundle/configure/index.adoc[].

--- a/modules/troubleshoot/pages/debug-bundle/overview.adoc
+++ b/modules/troubleshoot/pages/debug-bundle/overview.adoc
@@ -39,7 +39,7 @@ include::reference:partial$bundle-contents.adoc[]
 ====
 
 In addition to the preceding files and directories, the debug bundle also includes 
-all stack traces from the root cause of a crash loop for up to 50 crashes in FIFO order. Logs include:
+up to 50 of the most recent stack traces from the root cause of a crash loop. Logs include:
 
 - Cluster UUID
 - Node ID


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-851
Review deadline: **March 14**

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
