### PR TITLE
rpk support for protobuf well-known types

### DIFF
--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -7,10 +7,6 @@ This topic includes new content added in version {page-component-version} Beta. 
 * xref:redpanda-cloud:get-started:whats-new-cloud.adoc[]
 * xref:redpanda-cloud:get-started:cloud-overview.adoc#redpanda-cloud-vs-self-managed-feature-compatibility[Redpanda Cloud vs Self-Managed feature compatibility]
 
-== Protobuf well-known types in `rpk`
-
-Support for https://protobuf.dev/reference/protobuf/google.protobuf/[Protobuf well-known types^] is available in `rpk` when encoding and decoding records using Schema Registry.
-
 == Redpanda Console v3.0.0 (beta)
 
 The Redpanda Console v3.0.0 beta release includes the following updates:
@@ -60,6 +56,10 @@ xref:manage:iceberg/topic-iceberg-integration.adoc[Iceberg-enabled topics] now s
 == Protobuf normalization in Schema Registry
 
 Redpanda now supports normalization of Protobuf schemas in the Schema Registry. You can normalize Avro, JSON, and Protobuf schemas both during registration and lookup. For more information, see the xref:manage:schema-reg/schema-reg-overview.adoc#schema-normalization[Schema Registry overview], and the xref:api:ROOT:pandaproxy-schema-registry.adoc[Schema Registry API reference].
+
+== Protobuf well-known types in `rpk`
+
+Support for https://protobuf.dev/reference/protobuf/google.protobuf/[Protobuf well-known types^] is available in `rpk` when encoding and decoding records using Schema Registry.
 
 == SASL/PLAIN authentication
 

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -7,6 +7,10 @@ This topic includes new content added in version {page-component-version} Beta. 
 * xref:redpanda-cloud:get-started:whats-new-cloud.adoc[]
 * xref:redpanda-cloud:get-started:cloud-overview.adoc#redpanda-cloud-vs-self-managed-feature-compatibility[Redpanda Cloud vs Self-Managed feature compatibility]
 
+== Protobuf well-known types in `rpk`
+
+Support for https://protobuf.dev/reference/protobuf/google.protobuf/[Protobuf well-known types^] is available in `rpk` when encoding and decoding records using Schema Registry.
+
 == Redpanda Console v3.0.0 (beta)
 
 The Redpanda Console v3.0.0 beta release includes the following updates:


### PR DESCRIPTION
## Description

Previously, using rpk to produce to or consume a topic using well-known protobuf types would fail, even when using a schema registered in Schema Registry. This is now fixed as of 25.1 and has been backported to 24.3. There are no changes to actual rpk usage.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 1 Apr

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
