### PR TITLE
Document the need for v2.8.3+ of Console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/
 .docusaurus
 testResults*.json
 .hyperlint/reviewer/vale-style-guide/styles/Google/
+tools/

--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -41,15 +41,15 @@ The Enterprise Edition is licensed with the https://github.com/redpanda-data/red
 
 Enterprise features require an Enterprise Edition license key, sometimes called enterprise license, license key, or license.
 
-Starting with version 24.3, new Redpanda clusters automatically receive a trial license that's valid for 30 days, allowing unrestricted use of enterprise features. This evaluation period begins when the cluster is created for the first time. After this period expires, inactive enterprise features are disabled, and active features enter a restricted state.
-
+- **Redpanda**: Starting with version 24.3, new Redpanda clusters automatically receive a trial license that's valid for 30 days, allowing unrestricted use of enterprise features. This evaluation period begins when the cluster is created for the first time. After this period expires, inactive enterprise features are disabled, and active features enter a restricted state.
++
 To get a trial license key or extend your trial period, https://redpanda.com/try-enterprise[generate a new trial license key]. Or, https://redpanda.com/upgrade[upgrade to Redpanda Enterprise^].
-
++
 include::get-started:partial$licensing/block-upgrades-note.adoc[]
++
+IMPORTANT: To avoid startup issues with Redpanda Console when a trial or Enterprise license expires, use Redpanda Console v2.8.3 or later with clusters running Redpanda 24.3 or later.
 
-IMPORTANT: Redpanda Console v2.8.3 or later is required with clusters running Redpanda 24.3 or later to avoid startup issues when a trial or Enterprise license expires.
-
-To evaluate enterprise features in Redpanda Connect, you must xref:redpanda-connect:get-started:licensing.adoc#apply-a-license-key-to-redpanda-connect[apply a trial license key]. After the 30-day evaluation period, you are blocked from using enterprise connectors unless you https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^].
+- **Redpanda Connect**: To evaluate enterprise features in Redpanda Connect, you must xref:redpanda-connect:get-started:licensing.adoc#apply-a-license-key-to-redpanda-connect[apply a trial license key]. After the 30-day evaluation period, you are blocked from using enterprise connectors unless you https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^].
 
 [[self-managed]]
 === Redpanda enterprise features

--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -39,7 +39,7 @@ The Enterprise Edition is licensed with the https://github.com/redpanda-data/red
 
 === License keys
 
-Enterprise features require an Enterprise Edition license key, sometimes referred to as enterprise license, license key, or license.
+Enterprise features require an Enterprise Edition license key, sometimes called enterprise license, license key, or license.
 
 Starting with version 24.3, new Redpanda clusters automatically receive a trial license that's valid for 30 days, allowing unrestricted use of enterprise features. This evaluation period begins when the cluster is created for the first time. After this period expires, inactive enterprise features are disabled, and active features enter a restricted state.
 
@@ -47,9 +47,9 @@ To get a trial license key or extend your trial period, https://redpanda.com/try
 
 include::get-started:partial$licensing/block-upgrades-note.adoc[]
 
-To evaluate enterprise features in Redpanda Connect, you must xref:redpanda-connect:get-started:licensing.adoc#apply-a-license-key-to-redpanda-connect[apply a trial license key]. After the 30-day evaluation period, you are blocked from using enterprise connectors unless you https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^].
-
 IMPORTANT: Redpanda Console v2.8.3 or later is required with clusters running Redpanda 24.3 or later to avoid startup issues when a trial or Enterprise license expires.
+
+To evaluate enterprise features in Redpanda Connect, you must xref:redpanda-connect:get-started:licensing.adoc#apply-a-license-key-to-redpanda-connect[apply a trial license key]. After the 30-day evaluation period, you are blocked from using enterprise connectors unless you https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^].
 
 [[self-managed]]
 === Redpanda enterprise features

--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -45,12 +45,11 @@ Starting with version 24.3, new Redpanda clusters automatically receive a trial 
 
 To get a trial license key or extend your trial period, https://redpanda.com/try-enterprise[generate a new trial license key]. Or, https://redpanda.com/upgrade[upgrade to Redpanda Enterprise^].
 
-[NOTE]
-====
 include::get-started:partial$licensing/block-upgrades-note.adoc[]
-====
 
 To evaluate enterprise features in Redpanda Connect, you must xref:redpanda-connect:get-started:licensing.adoc#apply-a-license-key-to-redpanda-connect[apply a trial license key]. After the 30-day evaluation period, you are blocked from using enterprise connectors unless you https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^].
+
+IMPORTANT: Redpanda Console v2.8.3 or later is required with clusters running Redpanda 24.3 or later to avoid startup issues when a trial or Enterprise license expires.
 
 [[self-managed]]
 === Redpanda enterprise features


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1079
Review deadline: March 28

This pull request includes a small change to the `modules/get-started/pages/licensing/overview.adoc` file. The change adds an important note about the minimum required version of Redpanda Console to avoid startup issues when a trial or Enterprise license expires.

* [`modules/get-started/pages/licensing/overview.adoc`](diffhunk://#diff-a8d3b86ef1ed51c58d99d1f59f698cec23ad10083dccbb1020d9780eea06f707L48-R53): Added an important note specifying that Redpanda Console v2.8.3 or later is required with clusters running Redpanda 24.3 or later to avoid startup issues when a trial or Enterprise license expires.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
