### PR TITLE
Rolling restart Admin API

### DIFF
--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -7,6 +7,13 @@ This topic includes new content added in version {page-component-version} Beta. 
 * xref:redpanda-cloud:get-started:whats-new-cloud.adoc[]
 * xref:redpanda-cloud:get-started:cloud-overview.adoc#redpanda-cloud-vs-self-managed-feature-compatibility[Redpanda Cloud vs Self-Managed feature compatibility]
 
+== New health probes for broker restarts and upgrades
+
+The Redpanda Admin API now includes new health probes to help you ensure safe broker restarts and upgrades. The xref:api:ROOT:admin-api.adoc#get-/v1/broker/pre_restart_probe[`pre_restart_probe`] endpoint identifies potential risks if a broker is restarted, and xref:api:ROOT:admin-api.adoc#get-/v1/broker/post_restart_probe[`post_restart_probe`] indicates how much of its workloads a broker has reclaimed after the restart. See also: 
+
+* xref:manage:cluster-maintenance/rolling-restart.adoc[]
+* xref:upgrade:rolling-upgrade.adoc[]
+
 == Redpanda Console v3.0.0 (beta)
 
 The Redpanda Console v3.0.0 beta release includes the following updates:

--- a/modules/upgrade/partials/rolling-upgrades/enable-maintenance-mode.adoc
+++ b/modules/upgrade/partials/rolling-upgrades/enable-maintenance-mode.adoc
@@ -10,7 +10,7 @@ rpk cluster health
 .Example output:
 [%collapsible]
 ====
-[.no-copy]
+[,bash,role=no-copy]
 ----
 CLUSTER HEALTH OVERVIEW
 =======================
@@ -19,12 +19,40 @@ Controller ID:               0
 All nodes:                   [0 1 2] <2>
 Nodes down:                  [] <3>
 Leaderless partitions:       [] <3>
-Under-replicated partitions: [] <3>
+Under-replicated partitions: [1] <3>
 ----
 <1> The cluster is either healthy (`true`) or unhealthy (`false`).
 <2> The node IDs of all brokers in the cluster.
 <3> If the cluster is unhealthy, these fields will contain data.
-====
+==== 
+
+. Optional: You can use the Admin API (default port: 9644) to perform additional checks for potential risks with restarting a specific broker.
++
+[,bash]
+----
+curl -X GET "http://<broker-address>:<admin-api-port>/v1/broker/pre_restart_probe" | jq .
+----
++
+.Example output:
+[,json,role=no-copy]
+----
+// Returns tuples of partitions (in the format {namespace}/{topic_name}/{partition_id}) affected by the broker restart.
+
+{
+  "risks": {
+    "rf1_offline": [
+      "kafka/topic_a/0"
+    ],
+    "full_acks_produce_unavailable": [],
+    "unavailable": [],
+    "acks1_data_loss": []
+  }
+}
+----
++
+In this example, the restart probe indicates that there is an under-replicated partition `kafka/topic_a/0` (with a replication factor of 1) at risk of going offline if the broker is restarted.
++
+See the xref:api:ROOT:admin-api.adoc#get-/v1/broker/pre_restart_probe[Admin API reference] for more details on the restart probe endpoint.
 
 ifdef::rolling-upgrade[. Select a broker that has not been upgraded yet and place it into maintenance mode:]
 ifdef::rolling-restart[. Select a broker and place it into maintenance mode:]

--- a/modules/upgrade/partials/rolling-upgrades/post-upgrade-tasks.adoc
+++ b/modules/upgrade/partials/rolling-upgrades/post-upgrade-tasks.adoc
@@ -12,3 +12,18 @@ To view additional information about your brokers, run:
 ```bash
 rpk redpanda admin brokers list
 ```
+
+You can also use the xref:api:ROOT:admin-api.adoc#get-/v1/broker/post_restart_probe[Admin API] to check how much each broker has progressed in recovering its workloads:
+
+```bash
+curl -X GET "http://<broker-address>:<admin-api-port>/v1/broker/post_restart_probe"
+```
+
+.Example output:
+[,json,role=no-copy]
+----
+// Returns the load already reclaimed by broker, as a percentage of in-sync replicas
+{
+    "load_reclaimed_pc": 66
+}
+----


### PR DESCRIPTION
This pull request updates the Rolling Restart and Update Redpanda pages to include new Admin API endpoints. Related Admin API Reference update: https://github.com/redpanda-data/docs/pull/1019 

Documentation updates:

* [`modules/get-started/pages/whats-new.adoc`](diffhunk://#diff-7e9028daec2320182888e36f1be6d5a941c79362fab72135786f5b0cb0456a30R10-R16): Added new health probes `pre_restart_probe` and `post_restart_probe` to What's New.
* [`modules/upgrade/partials/rolling-upgrades/enable-maintenance-mode.adoc`](diffhunk://#diff-397081fe0c7da951526f4dc94ce8229b7ce34cbd28ada831e0bc73e0d8e59434L22-R56): Added example usage and output for the `pre_restart_probe` endpoint to perform additional checks before restarting a broker.
* [`modules/upgrade/partials/rolling-upgrades/post-upgrade-tasks.adoc`](diffhunk://#diff-1aa345be9aecb644ef660ab7118566515e6ff11371c0ff85ed41fdf4f74e5155R15-R29): Added example usage and output for the `post_restart_probe` endpoint to check broker workload recovery after a restart.

## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 27 March

## Page previews

[What's New](https://deploy-preview-1026--redpanda-docs-preview.netlify.app/25.1/get-started/whats-new/#new-health-probes-for-broker-restarts-and-upgrades)
[Perform a Rolling Restart](https://deploy-preview-1026--redpanda-docs-preview.netlify.app/25.1/manage/cluster-maintenance/rolling-restart/)
[Upgrade Redpanda in Linux](https://deploy-preview-1026--redpanda-docs-preview.netlify.app/25.1/upgrade/rolling-upgrade/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
