### PR TITLE
Update monitor-redpanda.adoc - Update URL for Prometheus operator install

### DIFF
--- a/modules/manage/partials/monitor-connectors.adoc
+++ b/modules/manage/partials/monitor-connectors.adoc
@@ -52,7 +52,7 @@ ifdef::env-kubernetes[]
 
 To configure Prometheus to monitor Redpanda metrics in Kubernetes, you can use the https://prometheus-operator.dev/[Prometheus Operator^]:
 
-. Follow the steps to https://prometheus-operator.dev/docs/user-guides/getting-started/[deploy the Prometheus Operator^].
+. Follow the steps to https://prometheus-operator.dev/docs/getting-started/installation/[deploy the Prometheus Operator^].
 +
 Make sure to configure the Prometheus resource to target your Pods that are running Kafka Connect:
 +

--- a/modules/manage/partials/monitor-redpanda.adoc
+++ b/modules/manage/partials/monitor-redpanda.adoc
@@ -27,7 +27,7 @@ ifdef::env-kubernetes[]
 
 To configure Prometheus to monitor Redpanda metrics in Kubernetes, you can use the https://prometheus-operator.dev/[Prometheus Operator^]:
 
-. Follow the steps to https://prometheus-operator.dev/docs/user-guides/getting-started/[deploy the Prometheus Operator^].
+. Follow the steps to https://prometheus-operator.dev/docs/getting-started/installation/[deploy the Prometheus Operator^].
 +
 Make sure to configure the Prometheus resource to target your Redpanda cluster:
 +


### PR DESCRIPTION
## Description

Update the URL for installing the latest Prometheus Operator as the getting started URL no longer existed. 

Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
