### PR TITLE
DOC-1171 Add FIPS to RPCN licensed features

### DIFF
--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -210,6 +210,10 @@ The following enterprise features are available with a valid Enterprise Edition 
 | Additional inputs, outputs, and processors available only to enterprise customers.
 | All enterprise connectors are blocked.
 
+| xref:redpanda-connect:get-started:quickstarts/rpk.adoc#fips-compliance[FIPS compliance]
+| Run Redpanda Connect using a FIPS-compliant version of `rpk`, the Redpanda command-line interface (CLI).
+| No change.
+
 | xref:redpanda-connect:components:redpanda/about.adoc[Redpanda Connect configuration service]
 | A configuration block that you can use to send logs and status events to a topic on a Redpanda cluster.
 | No change.


### PR DESCRIPTION
## Description

Resolves [DOC-1171](https://redpandadata.atlassian.net/browse/DOC-1171)
Review deadline: 11th April

This pull request includes an update to the `modules/get-started/pages/licensing/overview.adoc` file to add information about FIPS compliance for Redpanda Connect.

Key change:

* Added a new entry under enterprise features to indicate that Redpanda Connect can be run using a FIPS-compliant version of `rpk`, the Redpanda command-line interface (CLI).

## Page previews

[Editions and Enterprise Features](https://deploy-preview-1072--redpanda-docs-preview.netlify.app/current/get-started/licensing/overview/#connect)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)


[DOC-1171]: https://redpandadata.atlassian.net/browse/DOC-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ