### PR TITLE
DOC-1169 Add an extra broker to the hosts.ini

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/manual/production/production-deployment-automation.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/production/production-deployment-automation.adoc
@@ -178,8 +178,9 @@ If you didn't use Terraform, then you must manually update the `[redpanda]` sect
 [,ini]
 ----
 [redpanda]
-ip ansible_user=ssh_user ansible_become=True private_ip=pip id=0
-ip ansible_user=ssh_user ansible_become=True private_ip=pip id=1
+ip ansible_user=ssh_user ansible_become=True private_ip=pip
+ip ansible_user=ssh_user ansible_become=True private_ip=pip
+ip ansible_user=ssh_user ansible_become=True private_ip=pip
 
 [monitor]
 ip ansible_user=ssh_user ansible_become=True private_ip=pip id=1


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1169
Review deadline: April 4

This pull request includes a small change to the `modules/deploy/pages/deployment-option/self-hosted/manual/production/production-deployment-automation.adoc` file. The change involves updating the `[redpanda]` section to remove the `id` field from the IP configurations and add an extra broker.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
