### PR TITLE
Update whats-new.adoc for pause and resume

### DIFF
--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -72,6 +72,10 @@ Support for https://protobuf.dev/reference/protobuf/google.protobuf/[Protobuf we
 
 You now can configure Kafka clients to authenticate using xref:manage:security/authentication#enable-sasl.adoc[SASL/PLAIN] with a single account using the same username and password. Unlike SASL/SCRAM, which uses a challenge response with hashed credentials, SASL/PLAIN transmits plaintext passwords. You enable SASL/PLAIN by appending `PLAIN` to the list of SASL mechanisms.
 
+== Pause and resume uploads
+
+Redpanda now supports xref:manage:tiered-storage.adoc#pause-and-resume-uploads[pausing and resuming uploads] to object storage when running Tiered Storage, with no risk to data consistency or data loss. You can use the xref:reference:properties/object-storage-properties.adoc#cloud_storage_enable_segment_uploads[`cloud_storage_enable_segment_uploads`] property to pause or resume uploads to help you troubleshoot any issues that  occur in your cluster during uploads. 
+
 == Metrics
 
 The following metrics are new in this version:


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews
https://deploy-preview-1053--redpanda-docs-preview.netlify.app/25.1/get-started/whats-new/#pause-and-resume-uploads

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
