### PR TITLE
What's New- Trial license

### DIFF
--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -80,6 +80,10 @@ You now can configure Kafka clients to authenticate using xref:manage:security/a
 
 Redpanda now supports xref:manage:tiered-storage.adoc#pause-and-resume-uploads[pausing and resuming uploads] to object storage when running Tiered Storage, with no risk to data consistency or data loss. You can use the xref:reference:properties/object-storage-properties.adoc#cloud_storage_enable_segment_uploads[`cloud_storage_enable_segment_uploads`] property to pause or resume uploads to help you troubleshoot any issues that  occur in your cluster during uploads. 
 
+== Trial license 
+
+All new Redpanda clusters automatically receive a xref:manage:tiered-storage.adoc#pause-and-resume-uploads[trial license] valid for 30 days. You can extend this trial for 30 days using the new xref:reference:rpk/rpk-generate/rpk-generate-license.adoc[`rpk generate license`] command.
+
 == Metrics
 
 The following metrics are new in this version:

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -82,7 +82,7 @@ Redpanda now supports xref:manage:tiered-storage.adoc#pause-and-resume-uploads[p
 
 == Trial license 
 
-All new Redpanda clusters automatically receive a xref:manage:tiered-storage.adoc#pause-and-resume-uploads[trial license] valid for 30 days. You can extend this trial for 30 days using the new xref:reference:rpk/rpk-generate/rpk-generate-license.adoc[`rpk generate license`] command.
+All new Redpanda clusters automatically receive a xref:get-started:licensing/overview.adoc#trial-license[trial license] valid for 30 days. You can extend this trial for 30 days using the new xref:reference:rpk/rpk-generate/rpk-generate-license.adoc[`rpk generate license`] command.
 
 == Metrics
 


### PR DESCRIPTION
## Description

Resolves: Adds description of Trial license feature from 25.1 to the What's New topic.
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
