### PR TITLE
Clarify which metrics become available when property is enabled

### DIFF
--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -1184,6 +1184,8 @@ Enable idempotent producers.
 
 Enable exporting of some host metrics like `/proc/diskstats`, `/proc/snmp` and `/proc/net/netstat`.
 
+Host metrics are prefixed with xref:reference:internal-metrics-reference.adoc#vectorized_host_diskstats_discards[`vectorized_host`] and are available on the `/metrics` endpoint.
+
 *Requires restart:* Yes
 
 *Visibility:* `tunable`


### PR DESCRIPTION
## Description

Review deadline: April 4

This pull request includes a change to the `modules/reference/pages/properties/cluster-properties.adoc` file. The change adds information about the prefix for host metrics and their availability on the `/metrics` endpoint.

Documentation update:

* [`modules/reference/pages/properties/cluster-properties.adoc`](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R1187-R1188): Added information about the prefix for host metrics and their availability on the `/metrics` endpoint.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
