### PR TITLE
25.1 GA

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,15 +1,13 @@
 name: ROOT
 title: Self-Managed
 version: 25.1
-display_version: '25.1 Beta'
-prerelease: true
 start_page: home:index.adoc
 nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
     # Date of release in the format YYYY-MM-DD
-    page-release-date: 2024-12-03
+    page-release-date: 2025-04-07
     # Only used in the main branch (latest version)
     page-header-data:
       order: 2
@@ -20,8 +18,8 @@ asciidoc:
     # We try to fetch the latest versions from GitHub at build time
     # --
 
-    full-version: 24.3.9
-    latest-redpanda-tag: 'v24.3.9'
+    full-version: 25.1.1
+    latest-redpanda-tag: 'v25.1.1'
     latest-console-tag: 'v2.8.5'
     latest-release-commit: 'afe1a3f'
     latest-operator-version: 'v2.3.8-24.3.6'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [main, v/*, api, shared, site-search,'!v-end-of-life/*']
+    branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
     branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs


### PR DESCRIPTION
## Description

This pull request includes updates to versioning and branch configurations in the `antora.yml` and `local-antora-playbook.yml` files. The most important changes include updating the release date, version numbers, and modifying branch configurations.

Versioning updates:

* [`antora.yml`](diffhunk://#diff-8d4aad078b0eff4f312f62348b44d8f4b91666db46b69337e60751fb700068f9L4-R10): Updated the `page-release-date` to `2025-04-07` and changed `full-version` and `latest-redpanda-tag` to `25.1.1`. [[1]](diffhunk://#diff-8d4aad078b0eff4f312f62348b44d8f4b91666db46b69337e60751fb700068f9L4-R10) [[2]](diffhunk://#diff-8d4aad078b0eff4f312f62348b44d8f4b91666db46b69337e60751fb700068f9L23-R22)

Branch configuration updates:

* [`local-antora-playbook.yml`](diffhunk://#diff-430ed78ec72afb78849cef359188c9b20a3dde4623593958cba0dfb974cb2ac9L18-R18): Removed the `main` branch from the list of branches to be fetched from the `docs` repository.

## Page previews

https://deploy-preview-1059--redpanda-docs-preview.netlify.app/current/get-started/release-notes/redpanda/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
