### PR TITLE
Update the Kubernetes versioning scheme

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -23,8 +23,8 @@ asciidoc:
     latest-console-tag: 'v2.8.5'
     latest-release-commit: 'afe1a3f'
     latest-operator-version: 'v2.3.8-24.3.6'
-    operator-beta-tag: 'v25.1-k8s1-beta1'
-    helm-beta-tag: 'v25.1-k8s1-beta1'
+    operator-beta-tag: 'v25.1.1-beta1'
+    helm-beta-tag: 'v25.1.1-beta1'
     latest-redpanda-helm-chart-version: 5.10.1
     redpanda-beta-version: '25.1.1-rc3'
     redpanda-beta-tag: '25.1.1-rc3'

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-25.1-beta.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-25.1-beta.adoc
@@ -10,7 +10,7 @@ This beta version is available for testing and feedback. It is not supported by 
 
 Make sure that your Kubernetes cluster meets the xref:./k-requirements.adoc[requirements].
 
-== Install Redpanda Operator v25.1-k8s1-beta1
+== Install Redpanda Operator v25.1.1-beta1
 
 The Redpanda Operator is namespace scoped. You must install the Redpanda Operator in the same namespace as your Redpanda resource (Redpanda cluster).
 
@@ -126,7 +126,7 @@ kubectl get pod --namespace <namespace>
 If it's taking too long, see xref:manage:kubernetes/troubleshooting/k-troubleshoot.adoc[Troubleshooting].
 
 
-== Install the Redpanda Helm chart v25.1-k8s1-beta1
+== Install the Redpanda Helm chart v25.1.1-beta1
 
 . Install cert-manager using Helm:
 +

--- a/modules/get-started/pages/release-notes/helm-charts.adoc
+++ b/modules/get-started/pages/release-notes/helm-charts.adoc
@@ -12,7 +12,7 @@ See also:
 * xref:upgrade:k-compatibility.adoc[]
 * xref:upgrade:k-rolling-upgrade.adoc[]
 
-== Redpanda chart v25.1-k8s1-beta1
+== Redpanda chart v25.1.1-beta1
 
 link:https://github.com/redpanda-data/redpanda-operator/blob/release/v25.1.x/charts/redpanda/CHANGELOG.md[Changelog^].
 

--- a/modules/get-started/pages/release-notes/operator.adoc
+++ b/modules/get-started/pages/release-notes/operator.adoc
@@ -9,7 +9,7 @@ See also:
 * xref:upgrade:k-compatibility.adoc[]
 * xref:upgrade:k-rolling-upgrade.adoc[]
 
-== Redpanda Operator v25.1-k8s1-beta1
+== Redpanda Operator v25.1.1-beta1
 
 link:https://github.com/redpanda-data/redpanda-operator/blob/release/v25.1.x/operator/CHANGELOG.md[Changelog^].
 

--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -10,13 +10,15 @@ include::partial$versioning.adoc[]
 
 The Redpanda Helm chart and Redpanda Operator are versioned and tested alongside specific Redpanda core releases, Kubernetes, and Helm.
 
-Starting from version v25.1-k8s1-beta1, the Redpanda Operator and Redpanda Helm chart follow a new versioning scheme aligned with Redpanda core releases:
+Starting from version v25.1.1-beta1, the Redpanda Operator and Redpanda Helm chart follow a new versioning scheme aligned with Redpanda core releases:
 
 - `v25.1` refers to the Redpanda core feature release deployed by default.
 
-- The suffix `-k8s<number>` denotes the Kubernetes-specific version, where `<number>` is the unique patch version for either the operator or Helm chart.
+- The patch version denotes the patch version for either the operator or Helm chart. It is not the patch version of Redpanda core.
 
-Each Redpanda Operator and Helm chart version supports the corresponding Redpanda core version plus one minor version above and one below. This approach ensures flexibility and ease during upgrades. For example, Redpanda Operator version 25.1-k8sx supports Redpanda core versions 25.2.x, 25.1.x, and 24.3.x.
+- The beta version is used for pre-release versions of the Redpanda Operator and Helm chart. These versions are not intended for production use.
+
+Each Redpanda Operator and Helm chart version supports the corresponding Redpanda core version plus one minor version above and one below. This approach ensures flexibility during upgrades. For example, Redpanda Operator version 25.1.1 supports Redpanda core versions 25.2.x, 25.1.x, and 24.3.x.
 
 Redpanda Operator and Helm chart versions are supported only while their associated Redpanda core version remains supported. If the core version reaches End-of-Life (EoL), the corresponding Operator and Helm chart versions also reach EoL.
 
@@ -36,9 +38,9 @@ NOTE: Beta versions are available only for testing and feedback. They are not su
 // |1.30.x - 1.33.x
 
 |25.1.x
-|25.1-k8s-beta, 5.10.x, 5.9.x
-|25.1-k8s-beta, 0.4.41, 0.4.36
-|25.1-k8s-beta, 2.4.x, 2.3.x
+|25.1.1-beta1, 5.10.x, 5.9.x
+|25.1.1-beta1, 0.4.41, 0.4.36
+|25.1.1-beta1, 2.4.x, 2.3.x
 |3.12+
 |1.29.x - 1.32.x
 
@@ -72,8 +74,8 @@ This interdependency is established when you add or update the Redpanda chart re
 |Redpanda Console |Helm Chart |Operator
 
 |v3.x.x
-|v25.1-k8s-beta
-|v25.1-k8s-beta
+|v25.1.1-beta1
+|v25.1.1-beta1
 
 |v2.x.x
 | 5.10.1, 5.9.x, 5.8.x


### PR DESCRIPTION
## Description

Review deadline: April 9

This pull request includes updates to the versioning scheme for the Redpanda Operator and Helm chart in various documentation files. The changes primarily involve updating the version numbers to a new beta version format.

Version updates:

* [`antora.yml`](diffhunk://#diff-8d4aad078b0eff4f312f62348b44d8f4b91666db46b69337e60751fb700068f9L26-R27): Updated `operator-beta-tag` and `helm-beta-tag` to `v25.1.1-beta1`.
* [`modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-25.1-beta.adoc`](diffhunk://#diff-ea1a0260a0819af1e6f1b107447c267aaa22424dfde7b890602a718be391ab18L13-R13): Updated installation instructions to use Redpanda Operator and Helm chart version `v25.1.1-beta1`. [[1]](diffhunk://#diff-ea1a0260a0819af1e6f1b107447c267aaa22424dfde7b890602a718be391ab18L13-R13) [[2]](diffhunk://#diff-ea1a0260a0819af1e6f1b107447c267aaa22424dfde7b890602a718be391ab18L129-R129)
* [`modules/get-started/pages/release-notes/helm-charts.adoc`](diffhunk://#diff-4526c926bda17e53d9faf0c5c77602a4e495cdfbb1897b92ffc331bcf55bddb0L15-R15): Updated release notes to reflect Redpanda chart version `v25.1.1-beta1`.
* [`modules/get-started/pages/release-notes/operator.adoc`](diffhunk://#diff-0c17f8d6fb880def78dd4822f5c284765162bc2ce03a8455590461c6b340c295L12-R12): Updated release notes to reflect Redpanda Operator version `v25.1.1-beta1`.
* [`modules/upgrade/pages/k-compatibility.adoc`](diffhunk://#diff-93aafe1b444825c515ad00c3bc0535a80cd07b12c929d172ac39af8f84f91a0bL13-R21): Updated compatibility documentation to reflect the new versioning scheme and version `v25.1.1-beta1`. [[1]](diffhunk://#diff-93aafe1b444825c515ad00c3bc0535a80cd07b12c929d172ac39af8f84f91a0bL13-R21) [[2]](diffhunk://#diff-93aafe1b444825c515ad00c3bc0535a80cd07b12c929d172ac39af8f84f91a0bL39-R43) [[3]](diffhunk://#diff-93aafe1b444825c515ad00c3bc0535a80cd07b12c929d172ac39af8f84f91a0bL75-R78)

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
