### PR TITLE
Adds new properties added in 25.1.1-rc2

### DIFF
--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -83,6 +83,12 @@ The following cluster properties are new in this version:
 - xref:reference:properties/cluster-properties.adoc#raft_max_buffered_follower_append_entries_bytes_per_shard[`raft_max_buffered_follower_append_entries_bytes_per_shard`]: Limits the maximum bytes buffered for follower append entries per shard.
 - xref:reference:properties/cluster-properties.adoc#raft_max_inflight_follower_append_entries_requests_per_shard[`raft_max_inflight_follower_append_entries_requests_per_shard`]: Replaces the deprecated `raft_max_concurrent_append_requests_per_follower` to limit in-flight follower append requests per shard.
 
+=== Tiered Storage
+
+- xref:reference:properties/object-storage-properties.adoc#cloud_storage_enable_remote_allow_gaps[`cloud_storage_enable_remote_allow_gaps`]: Controls the eviction of locally stored log segments when Tiered Storage uploads are paused.
+
+- xref:reference:properties/object-storage-properties.adoc#cloud_storage_enable_segment_uploads[`cloud_storage_enable_segment_uploads`]: Controls the upload of log segments to Tiered Storage. If set to `false`, this property temporarily pauses all log segment uploads from the Redpanda cluster.
+
 === TLS configuration
 
 - xref:reference:properties/cluster-properties.adoc#tls_enable_renegotiation[`tls_enable_renegotiation`]: Enables support for TLS renegotiation.

--- a/modules/reference/pages/properties/broker-properties.adoc
+++ b/modules/reference/pages/properties/broker-properties.adoc
@@ -38,7 +38,7 @@ Specifies the TLS configuration for the HTTP Admin API.
 
 *Visibility:* `user`
 
-*Default:* `null`
+*Default:* `{}`
 
 ---
 
@@ -177,7 +177,7 @@ Transport Layer Security (TLS) configuration for the Kafka API endpoint.
 
 *Visibility:* `user`
 
-*Default:* `null`
+*Default:* `{}`
 
 ---
 
@@ -218,6 +218,18 @@ Broker IDs are immutable. After a broker joins the cluster, its `node_id` *canno
 *Visibility:* `user`
 
 *Default:* `null`
+
+---
+
+=== node_id_overrides
+
+List of broker IDs and UUID to override at broker startup. Each entry includes the current UUID and desired ID and UUID. Each entry applies to a given broker only if 'current' matches that broker's current UUID.
+
+*Visibility:* `user`
+
+*Type:* array
+
+*Default:* `{}`
 
 ---
 
@@ -307,7 +319,7 @@ The `seed_servers` list must be consistent across all seed brokers to prevent cl
 
 *Type:* array
 
-*Default:* `null`
+*Default:* `{}`
 
 ---
 
@@ -373,7 +385,9 @@ For information on how to edit broker properties for the Schema Registry, see xr
 
 === api_doc_dir
 
-API doc directory.
+Path to the API specifications for the HTTP Proxy API.
+
+*Requires restart:* Yes
 
 *Visibility:* `user`
 
@@ -411,7 +425,7 @@ TLS configuration for Schema Registry API.
 
 *Visibility:* `user`
 
-*Default:* `null`
+*Default:* `{}`
 
 ---
 
@@ -510,7 +524,7 @@ TLS configuration for Pandaproxy api.
 
 *Visibility:* `user`
 
-*Default:* `null`
+*Default:* `{}`
 
 ---
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -663,6 +663,20 @@ When set to `true`, Redpanda can re-upload data for compacted topics to object s
 
 ---
 
+=== cloud_storage_enable_remote_allow_gaps
+
+Controls the eviction of locally stored log segments when Tiered Storage uploads are paused. Set to `false` to only evict data that has already been uploaded to object storage. If the retained data fills the local volume, Redpanda throttles producers. Set to `true` to allow the eviction of locally stored log segments, which may create gaps in offsets.
+
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `false`
+
+---
+
 === cloud_storage_enable_remote_read
 
 Default remote read config value for new topics.
@@ -711,9 +725,23 @@ Enable routine checks (scrubbing) of object storage partitions. The scrubber val
 
 Enables adjacent segment merging. The segments are reuploaded if there is an opportunity for that and if it will improve the performance of Tiered Storage.
 
-*Related topics*: 
+*Requires restart:* No
+
+*Visibility:* `tunable`
+
+*Type:* boolean
+
+*Default:* `true`
+
+*Related topics*:
 
 * xref:manage:tiered-storage.adoc#object-storage-housekeeping[Object storage housekeeping]
+
+---
+
+=== cloud_storage_enable_segment_uploads
+
+Controls the upload of log segments to Tiered Storage. If set to `false`, this property temporarily pauses all log segment uploads from the Redpanda cluster. When the uploads are paused, the <<cloud_storage_enable_remote_allow_gaps, `cloud_storage_enable_remote_allow_gaps`>> cluster configuration and `redpanda.remote.allowgaps` topic properties control local retention behavior.
 
 *Requires restart:* No
 


### PR DESCRIPTION
This pull request includes several updates to the documentation for cluster properties, with a focus on Tiered Storage. The key changes involve adding new properties for Tiered Storage and updating default values for various TLS configurations.

### New properties for Tiered Storage:

* Added `cloud_storage_enable_remote_allow_gaps` to control the eviction of locally stored log segments when Tiered Storage uploads are paused. [[1]](diffhunk://#diff-7e9028daec2320182888e36f1be6d5a941c79362fab72135786f5b0cb0456a30R86-R91) [[2]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R666-R679)
* Added `cloud_storage_enable_segment_uploads` to control the upload of log segments to Tiered Storage. [[1]](diffhunk://#diff-7e9028daec2320182888e36f1be6d5a941c79362fab72135786f5b0cb0456a30R86-R91) [[2]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R728-R745)

### Updates to TLS configuration:

* Changed the default value for various TLS configuration properties from `null` to `{}`:
  * HTTP Admin API
  * Kafka API endpoint
  * Schema Registry API
  * Pandaproxy API

### Additional changes:

* Added a new property `node_id_overrides` to override broker IDs and UUIDs at startup.
* Updated the description for the `api_doc_dir` property to specify that it is the path to the API specifications for the HTTP Proxy API and requires a restart.

Review deadline: March 19

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
