### PR TITLE
Add new Iceberg oauth2 config

### DIFF
--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -83,7 +83,7 @@ endif::[]
 
 == Integrate filesystem-based catalog (`object_storage`)
 
-By default, Iceberg topics use the filesystem-based catalog (config_ref:iceberg_catalog_type,true,properties/cluster-properties[`iceberg_catalog_type`] cluster property set to `object_storage`). Redpanda stores the table metadata in hhttps://iceberg.apache.org/docs/latest/java-api-quickstart/#using-a-hadoop-catalog[HadoopCatalog^] format in the same object storage bucket or container as the data files.
+By default, Iceberg topics use the filesystem-based catalog (config_ref:iceberg_catalog_type,true,properties/cluster-properties[`iceberg_catalog_type`] cluster property set to `object_storage`). Redpanda stores the table metadata in https://iceberg.apache.org/docs/latest/java-api-quickstart/#using-a-hadoop-catalog[HadoopCatalog^] format in the same object storage bucket or container as the data files.
 
 If using the `object_storage` catalog type, you provide the object storage URI of the table's `metadata.json` file to an Iceberg client so it can access the catalog and data files for your Redpanda Iceberg tables.
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2125,6 +2125,27 @@ The OAuth URI used to retrieve access tokens for Iceberg REST catalog authentica
 
 // end::iceberg_rest_catalog_oauth2_server_uri[]
 
+// tag::iceberg_rest_catalog_oauth2_scope[]
+=== iceberg_rest_catalog_oauth2_scope
+
+The OAuth scope used to retrieve access tokens for Iceberg catalog authentication. Only meaningful when `iceberg_rest_catalog_authentication_mode` is set to `oauth2`.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `principal_role:all`
+
+**Related topics**:
+
+- xref:manage:iceberg/use-iceberg-catalogs.adoc[]
+
+---
+
+// end::iceberg_rest_catalog_oauth2_scope[]
+
 // tag::iceberg_rest_catalog_prefix[]
 === iceberg_rest_catalog_prefix
 


### PR DESCRIPTION
## Description

This pull request includes updates to the documentation for configuring Iceberg catalogs in Redpanda. The changes primarily involve corrections and additions to the `use-iceberg-catalogs.adoc` and `cluster-properties.adoc` files.

Documentation updates:

* [`modules/manage/partials/iceberg/use-iceberg-catalogs.adoc`](diffhunk://#diff-8a1d2144ab6d9a2c0149032efbcfcd9bade68a17cd3b60b8a1fd7027881db5f4L86-R86): Corrected a typo in the URL for the HadoopCatalog format link.
* [`modules/reference/pages/properties/cluster-properties.adoc`](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2128-R2148): Added a new section for the `iceberg_rest_catalog_oauth2_scope` property, detailing its purpose, requirements, and related topics.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 16 Apr

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
