### PR TITLE
Add beta docs to the local build

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
+    branches: [v/*, beta, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
     branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs


### PR DESCRIPTION
## Description

This pull request includes a small change to the `local-antora-playbook.yml` file. The change updates the branches list for the `redpanda-data/docs` repository to include the `beta` branch.

* [`local-antora-playbook.yml`](diffhunk://#diff-430ed78ec72afb78849cef359188c9b20a3dde4623593958cba0dfb974cb2ac9L18-R18): Updated the branches list for the `redpanda-data/docs` repository to include the `beta` branch.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
