### PR TITLE
auto-docs: Update Cloud API spec

### DIFF
--- a/modules/ROOT/attachments/cloud-controlplane-api.yaml
+++ b/modules/ROOT/attachments/cloud-controlplane-api.yaml
@@ -264,6 +264,31 @@ components:
       type: object
     CloudStorage.Azure:
       properties:
+        allowed_ips:
+          description: |-
+            List of public IP or IP ranges in CIDR Format.
+
+            - Only IPv4 addresses are allowed.
+            - Private IP address ranges as defined in RFC 1918 are not allowed.
+            - Small address ranges using "/31" or "/32" prefix sizes are not
+            supported. These ranges should be configured using individual IP
+            address rules without prefix specified.
+            - allowed_ips have no effect on requests originating from the same
+            Azure region as the storage account. Use allowed_subnet_ids to allow
+            same-region requests. Services deployed in the same region as the
+            storage account use private Azure IP addresses for communication. Thus,
+            you cannot allow access to specific Azure services based on their
+            public outbound IP address range.
+          items:
+            type: string
+          type: array
+        allowed_subnet_ids:
+          description: |-
+            A list of virtual network subnet ids that are allowed to access the
+            storage account.
+          items:
+            type: string
+          type: array
         container_name:
           type: string
         resource_group_name:
@@ -2454,7 +2479,7 @@ components:
         update_type:
           items:
             $ref: '#/components/schemas/UpdateClusterType'
-          title: Update operation types based on the properties modified in the cluster
+          title: Update operation types, based on the properties modified in the cluster
           type: array
       title: UpdateClusterMetadata
       type: object
@@ -3157,7 +3182,7 @@ paths:
                     For example, if the name of a tag is "gcp.network-tag.network-tag-foo", the network tag named
                     "network-tag-foo" will be added to the Redpanda cluster GKE nodes.
                     Note: The value of a network tag will be ignored.
-                    See the official [GCP VPC](https://cloud.google.com/vpc/docs/add-remove-network-tags) for more details on network tags.
+                    See the details on network tags at https://cloud.google.com/vpc/docs/add-remove-network-tags.
                   type: object
                 cluster_configuration:
                   $ref: '#/components/schemas/ClusterUpdate.ClusterConfiguration'
@@ -4643,6 +4668,7 @@ paths:
         - description: Display name of the Serverless region
           in: query
           name: name
+          required: true
           schema:
             type: string
       responses:
@@ -4675,6 +4701,7 @@ paths:
         - description: Cloud provider where Serverless region is hosted.
           in: query
           name: cloud_provider
+          required: true
           schema:
             enum:
               - CLOUD_PROVIDER_AWS

--- a/modules/ROOT/attachments/cloud-controlplane-api.yaml
+++ b/modules/ROOT/attachments/cloud-controlplane-api.yaml
@@ -284,7 +284,7 @@ components:
           type: array
         allowed_subnet_ids:
           description: |-
-            A list of virtual network subnet ids that are allowed to access the
+            A list of virtual network subnet IDs that are allowed to access the
             storage account.
           items:
             type: string
@@ -3182,7 +3182,7 @@ paths:
                     For example, if the name of a tag is "gcp.network-tag.network-tag-foo", the network tag named
                     "network-tag-foo" will be added to the Redpanda cluster GKE nodes.
                     Note: The value of a network tag will be ignored.
-                    See the details on network tags at https://cloud.google.com/vpc/docs/add-remove-network-tags.
+                    See the official [GCP VPC](https://cloud.google.com/vpc/docs/add-remove-network-tags) for more details on network tags.
                   type: object
                 cluster_configuration:
                   $ref: '#/components/schemas/ClusterUpdate.ClusterConfiguration'

--- a/modules/ROOT/attachments/cloud-dataplane-api.yaml
+++ b/modules/ROOT/attachments/cloud-dataplane-api.yaml
@@ -1178,7 +1178,7 @@ components:
           type: object
         url:
           description: |-
-            URL to connect to the pipeline, e.g. via http_server.
+            URL to connect to the pipeline, for example, using http_server.
             May be empty if no http_server is used.
           type: string
       required:
@@ -1227,7 +1227,7 @@ components:
         tags:
           additionalProperties:
             type: string
-          description: Optional lList of tags to attach to a pipeline.
+          description: Optional list of tags to attach to a pipeline.
           type: object
       required:
         - display_name

--- a/modules/ROOT/attachments/cloud-dataplane-api.yaml
+++ b/modules/ROOT/attachments/cloud-dataplane-api.yaml
@@ -1178,7 +1178,7 @@ components:
           type: object
         url:
           description: |-
-            URL to connect to the pipeline, for example, using http_server.
+            URL to connect to the pipeline, e.g. via http_server.
             May be empty if no http_server is used.
           type: string
       required:
@@ -1227,7 +1227,7 @@ components:
         tags:
           additionalProperties:
             type: string
-          description: Optional list of tags to attach to a pipeline.
+          description: Optional lList of tags to attach to a pipeline.
           type: object
       required:
         - display_name


### PR DESCRIPTION
This PR updates the OpenAPI spec file for the Cloud API.
Triggered by commit: [452f3dbdd827417fc7ca86e42baa1af10b27b714](https://github.com/redpanda-data/cloudv2/commit/452f3dbdd827417fc7ca86e42baa1af10b27b714)

https://deploy-preview-1081--redpanda-docs-preview.netlify.app/api/cloud-controlplane-api/#overview
https://deploy-preview-1081--redpanda-docs-preview.netlify.app/api/cloud-dataplane-api/#overview