### PR TITLE
Fix error with indentation in spec

### DIFF
--- a/modules/ROOT/attachments/cloud-dataplane-api.yaml
+++ b/modules/ROOT/attachments/cloud-dataplane-api.yaml
@@ -1178,7 +1178,7 @@ components:
           type: object
         url:
           description: |-
-         URL to connect to the pipeline, for example, using http_server.
+            URL to connect to the pipeline, for example, using http_server.
             May be empty if no http_server is used.
           type: string
       required:


### PR DESCRIPTION
## Description

Fix "Unable to load spec" error

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 15 Apr

## Page previews

https://deploy-preview-1077--redpanda-docs-preview.netlify.app/api/cloud-dataplane-api/#overview

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
