### PR TITLE
rpk: update profile docs

### DIFF
--- a/modules/get-started/pages/config-rpk-profile.adoc
+++ b/modules/get-started/pages/config-rpk-profile.adoc
@@ -64,16 +64,18 @@ rpk profile use <name-of-profile-to-use>
 
 === Set or edit configuration values
 
+You can customize settings for a single profile. To set a profile's configuration:
+
+* Use xref:reference:rpk/rpk-profile/rpk-profile-set.adoc[`rpk profile set`] to set `key=value` pairs of configuration options to write to the profile's section of `rpk.yaml`.
+* Use xref:reference:rpk/rpk-profile/rpk-profile-edit.adoc[`rpk profile edit`] to edit the profile's section of the `rpk.yaml` file in your default editor.
+
 You can configure settings that apply to all profiles. To set these `globals`:
 
 * Use xref:reference:rpk/rpk-profile/rpk-profile-set-globals.adoc[`rpk profile set-globals`] to set `key=value` pairs to write to the globals section
 of `rpk.yaml`.
 * Use xref:reference:rpk/rpk-profile/rpk-profile-edit-globals.adoc[`rpk profile edit-globals`] to edit the globals section of the `rpk.yaml` file in your default editor.
 
-You can customize settings for a single profile. To set a profile's configuration:
-
-* Use xref:reference:rpk/rpk-profile/rpk-profile-set.adoc[`rpk profile set`] to set `key=value` pairs of configuration options to write to the profile's section of `rpk.yaml`.
-* Use xref:reference:rpk/rpk-profile/rpk-profile-edit.adoc[`rpk profile edit`] to edit the profile's section of the `rpk.yaml` file in your default editor.
+For a list of all the available properties that can be set in your profile, see xref:reference:rpk/rpk-x-options.adoc[`rpk -X options`]
 
 ==== Customize command prompt per profile
 

--- a/modules/get-started/pages/config-rpk-profile.adoc
+++ b/modules/get-started/pages/config-rpk-profile.adoc
@@ -75,7 +75,7 @@ You can configure settings that apply to all profiles. To set these `globals`:
 of `rpk.yaml`.
 * Use xref:reference:rpk/rpk-profile/rpk-profile-edit-globals.adoc[`rpk profile edit-globals`] to edit the globals section of the `rpk.yaml` file in your default editor.
 
-For a list of all the available properties that can be set in your profile, see xref:reference:rpk/rpk-x-options.adoc[`rpk -X options`]
+TIP: For a list of all the available properties that can be set in your profile, see xref:reference:rpk/rpk-x-options.adoc[`rpk -X options`].
 
 ==== Customize command prompt per profile
 

--- a/modules/get-started/pages/intro-to-rpk.adoc
+++ b/modules/get-started/pages/intro-to-rpk.adoc
@@ -24,7 +24,7 @@ endif::[]
 
 You can specify `rpk` command properties in the following ways:
 
-* Create an xref:get-started:config-rpk-profile.adoc[`rpk profile`]
+* Create an xref:get-started:config-rpk-profile.adoc[`rpk profile`].
 * Specify the appropriate flag on the command line.
 * Define the corresponding environment variables.
 +
@@ -57,7 +57,7 @@ Or, get a detailed description about each option with `-X help`:
 rpk -X help
 ----
 
-Every `-X` option can be translated into an environment variable by prefixing with `RPK_` and replacing periods (`.`) with underscores (`_`). For example, the flag `tls.enabled` has the equivalent environment variable `RPK_TLS_ENABLED`.
+Every `-X` option can be translated into an environment variable by prefixing it with `RPK_` and replacing periods (`.`) with underscores (`_`). For example, the flag `tls.enabled` has the equivalent environment variable `RPK_TLS_ENABLED`.
 
 Some of the common configuration properties apply across all `rpk` commands as defaults. These default properties have keys with names starting with `globals`, and they're viewable in `rpk -X list` and `rpk -X help`. For more details, see xref:reference:rpk/rpk-x-options.adoc[`rpk -X options`].
 

--- a/modules/get-started/pages/intro-to-rpk.adoc
+++ b/modules/get-started/pages/intro-to-rpk.adoc
@@ -20,28 +20,21 @@ ifndef::env-cloud[]
 * xref:get-started:rpk-quickstart.adoc[]
 endif::[]
 
-== Specify command properties
+== Specify configuration properties
 
 You can specify `rpk` command properties in the following ways:
 
+* Create an xref:get-started:config-rpk-profile.adoc[`rpk profile`]
 * Specify the appropriate flag on the command line.
 * Define the corresponding environment variables.
 +
 Environment variable settings only last for the duration of a shell session.
 
-* Edit the configuration file settings in the `rpk` section of the `redpanda.yaml` file.
-+
-Configuration file property settings stay the same for each shell session.
-
-* Edit the configuration file settings in the `rpk.yaml` file.
-+
-Configuration file property settings stay the same for each shell session.
-
 Command line flag settings take precedence over the corresponding environment variables, and environment variables take precedence over configuration file settings. If a required flag is not specified on the command line, Redpanda searches the environment variable. If the environment variable is not set, the value in the `rpk.yaml` configuration file is used, if that file is available, otherwise the value in the `redpanda.yaml` configuration file is used.
 
 TIP: If you specify `rpk` command properties in the configuration files or as environment variables, you don't need to specify them again on the command line.
 
-== Common configuration properties
+=== Common configuration properties
 
 Every `rpk` command supports a set of common configuration properties. You can set one or more options in an `rpk` command by using the `-X` flag:
 
@@ -64,7 +57,9 @@ Or, get a detailed description about each option with `-X help`:
 rpk -X help
 ----
 
-Some of the common configuration properties apply across all `rpk` commands as defaults. These default properties have keys with names starting with `defaults`, and they're viewable in `rpk -X list` and `rpk -X help`. For more details, see xref:reference:rpk/rpk-x-options.adoc[`rpk -X options`].
+Every `-X` option can be translated into an environment variable by prefixing with `RPK_` and replacing periods (`.`) with underscores (`_`). For example, the flag `tls.enabled` has the equivalent environment variable `RPK_TLS_ENABLED`.
+
+Some of the common configuration properties apply across all `rpk` commands as defaults. These default properties have keys with names starting with `globals`, and they're viewable in `rpk -X list` and `rpk -X help`. For more details, see xref:reference:rpk/rpk-x-options.adoc[`rpk -X options`].
 
 == Next steps
 


### PR DESCRIPTION
## Description

There are multiple changes here:

1. Update `default` -> `global`
2. Not documenting the manipulation of the redpanda.yaml (deprecated) or rpk.yaml (we use rpk profile for this instead)
3. Adding information about how to turn a flag into an env variable.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
