### PR TITLE
Fix Console migration guide

### DIFF
--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -107,7 +107,7 @@ Here is an example configuration for **runtime acquisition mode**:
 [,yaml]
 ----
 authentication:
-  jwtSigningSecret: "<secret-key>"  <1>
+  jwtSigningKey: "<secret-key>"  <1>
   useSecureCookies: true  <2>
   oidc:
     enabled: true  <3>
@@ -125,7 +125,7 @@ authentication:
     prompt: "consent"  <10>
 ----
 
-<1> `authentication.jwtSigningSecret` (required): The secret key for signing JWTs. Keep it confidential. It must be at least 32 characters long. Use xref:console:config/configure-console.adoc#environment-variables[environment variables] or command-line flags for sensitive data.
+<1> `authentication.jwtSigningKey` (required): The secret key for signing JWTs. Keep it confidential. It must be at least 32 characters long. Use xref:console:config/configure-console.adoc#environment-variables[environment variables] or command-line flags for sensitive data.
 <2> `authentication.useSecureCookies`: A boolean flag indicating whether session cookies should be marked as secure. This should be set to true in production environments to enforce HTTPS.
 <3> `authentication.oidc.enabled` (required): Enables OIDC-based authentication. When enabled, external identity providers can be used for single sign-on.
 <4> `authentication.oidc.issuerUrl` (required): The URL of the OIDC identity provider.
@@ -141,7 +141,7 @@ Here is an example configuration for **static token mode**:
 [,yaml]
 ----
 authentication:
-  jwtSigningSecret: "<secret-key>"
+  jwtSigningKey: "<secret-key>"
   useSecureCookies: true
   oidc:
     enabled: true
@@ -175,7 +175,7 @@ authentication:
   basic:
     enabled: true <3>
 ----
-<1> `authentication.jwtSigningSecret` (required): The secret key for signing JWTs. Keep it confidential. Minimum 32 characters. Use xref:console:config/configure-console.adoc#environment-variables[environment variables] or command-line flags for sensitive data.
+<1> `authentication.jwtSigningKey` (required): The secret key for signing JWTs. Keep it confidential. Minimum 32 characters. Use xref:console:config/configure-console.adoc#environment-variables[environment variables] or command-line flags for sensitive data.
 <2> `authentication.useSecureCookies`: A boolean flag indicating whether the JWT cookie should be marked as secure. Set to true in production to enforce HTTPS.
 <3> `authentication.basic.enabled` (required): Enables or disables basic (username/password) authentication. When enabled, credentials are mapped to SASL-SCRAM for Kafka.
 

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -202,7 +202,7 @@ Suppose you're asked to find all transactions related to the `.edu` domain. You 
 // (step {"action":"find", "selector": "[data-testid='add-topic-filter-javascript']", "matchText": "JavaScript Filter", "click": true, "timeout": 10000})
 . Give your filter a name, such as "Find .edu domains".
 // (step {"action":"find", "selector": "[data-testid='add-javascript-filter-name']", "typeKeys": "Find .edu domains", "click": true, "timeout": 10000})
-// (step {"action":"saveScreenshot", "path": "js-filter.png", "directory": "../../modules/console/images", "overwrite": "byVariation", "maxVariation": 10})
+// (step {"action":"saveScreenshot", "path": "js-filter.png", "directory": "../../modules/console/images", "overwrite": "byVariation", "maxVariation": 30})
 +
 image::console:js-filter.png[]
 

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -32,7 +32,7 @@ See xref:console:config/security/authentication.adoc[] for more information.
 
 * **Authentication and authorization:**
   - Renamed the `login` stanza to `authentication`.
-  - Renamed `login.jwtSecret` to `authentication.jwtSigningSecret`.
+  - Renamed `login.jwtSecret` to `authentication.jwtSigningKey`.
   - Removed the plain login provider.
   - OIDC group-based authorization is no longer supported.
   - Role bindings must now be configured in the `authorization.roleBindings` stanza (no longer stored in a separate file).
@@ -52,7 +52,7 @@ See xref:console:config/security/authentication.adoc[] for more information.
   - Renamed the `connect` stanza to `kafkaConnect` to avoid ambiguity with Redpanda Connect.
 
 * **Console settings:**
-  - Moved `console.maxDeserializationPayloadSize` to `serde.console.maxDeserializationPayloadSize`.
+  - Moved `console.maxDeserializationPayloadSize` to `serde.maxDeserializationPayloadSize`.
 
 *Action required*: xref:upgrade:migrate/console-v3.adoc[].
 

--- a/modules/shared/attachments/redpanda-console-config.yaml
+++ b/modules/shared/attachments/redpanda-console-config.yaml
@@ -82,7 +82,7 @@ schemaRegistry:
 # Console authentication
 #----------------------------------------------------------------------------
 authentication:
-  jwtSigningSecret: "secret-value"
+  jwtSigningKey: "secret-value"
   useSecureCookies: true
   # Optionally enable cookie chunking if cookie size is an issue.
   # useCookieChunking: false

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -285,7 +285,7 @@ See xref:upgrade:migrate/console-v3.adoc[].
 
 | v3.0.0
 | `login.jwtSecret`
-| The field `login.jwtSecret` has been renamed to `authentication.jwtSigningSecret` to reflect its purpose more accurately.
+| The field `login.jwtSecret` has been renamed to `authentication.jwtSigningKey` to reflect its purpose more accurately.
 
 | v3.0.0
 | Group-based authorization through OIDC

--- a/modules/upgrade/pages/migrate/console-v3.adoc
+++ b/modules/upgrade/pages/migrate/console-v3.adoc
@@ -58,7 +58,7 @@ schemaRegistry:
   authentication:
     impersonateUser: true
 authentication:  <2>
-  jwtSigningSecret: "secret-key"
+  jwtSigningKey: "secret-key"
   useSecureCookies: false
   basic:
     enabled: true  <3>
@@ -99,7 +99,7 @@ redpanda:
         password: "some-other-secret-password"
       #bearerToken: "example-bearer-token" # For OAuth2 bearer token
 authentication:
-  jwtSigningSecret: "secret-key"
+  jwtSigningKey: "secret-key"
   useSecureCookies: false
   basic:
     enabled: true
@@ -155,7 +155,7 @@ kafka:
     enabled: true
     impersonateUser: true <1>
 authentication: <2>
-  jwtSigningSecret: "old-google-secret"
+  jwtSigningKey: "old-google-secret"
   useSecureCookies: true
   oidc: <3>
     enabled: true
@@ -289,6 +289,7 @@ connect:
 [source,yaml,role="no-wrap"]
 ----
 serde:
+  maxDeserializationPayloadSize: 20480
   protobuf:
     enabled: false
     mappings: []
@@ -296,8 +297,6 @@ serde:
     enabled: false
   messagePack:
     enabled: false
-  console:
-    maxDeserializationPayloadSize: 20480
 kafkaConnect:
   enabled: false
   clusters: []


### PR DESCRIPTION
## Description

Review deadline: April 15

This pull request includes several changes to the `Redpanda Console` configuration documentation to improve clarity and accuracy. The main changes involve renaming configuration keys and updating references to reflect these changes.

Key changes:

### Configuration Key Updates:
* Renamed `jwtSigningSecret` to `jwtSigningKey` across various configuration examples and descriptions. [[1]](diffhunk://#diff-dcbd0b62522d079543df3fcf768c3a70f48179666d1073a06ee77482a60e85e3L110-R110) [[2]](diffhunk://#diff-dcbd0b62522d079543df3fcf768c3a70f48179666d1073a06ee77482a60e85e3L128-R128) [[3]](diffhunk://#diff-dcbd0b62522d079543df3fcf768c3a70f48179666d1073a06ee77482a60e85e3L144-R144) [[4]](diffhunk://#diff-dcbd0b62522d079543df3fcf768c3a70f48179666d1073a06ee77482a60e85e3L178-R178) [[5]](diffhunk://#diff-a640eeccc6b9d0796d18721890740d7a13c82aa258ae0ccace7597c4baa7f68dL85-R85) [[6]](diffhunk://#diff-4c3393212764a124c47b6ecc7e338c16ba61dd2ed229c1fbe92f47926c08b6f9L61-R61) [[7]](diffhunk://#diff-4c3393212764a124c47b6ecc7e338c16ba61dd2ed229c1fbe92f47926c08b6f9L102-R102) [[8]](diffhunk://#diff-4c3393212764a124c47b6ecc7e338c16ba61dd2ed229c1fbe92f47926c08b6f9L158-R158)

### Documentation Updates:
* Updated the release notes to reflect the renaming of the `jwtSigningSecret` to `jwtSigningKey`.
* Updated the migration guide to reflect the renaming of the `jwtSigningSecret` to `jwtSigningKey`.

### Other Configuration Changes:
* Moved `console.maxDeserializationPayloadSize` to `serde.maxDeserializationPayloadSize`. [[1]](diffhunk://#diff-fc3054c55a548a4251d6c9e7fbaf1ed2d657cfcba83ea857e47c52f70a79829eL55-R55) [[2]](diffhunk://#diff-4c3393212764a124c47b6ecc7e338c16ba61dd2ed229c1fbe92f47926c08b6f9R292-L300)

Related: https://github.com/redpanda-data/docs-ui/pull/278

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
