### PR TITLE
Add beta install docs for Redpanda Console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/_redirects
 .vscode
 poc-docs/
 docs/
+gen/
 .docusaurus
 testResults*.json
 tools/property-extractor/

--- a/modules/get-started/pages/install-beta.adoc
+++ b/modules/get-started/pages/install-beta.adoc
@@ -166,7 +166,7 @@ helm install redpanda redpanda/redpanda \
 
 . Generate and deploy the manifest for Redpanda Console v3 beta:
 +
-[source,bash,subs="attributes+"]
+[source,bash,role="no-wrap",subs="attributes+"]
 ----
 helm template consolev3 oci://registry-1.docker.io/redpandadata/console-unstable \
   --namespace <namespace> \

--- a/modules/get-started/pages/install-beta.adoc
+++ b/modules/get-started/pages/install-beta.adoc
@@ -169,7 +169,7 @@ helm install redpanda redpanda/redpanda \
 [source,bash,subs="attributes+"]
 ----
 helm template consolev3 oci://registry-1.docker.io/redpandadata/console-unstable \
-  --namespace redpanda \
+  --namespace <namespace> \
   --create-namespace \
   --version v0.0-k8s0-968fcab9-helm-chart \
   --set "image.tag={console-beta-tag}" \
@@ -203,7 +203,7 @@ kubectl apply -f console-deployment-v3.yaml
 . Forward the ports to access Redpanda Console locally:
 +
 ```bash
-kubectl port-forward svc/redpanda-console 8080:8080
+kubectl --namespace <namespace> port-forward svc/consolev3-console-unstable 8080:8080
 ```
 
 . Navigate to http://localhost:8080.

--- a/modules/get-started/pages/install-beta.adoc
+++ b/modules/get-started/pages/install-beta.adoc
@@ -12,7 +12,7 @@ Docker::
 +
 --
 
-. Pull the latest RC build from https://hub.docker.com/r/redpandadata/redpanda-unstable/tags[dockerhub^]:
+. Pull the latest RC build from https://hub.docker.com/r/redpandadata/redpanda-unstable/tags[Docker Hub^]:
 +
 [source,bash,subs="attributes+"]
 ----
@@ -151,8 +151,8 @@ Kubernetes::
 +
 --
 
-Install Redpanda with Helm from the RC build in https://hub.docker.com/r/redpandadata/redpanda-unstable/tags[dockerhub^]:
-
+. Install Redpanda with Helm from the RC build in https://hub.docker.com/r/redpandadata/redpanda-unstable/tags[Docker Hub^]:
++
 [source,bash,subs="attributes+"]
 ----
 helm repo add redpanda https://charts.redpanda.com
@@ -161,8 +161,52 @@ helm repo update
 helm install cert-manager jetstack/cert-manager --set crds.enabled=true --namespace cert-manager --create-namespace
 helm install redpanda redpanda/redpanda \
   --namespace <namespace> \
-  --create-namespace --set image.repository=docker.redpanda.com/redpandadata/redpanda-unstable --set image.tag={redpanda-beta-tag}
+  --create-namespace --set image.repository=docker.redpanda.com/redpandadata/redpanda-unstable --set image.tag={redpanda-beta-tag} --set console.enabled=false
 ----
+
+. Generate and deploy the manifest for Redpanda Console v3 beta:
++
+[source,bash,subs="attributes+"]
+----
+helm template consolev3 oci://registry-1.docker.io/redpandadata/console-unstable \
+  --namespace redpanda \
+  --create-namespace \
+  --version v0.0-k8s0-968fcab9-helm-chart \
+  --set "image.tag={console-beta-tag}" \
+  --set "secretMounts[0].name=redpanda-default-cert" \
+  --set "secretMounts[0].secretName=redpanda-default-cert" \
+  --set "secretMounts[0].defaultMode=272" \
+  --set "secretMounts[0].path=/etc/tls/certs/default" \
+  --set "config.kafka.brokers[0]=redpanda-0.redpanda.redpanda.svc.cluster.local.:9093" \
+  --set "config.kafka.brokers[1]=redpanda-1.redpanda.redpanda.svc.cluster.local.:9093" \
+  --set "config.kafka.brokers[0]=redpanda-2.redpanda.redpanda.svc.cluster.local.:9093" \
+  --set "config.kafka.sasl.enabled=false" \
+  --set "config.kafka.tls.caFilepath=/etc/tls/certs/default/ca.crt" \
+  --set "config.kafka.tls.enabled=true" \
+  --set "config.kafka.tls.insecureSkipTlsVerify=false" \
+  --set "config.schemaRegistry.enabled=true" \
+  --set "config.schemaRegistry.tls.caFilepath=/etc/tls/certs/default/ca.crt" \
+  --set "config.schemaRegistry.tls.enabled=true" \
+  --set "config.schemaRegistry.tls.insecureSkipTlsVerify=false" \
+  --set "config.schemaRegistry.urls[0]=https://redpanda-0.redpanda.redpanda.svc.cluster.local.:8081" \
+  --set "config.schemaRegistry.urls[1]=https://redpanda-1.redpanda.redpanda.svc.cluster.local.:8081" \
+  --set "config.schemaRegistry.urls[2]=https://redpanda-2.redpanda.redpanda.svc.cluster.local.:8081" \
+  --set "config.redpanda.adminApi.enabled=true" \
+  --set "config.redpanda.adminApi.tls.caFilepath=/etc/tls/certs/default/ca.crt" \
+  --set "config.redpanda.adminApi.tls.enabled=true" \
+  --set "config.redpanda.adminApi.tls.insecureSkipTlsVerify=false" \
+  --set "config.redpanda.adminApi.urls[0]=https://redpanda.redpanda.svc.cluster.local.:9644" > console-deployment-v3.yaml
+
+kubectl apply -f console-deployment-v3.yaml
+----
+
+. Forward the ports to access Redpanda Console locally:
++
+```bash
+kubectl port-forward svc/redpanda-console 8080:8080
+```
+
+. Navigate to http://localhost:8080.
 
 --
 =====


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1137
Review deadline: March 24

This pull request includes updates to the documentation for installing Redpanda beta, specifically in the `modules/get-started/pages/install-beta.adoc` file. The changes improve clarity and add new instructions for deploying Redpanda Console v3 beta.

Documentation updates:

* Changed references from "dockerhub" to "Docker Hub" for consistency. [[1]](diffhunk://#diff-539ff48a0034cf2d5844238f3af6dd497f33a6c3e6e7744a4a6d6658349da305L15-R15) [[2]](diffhunk://#diff-539ff48a0034cf2d5844238f3af6dd497f33a6c3e6e7744a4a6d6658349da305L154-R155)

New deployment instructions:

* Added detailed instructions for generating and deploying the manifest for Redpanda Console v3 beta using Helm.

## Page previews

https://deploy-preview-1028--redpanda-docs-preview.netlify.app/25.1/get-started/install-beta/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
