### PR TITLE
Add support for internal metrics generation

### DIFF
--- a/gen/v25.1/metrics/internal-metrics.adoc
+++ b/gen/v25.1/metrics/internal-metrics.adoc
@@ -1,0 +1,4695 @@
+=== vectorized_alien_receive_batch_queue_length
+
+Current receive batch queue length
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_alien_total_received_messages
+
+Total number of received messages
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_alien_total_sent_messages
+
+Total number of sent messages
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_application_build
+
+Redpanda build information
+
+*Type*: gauge
+
+*Labels*:
+
+- `revision`
+- `shard`
+- `version`
+
+---
+
+=== vectorized_application_fips_mode
+
+Identifies whether or not Redpanda is running in FIPS mode.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_application_uptime
+
+Redpanda uptime in milliseconds
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_archival_upload_backlog_controller_backlog_size
+
+controller backlog
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_archival_upload_backlog_controller_error
+
+current controller error, i.e difference between set point and backlog size
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_archival_upload_backlog_controller_shares
+
+controller output, i.e. number of shares
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_authorization_result
+
+Total number of authorization results by type
+
+*Type*: counter
+
+*Labels*:
+
+- `type`
+
+---
+
+=== vectorized_chunk_cache_available_size_bytes
+
+Total size of all free segment appender chunks in the cache, in bytes.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_chunk_cache_total_size_bytes
+
+Total size of all segment appender chunks in any state, in bytes.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_chunk_cache_wait_count
+
+Count of how many times we had to wait for a chunk to become available
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_client_active_downloads
+
+Number of active GET requests at the moment
+
+*Type*: gauge
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_active_requests
+
+Number of active HTTP requests at the moment (includes PUT and GET)
+
+*Type*: gauge
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_active_uploads
+
+Number of active PUT requests at the moment
+
+*Type*: gauge
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_all_requests
+
+Number of completed HTTP requests (includes PUT and GET)
+
+*Type*: counter
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_client_pool_utilization
+
+Utilization of the cloud storage pool(0 - unused, 100 - fully utilized)
+
+*Type*: gauge
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_lease_duration
+
+Lease duration histogram
+
+*Type*: histogram
+
+---
+
+=== vectorized_cloud_client_num_borrows
+
+Number of time current shard had to borrow a cloud storage client from another shard
+
+*Type*: counter
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_num_nosuchkey
+
+Total number of NoSuchKey errors received from cloud storage provider
+
+*Type*: counter
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_num_rpc_errors
+
+Total number of REST API errors received from cloud storage provider
+
+*Type*: counter
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_num_slowdowns
+
+Total number of SlowDown errors received from cloud storage provider
+
+*Type*: counter
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_num_transport_errors
+
+Total number of transport errors (TCP and TLS)
+
+*Type*: counter
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_total_downloads
+
+Number of completed GET requests
+
+*Type*: counter
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_total_inbound_bytes
+
+Total number of bytes received from cloud storage
+
+*Type*: counter
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_total_outbound_bytes
+
+Total number of bytes sent to cloud storage
+
+*Type*: counter
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_client_total_uploads
+
+Number of completed PUT requests
+
+*Type*: counter
+
+*Labels*:
+
+- `endpoint`
+- `region`
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_bytes_received
+
+Number of bytes received from cloud storage
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_bytes_sent
+
+Number of bytes sent to cloud storage
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_cache_cached_gets
+
+Total number of get requests that are already in cache.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_cache_files
+
+Current number of files in cache.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_cache_gets
+
+Total number of cache get requests.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_cache_in_progress_files
+
+Current number of files that are being put to cache.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_cache_puts
+
+Total number of files put into cache.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_cache_size_bytes
+
+Current cache size in bytes.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_client_acquisition_latency
+
+Client acquisition latency histogram
+
+*Type*: histogram
+
+---
+
+=== vectorized_cloud_storage_cluster_metadata_manifest_downloads
+
+Number of partition manifest downloads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_cluster_metadata_manifest_uploads
+
+Number of partition manifest uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_controller_snapshot_failed_uploads
+
+Number of failed controller snapshot uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_controller_snapshot_successful_uploads
+
+Number of completed controller snapshot uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_controller_snapshot_upload_backoff
+
+Number of times backoff was applied during controller snapshot uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_download_backoff
+
+Number of times backoff  was applied during log-segment downloads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_failed_downloads
+
+Number of failed log-segment downloads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_failed_index_downloads
+
+Number of failed segment index downloads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_failed_index_uploads
+
+Number of failed segment index uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_failed_manifest_downloads
+
+Number of failed manifest downloads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_failed_manifest_uploads
+
+Number of failed manifest uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_failed_uploads
+
+Number of failed log-segment uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_index_downloads
+
+Number of segment indices downloaded
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_index_uploads
+
+Number of segment indices uploaded
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_manifest_download_backoff
+
+Number of times backoff was applied during manifest download
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_manifest_upload_backoff
+
+Number of times backoff was applied during manifest upload
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_partition_chunk_size
+
+Size of chunk downloaded from cloud storage
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `topic`
+
+---
+
+=== vectorized_cloud_storage_partition_manifest_downloads
+
+Number of partition manifest downloads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_partition_manifest_uploads
+
+Number of partition manifest (re)uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_partition_read_bytes
+
+Total bytes read from remote partition
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `topic`
+
+---
+
+=== vectorized_cloud_storage_partition_read_records
+
+Total number of records read from remote partition
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `topic`
+
+---
+
+=== vectorized_cloud_storage_read_path_chunk_hydration_latency
+
+Chunk hydration latency histogram
+
+*Type*: histogram
+
+---
+
+=== vectorized_cloud_storage_read_path_chunks_hydrated
+
+Total number of hydrated chunks (some may have been evicted from the cache)
+
+*Type*: counter
+
+---
+
+=== vectorized_cloud_storage_read_path_downloads_throttled_sum
+
+Total amount of time downloads were throttled (ms)
+
+*Type*: counter
+
+---
+
+=== vectorized_cloud_storage_read_path_hydrations_in_progress
+
+Active hydrations in progress
+
+*Type*: counter
+
+---
+
+=== vectorized_cloud_storage_read_path_materialized_segments
+
+Current number of materialized remote segments
+
+*Type*: gauge
+
+---
+
+=== vectorized_cloud_storage_read_path_readers
+
+Current number of remote partition readers
+
+*Type*: gauge
+
+---
+
+=== vectorized_cloud_storage_read_path_segment_readers
+
+Current number of remote segment readers
+
+*Type*: gauge
+
+---
+
+=== vectorized_cloud_storage_read_path_spillover_manifest_bytes
+
+Total amount of memory used by spillover manifests
+
+*Type*: gauge
+
+---
+
+=== vectorized_cloud_storage_read_path_spillover_manifest_hydrated
+
+Number of times spillover manifests were saved to the cache
+
+*Type*: counter
+
+---
+
+=== vectorized_cloud_storage_read_path_spillover_manifest_instances
+
+Total number of spillover manifests stored in memory
+
+*Type*: gauge
+
+---
+
+=== vectorized_cloud_storage_read_path_spillover_manifest_latency
+
+Spillover manifest materialization latency histogram
+
+*Type*: histogram
+
+---
+
+=== vectorized_cloud_storage_read_path_spillover_manifest_materialized
+
+Number of times spillover manifests were loaded from the cache
+
+*Type*: counter
+
+---
+
+=== vectorized_cloud_storage_segment_download_latency
+
+Segment download latency histogram
+
+*Type*: histogram
+
+---
+
+=== vectorized_cloud_storage_spillover_manifest_downloads
+
+Number of spillover manifest downloads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_spillover_manifest_uploads
+
+Number of spillover manifest (re)uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_successful_downloads
+
+Number of completed log-segment downloads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_successful_uploads
+
+Number of completed log-segment uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_topic_manifest_downloads
+
+Number of topic manifest downloads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_topic_manifest_uploads
+
+Number of topic manifest uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cloud_storage_upload_backoff
+
+Number of times backoff was applied during log-segment uploads
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cluster_controller_pending_partition_operations
+
+Number of partitions with ongoing/requested operations
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cluster_features_enterprise_license_expiry_sec
+
+Number of seconds remaining until the Enterprise license expires
+
+*Type*: gauge
+
+---
+
+=== vectorized_cluster_partition_batches_produced
+
+Total number of batches produced
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_bytes_fetched_from_follower_total
+
+Total number of bytes fetched from follower (not all might be returned to the client)
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_bytes_fetched_total
+
+Total number of bytes fetched (not all might be returned to the client)
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_bytes_produced_total
+
+Total number of bytes produced
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_cloud_storage_segments_metadata_bytes
+
+Current number of bytes consumed by remote segments managed for this partition
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_committed_offset
+
+Partition commited offset. i.e. safely persisted on majority of replicas
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_end_offset
+
+Last offset stored by current partition on this node
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_high_watermark
+
+Partion high watermark i.e. highest consumable offset
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_iceberg_offsets_pending_commit
+
+Total number of offsets that are pending commit to iceberg catalog.  Lag is reported only on leader while followers report 0. -1 is reported if iceberg is disabled while -2 indicates the lag is not yet computed.
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_iceberg_offsets_pending_translation
+
+Total number of offsets that are pending translation to iceberg. Lag is reported only on leader replicas while followers report 0. -1 is reported if iceberg is disabled while -2 indicates the lag is not yet computed.
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_last_stable_offset
+
+Last stable offset
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_leader
+
+Flag indicating if this partition instance is a leader
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_leader_id
+
+Id of current partition leader
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_moving_from_node
+
+Amount of partitions that are moving from node
+
+*Type*: gauge
+
+---
+
+=== vectorized_cluster_partition_moving_to_node
+
+Amount of partitions that are moving to node
+
+*Type*: gauge
+
+---
+
+=== vectorized_cluster_partition_node_cancelling_movements
+
+Amount of cancelling partition movements for node
+
+*Type*: gauge
+
+---
+
+=== vectorized_cluster_partition_num_with_broken_rack_constraint
+
+Number of partitions that don't satisfy the rack awareness constraint
+
+*Type*: gauge
+
+---
+
+=== vectorized_cluster_partition_records_fetched
+
+Total number of records fetched
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_records_produced
+
+Total number of records produced
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_start_offset
+
+start offset
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_partition_under_replicated_replicas
+
+Number of under replicated replicas
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_cluster_producer_state_manager_evicted_producers
+
+Number of evicted producers so far.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cluster_producer_state_manager_producer_manager_total_active_producers
+
+Total number of active idempotent and transactional producers.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cluster_shard_placement_assigned_partitions
+
+Number of partitions assigned to this shard
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cluster_shard_placement_hosted_partitions
+
+Number of partitions hosted on this shard
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_cluster_shard_placement_partitions_to_reconcile
+
+Number of partitions needing reconciliation of shard-local state
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_data_transforms_log_manager_buffer_usage_ratio
+
+Transform log manager buffer usage ratio
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_data_transforms_log_manager_write_errors_total
+
+Running count of errors while writing to the transform logs topic
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_debug_bundle_failed_generation_count
+
+Running count of failed debug bundle generations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_debug_bundle_last_failed_bundle_timestamp_seconds
+
+Timestamp of last failed debug bundle generation (seconds since epoch)
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_debug_bundle_last_successful_bundle_timestamp_seconds
+
+Timestamp of last successful debug bundle generation (seconds since epoch)
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_debug_bundle_successful_generation_count
+
+Running count of successful debug bundle generations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_httpd_connections_current
+
+The current number of open  connections
+
+*Type*: gauge
+
+*Labels*:
+
+- `service`
+- `shard`
+
+---
+
+=== vectorized_httpd_connections_total
+
+The total number of connections opened
+
+*Type*: counter
+
+*Labels*:
+
+- `service`
+- `shard`
+
+---
+
+=== vectorized_httpd_read_errors
+
+The total number of errors while reading http requests
+
+*Type*: counter
+
+*Labels*:
+
+- `service`
+- `shard`
+
+---
+
+=== vectorized_httpd_reply_errors
+
+The total number of errors while replying to http
+
+*Type*: counter
+
+*Labels*:
+
+- `service`
+- `shard`
+
+---
+
+=== vectorized_httpd_requests_served
+
+The total number of http requests served
+
+*Type*: counter
+
+*Labels*:
+
+- `service`
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_active_connections
+
+internal_rpc: Currently active connections
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_connection_close_errors
+
+internal_rpc: Number of errors when shutting down the connection
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_connections_rejected
+
+internal_rpc: Number of connection attempts rejected for hitting open connection count limits
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_connections_rejected_rate_limit
+
+internal_rpc: Number of connection attempts rejected for hitting connection rate limits
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_connections_wait_rate
+
+internal_rpc: Number of connections are blocked by connection rate
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_connects
+
+internal_rpc: Number of accepted connections
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_consumed_mem_bytes
+
+internal_rpc: Memory consumed by request processing
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_corrupted_headers
+
+internal_rpc: Number of requests with corrupted headers
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_dispatch_handler_latency
+
+internal_rpc: Latency 
+
+*Type*: histogram
+
+---
+
+=== vectorized_internal_rpc_latency
+
+Internal RPC service latency
+
+*Type*: histogram
+
+---
+
+=== vectorized_internal_rpc_max_service_mem_bytes
+
+internal_rpc: Maximum memory allowed for RPC
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_method_not_found_errors
+
+internal_rpc: Number of requests with not available RPC method
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_produce_bad_create_time
+
+number of produce requests with timestamps too far in the future or in the past
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_received_bytes
+
+internal_rpc: Number of bytes received from the clients in valid requests
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_requests_blocked_memory
+
+internal_rpc: Number of requests blocked in memory backpressure
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_requests_completed
+
+internal_rpc: Number of successful requests
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_requests_pending
+
+internal_rpc: Number of requests pending in the queue
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_sent_bytes
+
+internal_rpc: Number of bytes sent to clients
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_internal_rpc_service_errors
+
+internal_rpc: Number of service errors
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_io_queue_activations
+
+The number of times the class was woken up from idle
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+- `stream`
+
+---
+
+=== vectorized_io_queue_adjusted_consumption
+
+Consumed disk capacity units adjusted for class shares and idling preemption
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+- `stream`
+
+---
+
+=== vectorized_io_queue_consumption
+
+Accumulated disk capacity units consumed by this class; an increment per-second rate indicates full utilization
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+- `stream`
+
+---
+
+=== vectorized_io_queue_delay
+
+random delay time in the queue
+
+*Type*: gauge
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_disk_queue_length
+
+Number of requests in the disk
+
+*Type*: gauge
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_flow_ratio
+
+Ratio of dispatch rate to completion rate. Is expected to be 1.0+ growing larger on reactor stalls or (!) disk problems
+
+*Type*: gauge
+
+*Labels*:
+
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_queue_length
+
+Number of requests in the queue
+
+*Type*: gauge
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_shares
+
+current amount of shares
+
+*Type*: gauge
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_starvation_time_sec
+
+Total time spent starving for disk
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_total_bytes
+
+Total bytes passed in the queue
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_total_delay_sec
+
+Total time spent in the queue
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_total_exec_sec
+
+Total time spent in disk
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_total_operations
+
+Total operations passed in the queue
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_total_read_bytes
+
+Total read bytes passed in the queue
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_total_read_ops
+
+Total read operations passed in the queue
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_total_split_bytes
+
+Total number of bytes split
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_total_split_ops
+
+Total number of requests split
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_total_write_bytes
+
+Total write bytes passed in the queue
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_io_queue_total_write_ops
+
+Total write operations passed in the queue
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== vectorized_kafka_batch_size
+
+Batch size across all topics measured at the kafka layer.
+
+*Type*: histogram
+
+---
+
+=== vectorized_kafka_fetch_pid_delay_seconds_total
+
+A running total of fetch delay set by the pid controller.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_fetch_pid_error_total
+
+A running total of error in the fetch PID controller.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_fetch_read_distribution
+
+Read path time distribution histogram
+
+*Type*: histogram
+
+---
+
+=== vectorized_kafka_fetch_sessions_cache_mem_usage_bytes
+
+Fetch sessions cache memory usage in bytes
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_fetch_sessions_cache_sessions_count
+
+Total number of fetch sessions
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_group_offset
+
+Group topic partition offset
+
+*Type*: gauge
+
+*Labels*:
+
+- `group`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_kafka_handler_latency_microseconds
+
+Latency histogram of kafka requests
+
+*Type*: histogram
+
+---
+
+=== vectorized_kafka_handler_received_bytes_total
+
+Number of bytes received from kafka requests
+
+*Type*: counter
+
+*Labels*:
+
+- `handler`
+- `shard`
+
+---
+
+=== vectorized_kafka_handler_requests_completed_total
+
+Number of kafka requests completed
+
+*Type*: counter
+
+*Labels*:
+
+- `handler`
+- `shard`
+
+---
+
+=== vectorized_kafka_handler_requests_errored_total
+
+Number of kafka requests errored
+
+*Type*: counter
+
+*Labels*:
+
+- `handler`
+- `shard`
+
+---
+
+=== vectorized_kafka_handler_requests_in_progress_total
+
+A running total of kafka requests in progress
+
+*Type*: counter
+
+*Labels*:
+
+- `handler`
+- `shard`
+
+---
+
+=== vectorized_kafka_handler_sent_bytes_total
+
+Number of bytes sent in kafka replies
+
+*Type*: counter
+
+*Labels*:
+
+- `handler`
+- `shard`
+
+---
+
+=== vectorized_kafka_latency_fetch_latency_us
+
+Fetch Latency
+
+*Type*: histogram
+
+---
+
+=== vectorized_kafka_latency_produce_latency_us
+
+Produce Latency
+
+*Type*: histogram
+
+---
+
+=== vectorized_kafka_quotas_client_quota_throttle_time
+
+Client quota throttling delay per rule and quota type (in seconds)
+
+*Type*: histogram
+
+---
+
+=== vectorized_kafka_quotas_client_quota_throughput
+
+Client quota throughput per rule and quota type
+
+*Type*: histogram
+
+---
+
+=== vectorized_kafka_quotas_quota_effective
+
+Currently effective quota, in bytes/s
+
+*Type*: counter
+
+*Labels*:
+
+- `direction`
+- `shard`
+
+---
+
+=== vectorized_kafka_quotas_throttle_time
+
+Throttle time histogram (in seconds)
+
+*Type*: histogram
+
+---
+
+=== vectorized_kafka_quotas_traffic_egress
+
+Amount of Kafka traffic published to the clients that was taken into processing, in bytes
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_quotas_traffic_intake
+
+Amount of Kafka traffic received from the clients that is taken into processing, in bytes
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_active_connections
+
+kafka_rpc: Currently active connections
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_connection_close_errors
+
+kafka_rpc: Number of errors when shutting down the connection
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_connections_rejected
+
+kafka_rpc: Number of connection attempts rejected for hitting open connection count limits
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_connections_rejected_rate_limit
+
+kafka_rpc: Number of connection attempts rejected for hitting connection rate limits
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_connections_wait_rate
+
+kafka_rpc: Number of connections are blocked by connection rate
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_connects
+
+kafka_rpc: Number of accepted connections
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_consumed_mem_bytes
+
+kafka_rpc: Memory consumed by request processing
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_corrupted_headers
+
+kafka_rpc: Number of requests with corrupted headers
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_dispatch_handler_latency
+
+kafka_rpc: Latency 
+
+*Type*: histogram
+
+---
+
+=== vectorized_kafka_rpc_fetch_avail_mem_bytes
+
+kafka_rpc: Memory available for fetch request processing
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_max_service_mem_bytes
+
+kafka_rpc: Maximum memory allowed for RPC
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_method_not_found_errors
+
+kafka_rpc: Number of requests with not available RPC method
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_produce_bad_create_time
+
+number of produce requests with timestamps too far in the future or in the past
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_received_bytes
+
+kafka_rpc: Number of bytes received from the clients in valid requests
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_requests_blocked_memory
+
+kafka_rpc: Number of requests blocked in memory backpressure
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_requests_completed
+
+kafka_rpc: Number of successful requests
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_requests_pending
+
+kafka_rpc: Number of requests pending in the queue
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_sasl_session_expiration_total
+
+Total number of SASL session expirations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_sasl_session_reauth_attempts_total
+
+Total number of SASL reauthentication attempts
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_sasl_session_revoked_total
+
+Total number of SASL sessions revoked
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_sent_bytes
+
+kafka_rpc: Number of bytes sent to clients
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_rpc_service_errors
+
+kafka_rpc: Number of service errors
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_schema_id_cache_batches_decompressed
+
+Total number of batches decompressed for server-side schema ID validation
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_schema_id_cache_hits
+
+Total number of hits for the server-side schema ID validation cache (see cluster config: kafka_schema_id_validation_cache_capacity)
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_kafka_schema_id_cache_misses
+
+Total number of misses for the server-side schema ID validation cache (see cluster config: kafka_schema_id_validation_cache_capacity)
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_leader_balancer_leader_transfer_error
+
+Number of errors attempting to transfer leader
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_leader_balancer_leader_transfer_no_improvement
+
+Number of times no balance improvement was found
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_leader_balancer_leader_transfer_succeeded
+
+Number of successful leader transfers
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_leader_balancer_leader_transfer_timeout
+
+Number of timeouts attempting to transfer leader
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_allocated_memory
+
+Allocated memory size in bytes
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_available_memory
+
+Total shard memory potentially available in bytes (free_memory plus reclaimable)
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_available_memory_low_water_mark
+
+The low-water mark for available_memory from process start
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_cross_cpu_free_operations
+
+Total number of cross cpu free
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_free_memory
+
+Free memory size in bytes
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_free_operations
+
+Total number of free operations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_malloc_failed
+
+Total count of failed memory allocations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_malloc_live_objects
+
+Number of live objects
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_malloc_operations
+
+Total number of malloc operations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_reclaims_operations
+
+Total reclaims operations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_memory_total_memory
+
+Total memory size in bytes
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_network_bytes_received
+
+Counts the number of bytes received from network sockets.
+
+*Type*: counter
+
+*Labels*:
+
+- `group`
+- `shard`
+
+---
+
+=== vectorized_network_bytes_sent
+
+Counts the number of bytes written to network sockets.
+
+*Type*: counter
+
+*Labels*:
+
+- `group`
+- `shard`
+
+---
+
+=== vectorized_node_status_rpcs_received
+
+Number of node status RPCs received by this node
+
+*Type*: gauge
+
+---
+
+=== vectorized_node_status_rpcs_sent
+
+Number of node status RPCs sent by this node
+
+*Type*: gauge
+
+---
+
+=== vectorized_node_status_rpcs_timed_out
+
+Number of timed out node status RPCs from this node
+
+*Type*: gauge
+
+---
+
+=== vectorized_pandaproxy_request_errors_total
+
+Total number of rest_proxy server errors
+
+*Type*: counter
+
+*Labels*:
+
+- `operation`
+- `shard`
+- `status`
+
+---
+
+=== vectorized_pandaproxy_request_latency
+
+Request latency
+
+*Type*: histogram
+
+---
+
+=== vectorized_raft_append_entries_buffer_flushes
+
+Number of append entries buffer flushes
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_buffered_protocol_buffered_bytes
+
+Total size of append entries requests in the queue
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+- `target_node_id`
+
+---
+
+=== vectorized_raft_buffered_protocol_buffered_requests
+
+Total number of append entries requests in the queue
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+- `target_node_id`
+
+---
+
+=== vectorized_raft_buffered_protocol_inflight_requests
+
+Number of append entries requests that were sent to the target node and are awaiting responses.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+- `target_node_id`
+
+---
+
+=== vectorized_raft_configuration_change_in_progress
+
+Indicates if current raft group configuration is in joint state i.e. configuration is being changed
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_done_replicate_requests
+
+Number of finished replicate requests
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_full_heartbeat_requests
+
+Number of full heartbeats sent by the leader
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_group_configuration_updates
+
+Number of raft group configuration updates
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_group_count
+
+Number of raft groups
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_raft_heartbeat_requests_errors
+
+Number of failed heartbeat requests
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_leader_for
+
+Number of groups for which node is a leader
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_leadership_changes
+
+Number of won leader elections
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_learners_gap_bytes
+
+Total numbers of bytes that must be delivered to learners
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_raft_lightweight_heartbeat_requests
+
+Number of lightweight heartbeats sent by the leader
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_log_flushes
+
+Number of log flushes
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_log_truncations
+
+Number of log truncations
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_offset_translator_inconsistency_errors
+
+Number of append entries requests that failed the offset translator consistency check
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_received_append_requests
+
+Number of append requests received
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_received_vote_requests
+
+Number of vote requests received
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_recovery_offsets_pending
+
+Sum of offsets that partitions on this node need to recover.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_raft_recovery_partition_movement_assigned_bandwidth
+
+Bandwidth assigned for partition movement in last tick. bytes/sec
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_raft_recovery_partition_movement_available_bandwidth
+
+Bandwidth available for partition movement. bytes/sec
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_raft_recovery_partitions_active
+
+Number of partition replicas are currently recovering on this node.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_raft_recovery_partitions_to_recover
+
+Number of partition replicas that have to recover for this node.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_raft_recovery_requests
+
+Number of recovery requests
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_recovery_requests_errors
+
+Number of failed recovery requests
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_replicate_ack_all_requests
+
+Number of replicate requests with quorum ack consistency and explicit flush.
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_replicate_ack_all_requests_no_flush
+
+Number of replicate requests with quorum ack consistency but without an explicit flush.
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_replicate_ack_leader_requests
+
+Number of replicate requests with leader ack consistency
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_replicate_ack_none_requests
+
+Number of replicate requests with no ack consistency
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_replicate_batch_flush_requests
+
+Number of replicate batch flushes
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_replicate_request_errors
+
+Number of failed replicate requests
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_raft_sent_vote_requests
+
+Number of vote requests sent
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_reactor_abandoned_failed_futures
+
+Total number of abandoned failed futures, futures destroyed while still containing an exception
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_aio_bytes_read
+
+Total aio-reads bytes
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_aio_bytes_write
+
+Total aio-writes bytes
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_aio_errors
+
+Total aio errors
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_aio_outsizes
+
+Total number of aio operations that exceed IO limit
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_aio_reads
+
+Total aio-reads operations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_aio_writes
+
+Total aio-writes operations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_awake_time_ms_total
+
+Total reactor awake time (wall_clock)
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_cpp_exceptions
+
+Total number of C++ exceptions
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_cpu_busy_ms
+
+Total cpu busy time in milliseconds
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_cpu_steal_time_ms
+
+Total steal time, the time in which something else was running while the reactor was runnable (not sleeping).Because this is in userspace, some time that could be legitimally thought as steal time is not accounted as such. For example, if we are sleeping and can wake up but the kernel hasn't woken us up yet.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_cpu_used_time_ms
+
+Total reactor thread CPU time (from CLOCK_THREAD_CPUTIME)
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_fstream_read_bytes
+
+Counts bytes read from disk file streams.  A high rate indicates high disk activity. Divide by fstream_reads to determine average read size.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_fstream_read_bytes_blocked
+
+Counts the number of bytes read from disk that could not be satisfied from read-ahead buffers, and had to block. Indicates short streams, or incorrect read ahead configuration.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_fstream_reads
+
+Counts reads from disk file streams.  A high rate indicates high disk activity. Contrast with other fstream_read* counters to locate bottlenecks.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_fstream_reads_ahead_bytes_discarded
+
+Counts the number of buffered bytes that were read ahead of time and were discarded because they were not needed, wasting disk bandwidth. Indicates over-eager read ahead configuration.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_fstream_reads_aheads_discarded
+
+Counts the number of times a buffer that was read ahead of time and was discarded because it was not needed, wasting disk bandwidth. Indicates over-eager read ahead configuration.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_fstream_reads_blocked
+
+Counts the number of times a disk read could not be satisfied from read-ahead buffers, and had to block. Indicates short streams, or incorrect read ahead configuration.
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_fsyncs
+
+Total number of fsync operations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_io_threaded_fallbacks
+
+Total number of io-threaded-fallbacks operations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_logging_failures
+
+Total number of logging failures
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_polls
+
+Number of times pollers were executed
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_sleep_time_ms_total
+
+Total reactor sleep time (wall clock)
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_stalls
+
+A histogram of reactor stall durations
+
+*Type*: histogram
+
+---
+
+=== vectorized_reactor_tasks_pending
+
+Number of pending tasks in the queue
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_tasks_processed
+
+Total tasks processed
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_timers_pending
+
+Number of tasks in the timer-pending queue
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_reactor_utilization
+
+CPU utilization
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_rest_proxy_inflight_requests_memory_usage_ratio
+
+Memory usage ratio of in-flight requests in the rest_proxy
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_rest_proxy_inflight_requests_usage_ratio
+
+Usage ratio of in-flight requests in the rest_proxy
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_rest_proxy_queued_requests_memory_blocked
+
+Number of requests queued in rest_proxy, due to memory limitations
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_rpc_client_active_connections
+
+Currently active connections
+
+*Type*: gauge
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_client_correlation_errors
+
+Number of errors in client correlation id
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_connection_errors
+
+Number of connection errors
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_connects
+
+Connection attempts
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_corrupted_headers
+
+Number of responses with corrupted headers
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_in_bytes
+
+Total number of bytes received
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_out_bytes
+
+Total number of bytes sent (including headers)
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_read_dispatch_errors
+
+Number of errors while dispatching responses
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_request_errors
+
+Number or requests errors
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_request_timeouts
+
+Number or requests timeouts
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_requests
+
+Number of requests
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_requests_blocked_memory
+
+Number of requests that are blocked because of insufficient memory
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_requests_pending
+
+Number of requests pending
+
+*Type*: gauge
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_rpc_client_server_correlation_errors
+
+Number of responses with wrong correlation id
+
+*Type*: counter
+
+*Labels*:
+
+- `connection_cache_label`
+- `shard`
+- `target`
+
+---
+
+=== vectorized_scheduler_queue_length
+
+Size of backlog on this queue, in tasks; indicates whether the queue is busy and/or contended
+
+*Type*: gauge
+
+*Labels*:
+
+- `group`
+- `shard`
+
+---
+
+=== vectorized_scheduler_runtime_ms
+
+Accumulated runtime of this task queue; an increment rate of 1000ms per second indicates full utilization
+
+*Type*: counter
+
+*Labels*:
+
+- `group`
+- `shard`
+
+---
+
+=== vectorized_scheduler_shares
+
+Shares allocated to this queue
+
+*Type*: gauge
+
+*Labels*:
+
+- `group`
+- `shard`
+
+---
+
+=== vectorized_scheduler_starvetime_ms
+
+Accumulated starvation time of this task queue; an increment rate of 1000ms per second indicates the scheduler feels really bad
+
+*Type*: counter
+
+*Labels*:
+
+- `group`
+- `shard`
+
+---
+
+=== vectorized_scheduler_tasks_processed
+
+Count of tasks executing on this queue; indicates together with runtime_ms indicates length of tasks
+
+*Type*: counter
+
+*Labels*:
+
+- `group`
+- `shard`
+
+---
+
+=== vectorized_scheduler_time_spent_on_task_quota_violations_ms
+
+Total amount in milliseconds we were in violation of the task quota
+
+*Type*: counter
+
+*Labels*:
+
+- `group`
+- `shard`
+
+---
+
+=== vectorized_scheduler_waittime_ms
+
+Accumulated waittime of this task queue; an increment rate of 1000ms per second indicates queue is waiting for something (e.g. IO)
+
+*Type*: counter
+
+*Labels*:
+
+- `group`
+- `shard`
+
+---
+
+=== vectorized_schema_registry_cache_schema_count
+
+The number of schemas in the store
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_schema_registry_cache_schema_memory_bytes
+
+The memory usage of schemas in the store
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_schema_registry_cache_subject_count
+
+The number of subjects in the store
+
+*Type*: gauge
+
+*Labels*:
+
+- `deleted`
+- `shard`
+
+---
+
+=== vectorized_schema_registry_cache_subject_version_count
+
+The number of versions in the subject
+
+*Type*: gauge
+
+*Labels*:
+
+- `deleted`
+- `shard`
+- `subject`
+
+---
+
+=== vectorized_schema_registry_inflight_requests_memory_usage_ratio
+
+Memory usage ratio of in-flight requests in the schema_registry
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_schema_registry_inflight_requests_usage_ratio
+
+Usage ratio of in-flight requests in the schema_registry
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_schema_registry_queued_requests_memory_blocked
+
+Number of requests queued in schema_registry, due to memory limitations
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_security_audit_buffer_usage_ratio
+
+Audit event buffer usage ratio.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_security_audit_client_buffer_usage_ratio
+
+Audit client send buffer usage ratio
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_security_audit_errors_total
+
+Running count of errors in creating/publishing audit event log entries
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_security_audit_last_event_timestamp_seconds
+
+Timestamp of last successful publish on the audit log (seconds since epoch)
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_available_reclaimable_bytes
+
+Total amount of available reclaimable data by space management.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_disk_usage_bytes
+
+Total amount of disk usage under control of space management.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_local_retention_reclaimable_bytes
+
+Total amount of reclaimable data above the local retention target (ref: retention.local.target.{ms,bytes}).
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_reclaim_active_segment_bytes
+
+Estimated amount of data above the active segment to be reclaimed by space management
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_reclaim_estimate_bytes
+
+Estimated amount of data to be reclaimed by space management in last schedule.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_reclaim_local_bytes
+
+Estimated amount of data above local retention to be reclaimed by space management
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_reclaim_low_hinted_bytes
+
+Estimated amount of data above the hinted low-space threshold to be reclaimed by space management
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_reclaim_low_non_hinted_bytes
+
+Estimated amount of data above the non-hinted low-space threshold to be reclaimed by space management
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_retention_reclaimable_bytes
+
+Total amount of reclaimable data through standard retention policy (ref: retention.{ms,bytes}).
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_target_disk_size_bytes
+
+Target maximum number of stored bytes.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_space_management_target_excess_bytes
+
+Amount of data usage that exceeds target threshold.
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_stall_detector_reported
+
+Total number of reported stalls, look in the traces for the exact reason
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_compaction_backlog_controller_backlog_size
+
+controller backlog
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_compaction_backlog_controller_error
+
+current controller error, i.e difference between set point and backlog size
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_compaction_backlog_controller_shares
+
+controller output, i.e. number of shares
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_kvstore_cached_bytes
+
+Size of the database in memory
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_kvstore_entries_fetched
+
+Number of entries fetched
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_kvstore_entries_removed
+
+Number of entries removaled
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_kvstore_entries_written
+
+Number of entries written
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_kvstore_key_count
+
+Number of keys in the database
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_kvstore_segments_rolled
+
+Number of segments rolled
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_log_batch_parse_errors
+
+Number of batch parsing (reading) errors
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_batch_write_errors
+
+Number of batch write errors
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_batches_read
+
+Total number of batches read
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_batches_written
+
+Total number of batches written
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_bytes_prefix_truncated
+
+Number of bytes removed by prefix truncation.
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_cache_hits
+
+Reader cache hits
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_cache_misses
+
+Reader cache misses
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_cached_batches_read
+
+Total number of cached batches read
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_cached_read_bytes
+
+Total number of cached bytes read
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_chunked_compaction_runs
+
+Number of times chunked compaction was ran. This metric also corresponds to the number of times the compaction key-offset map was unable to be built for a single segment.
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_cleanly_compacted_segment
+
+Number of segments cleanly compacted (i.e, had their keys de-duplicated with all previous segments before them to the front of the log)
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_closed_segment_bytes
+
+Number of bytes within closed segments of the log
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_compacted_segment
+
+Number of compacted segments
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_compaction_ratio
+
+Average segment compaction ratio
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `topic`
+
+---
+
+=== vectorized_storage_log_compaction_removed_bytes
+
+Number of bytes removed by a compaction operation
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_complete_sliding_window_rounds
+
+Number of rounds of sliding window compaction that have been driven to completion.
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_corrupted_compaction_indices
+
+Number of times we had to re-construct the .compaction index on a segment
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_dirty_segment_bytes
+
+Number of bytes within dirty segments of the log
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_log_segments_active
+
+Current number of local log segments
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_log_segments_created
+
+Total number of local log segments created since node startup
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_log_segments_removed
+
+Total number of local log segments removed since node startup
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_partition_size
+
+Current size of partition in bytes
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_read_bytes
+
+Total number of bytes read
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_readers_added
+
+Number of readers added to cache
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_readers_evicted
+
+Number of readers evicted from cache
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_segments_marked_tombstone_free
+
+Number of segments that have been verified through the compaction process to be tombstone free.
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_tombstones_removed
+
+Number of tombstone records removed by compaction due to the delete.retention.ms setting.
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_log_written_bytes
+
+Total number of bytes written
+
+*Type*: counter
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_storage_manager_housekeeping_log_processed
+
+Number of logs processed by housekeeping
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_manager_logs
+
+Number of logs managed
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_storage_manager_urgent_gc_runs
+
+Number of urgent GC runs
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== vectorized_tx_partition_idempotency_pid_cache_size
+
+Number of active producers (known producer_id seq number pairs).
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+
+=== vectorized_tx_partition_tx_num_inflight_requests
+
+Number of ongoing transactional requests.
+
+*Type*: gauge
+
+*Labels*:
+
+- `namespace`
+- `partition`
+- `shard`
+- `topic`
+
+---
+

--- a/gen/v25.1/metrics/metrics.adoc
+++ b/gen/v25.1/metrics/metrics.adoc
@@ -1,0 +1,1384 @@
+=== redpanda_application_build
+
+Redpanda build information
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_revision`
+- `redpanda_version`
+
+---
+
+=== redpanda_application_fips_mode
+
+Identifies whether or not Redpanda is running in FIPS mode.
+
+*Type*: gauge
+
+---
+
+=== redpanda_application_uptime_seconds_total
+
+Redpanda uptime in seconds
+
+*Type*: gauge
+
+---
+
+=== redpanda_authorization_result
+
+Total number of authorization results by type
+
+*Type*: counter
+
+*Labels*:
+
+- `type`
+
+---
+
+=== redpanda_cloud_client_backoff
+
+Total number of requests that backed off
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_endpoint`
+- `redpanda_region`
+
+---
+
+=== redpanda_cloud_client_client_pool_utilization
+
+Utilization of the cloud storage pool(0 - unused, 100 - fully utilized)
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_endpoint`
+- `redpanda_region`
+- `shard`
+
+---
+
+=== redpanda_cloud_client_download_backoff
+
+Total number of download requests that backed off
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_endpoint`
+- `redpanda_region`
+
+---
+
+=== redpanda_cloud_client_downloads
+
+Total number of requests that downloaded an object from cloud storage
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_endpoint`
+- `redpanda_region`
+
+---
+
+=== redpanda_cloud_client_lease_duration
+
+Lease duration histogram
+
+*Type*: histogram
+
+---
+
+=== redpanda_cloud_client_not_found
+
+Total number of requests for which the object was not found
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_endpoint`
+- `redpanda_region`
+
+---
+
+=== redpanda_cloud_client_num_borrows
+
+Number of time current shard had to borrow a cloud storage client from another shard
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_endpoint`
+- `redpanda_region`
+- `shard`
+
+---
+
+=== redpanda_cloud_client_upload_backoff
+
+Total number of upload requests that backed off
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_endpoint`
+- `redpanda_region`
+
+---
+
+=== redpanda_cloud_client_uploads
+
+Total number of requests that uploaded an object to cloud storage
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_endpoint`
+- `redpanda_region`
+
+---
+
+=== redpanda_cloud_storage_active_segments
+
+Number of remote log segments currently hydrated for read
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_anomalies
+
+Count of missing partition manifest anomalies for the topic
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_namespace`
+- `redpanda_severity`
+- `redpanda_topic`
+- `redpanda_type`
+
+---
+
+=== redpanda_cloud_storage_cache_op_hit
+
+Number of get requests for objects that are already in cache.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_cache_op_in_progress_files
+
+Number of files that are being put to cache.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_cache_op_miss
+
+Number of failed get requests because of missing object in the cache.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_cache_op_put
+
+Number of objects written into cache.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_cache_space_files
+
+Number of objects in cache.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_cache_space_hwm_files
+
+High watermark of number of objects in cache.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_cache_space_hwm_size_bytes
+
+High watermark of sum of size of cached objects.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_cache_space_size_bytes
+
+Sum of size of cached objects.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_cache_space_tracker_size
+
+Number of entries in cache access tracker
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_cache_space_tracker_syncs
+
+Number of times the access tracker was updated with cache disk data
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_cache_trim_carryover_trims
+
+Number of times we invoked carryover trim.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_cache_trim_exhaustive_trims
+
+Number of times we couldn't free enough space with a fast trim and had to fall back to a slower exhaustive trim.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_cache_trim_failed_trims
+
+Number of times could not free the expected amount of space, indicating possible bug or configuration issue.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_cache_trim_fast_trims
+
+Number of times we have trimmed the cache using the normal (fast) mode.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_cache_trim_in_mem_trims
+
+Number of times we trimmed the cache using the in-memory access tracker.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_errors_total
+
+Number of transmit errors
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_direction`
+
+---
+
+=== redpanda_cloud_storage_housekeeping_drains
+
+Number of times upload housekeeping queue was drained
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_housekeeping_jobs_completed
+
+Number of executed housekeeping jobs
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_housekeeping_jobs_failed
+
+Number of failed housekeeping jobs
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_housekeeping_jobs_skipped
+
+Number of skipped housekeeping jobs
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_housekeeping_pauses
+
+Number of times upload housekeeping was paused
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_housekeeping_requests_throttled_average_rate
+
+Average rate of requests from the read and write path which were throttled by tiered storage (per shard)
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_cloud_storage_housekeeping_resumes
+
+Number of times upload housekeeping was resumed
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_housekeeping_rounds
+
+Number of upload housekeeping rounds
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_jobs_cloud_segment_reuploads
+
+Number of segment reuploads from cloud storage sources (cloud storage cache or direct download from cloud storage)
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_jobs_local_segment_reuploads
+
+Number of segment reuploads from local data directory
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_jobs_manifest_reuploads
+
+Number of manifest reuploads performed by all housekeeping jobs
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_jobs_metadata_syncs
+
+Number of archival configuration updates performed by all housekeeping jobs
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_jobs_segment_deletions
+
+Number of segments deleted by all housekeeping jobs
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_limits_downloads_throttled_sum
+
+Total amount of time downloads were throttled (ms)
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_partition_manifest_uploads_total
+
+Successful partition manifest uploads
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_partition_readers
+
+Number of partition reader instances (number of current fetch/timequery requests reading from tiered storage)
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_partition_readers_delayed
+
+How many partition reades were delayed due to hitting reader limit. This indicates cluster is saturated with tiered storage reads.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_readers
+
+Number of segment read cursors for hydrated remote log segments
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_segment_index_uploads_total
+
+Successful segment index uploads
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_segment_materializations_delayed
+
+How many segment materializations were delayed due to hitting reader limit. This indicates cluster is saturated with tiered storage reads.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_segment_readers_delayed
+
+How many segment readers were delayed due to hitting reader limit. This indicates cluster is saturated with tiered storage reads.
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_segment_uploads_total
+
+Successful data segment uploads
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_spillover_manifest_uploads_total
+
+Successful spillover manifest uploads
+
+*Type*: counter
+
+---
+
+=== redpanda_cloud_storage_spillover_manifests_materialized_bytes
+
+Bytes of memory used for spilled manifests currently cached in memory
+
+*Type*: gauge
+
+---
+
+=== redpanda_cloud_storage_spillover_manifests_materialized_count
+
+How many spilled manifests are currently cached in memory
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_brokers
+
+Number of configured brokers in the cluster
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_controller_log_limit_requests_available_rps
+
+Controller log rate limiting. Available rps for group
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_cmd_group`
+
+---
+
+=== redpanda_cluster_controller_log_limit_requests_dropped
+
+Controller log rate limiting. Amount of requests that are dropped due to exceeding limit in group
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_cmd_group`
+
+---
+
+=== redpanda_cluster_features_enterprise_license_expiry_sec
+
+Number of seconds remaining until the Enterprise license expires
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_latest_cluster_metadata_manifest_age
+
+Age in seconds of the latest cluster_metadata_manifest uploaded
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_members_backend_queued_node_operations
+
+Number of queued node operations
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_cluster_non_homogenous_fips_mode
+
+Number of nodes that have a non-homogenous FIPS mode value
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_partition_moving_from_node
+
+Amount of partitions that are moving from node
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_partition_moving_to_node
+
+Amount of partitions that are moving to node
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_partition_node_cancelling_movements
+
+Amount of cancelling partition movements for node
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_partition_num_with_broken_rack_constraint
+
+Number of partitions that don't satisfy the rack awareness constraint
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_partitions
+
+Number of partitions in the cluster (replicas not included)
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_topics
+
+Number of topics in the cluster
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_unavailable_partitions
+
+Number of partitions that lack quorum among replicants
+
+*Type*: gauge
+
+---
+
+=== redpanda_cpu_busy_seconds_total
+
+Total CPU busy time in seconds
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_debug_bundle_failed_generation_count
+
+Running count of failed debug bundle generations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_debug_bundle_last_failed_bundle_timestamp_seconds
+
+Timestamp of last failed debug bundle generation (seconds since epoch)
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_debug_bundle_last_successful_bundle_timestamp_seconds
+
+Timestamp of last successful debug bundle generation (seconds since epoch)
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_debug_bundle_successful_generation_count
+
+Running count of successful debug bundle generations
+
+*Type*: counter
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_io_queue_total_read_ops
+
+Total read operations passed in the queue
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== redpanda_io_queue_total_write_ops
+
+Total write operations passed in the queue
+
+*Type*: counter
+
+*Labels*:
+
+- `class`
+- `iogroup`
+- `mountpoint`
+- `shard`
+
+---
+
+=== redpanda_kafka_consumer_group_committed_offset
+
+Consumer group committed offset
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_group`
+- `redpanda_partition`
+- `redpanda_topic`
+- `shard`
+
+---
+
+=== redpanda_kafka_consumer_group_consumers
+
+Number of consumers in a group
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_group`
+- `shard`
+
+---
+
+=== redpanda_kafka_consumer_group_lag_max
+
+Maximum consumer group lag across topic-partitions
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_group`
+- `shard`
+
+---
+
+=== redpanda_kafka_consumer_group_lag_sum
+
+Sum of consumer group lag for all topic-partitions
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_group`
+- `shard`
+
+---
+
+=== redpanda_kafka_consumer_group_topics
+
+Number of topics in a group
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_group`
+- `shard`
+
+---
+
+=== redpanda_kafka_handler_latency_seconds
+
+Latency histogram of kafka requests
+
+*Type*: histogram
+
+---
+
+=== redpanda_kafka_max_offset
+
+Latest readable offset of the partition (i.e. high watermark)
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_namespace`
+- `redpanda_partition`
+- `redpanda_topic`
+
+---
+
+=== redpanda_kafka_partitions
+
+Configured number of partitions for the topic
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_namespace`
+- `redpanda_topic`
+
+---
+
+=== redpanda_kafka_quotas_client_quota_throttle_time
+
+Client quota throttling delay per rule and quota type (in seconds)
+
+*Type*: histogram
+
+---
+
+=== redpanda_kafka_quotas_client_quota_throughput
+
+Client quota throughput per rule and quota type
+
+*Type*: histogram
+
+---
+
+=== redpanda_kafka_records_fetched_total
+
+Total number of records fetched
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_namespace`
+- `redpanda_topic`
+
+---
+
+=== redpanda_kafka_records_produced_total
+
+Total number of records produced
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_namespace`
+- `redpanda_topic`
+
+---
+
+=== redpanda_kafka_replicas
+
+Configured number of replicas for the topic
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_namespace`
+- `redpanda_topic`
+
+---
+
+=== redpanda_kafka_request_bytes_total
+
+Total number of bytes produced per topic
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_namespace`
+- `redpanda_request`
+- `redpanda_topic`
+
+---
+
+=== redpanda_kafka_request_latency_seconds
+
+Internal latency of kafka produce requests
+
+*Type*: histogram
+
+---
+
+=== redpanda_kafka_rpc_sasl_session_expiration_total
+
+Total number of SASL session expirations
+
+*Type*: counter
+
+---
+
+=== redpanda_kafka_rpc_sasl_session_reauth_attempts_total
+
+Total number of SASL reauthentication attempts
+
+*Type*: counter
+
+---
+
+=== redpanda_kafka_rpc_sasl_session_revoked_total
+
+Total number of SASL sessions revoked
+
+*Type*: counter
+
+---
+
+=== redpanda_kafka_under_replicated_replicas
+
+Number of under replicated replicas (i.e. replicas that are live, but not at the latest offest)
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_namespace`
+- `redpanda_partition`
+- `redpanda_topic`
+
+---
+
+=== redpanda_memory_allocated_memory
+
+Allocated memory size in bytes
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_memory_available_memory
+
+Total shard memory potentially available in bytes (free_memory plus reclaimable)
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_memory_available_memory_low_water_mark
+
+The low-water mark for available_memory from process start
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_memory_free_memory
+
+Free memory size in bytes
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_node_status_rpcs_received
+
+Number of node status RPCs received by this node
+
+*Type*: gauge
+
+---
+
+=== redpanda_node_status_rpcs_sent
+
+Number of node status RPCs sent by this node
+
+*Type*: gauge
+
+---
+
+=== redpanda_node_status_rpcs_timed_out
+
+Number of timed out node status RPCs from this node
+
+*Type*: gauge
+
+---
+
+=== redpanda_raft_leadership_changes
+
+Number of won leader elections across all partitions in given topic
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_namespace`
+- `redpanda_topic`
+
+---
+
+=== redpanda_raft_learners_gap_bytes
+
+Total numbers of bytes that must be delivered to learners
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_raft_recovery_offsets_pending
+
+Sum of offsets that partitions on this node need to recover.
+
+*Type*: gauge
+
+---
+
+=== redpanda_raft_recovery_partition_movement_available_bandwidth
+
+Bandwidth available for partition movement. bytes/sec
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_raft_recovery_partition_movement_consumed_bandwidth
+
+Bandwidth consumed for partition movement. bytes/sec
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_raft_recovery_partitions_active
+
+Number of partition replicas are currently recovering on this node.
+
+*Type*: gauge
+
+---
+
+=== redpanda_raft_recovery_partitions_to_recover
+
+Number of partition replicas that have to recover for this node.
+
+*Type*: gauge
+
+---
+
+=== redpanda_rest_proxy_inflight_requests_memory_usage_ratio
+
+Memory usage ratio of in-flight requests in the rest_proxy
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_rest_proxy_inflight_requests_usage_ratio
+
+Usage ratio of in-flight requests in the rest_proxy
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_rest_proxy_queued_requests_memory_blocked
+
+Number of requests queued in rest_proxy, due to memory limitations
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_rest_proxy_request_errors_total
+
+Total number of rest_proxy server errors
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_status`
+
+---
+
+=== redpanda_rest_proxy_request_latency_seconds
+
+Internal latency of request for rest_proxy
+
+*Type*: histogram
+
+---
+
+=== redpanda_rpc_active_connections
+
+Count of currently active connections
+
+*Type*: gauge
+
+*Labels*:
+
+- `redpanda_server`
+
+---
+
+=== redpanda_rpc_received_bytes
+
+internal: Number of bytes received from the clients in valid requests
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_server`
+
+---
+
+=== redpanda_rpc_request_errors_total
+
+Number of rpc errors
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_server`
+
+---
+
+=== redpanda_rpc_request_latency_seconds
+
+RPC latency
+
+*Type*: histogram
+
+---
+
+=== redpanda_rpc_sent_bytes
+
+internal: Number of bytes sent to clients
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_server`
+
+---
+
+=== redpanda_scheduler_runtime_seconds_total
+
+Accumulated runtime of task queue associated with this scheduling group
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_scheduling_group`
+- `shard`
+
+---
+
+=== redpanda_schema_registry_cache_schema_count
+
+The number of schemas in the store
+
+*Type*: gauge
+
+---
+
+=== redpanda_schema_registry_cache_schema_memory_bytes
+
+The memory usage of schemas in the store
+
+*Type*: gauge
+
+---
+
+=== redpanda_schema_registry_cache_subject_count
+
+The number of subjects in the store
+
+*Type*: gauge
+
+*Labels*:
+
+- `deleted`
+
+---
+
+=== redpanda_schema_registry_cache_subject_version_count
+
+The number of versions in the subject
+
+*Type*: gauge
+
+*Labels*:
+
+- `deleted`
+- `subject`
+
+---
+
+=== redpanda_schema_registry_inflight_requests_memory_usage_ratio
+
+Memory usage ratio of in-flight requests in the schema_registry
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_schema_registry_inflight_requests_usage_ratio
+
+Usage ratio of in-flight requests in the schema_registry
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_schema_registry_queued_requests_memory_blocked
+
+Number of requests queued in schema_registry, due to memory limitations
+
+*Type*: gauge
+
+*Labels*:
+
+- `shard`
+
+---
+
+=== redpanda_schema_registry_request_errors_total
+
+Total number of schema_registry server errors
+
+*Type*: counter
+
+*Labels*:
+
+- `redpanda_status`
+
+---
+
+=== redpanda_schema_registry_request_latency_seconds
+
+Internal latency of request for schema_registry
+
+*Type*: histogram
+
+---
+
+=== redpanda_security_audit_errors_total
+
+Running count of errors in creating/publishing audit event log entries
+
+*Type*: counter
+
+---
+
+=== redpanda_security_audit_last_event_timestamp_seconds
+
+Timestamp of last successful publish on the audit log (seconds since epoch)
+
+*Type*: counter
+
+---
+
+=== redpanda_storage_cache_disk_free_bytes
+
+Disk storage bytes free.
+
+*Type*: gauge
+
+---
+
+=== redpanda_storage_cache_disk_free_space_alert
+
+Status of low storage space alert. 0-OK, 1-Low Space 2-Degraded
+
+*Type*: gauge
+
+---
+
+=== redpanda_storage_cache_disk_total_bytes
+
+Total size of attached storage, in bytes.
+
+*Type*: gauge
+
+---
+
+=== redpanda_storage_disk_free_bytes
+
+Disk storage bytes free.
+
+*Type*: gauge
+
+---
+
+=== redpanda_storage_disk_free_space_alert
+
+Status of low storage space alert. 0-OK, 1-Low Space 2-Degraded
+
+*Type*: gauge
+
+---
+
+=== redpanda_storage_disk_total_bytes
+
+Total size of attached storage, in bytes.
+
+*Type*: gauge
+
+---
+
+=== redpanda_wasm_binary_executable_memory_usage
+
+The amount of executable memory used for WebAssembly binaries
+
+*Type*: gauge
+
+---
+

--- a/gen/v25.1/metrics/metrics.json
+++ b/gen/v25.1/metrics/metrics.json
@@ -1,0 +1,3759 @@
+{
+    "public": {
+        "redpanda_application_build": {
+            "description": "Redpanda build information",
+            "type": "gauge",
+            "labels": [
+                "redpanda_revision",
+                "redpanda_version"
+            ]
+        },
+        "redpanda_application_fips_mode": {
+            "description": "Identifies whether or not Redpanda is running in FIPS mode.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_application_uptime_seconds_total": {
+            "description": "Redpanda uptime in seconds",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_authorization_result": {
+            "description": "Total number of authorization results by type",
+            "type": "counter",
+            "labels": [
+                "type"
+            ]
+        },
+        "redpanda_cloud_client_backoff": {
+            "description": "Total number of requests that backed off",
+            "type": "counter",
+            "labels": [
+                "redpanda_endpoint",
+                "redpanda_region"
+            ]
+        },
+        "redpanda_cloud_client_client_pool_utilization": {
+            "description": "Utilization of the cloud storage pool(0 - unused, 100 - fully utilized)",
+            "type": "gauge",
+            "labels": [
+                "redpanda_endpoint",
+                "redpanda_region",
+                "shard"
+            ]
+        },
+        "redpanda_cloud_client_download_backoff": {
+            "description": "Total number of download requests that backed off",
+            "type": "counter",
+            "labels": [
+                "redpanda_endpoint",
+                "redpanda_region"
+            ]
+        },
+        "redpanda_cloud_client_downloads": {
+            "description": "Total number of requests that downloaded an object from cloud storage",
+            "type": "counter",
+            "labels": [
+                "redpanda_endpoint",
+                "redpanda_region"
+            ]
+        },
+        "redpanda_cloud_client_lease_duration": {
+            "description": "Lease duration histogram",
+            "type": "histogram",
+            "labels": {}
+        },
+        "redpanda_cloud_client_not_found": {
+            "description": "Total number of requests for which the object was not found",
+            "type": "counter",
+            "labels": [
+                "redpanda_endpoint",
+                "redpanda_region"
+            ]
+        },
+        "redpanda_cloud_client_num_borrows": {
+            "description": "Number of time current shard had to borrow a cloud storage client from another shard",
+            "type": "counter",
+            "labels": [
+                "redpanda_endpoint",
+                "redpanda_region",
+                "shard"
+            ]
+        },
+        "redpanda_cloud_client_upload_backoff": {
+            "description": "Total number of upload requests that backed off",
+            "type": "counter",
+            "labels": [
+                "redpanda_endpoint",
+                "redpanda_region"
+            ]
+        },
+        "redpanda_cloud_client_uploads": {
+            "description": "Total number of requests that uploaded an object to cloud storage",
+            "type": "counter",
+            "labels": [
+                "redpanda_endpoint",
+                "redpanda_region"
+            ]
+        },
+        "redpanda_cloud_storage_active_segments": {
+            "description": "Number of remote log segments currently hydrated for read",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_anomalies": {
+            "description": "Count of missing partition manifest anomalies for the topic",
+            "type": "gauge",
+            "labels": [
+                "redpanda_namespace",
+                "redpanda_severity",
+                "redpanda_topic",
+                "redpanda_type"
+            ]
+        },
+        "redpanda_cloud_storage_cache_op_hit": {
+            "description": "Number of get requests for objects that are already in cache.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_op_in_progress_files": {
+            "description": "Number of files that are being put to cache.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_op_miss": {
+            "description": "Number of failed get requests because of missing object in the cache.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_op_put": {
+            "description": "Number of objects written into cache.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_space_files": {
+            "description": "Number of objects in cache.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_space_hwm_files": {
+            "description": "High watermark of number of objects in cache.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_space_hwm_size_bytes": {
+            "description": "High watermark of sum of size of cached objects.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_space_size_bytes": {
+            "description": "Sum of size of cached objects.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_space_tracker_size": {
+            "description": "Number of entries in cache access tracker",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_space_tracker_syncs": {
+            "description": "Number of times the access tracker was updated with cache disk data",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_trim_carryover_trims": {
+            "description": "Number of times we invoked carryover trim.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_trim_exhaustive_trims": {
+            "description": "Number of times we couldn't free enough space with a fast trim and had to fall back to a slower exhaustive trim.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_trim_failed_trims": {
+            "description": "Number of times could not free the expected amount of space, indicating possible bug or configuration issue.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_trim_fast_trims": {
+            "description": "Number of times we have trimmed the cache using the normal (fast) mode.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_cache_trim_in_mem_trims": {
+            "description": "Number of times we trimmed the cache using the in-memory access tracker.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_errors_total": {
+            "description": "Number of transmit errors",
+            "type": "counter",
+            "labels": [
+                "redpanda_direction"
+            ]
+        },
+        "redpanda_cloud_storage_housekeeping_drains": {
+            "description": "Number of times upload housekeeping queue was drained",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_housekeeping_jobs_completed": {
+            "description": "Number of executed housekeeping jobs",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_housekeeping_jobs_failed": {
+            "description": "Number of failed housekeeping jobs",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_housekeeping_jobs_skipped": {
+            "description": "Number of skipped housekeeping jobs",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_housekeeping_pauses": {
+            "description": "Number of times upload housekeeping was paused",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_housekeeping_requests_throttled_average_rate": {
+            "description": "Average rate of requests from the read and write path which were throttled by tiered storage (per shard)",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_cloud_storage_housekeeping_resumes": {
+            "description": "Number of times upload housekeeping was resumed",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_housekeeping_rounds": {
+            "description": "Number of upload housekeeping rounds",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_jobs_cloud_segment_reuploads": {
+            "description": "Number of segment reuploads from cloud storage sources (cloud storage cache or direct download from cloud storage)",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_jobs_local_segment_reuploads": {
+            "description": "Number of segment reuploads from local data directory",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_jobs_manifest_reuploads": {
+            "description": "Number of manifest reuploads performed by all housekeeping jobs",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_jobs_metadata_syncs": {
+            "description": "Number of archival configuration updates performed by all housekeeping jobs",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_jobs_segment_deletions": {
+            "description": "Number of segments deleted by all housekeeping jobs",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_limits_downloads_throttled_sum": {
+            "description": "Total amount of time downloads were throttled (ms)",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_partition_manifest_uploads_total": {
+            "description": "Successful partition manifest uploads",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_partition_readers": {
+            "description": "Number of partition reader instances (number of current fetch/timequery requests reading from tiered storage)",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_partition_readers_delayed": {
+            "description": "How many partition reades were delayed due to hitting reader limit. This indicates cluster is saturated with tiered storage reads.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_readers": {
+            "description": "Number of segment read cursors for hydrated remote log segments",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_segment_index_uploads_total": {
+            "description": "Successful segment index uploads",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_segment_materializations_delayed": {
+            "description": "How many segment materializations were delayed due to hitting reader limit. This indicates cluster is saturated with tiered storage reads.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_segment_readers_delayed": {
+            "description": "How many segment readers were delayed due to hitting reader limit. This indicates cluster is saturated with tiered storage reads.",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_segment_uploads_total": {
+            "description": "Successful data segment uploads",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_spillover_manifest_uploads_total": {
+            "description": "Successful spillover manifest uploads",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_spillover_manifests_materialized_bytes": {
+            "description": "Bytes of memory used for spilled manifests currently cached in memory",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cloud_storage_spillover_manifests_materialized_count": {
+            "description": "How many spilled manifests are currently cached in memory",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_brokers": {
+            "description": "Number of configured brokers in the cluster",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_controller_log_limit_requests_available_rps": {
+            "description": "Controller log rate limiting. Available rps for group",
+            "type": "gauge",
+            "labels": [
+                "redpanda_cmd_group"
+            ]
+        },
+        "redpanda_cluster_controller_log_limit_requests_dropped": {
+            "description": "Controller log rate limiting. Amount of requests that are dropped due to exceeding limit in group",
+            "type": "counter",
+            "labels": [
+                "redpanda_cmd_group"
+            ]
+        },
+        "redpanda_cluster_features_enterprise_license_expiry_sec": {
+            "description": "Number of seconds remaining until the Enterprise license expires",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_latest_cluster_metadata_manifest_age": {
+            "description": "Age in seconds of the latest cluster_metadata_manifest uploaded",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_members_backend_queued_node_operations": {
+            "description": "Number of queued node operations",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_cluster_non_homogenous_fips_mode": {
+            "description": "Number of nodes that have a non-homogenous FIPS mode value",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_partition_moving_from_node": {
+            "description": "Amount of partitions that are moving from node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_partition_moving_to_node": {
+            "description": "Amount of partitions that are moving to node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_partition_node_cancelling_movements": {
+            "description": "Amount of cancelling partition movements for node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_partition_num_with_broken_rack_constraint": {
+            "description": "Number of partitions that don't satisfy the rack awareness constraint",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_partitions": {
+            "description": "Number of partitions in the cluster (replicas not included)",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_topics": {
+            "description": "Number of topics in the cluster",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cluster_unavailable_partitions": {
+            "description": "Number of partitions that lack quorum among replicants",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_cpu_busy_seconds_total": {
+            "description": "Total CPU busy time in seconds",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_debug_bundle_failed_generation_count": {
+            "description": "Running count of failed debug bundle generations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_debug_bundle_last_failed_bundle_timestamp_seconds": {
+            "description": "Timestamp of last failed debug bundle generation (seconds since epoch)",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_debug_bundle_last_successful_bundle_timestamp_seconds": {
+            "description": "Timestamp of last successful debug bundle generation (seconds since epoch)",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_debug_bundle_successful_generation_count": {
+            "description": "Running count of successful debug bundle generations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_io_queue_total_read_ops": {
+            "description": "Total read operations passed in the queue",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "redpanda_io_queue_total_write_ops": {
+            "description": "Total write operations passed in the queue",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "redpanda_kafka_consumer_group_committed_offset": {
+            "description": "Consumer group committed offset",
+            "type": "gauge",
+            "labels": [
+                "redpanda_group",
+                "redpanda_partition",
+                "redpanda_topic",
+                "shard"
+            ]
+        },
+        "redpanda_kafka_consumer_group_consumers": {
+            "description": "Number of consumers in a group",
+            "type": "gauge",
+            "labels": [
+                "redpanda_group",
+                "shard"
+            ]
+        },
+        "redpanda_kafka_consumer_group_lag_max": {
+            "description": "Maximum consumer group lag across topic-partitions",
+            "type": "gauge",
+            "labels": [
+                "redpanda_group",
+                "shard"
+            ]
+        },
+        "redpanda_kafka_consumer_group_lag_sum": {
+            "description": "Sum of consumer group lag for all topic-partitions",
+            "type": "gauge",
+            "labels": [
+                "redpanda_group",
+                "shard"
+            ]
+        },
+        "redpanda_kafka_consumer_group_topics": {
+            "description": "Number of topics in a group",
+            "type": "gauge",
+            "labels": [
+                "redpanda_group",
+                "shard"
+            ]
+        },
+        "redpanda_kafka_handler_latency_seconds": {
+            "description": "Latency histogram of kafka requests",
+            "type": "histogram",
+            "labels": {}
+        },
+        "redpanda_kafka_max_offset": {
+            "description": "Latest readable offset of the partition (i.e. high watermark)",
+            "type": "gauge",
+            "labels": [
+                "redpanda_namespace",
+                "redpanda_partition",
+                "redpanda_topic"
+            ]
+        },
+        "redpanda_kafka_partitions": {
+            "description": "Configured number of partitions for the topic",
+            "type": "gauge",
+            "labels": [
+                "redpanda_namespace",
+                "redpanda_topic"
+            ]
+        },
+        "redpanda_kafka_quotas_client_quota_throttle_time": {
+            "description": "Client quota throttling delay per rule and quota type (in seconds)",
+            "type": "histogram",
+            "labels": {}
+        },
+        "redpanda_kafka_quotas_client_quota_throughput": {
+            "description": "Client quota throughput per rule and quota type",
+            "type": "histogram",
+            "labels": {}
+        },
+        "redpanda_kafka_records_fetched_total": {
+            "description": "Total number of records fetched",
+            "type": "counter",
+            "labels": [
+                "redpanda_namespace",
+                "redpanda_topic"
+            ]
+        },
+        "redpanda_kafka_records_produced_total": {
+            "description": "Total number of records produced",
+            "type": "counter",
+            "labels": [
+                "redpanda_namespace",
+                "redpanda_topic"
+            ]
+        },
+        "redpanda_kafka_replicas": {
+            "description": "Configured number of replicas for the topic",
+            "type": "gauge",
+            "labels": [
+                "redpanda_namespace",
+                "redpanda_topic"
+            ]
+        },
+        "redpanda_kafka_request_bytes_total": {
+            "description": "Total number of bytes produced per topic",
+            "type": "counter",
+            "labels": [
+                "redpanda_namespace",
+                "redpanda_request",
+                "redpanda_topic"
+            ]
+        },
+        "redpanda_kafka_request_latency_seconds": {
+            "description": "Internal latency of kafka produce requests",
+            "type": "histogram",
+            "labels": {}
+        },
+        "redpanda_kafka_rpc_sasl_session_expiration_total": {
+            "description": "Total number of SASL session expirations",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_kafka_rpc_sasl_session_reauth_attempts_total": {
+            "description": "Total number of SASL reauthentication attempts",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_kafka_rpc_sasl_session_revoked_total": {
+            "description": "Total number of SASL sessions revoked",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_kafka_under_replicated_replicas": {
+            "description": "Number of under replicated replicas (i.e. replicas that are live, but not at the latest offest)",
+            "type": "gauge",
+            "labels": [
+                "redpanda_namespace",
+                "redpanda_partition",
+                "redpanda_topic"
+            ]
+        },
+        "redpanda_memory_allocated_memory": {
+            "description": "Allocated memory size in bytes",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_memory_available_memory": {
+            "description": "Total shard memory potentially available in bytes (free_memory plus reclaimable)",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_memory_available_memory_low_water_mark": {
+            "description": "The low-water mark for available_memory from process start",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_memory_free_memory": {
+            "description": "Free memory size in bytes",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_node_status_rpcs_received": {
+            "description": "Number of node status RPCs received by this node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_node_status_rpcs_sent": {
+            "description": "Number of node status RPCs sent by this node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_node_status_rpcs_timed_out": {
+            "description": "Number of timed out node status RPCs from this node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_raft_leadership_changes": {
+            "description": "Number of won leader elections across all partitions in given topic",
+            "type": "counter",
+            "labels": [
+                "redpanda_namespace",
+                "redpanda_topic"
+            ]
+        },
+        "redpanda_raft_learners_gap_bytes": {
+            "description": "Total numbers of bytes that must be delivered to learners",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_raft_recovery_offsets_pending": {
+            "description": "Sum of offsets that partitions on this node need to recover.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_raft_recovery_partition_movement_available_bandwidth": {
+            "description": "Bandwidth available for partition movement. bytes/sec",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_raft_recovery_partition_movement_consumed_bandwidth": {
+            "description": "Bandwidth consumed for partition movement. bytes/sec",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_raft_recovery_partitions_active": {
+            "description": "Number of partition replicas are currently recovering on this node.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_raft_recovery_partitions_to_recover": {
+            "description": "Number of partition replicas that have to recover for this node.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_rest_proxy_inflight_requests_memory_usage_ratio": {
+            "description": "Memory usage ratio of in-flight requests in the rest_proxy",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_rest_proxy_inflight_requests_usage_ratio": {
+            "description": "Usage ratio of in-flight requests in the rest_proxy",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_rest_proxy_queued_requests_memory_blocked": {
+            "description": "Number of requests queued in rest_proxy, due to memory limitations",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_rest_proxy_request_errors_total": {
+            "description": "Total number of rest_proxy server errors",
+            "type": "counter",
+            "labels": [
+                "redpanda_status"
+            ]
+        },
+        "redpanda_rest_proxy_request_latency_seconds": {
+            "description": "Internal latency of request for rest_proxy",
+            "type": "histogram",
+            "labels": {}
+        },
+        "redpanda_rpc_active_connections": {
+            "description": "Count of currently active connections",
+            "type": "gauge",
+            "labels": [
+                "redpanda_server"
+            ]
+        },
+        "redpanda_rpc_received_bytes": {
+            "description": "internal: Number of bytes received from the clients in valid requests",
+            "type": "counter",
+            "labels": [
+                "redpanda_server"
+            ]
+        },
+        "redpanda_rpc_request_errors_total": {
+            "description": "Number of rpc errors",
+            "type": "counter",
+            "labels": [
+                "redpanda_server"
+            ]
+        },
+        "redpanda_rpc_request_latency_seconds": {
+            "description": "RPC latency",
+            "type": "histogram",
+            "labels": {}
+        },
+        "redpanda_rpc_sent_bytes": {
+            "description": "internal: Number of bytes sent to clients",
+            "type": "counter",
+            "labels": [
+                "redpanda_server"
+            ]
+        },
+        "redpanda_scheduler_runtime_seconds_total": {
+            "description": "Accumulated runtime of task queue associated with this scheduling group",
+            "type": "counter",
+            "labels": [
+                "redpanda_scheduling_group",
+                "shard"
+            ]
+        },
+        "redpanda_schema_registry_cache_schema_count": {
+            "description": "The number of schemas in the store",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_schema_registry_cache_schema_memory_bytes": {
+            "description": "The memory usage of schemas in the store",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_schema_registry_cache_subject_count": {
+            "description": "The number of subjects in the store",
+            "type": "gauge",
+            "labels": [
+                "deleted"
+            ]
+        },
+        "redpanda_schema_registry_cache_subject_version_count": {
+            "description": "The number of versions in the subject",
+            "type": "gauge",
+            "labels": [
+                "deleted",
+                "subject"
+            ]
+        },
+        "redpanda_schema_registry_inflight_requests_memory_usage_ratio": {
+            "description": "Memory usage ratio of in-flight requests in the schema_registry",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_schema_registry_inflight_requests_usage_ratio": {
+            "description": "Usage ratio of in-flight requests in the schema_registry",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_schema_registry_queued_requests_memory_blocked": {
+            "description": "Number of requests queued in schema_registry, due to memory limitations",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "redpanda_schema_registry_request_errors_total": {
+            "description": "Total number of schema_registry server errors",
+            "type": "counter",
+            "labels": [
+                "redpanda_status"
+            ]
+        },
+        "redpanda_schema_registry_request_latency_seconds": {
+            "description": "Internal latency of request for schema_registry",
+            "type": "histogram",
+            "labels": {}
+        },
+        "redpanda_security_audit_errors_total": {
+            "description": "Running count of errors in creating/publishing audit event log entries",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_security_audit_last_event_timestamp_seconds": {
+            "description": "Timestamp of last successful publish on the audit log (seconds since epoch)",
+            "type": "counter",
+            "labels": {}
+        },
+        "redpanda_storage_cache_disk_free_bytes": {
+            "description": "Disk storage bytes free.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_storage_cache_disk_free_space_alert": {
+            "description": "Status of low storage space alert. 0-OK, 1-Low Space 2-Degraded",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_storage_cache_disk_total_bytes": {
+            "description": "Total size of attached storage, in bytes.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_storage_disk_free_bytes": {
+            "description": "Disk storage bytes free.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_storage_disk_free_space_alert": {
+            "description": "Status of low storage space alert. 0-OK, 1-Low Space 2-Degraded",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_storage_disk_total_bytes": {
+            "description": "Total size of attached storage, in bytes.",
+            "type": "gauge",
+            "labels": {}
+        },
+        "redpanda_wasm_binary_executable_memory_usage": {
+            "description": "The amount of executable memory used for WebAssembly binaries",
+            "type": "gauge",
+            "labels": {}
+        }
+    },
+    "internal": {
+        "vectorized_alien_receive_batch_queue_length": {
+            "description": "Current receive batch queue length",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_alien_total_received_messages": {
+            "description": "Total number of received messages",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_alien_total_sent_messages": {
+            "description": "Total number of sent messages",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_application_build": {
+            "description": "Redpanda build information",
+            "type": "gauge",
+            "labels": [
+                "revision",
+                "shard",
+                "version"
+            ]
+        },
+        "vectorized_application_fips_mode": {
+            "description": "Identifies whether or not Redpanda is running in FIPS mode.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_application_uptime": {
+            "description": "Redpanda uptime in milliseconds",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_archival_upload_backlog_controller_backlog_size": {
+            "description": "controller backlog",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_archival_upload_backlog_controller_error": {
+            "description": "current controller error, i.e difference between set point and backlog size",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_archival_upload_backlog_controller_shares": {
+            "description": "controller output, i.e. number of shares",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_authorization_result": {
+            "description": "Total number of authorization results by type",
+            "type": "counter",
+            "labels": [
+                "type"
+            ]
+        },
+        "vectorized_chunk_cache_available_size_bytes": {
+            "description": "Total size of all free segment appender chunks in the cache, in bytes.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_chunk_cache_total_size_bytes": {
+            "description": "Total size of all segment appender chunks in any state, in bytes.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_chunk_cache_wait_count": {
+            "description": "Count of how many times we had to wait for a chunk to become available",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_active_downloads": {
+            "description": "Number of active GET requests at the moment",
+            "type": "gauge",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_active_requests": {
+            "description": "Number of active HTTP requests at the moment (includes PUT and GET)",
+            "type": "gauge",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_active_uploads": {
+            "description": "Number of active PUT requests at the moment",
+            "type": "gauge",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_all_requests": {
+            "description": "Number of completed HTTP requests (includes PUT and GET)",
+            "type": "counter",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_client_pool_utilization": {
+            "description": "Utilization of the cloud storage pool(0 - unused, 100 - fully utilized)",
+            "type": "gauge",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_lease_duration": {
+            "description": "Lease duration histogram",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_cloud_client_num_borrows": {
+            "description": "Number of time current shard had to borrow a cloud storage client from another shard",
+            "type": "counter",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_num_nosuchkey": {
+            "description": "Total number of NoSuchKey errors received from cloud storage provider",
+            "type": "counter",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_num_rpc_errors": {
+            "description": "Total number of REST API errors received from cloud storage provider",
+            "type": "counter",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_num_slowdowns": {
+            "description": "Total number of SlowDown errors received from cloud storage provider",
+            "type": "counter",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_num_transport_errors": {
+            "description": "Total number of transport errors (TCP and TLS)",
+            "type": "counter",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_total_downloads": {
+            "description": "Number of completed GET requests",
+            "type": "counter",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_total_inbound_bytes": {
+            "description": "Total number of bytes received from cloud storage",
+            "type": "counter",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_total_outbound_bytes": {
+            "description": "Total number of bytes sent to cloud storage",
+            "type": "counter",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_client_total_uploads": {
+            "description": "Number of completed PUT requests",
+            "type": "counter",
+            "labels": [
+                "endpoint",
+                "region",
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_bytes_received": {
+            "description": "Number of bytes received from cloud storage",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_bytes_sent": {
+            "description": "Number of bytes sent to cloud storage",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_cache_cached_gets": {
+            "description": "Total number of get requests that are already in cache.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_cache_files": {
+            "description": "Current number of files in cache.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_cache_gets": {
+            "description": "Total number of cache get requests.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_cache_in_progress_files": {
+            "description": "Current number of files that are being put to cache.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_cache_puts": {
+            "description": "Total number of files put into cache.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_cache_size_bytes": {
+            "description": "Current cache size in bytes.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_client_acquisition_latency": {
+            "description": "Client acquisition latency histogram",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_cluster_metadata_manifest_downloads": {
+            "description": "Number of partition manifest downloads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_cluster_metadata_manifest_uploads": {
+            "description": "Number of partition manifest uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_controller_snapshot_failed_uploads": {
+            "description": "Number of failed controller snapshot uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_controller_snapshot_successful_uploads": {
+            "description": "Number of completed controller snapshot uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_controller_snapshot_upload_backoff": {
+            "description": "Number of times backoff was applied during controller snapshot uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_download_backoff": {
+            "description": "Number of times backoff  was applied during log-segment downloads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_failed_downloads": {
+            "description": "Number of failed log-segment downloads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_failed_index_downloads": {
+            "description": "Number of failed segment index downloads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_failed_index_uploads": {
+            "description": "Number of failed segment index uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_failed_manifest_downloads": {
+            "description": "Number of failed manifest downloads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_failed_manifest_uploads": {
+            "description": "Number of failed manifest uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_failed_uploads": {
+            "description": "Number of failed log-segment uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_index_downloads": {
+            "description": "Number of segment indices downloaded",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_index_uploads": {
+            "description": "Number of segment indices uploaded",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_manifest_download_backoff": {
+            "description": "Number of times backoff was applied during manifest download",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_manifest_upload_backoff": {
+            "description": "Number of times backoff was applied during manifest upload",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_partition_chunk_size": {
+            "description": "Size of chunk downloaded from cloud storage",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "topic"
+            ]
+        },
+        "vectorized_cloud_storage_partition_manifest_downloads": {
+            "description": "Number of partition manifest downloads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_partition_manifest_uploads": {
+            "description": "Number of partition manifest (re)uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_partition_read_bytes": {
+            "description": "Total bytes read from remote partition",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "topic"
+            ]
+        },
+        "vectorized_cloud_storage_partition_read_records": {
+            "description": "Total number of records read from remote partition",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "topic"
+            ]
+        },
+        "vectorized_cloud_storage_read_path_chunk_hydration_latency": {
+            "description": "Chunk hydration latency histogram",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_chunks_hydrated": {
+            "description": "Total number of hydrated chunks (some may have been evicted from the cache)",
+            "type": "counter",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_downloads_throttled_sum": {
+            "description": "Total amount of time downloads were throttled (ms)",
+            "type": "counter",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_hydrations_in_progress": {
+            "description": "Active hydrations in progress",
+            "type": "counter",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_materialized_segments": {
+            "description": "Current number of materialized remote segments",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_readers": {
+            "description": "Current number of remote partition readers",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_segment_readers": {
+            "description": "Current number of remote segment readers",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_spillover_manifest_bytes": {
+            "description": "Total amount of memory used by spillover manifests",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_spillover_manifest_hydrated": {
+            "description": "Number of times spillover manifests were saved to the cache",
+            "type": "counter",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_spillover_manifest_instances": {
+            "description": "Total number of spillover manifests stored in memory",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_spillover_manifest_latency": {
+            "description": "Spillover manifest materialization latency histogram",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_read_path_spillover_manifest_materialized": {
+            "description": "Number of times spillover manifests were loaded from the cache",
+            "type": "counter",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_segment_download_latency": {
+            "description": "Segment download latency histogram",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_cloud_storage_spillover_manifest_downloads": {
+            "description": "Number of spillover manifest downloads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_spillover_manifest_uploads": {
+            "description": "Number of spillover manifest (re)uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_successful_downloads": {
+            "description": "Number of completed log-segment downloads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_successful_uploads": {
+            "description": "Number of completed log-segment uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_topic_manifest_downloads": {
+            "description": "Number of topic manifest downloads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_topic_manifest_uploads": {
+            "description": "Number of topic manifest uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cloud_storage_upload_backoff": {
+            "description": "Number of times backoff was applied during log-segment uploads",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cluster_controller_pending_partition_operations": {
+            "description": "Number of partitions with ongoing/requested operations",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cluster_features_enterprise_license_expiry_sec": {
+            "description": "Number of seconds remaining until the Enterprise license expires",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_cluster_partition_batches_produced": {
+            "description": "Total number of batches produced",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_bytes_fetched_from_follower_total": {
+            "description": "Total number of bytes fetched from follower (not all might be returned to the client)",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_bytes_fetched_total": {
+            "description": "Total number of bytes fetched (not all might be returned to the client)",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_bytes_produced_total": {
+            "description": "Total number of bytes produced",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_cloud_storage_segments_metadata_bytes": {
+            "description": "Current number of bytes consumed by remote segments managed for this partition",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_committed_offset": {
+            "description": "Partition commited offset. i.e. safely persisted on majority of replicas",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_end_offset": {
+            "description": "Last offset stored by current partition on this node",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_high_watermark": {
+            "description": "Partion high watermark i.e. highest consumable offset",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_iceberg_offsets_pending_commit": {
+            "description": "Total number of offsets that are pending commit to iceberg catalog.  Lag is reported only on leader while followers report 0. -1 is reported if iceberg is disabled while -2 indicates the lag is not yet computed.",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_iceberg_offsets_pending_translation": {
+            "description": "Total number of offsets that are pending translation to iceberg. Lag is reported only on leader replicas while followers report 0. -1 is reported if iceberg is disabled while -2 indicates the lag is not yet computed.",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_last_stable_offset": {
+            "description": "Last stable offset",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_leader": {
+            "description": "Flag indicating if this partition instance is a leader",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_leader_id": {
+            "description": "Id of current partition leader",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_moving_from_node": {
+            "description": "Amount of partitions that are moving from node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_cluster_partition_moving_to_node": {
+            "description": "Amount of partitions that are moving to node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_cluster_partition_node_cancelling_movements": {
+            "description": "Amount of cancelling partition movements for node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_cluster_partition_num_with_broken_rack_constraint": {
+            "description": "Number of partitions that don't satisfy the rack awareness constraint",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_cluster_partition_records_fetched": {
+            "description": "Total number of records fetched",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_records_produced": {
+            "description": "Total number of records produced",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_start_offset": {
+            "description": "start offset",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_partition_under_replicated_replicas": {
+            "description": "Number of under replicated replicas",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_cluster_producer_state_manager_evicted_producers": {
+            "description": "Number of evicted producers so far.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cluster_producer_state_manager_producer_manager_total_active_producers": {
+            "description": "Total number of active idempotent and transactional producers.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cluster_shard_placement_assigned_partitions": {
+            "description": "Number of partitions assigned to this shard",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cluster_shard_placement_hosted_partitions": {
+            "description": "Number of partitions hosted on this shard",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_cluster_shard_placement_partitions_to_reconcile": {
+            "description": "Number of partitions needing reconciliation of shard-local state",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_data_transforms_log_manager_buffer_usage_ratio": {
+            "description": "Transform log manager buffer usage ratio",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_data_transforms_log_manager_write_errors_total": {
+            "description": "Running count of errors while writing to the transform logs topic",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_debug_bundle_failed_generation_count": {
+            "description": "Running count of failed debug bundle generations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_debug_bundle_last_failed_bundle_timestamp_seconds": {
+            "description": "Timestamp of last failed debug bundle generation (seconds since epoch)",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_debug_bundle_last_successful_bundle_timestamp_seconds": {
+            "description": "Timestamp of last successful debug bundle generation (seconds since epoch)",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_debug_bundle_successful_generation_count": {
+            "description": "Running count of successful debug bundle generations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_httpd_connections_current": {
+            "description": "The current number of open  connections",
+            "type": "gauge",
+            "labels": [
+                "service",
+                "shard"
+            ]
+        },
+        "vectorized_httpd_connections_total": {
+            "description": "The total number of connections opened",
+            "type": "counter",
+            "labels": [
+                "service",
+                "shard"
+            ]
+        },
+        "vectorized_httpd_read_errors": {
+            "description": "The total number of errors while reading http requests",
+            "type": "counter",
+            "labels": [
+                "service",
+                "shard"
+            ]
+        },
+        "vectorized_httpd_reply_errors": {
+            "description": "The total number of errors while replying to http",
+            "type": "counter",
+            "labels": [
+                "service",
+                "shard"
+            ]
+        },
+        "vectorized_httpd_requests_served": {
+            "description": "The total number of http requests served",
+            "type": "counter",
+            "labels": [
+                "service",
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_active_connections": {
+            "description": "internal_rpc: Currently active connections",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_connection_close_errors": {
+            "description": "internal_rpc: Number of errors when shutting down the connection",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_connections_rejected": {
+            "description": "internal_rpc: Number of connection attempts rejected for hitting open connection count limits",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_connections_rejected_rate_limit": {
+            "description": "internal_rpc: Number of connection attempts rejected for hitting connection rate limits",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_connections_wait_rate": {
+            "description": "internal_rpc: Number of connections are blocked by connection rate",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_connects": {
+            "description": "internal_rpc: Number of accepted connections",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_consumed_mem_bytes": {
+            "description": "internal_rpc: Memory consumed by request processing",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_corrupted_headers": {
+            "description": "internal_rpc: Number of requests with corrupted headers",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_dispatch_handler_latency": {
+            "description": "internal_rpc: Latency ",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_internal_rpc_latency": {
+            "description": "Internal RPC service latency",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_internal_rpc_max_service_mem_bytes": {
+            "description": "internal_rpc: Maximum memory allowed for RPC",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_method_not_found_errors": {
+            "description": "internal_rpc: Number of requests with not available RPC method",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_produce_bad_create_time": {
+            "description": "number of produce requests with timestamps too far in the future or in the past",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_received_bytes": {
+            "description": "internal_rpc: Number of bytes received from the clients in valid requests",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_requests_blocked_memory": {
+            "description": "internal_rpc: Number of requests blocked in memory backpressure",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_requests_completed": {
+            "description": "internal_rpc: Number of successful requests",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_requests_pending": {
+            "description": "internal_rpc: Number of requests pending in the queue",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_sent_bytes": {
+            "description": "internal_rpc: Number of bytes sent to clients",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_internal_rpc_service_errors": {
+            "description": "internal_rpc: Number of service errors",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_activations": {
+            "description": "The number of times the class was woken up from idle",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard",
+                "stream"
+            ]
+        },
+        "vectorized_io_queue_adjusted_consumption": {
+            "description": "Consumed disk capacity units adjusted for class shares and idling preemption",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard",
+                "stream"
+            ]
+        },
+        "vectorized_io_queue_consumption": {
+            "description": "Accumulated disk capacity units consumed by this class; an increment per-second rate indicates full utilization",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard",
+                "stream"
+            ]
+        },
+        "vectorized_io_queue_delay": {
+            "description": "random delay time in the queue",
+            "type": "gauge",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_disk_queue_length": {
+            "description": "Number of requests in the disk",
+            "type": "gauge",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_flow_ratio": {
+            "description": "Ratio of dispatch rate to completion rate. Is expected to be 1.0+ growing larger on reactor stalls or (!) disk problems",
+            "type": "gauge",
+            "labels": [
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_queue_length": {
+            "description": "Number of requests in the queue",
+            "type": "gauge",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_shares": {
+            "description": "current amount of shares",
+            "type": "gauge",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_starvation_time_sec": {
+            "description": "Total time spent starving for disk",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_total_bytes": {
+            "description": "Total bytes passed in the queue",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_total_delay_sec": {
+            "description": "Total time spent in the queue",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_total_exec_sec": {
+            "description": "Total time spent in disk",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_total_operations": {
+            "description": "Total operations passed in the queue",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_total_read_bytes": {
+            "description": "Total read bytes passed in the queue",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_total_read_ops": {
+            "description": "Total read operations passed in the queue",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_total_split_bytes": {
+            "description": "Total number of bytes split",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_total_split_ops": {
+            "description": "Total number of requests split",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_total_write_bytes": {
+            "description": "Total write bytes passed in the queue",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_io_queue_total_write_ops": {
+            "description": "Total write operations passed in the queue",
+            "type": "counter",
+            "labels": [
+                "class",
+                "iogroup",
+                "mountpoint",
+                "shard"
+            ]
+        },
+        "vectorized_kafka_batch_size": {
+            "description": "Batch size across all topics measured at the kafka layer.",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_kafka_fetch_pid_delay_seconds_total": {
+            "description": "A running total of fetch delay set by the pid controller.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_fetch_pid_error_total": {
+            "description": "A running total of error in the fetch PID controller.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_fetch_read_distribution": {
+            "description": "Read path time distribution histogram",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_kafka_fetch_sessions_cache_mem_usage_bytes": {
+            "description": "Fetch sessions cache memory usage in bytes",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_fetch_sessions_cache_sessions_count": {
+            "description": "Total number of fetch sessions",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_group_offset": {
+            "description": "Group topic partition offset",
+            "type": "gauge",
+            "labels": [
+                "group",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_kafka_handler_latency_microseconds": {
+            "description": "Latency histogram of kafka requests",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_kafka_handler_received_bytes_total": {
+            "description": "Number of bytes received from kafka requests",
+            "type": "counter",
+            "labels": [
+                "handler",
+                "shard"
+            ]
+        },
+        "vectorized_kafka_handler_requests_completed_total": {
+            "description": "Number of kafka requests completed",
+            "type": "counter",
+            "labels": [
+                "handler",
+                "shard"
+            ]
+        },
+        "vectorized_kafka_handler_requests_errored_total": {
+            "description": "Number of kafka requests errored",
+            "type": "counter",
+            "labels": [
+                "handler",
+                "shard"
+            ]
+        },
+        "vectorized_kafka_handler_requests_in_progress_total": {
+            "description": "A running total of kafka requests in progress",
+            "type": "counter",
+            "labels": [
+                "handler",
+                "shard"
+            ]
+        },
+        "vectorized_kafka_handler_sent_bytes_total": {
+            "description": "Number of bytes sent in kafka replies",
+            "type": "counter",
+            "labels": [
+                "handler",
+                "shard"
+            ]
+        },
+        "vectorized_kafka_latency_fetch_latency_us": {
+            "description": "Fetch Latency",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_kafka_latency_produce_latency_us": {
+            "description": "Produce Latency",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_kafka_quotas_client_quota_throttle_time": {
+            "description": "Client quota throttling delay per rule and quota type (in seconds)",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_kafka_quotas_client_quota_throughput": {
+            "description": "Client quota throughput per rule and quota type",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_kafka_quotas_quota_effective": {
+            "description": "Currently effective quota, in bytes/s",
+            "type": "counter",
+            "labels": [
+                "direction",
+                "shard"
+            ]
+        },
+        "vectorized_kafka_quotas_throttle_time": {
+            "description": "Throttle time histogram (in seconds)",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_kafka_quotas_traffic_egress": {
+            "description": "Amount of Kafka traffic published to the clients that was taken into processing, in bytes",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_quotas_traffic_intake": {
+            "description": "Amount of Kafka traffic received from the clients that is taken into processing, in bytes",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_active_connections": {
+            "description": "kafka_rpc: Currently active connections",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_connection_close_errors": {
+            "description": "kafka_rpc: Number of errors when shutting down the connection",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_connections_rejected": {
+            "description": "kafka_rpc: Number of connection attempts rejected for hitting open connection count limits",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_connections_rejected_rate_limit": {
+            "description": "kafka_rpc: Number of connection attempts rejected for hitting connection rate limits",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_connections_wait_rate": {
+            "description": "kafka_rpc: Number of connections are blocked by connection rate",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_connects": {
+            "description": "kafka_rpc: Number of accepted connections",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_consumed_mem_bytes": {
+            "description": "kafka_rpc: Memory consumed by request processing",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_corrupted_headers": {
+            "description": "kafka_rpc: Number of requests with corrupted headers",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_dispatch_handler_latency": {
+            "description": "kafka_rpc: Latency ",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_kafka_rpc_fetch_avail_mem_bytes": {
+            "description": "kafka_rpc: Memory available for fetch request processing",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_max_service_mem_bytes": {
+            "description": "kafka_rpc: Maximum memory allowed for RPC",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_method_not_found_errors": {
+            "description": "kafka_rpc: Number of requests with not available RPC method",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_produce_bad_create_time": {
+            "description": "number of produce requests with timestamps too far in the future or in the past",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_received_bytes": {
+            "description": "kafka_rpc: Number of bytes received from the clients in valid requests",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_requests_blocked_memory": {
+            "description": "kafka_rpc: Number of requests blocked in memory backpressure",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_requests_completed": {
+            "description": "kafka_rpc: Number of successful requests",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_requests_pending": {
+            "description": "kafka_rpc: Number of requests pending in the queue",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_sasl_session_expiration_total": {
+            "description": "Total number of SASL session expirations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_sasl_session_reauth_attempts_total": {
+            "description": "Total number of SASL reauthentication attempts",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_sasl_session_revoked_total": {
+            "description": "Total number of SASL sessions revoked",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_sent_bytes": {
+            "description": "kafka_rpc: Number of bytes sent to clients",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_rpc_service_errors": {
+            "description": "kafka_rpc: Number of service errors",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_schema_id_cache_batches_decompressed": {
+            "description": "Total number of batches decompressed for server-side schema ID validation",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_schema_id_cache_hits": {
+            "description": "Total number of hits for the server-side schema ID validation cache (see cluster config: kafka_schema_id_validation_cache_capacity)",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_kafka_schema_id_cache_misses": {
+            "description": "Total number of misses for the server-side schema ID validation cache (see cluster config: kafka_schema_id_validation_cache_capacity)",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_leader_balancer_leader_transfer_error": {
+            "description": "Number of errors attempting to transfer leader",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_leader_balancer_leader_transfer_no_improvement": {
+            "description": "Number of times no balance improvement was found",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_leader_balancer_leader_transfer_succeeded": {
+            "description": "Number of successful leader transfers",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_leader_balancer_leader_transfer_timeout": {
+            "description": "Number of timeouts attempting to transfer leader",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_allocated_memory": {
+            "description": "Allocated memory size in bytes",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_available_memory": {
+            "description": "Total shard memory potentially available in bytes (free_memory plus reclaimable)",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_available_memory_low_water_mark": {
+            "description": "The low-water mark for available_memory from process start",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_cross_cpu_free_operations": {
+            "description": "Total number of cross cpu free",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_free_memory": {
+            "description": "Free memory size in bytes",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_free_operations": {
+            "description": "Total number of free operations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_malloc_failed": {
+            "description": "Total count of failed memory allocations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_malloc_live_objects": {
+            "description": "Number of live objects",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_malloc_operations": {
+            "description": "Total number of malloc operations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_reclaims_operations": {
+            "description": "Total reclaims operations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_memory_total_memory": {
+            "description": "Total memory size in bytes",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_network_bytes_received": {
+            "description": "Counts the number of bytes received from network sockets.",
+            "type": "counter",
+            "labels": [
+                "group",
+                "shard"
+            ]
+        },
+        "vectorized_network_bytes_sent": {
+            "description": "Counts the number of bytes written to network sockets.",
+            "type": "counter",
+            "labels": [
+                "group",
+                "shard"
+            ]
+        },
+        "vectorized_node_status_rpcs_received": {
+            "description": "Number of node status RPCs received by this node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_node_status_rpcs_sent": {
+            "description": "Number of node status RPCs sent by this node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_node_status_rpcs_timed_out": {
+            "description": "Number of timed out node status RPCs from this node",
+            "type": "gauge",
+            "labels": {}
+        },
+        "vectorized_pandaproxy_request_errors_total": {
+            "description": "Total number of rest_proxy server errors",
+            "type": "counter",
+            "labels": [
+                "operation",
+                "shard",
+                "status"
+            ]
+        },
+        "vectorized_pandaproxy_request_latency": {
+            "description": "Request latency",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_raft_append_entries_buffer_flushes": {
+            "description": "Number of append entries buffer flushes",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_buffered_protocol_buffered_bytes": {
+            "description": "Total size of append entries requests in the queue",
+            "type": "gauge",
+            "labels": [
+                "shard",
+                "target_node_id"
+            ]
+        },
+        "vectorized_raft_buffered_protocol_buffered_requests": {
+            "description": "Total number of append entries requests in the queue",
+            "type": "gauge",
+            "labels": [
+                "shard",
+                "target_node_id"
+            ]
+        },
+        "vectorized_raft_buffered_protocol_inflight_requests": {
+            "description": "Number of append entries requests that were sent to the target node and are awaiting responses.",
+            "type": "gauge",
+            "labels": [
+                "shard",
+                "target_node_id"
+            ]
+        },
+        "vectorized_raft_configuration_change_in_progress": {
+            "description": "Indicates if current raft group configuration is in joint state i.e. configuration is being changed",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_done_replicate_requests": {
+            "description": "Number of finished replicate requests",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_full_heartbeat_requests": {
+            "description": "Number of full heartbeats sent by the leader",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_group_configuration_updates": {
+            "description": "Number of raft group configuration updates",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_group_count": {
+            "description": "Number of raft groups",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_raft_heartbeat_requests_errors": {
+            "description": "Number of failed heartbeat requests",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_leader_for": {
+            "description": "Number of groups for which node is a leader",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_leadership_changes": {
+            "description": "Number of won leader elections",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_learners_gap_bytes": {
+            "description": "Total numbers of bytes that must be delivered to learners",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_raft_lightweight_heartbeat_requests": {
+            "description": "Number of lightweight heartbeats sent by the leader",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_log_flushes": {
+            "description": "Number of log flushes",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_log_truncations": {
+            "description": "Number of log truncations",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_offset_translator_inconsistency_errors": {
+            "description": "Number of append entries requests that failed the offset translator consistency check",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_received_append_requests": {
+            "description": "Number of append requests received",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_received_vote_requests": {
+            "description": "Number of vote requests received",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_recovery_offsets_pending": {
+            "description": "Sum of offsets that partitions on this node need to recover.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_raft_recovery_partition_movement_assigned_bandwidth": {
+            "description": "Bandwidth assigned for partition movement in last tick. bytes/sec",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_raft_recovery_partition_movement_available_bandwidth": {
+            "description": "Bandwidth available for partition movement. bytes/sec",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_raft_recovery_partitions_active": {
+            "description": "Number of partition replicas are currently recovering on this node.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_raft_recovery_partitions_to_recover": {
+            "description": "Number of partition replicas that have to recover for this node.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_raft_recovery_requests": {
+            "description": "Number of recovery requests",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_recovery_requests_errors": {
+            "description": "Number of failed recovery requests",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_replicate_ack_all_requests": {
+            "description": "Number of replicate requests with quorum ack consistency and explicit flush.",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_replicate_ack_all_requests_no_flush": {
+            "description": "Number of replicate requests with quorum ack consistency but without an explicit flush.",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_replicate_ack_leader_requests": {
+            "description": "Number of replicate requests with leader ack consistency",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_replicate_ack_none_requests": {
+            "description": "Number of replicate requests with no ack consistency",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_replicate_batch_flush_requests": {
+            "description": "Number of replicate batch flushes",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_replicate_request_errors": {
+            "description": "Number of failed replicate requests",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_raft_sent_vote_requests": {
+            "description": "Number of vote requests sent",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_reactor_abandoned_failed_futures": {
+            "description": "Total number of abandoned failed futures, futures destroyed while still containing an exception",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_aio_bytes_read": {
+            "description": "Total aio-reads bytes",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_aio_bytes_write": {
+            "description": "Total aio-writes bytes",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_aio_errors": {
+            "description": "Total aio errors",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_aio_outsizes": {
+            "description": "Total number of aio operations that exceed IO limit",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_aio_reads": {
+            "description": "Total aio-reads operations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_aio_writes": {
+            "description": "Total aio-writes operations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_awake_time_ms_total": {
+            "description": "Total reactor awake time (wall_clock)",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_cpp_exceptions": {
+            "description": "Total number of C++ exceptions",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_cpu_busy_ms": {
+            "description": "Total cpu busy time in milliseconds",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_cpu_steal_time_ms": {
+            "description": "Total steal time, the time in which something else was running while the reactor was runnable (not sleeping).Because this is in userspace, some time that could be legitimally thought as steal time is not accounted as such. For example, if we are sleeping and can wake up but the kernel hasn't woken us up yet.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_cpu_used_time_ms": {
+            "description": "Total reactor thread CPU time (from CLOCK_THREAD_CPUTIME)",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_fstream_read_bytes": {
+            "description": "Counts bytes read from disk file streams.  A high rate indicates high disk activity. Divide by fstream_reads to determine average read size.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_fstream_read_bytes_blocked": {
+            "description": "Counts the number of bytes read from disk that could not be satisfied from read-ahead buffers, and had to block. Indicates short streams, or incorrect read ahead configuration.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_fstream_reads": {
+            "description": "Counts reads from disk file streams.  A high rate indicates high disk activity. Contrast with other fstream_read* counters to locate bottlenecks.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_fstream_reads_ahead_bytes_discarded": {
+            "description": "Counts the number of buffered bytes that were read ahead of time and were discarded because they were not needed, wasting disk bandwidth. Indicates over-eager read ahead configuration.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_fstream_reads_aheads_discarded": {
+            "description": "Counts the number of times a buffer that was read ahead of time and was discarded because it was not needed, wasting disk bandwidth. Indicates over-eager read ahead configuration.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_fstream_reads_blocked": {
+            "description": "Counts the number of times a disk read could not be satisfied from read-ahead buffers, and had to block. Indicates short streams, or incorrect read ahead configuration.",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_fsyncs": {
+            "description": "Total number of fsync operations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_io_threaded_fallbacks": {
+            "description": "Total number of io-threaded-fallbacks operations",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_logging_failures": {
+            "description": "Total number of logging failures",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_polls": {
+            "description": "Number of times pollers were executed",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_sleep_time_ms_total": {
+            "description": "Total reactor sleep time (wall clock)",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_stalls": {
+            "description": "A histogram of reactor stall durations",
+            "type": "histogram",
+            "labels": {}
+        },
+        "vectorized_reactor_tasks_pending": {
+            "description": "Number of pending tasks in the queue",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_tasks_processed": {
+            "description": "Total tasks processed",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_timers_pending": {
+            "description": "Number of tasks in the timer-pending queue",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_reactor_utilization": {
+            "description": "CPU utilization",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_rest_proxy_inflight_requests_memory_usage_ratio": {
+            "description": "Memory usage ratio of in-flight requests in the rest_proxy",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_rest_proxy_inflight_requests_usage_ratio": {
+            "description": "Usage ratio of in-flight requests in the rest_proxy",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_rest_proxy_queued_requests_memory_blocked": {
+            "description": "Number of requests queued in rest_proxy, due to memory limitations",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_rpc_client_active_connections": {
+            "description": "Currently active connections",
+            "type": "gauge",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_client_correlation_errors": {
+            "description": "Number of errors in client correlation id",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_connection_errors": {
+            "description": "Number of connection errors",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_connects": {
+            "description": "Connection attempts",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_corrupted_headers": {
+            "description": "Number of responses with corrupted headers",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_in_bytes": {
+            "description": "Total number of bytes received",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_out_bytes": {
+            "description": "Total number of bytes sent (including headers)",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_read_dispatch_errors": {
+            "description": "Number of errors while dispatching responses",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_request_errors": {
+            "description": "Number or requests errors",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_request_timeouts": {
+            "description": "Number or requests timeouts",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_requests": {
+            "description": "Number of requests",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_requests_blocked_memory": {
+            "description": "Number of requests that are blocked because of insufficient memory",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_requests_pending": {
+            "description": "Number of requests pending",
+            "type": "gauge",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_rpc_client_server_correlation_errors": {
+            "description": "Number of responses with wrong correlation id",
+            "type": "counter",
+            "labels": [
+                "connection_cache_label",
+                "shard",
+                "target"
+            ]
+        },
+        "vectorized_scheduler_queue_length": {
+            "description": "Size of backlog on this queue, in tasks; indicates whether the queue is busy and/or contended",
+            "type": "gauge",
+            "labels": [
+                "group",
+                "shard"
+            ]
+        },
+        "vectorized_scheduler_runtime_ms": {
+            "description": "Accumulated runtime of this task queue; an increment rate of 1000ms per second indicates full utilization",
+            "type": "counter",
+            "labels": [
+                "group",
+                "shard"
+            ]
+        },
+        "vectorized_scheduler_shares": {
+            "description": "Shares allocated to this queue",
+            "type": "gauge",
+            "labels": [
+                "group",
+                "shard"
+            ]
+        },
+        "vectorized_scheduler_starvetime_ms": {
+            "description": "Accumulated starvation time of this task queue; an increment rate of 1000ms per second indicates the scheduler feels really bad",
+            "type": "counter",
+            "labels": [
+                "group",
+                "shard"
+            ]
+        },
+        "vectorized_scheduler_tasks_processed": {
+            "description": "Count of tasks executing on this queue; indicates together with runtime_ms indicates length of tasks",
+            "type": "counter",
+            "labels": [
+                "group",
+                "shard"
+            ]
+        },
+        "vectorized_scheduler_time_spent_on_task_quota_violations_ms": {
+            "description": "Total amount in milliseconds we were in violation of the task quota",
+            "type": "counter",
+            "labels": [
+                "group",
+                "shard"
+            ]
+        },
+        "vectorized_scheduler_waittime_ms": {
+            "description": "Accumulated waittime of this task queue; an increment rate of 1000ms per second indicates queue is waiting for something (e.g. IO)",
+            "type": "counter",
+            "labels": [
+                "group",
+                "shard"
+            ]
+        },
+        "vectorized_schema_registry_cache_schema_count": {
+            "description": "The number of schemas in the store",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_schema_registry_cache_schema_memory_bytes": {
+            "description": "The memory usage of schemas in the store",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_schema_registry_cache_subject_count": {
+            "description": "The number of subjects in the store",
+            "type": "gauge",
+            "labels": [
+                "deleted",
+                "shard"
+            ]
+        },
+        "vectorized_schema_registry_cache_subject_version_count": {
+            "description": "The number of versions in the subject",
+            "type": "gauge",
+            "labels": [
+                "deleted",
+                "shard",
+                "subject"
+            ]
+        },
+        "vectorized_schema_registry_inflight_requests_memory_usage_ratio": {
+            "description": "Memory usage ratio of in-flight requests in the schema_registry",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_schema_registry_inflight_requests_usage_ratio": {
+            "description": "Usage ratio of in-flight requests in the schema_registry",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_schema_registry_queued_requests_memory_blocked": {
+            "description": "Number of requests queued in schema_registry, due to memory limitations",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_security_audit_buffer_usage_ratio": {
+            "description": "Audit event buffer usage ratio.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_security_audit_client_buffer_usage_ratio": {
+            "description": "Audit client send buffer usage ratio",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_security_audit_errors_total": {
+            "description": "Running count of errors in creating/publishing audit event log entries",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_security_audit_last_event_timestamp_seconds": {
+            "description": "Timestamp of last successful publish on the audit log (seconds since epoch)",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_available_reclaimable_bytes": {
+            "description": "Total amount of available reclaimable data by space management.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_disk_usage_bytes": {
+            "description": "Total amount of disk usage under control of space management.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_local_retention_reclaimable_bytes": {
+            "description": "Total amount of reclaimable data above the local retention target (ref: retention.local.target.{ms,bytes}).",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_reclaim_active_segment_bytes": {
+            "description": "Estimated amount of data above the active segment to be reclaimed by space management",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_reclaim_estimate_bytes": {
+            "description": "Estimated amount of data to be reclaimed by space management in last schedule.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_reclaim_local_bytes": {
+            "description": "Estimated amount of data above local retention to be reclaimed by space management",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_reclaim_low_hinted_bytes": {
+            "description": "Estimated amount of data above the hinted low-space threshold to be reclaimed by space management",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_reclaim_low_non_hinted_bytes": {
+            "description": "Estimated amount of data above the non-hinted low-space threshold to be reclaimed by space management",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_retention_reclaimable_bytes": {
+            "description": "Total amount of reclaimable data through standard retention policy (ref: retention.{ms,bytes}).",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_target_disk_size_bytes": {
+            "description": "Target maximum number of stored bytes.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_space_management_target_excess_bytes": {
+            "description": "Amount of data usage that exceeds target threshold.",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_stall_detector_reported": {
+            "description": "Total number of reported stalls, look in the traces for the exact reason",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_compaction_backlog_controller_backlog_size": {
+            "description": "controller backlog",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_compaction_backlog_controller_error": {
+            "description": "current controller error, i.e difference between set point and backlog size",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_compaction_backlog_controller_shares": {
+            "description": "controller output, i.e. number of shares",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_kvstore_cached_bytes": {
+            "description": "Size of the database in memory",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_kvstore_entries_fetched": {
+            "description": "Number of entries fetched",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_kvstore_entries_removed": {
+            "description": "Number of entries removaled",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_kvstore_entries_written": {
+            "description": "Number of entries written",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_kvstore_key_count": {
+            "description": "Number of keys in the database",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_kvstore_segments_rolled": {
+            "description": "Number of segments rolled",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_log_batch_parse_errors": {
+            "description": "Number of batch parsing (reading) errors",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_batch_write_errors": {
+            "description": "Number of batch write errors",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_batches_read": {
+            "description": "Total number of batches read",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_batches_written": {
+            "description": "Total number of batches written",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_bytes_prefix_truncated": {
+            "description": "Number of bytes removed by prefix truncation.",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_cache_hits": {
+            "description": "Reader cache hits",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_cache_misses": {
+            "description": "Reader cache misses",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_cached_batches_read": {
+            "description": "Total number of cached batches read",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_cached_read_bytes": {
+            "description": "Total number of cached bytes read",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_chunked_compaction_runs": {
+            "description": "Number of times chunked compaction was ran. This metric also corresponds to the number of times the compaction key-offset map was unable to be built for a single segment.",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_cleanly_compacted_segment": {
+            "description": "Number of segments cleanly compacted (i.e, had their keys de-duplicated with all previous segments before them to the front of the log)",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_closed_segment_bytes": {
+            "description": "Number of bytes within closed segments of the log",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_compacted_segment": {
+            "description": "Number of compacted segments",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_compaction_ratio": {
+            "description": "Average segment compaction ratio",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_compaction_removed_bytes": {
+            "description": "Number of bytes removed by a compaction operation",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_complete_sliding_window_rounds": {
+            "description": "Number of rounds of sliding window compaction that have been driven to completion.",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_corrupted_compaction_indices": {
+            "description": "Number of times we had to re-construct the .compaction index on a segment",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_dirty_segment_bytes": {
+            "description": "Number of bytes within dirty segments of the log",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_log_segments_active": {
+            "description": "Current number of local log segments",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_log_segments_created": {
+            "description": "Total number of local log segments created since node startup",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_log_segments_removed": {
+            "description": "Total number of local log segments removed since node startup",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_partition_size": {
+            "description": "Current size of partition in bytes",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_read_bytes": {
+            "description": "Total number of bytes read",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_readers_added": {
+            "description": "Number of readers added to cache",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_readers_evicted": {
+            "description": "Number of readers evicted from cache",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_segments_marked_tombstone_free": {
+            "description": "Number of segments that have been verified through the compaction process to be tombstone free.",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_tombstones_removed": {
+            "description": "Number of tombstone records removed by compaction due to the delete.retention.ms setting.",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_log_written_bytes": {
+            "description": "Total number of bytes written",
+            "type": "counter",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_storage_manager_housekeeping_log_processed": {
+            "description": "Number of logs processed by housekeeping",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_manager_logs": {
+            "description": "Number of logs managed",
+            "type": "gauge",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_storage_manager_urgent_gc_runs": {
+            "description": "Number of urgent GC runs",
+            "type": "counter",
+            "labels": [
+                "shard"
+            ]
+        },
+        "vectorized_tx_partition_idempotency_pid_cache_size": {
+            "description": "Number of active producers (known producer_id seq number pairs).",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        },
+        "vectorized_tx_partition_tx_num_inflight_requests": {
+            "description": "Number of ongoing transactional requests.",
+            "type": "gauge",
+            "labels": [
+                "namespace",
+                "partition",
+                "shard",
+                "topic"
+            ]
+        }
+    }
+}

--- a/tools/metrics/extract_metrics.sh
+++ b/tools/metrics/extract_metrics.sh
@@ -8,6 +8,7 @@ fi
 
 # Make this tag accessible to docker-compose and Python
 export REDPANDA_VERSION="$TAG"
+REDPANDA_MAJOR_MINOR=$(echo "$TAG" | sed -E 's/^v?([0-9]+\.[0-9]+).*$/\1/')
 
 WORK_DIR="$(pwd)"
 
@@ -18,20 +19,22 @@ function check_docker_containers {
   fi
 }
 
-# Remove existing redpanda-quickstart directory for replayability
 if [ -d "redpanda-quickstart" ]; then
-  rm -rf redpanda-quickstart
+  echo "redpanda-quickstart directory exists, using existing one..."
+  cd redpanda-quickstart/docker-compose || exit 1
+else
+  echo "Setting up redpanda-quickstart folder..."
+  mkdir redpanda-quickstart && cd redpanda-quickstart || exit 1
+  curl -sSL https://docs.redpanda.com/redpanda-quickstart.tar.gz | tar xzf -
+  cd docker-compose || exit 1
 fi
-
-# Create folder and set up Redpanda quickstart
-echo "Setting up redpanda-quickstart folder..."
-mkdir redpanda-quickstart && cd redpanda-quickstart || exit 1
-curl -sSL https://docs.redpanda.com/redpanda-quickstart.tar.gz | tar xzf -
-cd docker-compose || exit 1
 
 # Check and handle Docker containers
 check_docker_containers
 docker compose up -d
+
+echo "Waiting 60 seconds for containers to initialize..."
+sleep 60
 
 cd "$WORK_DIR" || {
   echo "Failed to navigate back to the working directory: $WORK_DIR. Exiting."
@@ -70,3 +73,11 @@ if [ -f "$WORK_DIR/metrics.py" ]; then
 else
   echo "metrics.py not found in $WORK_DIR. Please ensure it exists."
 fi
+
+# Tear down Docker containers after the script has run
+echo "Tearing down Docker containers..."
+cd redpanda-quickstart/docker-compose || {
+  echo "Failed to navigate to docker-compose directory. Exiting.";
+  exit 1;
+}
+docker compose down --volumes

--- a/tools/metrics/extract_metrics.sh
+++ b/tools/metrics/extract_metrics.sh
@@ -25,7 +25,7 @@ if [ -d "redpanda-quickstart" ]; then
 else
   echo "Setting up redpanda-quickstart folder..."
   mkdir redpanda-quickstart && cd redpanda-quickstart || exit 1
-  curl -sSL https://docs.redpanda.com/redpanda-quickstart.tar.gz | tar xzf -
+  curl -sSL https://docs.redpanda.com/$REDPANDA_MAJOR_MINOR-redpanda-quickstart.tar.gz | tar xzf -
   cd docker-compose || exit 1
 fi
 


### PR DESCRIPTION
## Description

Partially resolves https://redpandadata.atlassian.net/browse/DOC-1115
Review deadline: March 14

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
