### PR TITLE
gha: use role instead of keys for fetch-acceptance-tests.yml

### DIFF
--- a/.github/workflows/fetch-acceptance-tests.yml
+++ b/.github/workflows/fetch-acceptance-tests.yml
@@ -14,9 +14,8 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
       - name: get secrets from aws sm
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:

--- a/.github/workflows/fetch-acceptance-tests.yml
+++ b/.github/workflows/fetch-acceptance-tests.yml
@@ -1,57 +1,52 @@
 ---
-  name: Fetch and Save Kubernetes Acceptance Tests
-  on:
-    workflow_dispatch:  # Allows manual trigger of the workflow
-    repository_dispatch:  # Allows other repositories to trigger this workflow
-      types: [trigger-acceptance-test-pull]
-  jobs:
-    fetch-and-save:
-      runs-on: ubuntu-latest
-      permissions:
-        id-token: write
-        contents: read
-      steps:
-        - name: configure aws credentials
-          uses: aws-actions/configure-aws-credentials@v4
-          with:
-            aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-            aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-            aws-region: us-west-2
-        - name: get secrets from aws sm
-          uses: aws-actions/aws-secretsmanager-get-secrets@v2
-          with:
-            secret-ids: |
-              ,sdlc/prod/github/actions_bot_token
-            parse-json-secrets: true
-
-        - name: Checkout the repository
-          uses: actions/checkout@v4
-          with:
-            ref: main
-            token: ${{ env.ACTIONS_BOT_TOKEN }}
-            path: redpanda-docs
-
-        - name: Set up Node.js
-          uses: actions/setup-node@v4
-          with:
-            node-version: '18'
-
-        - name: Install dependencies
-          run: |
-            cd ./redpanda-docs/scripts/fetch-from-github
-            npm install
-
-        - name: Run the script and save the output
-          run: node ./redpanda-docs/scripts/fetch-from-github/fetch.js redpanda-data redpanda-operator acceptance/features ../../modules/manage/examples/kubernetes
-          env:
-            VBOT_GITHUB_API_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
-
-        - name: Create pull request
-          uses: peter-evans/create-pull-request@v6
-          with:
-            commit-message: "auto-docs: Update K8s acceptance tests"
-            token: ${{ env.ACTIONS_BOT_TOKEN }}
-            branch: update-acceptance-tests
-            title: "auto-docs: Update K8s acceptance tests"
-            body: "This PR auto-updates the acceptance tests we use as examples in our Kubernetes docs."
-            labels: auto-docs
+name: Fetch and Save Kubernetes Acceptance Tests
+on:
+  workflow_dispatch:  # Allows manual trigger of the workflow
+  repository_dispatch:  # Allows other repositories to trigger this workflow
+    types: [trigger-acceptance-test-pull]
+jobs:
+  fetch-and-save:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: get secrets from aws sm
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/actions_bot_token
+          parse-json-secrets: true
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          path: redpanda-docs
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: |
+          cd ./redpanda-docs/scripts/fetch-from-github
+          npm install
+      - name: Run the script and save the output
+        run: node ./redpanda-docs/scripts/fetch-from-github/fetch.js redpanda-data redpanda-operator acceptance/features ../../modules/manage/examples/kubernetes
+        env:
+          VBOT_GITHUB_API_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "auto-docs: Update K8s acceptance tests"
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          branch: update-acceptance-tests
+          title: "auto-docs: Update K8s acceptance tests"
+          body: "This PR auto-updates the acceptance tests we use as examples in our Kubernetes docs."
+          labels: auto-docs

--- a/.github/workflows/fetch-acceptance-tests.yml
+++ b/.github/workflows/fetch-acceptance-tests.yml
@@ -6,7 +6,7 @@ on:
     types: [trigger-acceptance-test-pull]
 jobs:
   fetch-and-save:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DEVPROD-2837
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
