### PR TITLE
DOC-1218 Iceberg in Cloud prereq 25.1

### DIFF
--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -31,7 +31,7 @@ When you enable the Iceberg integration for a Redpanda topic, Redpanda brokers s
 To enable Iceberg for Redpanda topics, you must have the following:
 
 ifdef::env-cloud[]
-* A running xref:get-started:cluster-types/byoc/index.adoc[BYOC] cluster. The Iceberg integration is supported only for BYOC.
+* A running xref:get-started:cluster-types/byoc/index.adoc[BYOC] cluster on Redpanda version 25.1 or later. The Iceberg integration is supported only for BYOC, and the cluster properties to configure Iceberg are available with v25.1.
 * rpk: See xref:get-started:rpk-install.adoc[].
 * Familiarity with the Redpanda Cloud API. You must xref:redpanda-cloud:manage:api/cloud-api-authentication.adoc[authenticate] to the Cloud API and use the Control Plane API to update your cluster configuration.
 endif::[]


### PR DESCRIPTION
## Description

Update to Iceberg integration requirements:

* [`modules/manage/partials/iceberg/about-iceberg-topics.adoc`](diffhunk://#diff-ea5033692607173dad8ffa11b9e530bac4ee1d40279f0f826c446e7e75582c12L34-R34): Updated the requirement to specify that a BYOC cluster must be running on Redpanda version 25.1 or later for Iceberg integration, and clarified that the cluster properties to configure Iceberg are available with version 25.1.

(Since this is in docs repo, it needed a separate PR. Related to https://github.com/redpanda-data/cloud-docs/pull/255.)

Resolves [https://redpandadata.atlassian.net/browse/<jira-ticket>](https://redpandadata.atlassian.net/browse/DOC-1218)
Review deadline:

## Page previews
[Iceberg in Cloud Prereqs](https://deploy-preview-1070--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/about-iceberg-topics/#prerequisites)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)
