### PR TITLE
Provide upgrade instructions for Redpanda Console

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -90,7 +90,7 @@
 ** xref:manage:kubernetes/k-upgrade-kubernetes.adoc[Migrate Node Pools]
 ** xref:upgrade:deprecated/index.adoc[Deprecated Features]
 ** xref:upgrade:migrate/index.adoc[Migrate]
-*** xref:upgrade:migrate/console-v3.adoc[Migrate to Redpanda Console v3]
+*** xref:upgrade:migrate/console-v3.adoc[Migrate to Redpanda Console v3.0.x]
 *** xref:upgrade:migrate/data-migration.adoc[]
 *** xref:upgrade:migrate/kubernetes/helm-to-operator.adoc[]
 *** xref:upgrade:migrate/kubernetes/operator.adoc[]

--- a/modules/upgrade/pages/migrate/console-v3.adoc
+++ b/modules/upgrade/pages/migrate/console-v3.adoc
@@ -2,7 +2,7 @@
 :page-console-config-migrator: true
 :page-role: enable-ace-editor
 
-This guide provides step-by-step instructions for migrating from Redpanda Console v2.x.x (v2) to v3.x.x (v3). The new release introduces user impersonation to unify authentication and authorization between Redpanda Console and Redpanda, along with several breaking changes. This guide explains these changes and provides examples to help you update your configuration.
+This guide provides step-by-step instructions for migrating from Redpanda Console v2.x.x (v2) to v3.0.x (v3). The new release introduces user impersonation to unify authentication and authorization between Redpanda Console and Redpanda, along with several breaking changes. This guide explains these changes and provides examples to help you update your configuration.
 
 For details on the new authentication and authorization system, see xref:console:config/security/authentication.adoc[]. For a list of breaking changes, see xref:get-started:whats-new.adoc[].
 

--- a/modules/upgrade/pages/rolling-upgrade.adoc
+++ b/modules/upgrade/pages/rolling-upgrade.adoc
@@ -105,6 +105,84 @@ include::partial$rolling-upgrades/disable-maintenance-mode.adoc[]
 
 include::partial$rolling-upgrades/post-upgrade-tasks.adoc[]
 
+== Upgrade Redpanda Console
+
+Before upgrading to Console v3, xref:upgrade:migrate/console-v3.adoc[review the migration guide] to address breaking changes.
+
+[tabs]
+======
+Linux::
++
+--
+For Linux distributions, the process changes according to the distribution:
+
+[tabs]
+====
+Fedora/RedHat::
++
+In the terminal, run:
++
+[,bash]
+----
+sudo yum update redpanda-console -y
+----
+
+Debian/Ubuntu::
++
+In the terminal, run:
++
+[,bash,role="no-wrap"]
+----
+sudo apt-get update && sudo apt-get install --only-upgrade redpanda-console -y
+----
+
+====
+--
+
+Docker::
++
+--
+
+CAUTION: Running Redpanda Console directly on Docker is not supported for production usage. Docker should only be used for testing.
+
+To perform an upgrade you must replace the current image with a new one.
+
+. Check which image is currently running in Docker:
++
+```bash
+docker ps
+```
+
+. Stop and remove the current container:
++
+```bash
+docker stop <container-id>
+docker rm <container-id>
+```
+
+. Remove the existing Docker image:
++
+```bash
+docker rmi <image-id>
+```
+
+. Pull the desired Redpanda version, or adjust the setting to `latest` in the `version` tag:
++
+```bash
+docker pull docker.redpanda.com/redpandadata/console:<version>
+```
+
+. Restart the Docker container using the new image:
++
+```bash
+docker run -d --name <container-name> docker.redpanda.com/redpandadata/console:<version>
+```
+
+For more information, see the xref:get-started:quick-start.adoc[Redpanda Quickstart].
+
+--
+======
+
 == Troubleshooting
 
 include::troubleshoot:partial$errors-and-solutions.adoc[tags=deployment]

--- a/modules/upgrade/pages/rolling-upgrade.adoc
+++ b/modules/upgrade/pages/rolling-upgrade.adoc
@@ -107,7 +107,7 @@ include::partial$rolling-upgrades/post-upgrade-tasks.adoc[]
 
 == Upgrade Redpanda Console
 
-Before upgrading to Console v3, xref:upgrade:migrate/console-v3.adoc[review the migration guide] to address breaking changes.
+Before upgrading to Console v3.0.x, xref:upgrade:migrate/console-v3.adoc[review the migration guide] to address breaking changes.
 
 [tabs]
 ======
@@ -165,7 +165,7 @@ docker rm <container-id>
 docker rmi <image-id>
 ```
 
-. Pull the desired Redpanda version, or adjust the setting to `latest` in the `version` tag:
+. Pull the desired Redpanda version. Replace `<version>` with the version you want to upgrade to:
 +
 ```bash
 docker pull docker.redpanda.com/redpandadata/console:<version>

--- a/modules/upgrade/pages/rolling-upgrade.adoc
+++ b/modules/upgrade/pages/rolling-upgrade.adoc
@@ -143,7 +143,6 @@ Docker::
 +
 --
 
-CAUTION: Running Redpanda Console directly on Docker is not supported for production usage. Docker should only be used for testing.
 
 To perform an upgrade you must replace the current image with a new one.
 

--- a/modules/upgrade/partials/incompat-changes.adoc
+++ b/modules/upgrade/partials/incompat-changes.adoc
@@ -1,5 +1,7 @@
 === Review incompatible changes
 
+* Redpanda Console v3.0.0 introduces breaking changes. If you are using Redpanda Console v2.x, xref:upgrade:migrate/console-v3.adoc[review the migration guide] to address breaking changes before upgrading Redpanda Console.
+
 * Starting in version 24.2, when managing configuration properties using the AlterConfigs API directly, Redpanda resets all unspecified values to the default values. This aligns more closely with the behavior in Apache Kafka. There is no change if you're managing your configuration with tools like `rpk`, Redpanda Console, Kubernetes, Helm, or Terraform. 
 +
 NOTE: This does not pertain to the `redpanda.remote.` topic properties, such as `redpanda.remote.delete`. The remote properties are not reset to their defaults by the AlterConfigs API to avoid the possibility of unintentionally disabling Tiered Storage for a topic, which could cause significant operational issues for clusters designed to use Tiered Storage exclusively or with object storage as the only durable storage tier.


### PR DESCRIPTION
## Description

Review deadline: April 4

This pull request includes updates to the documentation for upgrading Redpanda Console and reviewing incompatible changes. The most important changes include the addition of detailed upgrade instructions for Redpanda Console and a note about breaking changes introduced in Redpanda Console v3.0.0.

### Documentation updates:

* [`modules/upgrade/pages/rolling-upgrade.adoc`](diffhunk://#diff-b378c30d2cbc11c0c7a7942845a29f0005cd87d2f82c0da2b4fc2c5c8d9ec592R108-R185): Added a new section with detailed instructions on how to upgrade Redpanda Console, including steps for Linux distributions and Docker.

* [`modules/upgrade/partials/incompat-changes.adoc`](diffhunk://#diff-a21ae59ea7c30d8d3321abb627d4a912fc34629bebac351e79a15ea126a3cd06R3-R4): Included a note about breaking changes introduced in Redpanda Console v3.0.0 and a reference to the migration guide for users upgrading from Redpanda Console v2.x.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
