### PR TITLE
Improve Hyperlint config to avoid false positives

### DIFF
--- a/.hyperlint/reviewer/custom-style-guide/code-formatting.adoc
+++ b/.hyperlint/reviewer/custom-style-guide/code-formatting.adoc
@@ -1,20 +1,12 @@
 = Redpanda Data Documentation Code Formatting Guidelines
 
-== Commands and code
-
-Don't start a sentence not inside a code block with a command or code. Instead, try to move the code into the middle of the sentence. For example, you can introduce the command with a more descriptive word like “Run”.
+== Rule: Do not start a sentence with a command or code.
 
 *Correct:* Run the `rpk topic create` command to create a new topic.
 
 *Incorrect:* `rpk topic create` creates a new topic.
 
-Similarly, do not start a sentence with a filename.
-
-*Correct:* The `redpanda.yaml` file contains configuration parameters.
-
-*Incorrect:* `redpanda.yaml` contains configuration parameters.
-
-This version is correct because the sentence starts with the definite article, providing a descriptive context before introducing the xref.
+This is incorrect because the sentence is starting with a command / code in backticks.
 
 *Correct:*
 
@@ -30,4 +22,12 @@ The xref:api:ROOT:admin-api.adoc#get-/v1/broker/pre_restart_probe[`pre_restart_p
 xref:api:ROOT:admin-api.adoc#get-/v1/broker/pre_restart_probe[`pre_restart_probe`] is an endpoint.
 ----
 
-This version is incorrect because it starts directly with the xref. According to our style guidelines, sentences should not begin with a command, code snippet, or filename. Instead, the xref should be integrated into a descriptive sentence.
+== Rule: Do not start a sentence with a filename.
+
+*Correct:* The `redpanda.yaml` file contains configuration parameters.
+
+*Incorrect:* `redpanda.yaml` contains configuration parameters.
+
+== Rule: Ignore AsciiDoc include directives
+
+Do not make comments on lines that begin with `include::`. This notation inserts the content from another file.

--- a/.hyperlint/reviewer/custom-style-guide/styles.adoc
+++ b/.hyperlint/reviewer/custom-style-guide/styles.adoc
@@ -1,8 +1,8 @@
 = Redpanda Data Documentation Style Guidelines
 
-=== Notes and warnings
+== Notes and warnings
 
-Redpanda product documentation uses AsciiDoc note and warning admonitions:
+Redpanda documentation uses AsciiDoc admonitions:
 
 [cols="1,1",options="header"]
 |===
@@ -28,7 +28,7 @@ For whole numbers between one and nine, spell out the number (for example, nine 
 * *Correct:* To run Redpanda in a three-node cluster, use this command: `rpk container start -n 3`
 * *Incorrect:* To run Redpanda in a 3-node cluster, use this command: `rpk container start -n 3`
 
-The exception to this is within code or when you’re referring to a default value. For example:
+The exception to this is within code or when you're referring to a default value. For example:
 
 * *Correct:* cloud_storage_upload_ctrl_d_coeff - The derivative coefficient for the upload controller. Default is 0.
 * *Incorrect:* cloud_storage_upload_ctrl_d_coeff - The derivative coefficient for the upload controller. Default is zero.

--- a/.hyperlint/reviewer/custom-style-guide/styles.adoc
+++ b/.hyperlint/reviewer/custom-style-guide/styles.adoc
@@ -28,7 +28,7 @@ For whole numbers between one and nine, spell out the number (for example, nine 
 * *Correct:* To run Redpanda in a three-node cluster, use this command: `rpk container start -n 3`
 * *Incorrect:* To run Redpanda in a 3-node cluster, use this command: `rpk container start -n 3`
 
-The exception to this is within code or when you're referring to a default value. For example:
+The exception to this is within code blocks or when you're referring to a default value. For example:
 
 * *Correct:* cloud_storage_upload_ctrl_d_coeff - The derivative coefficient for the upload controller. Default is 0.
 * *Incorrect:* cloud_storage_upload_ctrl_d_coeff - The derivative coefficient for the upload controller. Default is zero.

--- a/.hyperlint/reviewer/vale-style-guide/.vale.ini
+++ b/.hyperlint/reviewer/vale-style-guide/.vale.ini
@@ -16,7 +16,7 @@ BasedOnStyles = Vale, Google, CustomStyle
 # Vale.Terms = NO # comment this in to disable terms checks
 # Disable this rule because Google wants level 1 headings to be in sentence case.
 Google.Headings = NO
-Google.Wordlist = NO
+Google.WordList = NO
 
 [asciidoctor]
 experimental = YES

--- a/.hyperlint/reviewer/vale-style-guide/.vale.ini
+++ b/.hyperlint/reviewer/vale-style-guide/.vale.ini
@@ -14,7 +14,9 @@ BasedOnStyles = Vale, Google, CustomStyle
 
 # Vale.Spelling = NO # comment this in to disable spelling checks
 # Vale.Terms = NO # comment this in to disable terms checks
-
+# Disable this rule because Google wants level 1 headings to be in sentence case.
+Google.Headings = NO
+Google.Wordlist = NO
 
 [asciidoctor]
 experimental = YES
@@ -22,5 +24,3 @@ attribute-missing = drop
 
 [*.adoc]
 # Put ASCIIDOC specific rules here
-# Disable this rule because Google wants level 1 headings to be in sentence case.
-disable = Google.Headings-warning

--- a/.hyperlint/reviewer/vale-style-guide/styles/CustomStyle/We.yml
+++ b/.hyperlint/reviewer/vale-style-guide/styles/CustomStyle/We.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "Try to avoid using first-person plural like '%s'."
+message: "Try to avoid using first-person plural like '%s'. Instead use the first person singular, or rephrase the sentence to use Redpanda Data as the subject."
 link: 'https://developers.google.com/style/pronouns#personal-pronouns'
 level: warning
 ignorecase: true


### PR DESCRIPTION
## Description

Review deadline: March 27

This pull request includes several improvements to our Hyperlint configuration aimed at reducing false positives and aligning more closely with our Vale checks and custom style guide.

Updates to code formatting guidelines:

* [`.hyperlint/reviewer/custom-style-guide/code-formatting.adoc`](diffhunk://#diff-6108613eab428398899b9572bf8a11f4e16a00f6baf4cc35a812f505d8af770bL3-R9): Added rules to avoid starting sentences with commands, code, or filenames, and to ignore AsciiDoc include directives. [[1]](diffhunk://#diff-6108613eab428398899b9572bf8a11f4e16a00f6baf4cc35a812f505d8af770bL3-R9) [[2]](diffhunk://#diff-6108613eab428398899b9572bf8a11f4e16a00f6baf4cc35a812f505d8af770bL33-R33)

Updates to style guidelines:

* [`.hyperlint/reviewer/custom-style-guide/styles.adoc`](diffhunk://#diff-a5822d444e582080da6d60348dbca8e219add20b46a48a07054d9fbe1a2100ecL3-R5): Modified the section on notes and warnings to use simpler language and clarified the exception for spelling out numbers. [[1]](diffhunk://#diff-a5822d444e582080da6d60348dbca8e219add20b46a48a07054d9fbe1a2100ecL3-R5) [[2]](diffhunk://#diff-a5822d444e582080da6d60348dbca8e219add20b46a48a07054d9fbe1a2100ecL31-R31)

Vale configuration changes:

* [`.hyperlint/reviewer/vale-style-guide/.vale.ini`](diffhunk://#diff-fdfc2c360b8d4af9035c8b76badaca4ff2823e9653a0b94d1b798f42fd6952c8L17-L26): Disabled specific Google rules for headings and wordlists.
* [`.hyperlint/reviewer/vale-style-guide/styles/CustomStyle/We.yml`](diffhunk://#diff-ed436cf34ea3c27817b3fe7e92bdc476b6a6ffed6e2e538f577f84a641410b46L2-R2): Updated the message to provide clearer guidance on avoiding first-person plural pronouns.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
