### PR TITLE
Add Crash recording to What's New

### DIFF
--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -9,7 +9,7 @@ This topic includes new content added in version {page-component-version}. For a
 
 == Crash recording for improved support
 
-Redpanda now records detailed information about broker crashes to help streamline troubleshooting and reduce time to resolution. Crash reports include information such as a stack trace, exception details, the Redpanda broker version, and the timestamp of when the crash occurred. The recorded crash reports are now automatically collected as part of debug bundles, providing Redpanda customer support with more context to diagnose and resolve issues faster.
+Redpanda now records detailed information about broker crashes to help streamline troubleshooting and reduce time to resolution. Crash reports include information such as a stack trace, exception details, the Redpanda broker version, and the timestamp of when the crash occurred. The recorded crash reports are now automatically collected as part of xref:troubleshoot:debug-bundle/overview.adoc[debug bundles], providing Redpanda customer support with more context to diagnose and resolve issues faster.
 
 == New health probes for broker restarts and upgrades
 

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -7,6 +7,10 @@ This topic includes new content added in version {page-component-version}. For a
 * xref:redpanda-cloud:get-started:whats-new-cloud.adoc[]
 * xref:redpanda-cloud:get-started:cloud-overview.adoc#redpanda-cloud-vs-self-managed-feature-compatibility[Redpanda Cloud vs Self-Managed feature compatibility]
 
+== Crash recording for improved support
+
+Redpanda now records detailed information about broker crashes to help streamline troubleshooting and reduce time to resolution. Crash reports include information such as a stack trace, exception details, the Redpanda broker version, and the timestamp of when the crash occurred. The recorded crash reports are now automatically collected as part of debug bundles, providing Redpanda customer support with more context to diagnose and resolve issues faster.
+
 == New health probes for broker restarts and upgrades
 
 The Redpanda Admin API now includes new health probes to help you ensure safe broker restarts and upgrades. The xref:api:ROOT:admin-api.adoc#get-/v1/broker/pre_restart_probe[`pre_restart_probe`] endpoint identifies potential risks if a broker is restarted, and xref:api:ROOT:admin-api.adoc#get-/v1/broker/post_restart_probe[`post_restart_probe`] indicates how much of its workloads a broker has reclaimed after the restart. See also:

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -110,6 +110,14 @@ Reports the total number of bytes read from or written to the partitions of a to
 - xref:reference:public-metrics-reference.adoc#redpanda_cloud_storage_paused_archivers[`redpanda_cloud_storage_paused_archivers`]:
 Reports the number of paused archivers.
 
+== rpk commands
+
+The following `rpk` commands are new in this version:
+
+- xref:reference:rpk/rpk-generate/rpk-generate-license.adoc[`rpk generate license`]
+
+- xref:reference:rpk/rpk-topic/rpk-topic-analyze.adoc[`rpk topic analyze`]
+
 == Cluster properties
 
 The following cluster properties are new in this version:


### PR DESCRIPTION
## Description
This pull request includes an update to the Redpanda release notes to document new features and improvements. The most important change is the addition of detailed crash recording to aid in troubleshooting and support.

We added `crash_loop_sleep_sec` in this PR https://github.com/redpanda-data/docs/pull/966 but the rest of the changes related to this feature are in 25.1 only. 

New features:

* Added a section on crash recording that details how Redpanda now records information about broker crashes, including stack traces, exception details, broker version, and timestamps. This information is automatically collected as part of debug bundles to help Redpanda customer support diagnose and resolve issues more quickly. (`modules/get-started/pages/release-notes/redpanda.adoc`)

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 8 April

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
