### PR TITLE
Fix GitHub Action

### DIFF
--- a/.github/workflows/fetch-acceptance-tests.yml
+++ b/.github/workflows/fetch-acceptance-tests.yml
@@ -49,3 +49,4 @@ jobs:
           title: "auto-docs: Update K8s acceptance tests"
           body: "This PR auto-updates the acceptance tests we use as examples in our Kubernetes docs."
           labels: auto-docs
+          path: redpanda-docs


### PR DESCRIPTION
## Description

This pull request includes a small change to the `.github/workflows/fetch-acceptance-tests.yml` file. The change adds a `path` field to specify the location of the documentation to be updated. 

* [`.github/workflows/fetch-acceptance-tests.yml`](diffhunk://#diff-c216c35fa7712cd7be675113952c46180328dde7d438e5cac626bf5ad2f39919R52): Added `path: redpanda-docs` to specify the location of the documentation to be updated.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
