### PR TITLE
[Admin API] Add new rolling restart health endpoints

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -2297,25 +2297,25 @@ components:
           type: array
           items:
             type: string
-            description: ntp
+            description: Namespace, topic, partition ID
           description: Partitions with a replication factor of 1 that have a replica on the current broker.
         full_acks_produce_unavailable:
           type: array
           items:
             type: string
-            description: ntp
+            description: Namespace, topic, partition ID
           description: Partitions that may reject produce requests (with `acks=-1`) if the current broker is restarted.
         unavailable:
           type: array
           items:
             type: string
-            description: ntp
+            description: Namespace, topic, partition ID
           description: Partitions that may reject consume and produce requests if the current broker is restarted.
         acks1_data_loss:
           type: array
           items:
             type: string
-            description: ntp
+            description: Namespace, topic, partition ID
           description: Partitions that may lose data produced (with `acks=1`) if the current broker is restarted. 
     post_restart_check_result:
       type: object

--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -775,6 +775,41 @@ paths:
         200:
           description: Recommission broker success
           content: {}
+  /v1/broker/pre_restart_probe:
+    get:
+      tags:
+        - Brokers
+      summary: Check broker pre-restart
+      description: Check if it is safe to restart this broker. 
+      operationId: pre_restart_probe
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: "Limit the number of partitions listed for each risk type (default: 128)."
+      responses:
+        200:
+          description: Pre-restart check result. Returns risks associated with restarting the broker, and partitions affected, if any.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pre_restart_check_result'
+  /v1/broker/post_restart_probe:
+    get:
+      tags:
+      - Brokers
+      summary: Check broker post-restart
+      description: Check if the broker has recovered after a restart.
+      operationId: post_restart_probe
+      responses:
+        200:
+          description: Post-restart check result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/post_restart_check_result'
   /v1/cluster_view:
     get:
       tags:
@@ -2249,6 +2284,48 @@ components:
           type: string
         port:
           type: integer
+    pre_restart_check_result:
+      type: object
+      description: Pre-restart check result.
+      properties:
+        risks:
+          $ref: '#/components/schemas/restart_risks'
+    restart_risks:
+      description: Partitions affected by the current broker restart, grouped by risk type. Each partition list is truncated according to the optional limit specified in the request.
+      properties:
+        rf1_offline:
+          type: array
+          items:
+            type: string
+            description: ntp
+          description: Partitions with a replication factor of 1 that have a replica on the current broker.
+        full_acks_produce_unavailable:
+          type: array
+          items:
+            type: string
+            description: ntp
+          description: Partitions that may reject produce requests (with `acks=-1`) if the current broker is restarted.
+        unavailable:
+          type: array
+          items:
+            type: string
+            description: ntp
+          description: Partitions that may reject consume and produce requests if the current broker is restarted.
+        acks1_data_loss:
+          type: array
+          items:
+            type: string
+            description: ntp
+          description: Partitions that may lose data produced (with `acks=1`) if the current broker is restarted. 
+    post_restart_check_result:
+      type: object
+      description: Post-restart check result.
+      properties:
+        load_reclaimed_pc:
+          type: integer
+          description: The load that the broker has reclaimed after restarting, as a percentage of in-sync replicas.
+          minimum: 0
+          maximum: 100
     broker_locator:
       type: object
       properties:


### PR DESCRIPTION
## Description

This pull request introduces new endpoints to the `admin-api.yaml` file for checking the status of brokers before and after a restart. Additionally, it defines new schemas for the results of these checks.

This will accompany an update to the [Rolling Restart](https://deploy-preview-1026--redpanda-docs-preview.netlify.app/25.1/manage/cluster-maintenance/rolling-restart/) and [Upgrade Redpanda in Linux](https://deploy-preview-1026--redpanda-docs-preview.netlify.app/25.1/upgrade/rolling-upgrade/) guides (PR https://github.com/redpanda-data/docs/pull/1026).

New endpoints:

* Added `/v1/broker/pre_restart_probe` to check if it is safe to restart a broker, with an optional `limit` query parameter to limit the number of partitions listed for each risk type.
* Added `/v1/broker/post_restart_probe` to check if a broker has recovered after a restart.

New schemas:

* Defined `pre_restart_check_result` schema to describe the result of a pre-restart check, including risks associated with restarting the broker.
* Defined `restart_risks` schema to describe partitions affected by the current broker restart, grouped by risk type.
* Defined `post_restart_check_result` schema to describe the result of a post-restart check, which is the load reclaimed by the broker after restarting.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 21 March

## Page previews

https://deploy-preview-1019--redpanda-docs-preview.netlify.app/api/admin-api/#get-/v1/broker/pre_restart_probe
https://deploy-preview-1019--redpanda-docs-preview.netlify.app/api/admin-api/#get-/v1/broker/post_restart_probe

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
