### PR TITLE
Update Redpanda Console configuration to include URL schemes for endpoints

### DIFF
--- a/modules/console/pages/config/connect-to-redpanda.adoc
+++ b/modules/console/pages/config/connect-to-redpanda.adoc
@@ -28,8 +28,8 @@ Here is an example configuration for the Kafka API using OAuth for SASL authenti
 ----
 kafka:
   brokers:
-    - "broker1.example.com:9092"
-    - "broker2.example.com:9092"
+    - "http://broker1.example.com:9092"
+    - "http://broker2.example.com:9092"
   # Optional client identification:
   # clientId: "console"
   # rackId: "zone-a"
@@ -67,7 +67,7 @@ For clusters using Kerberos, the configuration may resemble the following:
 ----
 kafka:
   brokers:
-    - "broker1.example.com:9092"
+    - "http://broker1.example.com:9092"
   sasl:
     enabled: true
     mechanism: GSSAPI
@@ -90,7 +90,7 @@ NOTE: Because Redpanda Console supports only OIDC and basic authentication for i
 | Kafka API Configuration Option | Description
 
 | `brokers`
-| A list of broker endpoints in the format `<hostname>:<port>`. For high availability, include all broker URLs.
+| A list of Kafka broker endpoints including the URL scheme (`http://` or `https://`), hostname, and port. Include all brokers in your cluster for high availability.
 
 | `clientId` (optional)
 | An identifier used by Redpanda Console to identify itself to the cluster.
@@ -137,8 +137,8 @@ Example Schema Registry configuration:
 schemaRegistry:
   enabled: true
   urls:
-    - "broker1.example.com:8081"
-    - "broker2.example.com:8081"
+    - "http://broker1.example.com:8081"
+    - "http://broker2.example.com:8081"
 
   # Optional authentication settings
   authentication:
@@ -154,7 +154,7 @@ schemaRegistry:
 | Schema Registry Configuration Option | Description
 
 | `urls`
-| A list of Schema Registry endpoints in the format `<hostname>:<port>`. Include all endpoints for redundancy.
+| A list of Schema Registry endpoints including the URL scheme (`http://` or `https://`), hostname, and port. Include all endpoints for redundancy.
 
 | `authentication` (optional)
 | Configure authentication for the Schema Registry. Options include basic authentication or bearer tokens. For more detailed instructions on configuring authentication, see xref:console:config/security/authentication.adoc[].
@@ -173,8 +173,8 @@ redpanda:
   adminApi:
     enabled: true # Enable connection to the Admin API.
     urls:
-      - "broker1.example.com:9644" # Provide all endpoints (host:port) for high availability.
-      - "broker2.example.com:9644"
+      - "http://broker1.example.com:9644" # Provide all endpoints (host:port) for high availability.
+      - "http://broker2.example.com:9644"
     # Optional authentication settings
     authentication:
       impersonateUser: true # Use the logged-in user's credentials for authentication.
@@ -202,7 +202,7 @@ NOTE: Include the URLs of _all_ endpoints in the `redpanda.adminApi.urls` array.
 | Activates the connection to the Admin API. Set to `true` to enable the integration.
 
 | `urls`
-| A list of endpoints (host:port) for all brokers serving the Admin API. Providing all URLs enhances reliability.
+| A list of Admin API endpoints including the URL scheme (`http://` or `https://`), hostname, and port. Providing all URLs enhances reliability.
 
 | `authentication` (optional)
 | Provides credentials using basic authentication or bearer tokens when impersonation is disabled. For more detailed instructions on configuring authentication, see xref:console:config/security/authentication.adoc[].

--- a/modules/manage/pages/security/listener-configuration.adoc
+++ b/modules/manage/pages/security/listener-configuration.adoc
@@ -4,101 +4,138 @@
 :page-aliases: cluster-administration:listener-configuration.adoc
 :page-categories: Management, Security
 
+Apache Kafka® client libraries must be able to connect to every Redpanda broker instance. If the client and broker are on different subnets, advertise the location of the broker in the Redpanda configuration file so other brokers in the cluster can be found. If not, clients connecting to brokers outside their local network experience connectivity issues.
 
-Apache Kafka® client libraries must be able to connect to every Redpanda broker
-instance. If the client and broker are on different subnets, advertise the location of the broker in the Redpanda configuration file so other brokers in
-the cluster can be found. If not, clients connecting to brokers outside
-their local network experience connectivity issues.
-
-To try out Redpanda, see the
-xref:get-started:quick-start.adoc[Redpanda Quickstart].
+To try out Redpanda, see the xref:get-started:quick-start.adoc[Redpanda quickstart].
 
 == Anatomy of a listener
 
-Clients must connect to Redpanda with a TCP socket. A TCP socket is described by an IP address of an interface and a port on the machine that Redpanda runs on. For example:
+Clients connect to Redpanda over TCP. A listener is defined by an interface address and port on the machine running Redpanda. For example:
 
-[,yaml]
+[cols="1,1"]
+|===
+|Configuration | Description
+
+|`address: 0.0.0.0`
+|Listens on all available interfaces.
+
+|`port: 9092`
+|TCP port for Kafka clients.
+
+|===
+
+[source,yaml]
 ----
 redpanda:
   kafka_api:
     - address: 0.0.0.0
       port: 9092
 ----
-
-An address of `0.0.0.0` means that Redpanda listens on all interfaces.
 
 == Advertise a listener
 
-By default, the advertised address is the address the listener is bound to, but this is not usually an externally-routable address. Set the advertised address to an address the client can use to connect to the instance of Redpanda.
+By default, the advertised address is the same as the bound address. For clients outside the local host or subnet, you must set an externally reachable address or hostname. Invalid settings—including `0.0.0.0`—will fail startup validation.
 
-NOTE: Ensure that any configuration option with the `advertise_*` prefix uses a valid hostname or IP address. Do not use `0.0.0.0`. Invalid configurations, including the use of `0.0.0.0`, will cause the broker to fail during startup validation.
-
-If the client exists on another subnet, then it needs to know how to reach Redpanda. Do this by configuring the advertised address of the Kafka API in `redpanda.yaml`. For example, if Redpanda is running on the subnet `192.168.4.0/24` with IP address `192.168.4.1`, and the clients are running on the subnet `192.168.5.0/24`, then the client machine needs a gateway configured to route requests to `192.168.4.1`:
-
-[,yaml]
+[source,yaml]
 ----
 redpanda:
   advertised_kafka_api:
-    - address: 192.168.4.1
+    - address: 192.168.4.1 # Broker’s routable IP or FQDN
       port: 9092
 ----
 
-It's also possible to advertise a host name, provided the client can resolve the DNS and has a route to the host.
+[NOTE]
+====
+* Use a valid hostname or IP. Do not use `0.0.0.0`.
+* When using a DNS hostname, ensure clients can resolve it and that it matches any TLS certificate SAN.
+====
 
 == Multiple listeners
 
-Sometimes it's useful to have multiple configurations for accessing Redpanda with multiple routes.
+You can define multiple Kafka API listeners to support different interfaces, ports, or authentication methods. Each listener must have a unique `name` property, and the same `name` property must be used in the corresponding `advertised_kafka_api` stanza.
 
-Do this by creating multiple listeners, and providing a name for the listener. The name is used to connect the listener and its advertised address. For example:
-
-[,yaml]
+[source,yaml]
 ----
 redpanda:
   kafka_api:
-    - name: local
+    - name: local # Unique listener name
       address: 127.0.0.1
       port: 9092
+
     - name: subnet
       address: 192.168.4.1
       port: 9093
+
   advertised_kafka_api:
-    - name: local
+    - name: local # Must match the listener name
       address: 127.0.0.1
       port: 9092
+
     - name: subnet
       address: 192.168.4.1
       port: 9093
 ----
 
-You can also create additional listeners for different configurations of TLS or authentication.
+== TLS listeners and DNS hostnames
+
+For encrypted connections, you typically advertise a DNS name matching your TLS certificate. Always include a `name` property for the TLS listener and use it in both `kafka_api` and `advertised_kafka_api`.
+
+[source,yaml]
+----
+redpanda:
+  kafka_api:
+    - name: tls_listener
+      address: 0.0.0.0
+      port: 9094
+      authentication_method: mtls_identity
+
+  advertised_kafka_api:
+    - name: tls_listener
+      address: https://kafka.example.com
+      port: 9094
+
+  kafka_api_tls:
+    - name: tls_listener
+      enabled: true
+      key_file: /etc/redpanda/tls/broker.key
+      cert_file: /etc/redpanda/tls/broker.crt
+      truststore_file: /etc/redpanda/tls/ca.crt
+      require_client_auth: true
+----
+
+Ensure `kafka.example.com` matches the SAN in `broker.crt` and that clients trust the `ca.crt`.
 
 == Mixed-mode authentication with multiple listeners
 
-Redpanda supports using both SASL and mTLS principal extraction authentication methods using multiple listeners. This supports a variety of Kafka clients using various authentication schemes all connecting to your cluster. For example:
+Redpanda supports running multiple authentication schemes side by side. Each listener can specify its method, and must define a `name:`.
 
-[,yaml]
+[source,yaml]
 ----
 redpanda:
   kafka_api:
-    - address: 0.0.0.0
+    - name: sasl_listener
+      address: 0.0.0.0
       port: 9092
-      name: sasl_listener
       authentication_method: sasl
-    - address: 0.0.0.0
+
+    - name: mtls_listener
+      address: 0.0.0.0
       port: 9192
-      name: mtls_listener
       authentication_method: mtls_identity
+
   kafka_api_tls:
     - name: mtls_listener
       key_file: mtls_broker.key
       cert_file: mtls_broker.crt
       truststore_file: mtls_ca.crt
-      enabled: true
       require_client_auth: true
 ----
 
 == Listeners that can be advertised
 
-* `kafka_api` \-> `advertised_kafka_api`: The address that Kafka clients connect to, for each listener.
-* `rpc_server` \-> `advertised_rpc_api`: The address that other Redpanda instances connect to.
-* `pandaproxy_api` \-> `advertised_pandaproxy_api`: The address that HTTP clients connect to, for each listener.
+* `kafka_api` → `advertised_kafka_api`: Kafka clients connect here.
+* `rpc_server` → `advertised_rpc_api`: Other Redpanda brokers connect here.
+* `pandaproxy_api` → `advertised_pandaproxy_api`: HTTP clients connect here.
+
+For each advertised block, match the `name:` of the corresponding listener and provide a valid address and port.
+

--- a/modules/manage/pages/security/listener-configuration.adoc
+++ b/modules/manage/pages/security/listener-configuration.adoc
@@ -34,7 +34,7 @@ redpanda:
 
 == Advertise a listener
 
-By default, the advertised address is the same as the bound address. For clients outside the local host or subnet, you must set an externally reachable address or hostname. Invalid settings—including `0.0.0.0`—will fail startup validation.
+By default, the advertised address is the same as the bound address. For clients outside the local host or subnet, you must set an externally reachable address or hostname. Invalid settings, including `0.0.0.0`, will fail startup validation.
 
 [source,yaml]
 ----
@@ -47,7 +47,7 @@ redpanda:
 [NOTE]
 ====
 * Use a valid hostname or IP. Do not use `0.0.0.0`.
-* When using a DNS hostname, ensure clients can resolve it and that it matches any TLS certificate SAN.
+* When using a DNS hostname, ensure that clients can resolve it and that it matches any TLS certificate Subject Alternative Name (SAN).
 ====
 
 == Multiple listeners
@@ -107,7 +107,7 @@ Ensure `kafka.example.com` matches the SAN in `broker.crt` and that clients trus
 
 == Mixed-mode authentication with multiple listeners
 
-Redpanda supports running multiple authentication schemes side by side. Each listener can specify its method, and must define a `name:`.
+Redpanda supports running multiple authentication schemes concurrently. Each listener can specify its method, and must define a `name` property.
 
 [source,yaml]
 ----
@@ -133,9 +133,23 @@ redpanda:
 
 == Listeners that can be advertised
 
-* `kafka_api` → `advertised_kafka_api`: Kafka clients connect here.
-* `rpc_server` → `advertised_rpc_api`: Other Redpanda brokers connect here.
-* `pandaproxy_api` → `advertised_pandaproxy_api`: HTTP clients connect here.
+[cols="1m,1m,2a"]
+|===
+| Listener | Advertised Listener | Description
 
-For each advertised block, match the `name:` of the corresponding listener and provide a valid address and port.
+|kafka_api
+|advertised_kafka_api
+|Kafka clients connect here.
+
+|rpc_server
+|advertised_rpc_api
+|Other Redpanda brokers connect here.
+
+|pandaproxy_api
+|advertised_pandaproxy_api
+|HTTP proxy clients connect here.
+
+|===
+
+For each advertised listener, match the `name` of the corresponding listener and provide a valid address and port.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1254
Review deadline: April 18

This pull request updates documentation for Redpanda and Redpanda Console configuration to improve clarity and ensure consistency in specifying URL schemes (`http://` or `https://`) for various endpoints. It also reorganizes and enhances the listener configuration section to better describe how to handle DNS hostnames and multiple listeners.

### Updates to Redpanda Console config:

* Updated all examples of Kafka broker, Schema Registry, and Admin API configurations to include the URL scheme (`http://` or `https://`) in endpoint definitions. This ensures clarity and consistency in how endpoints are specified. [[1]](diffhunk://#diff-50a7a1c27464f0f16e2778da18ab6cdefb94fab27dc01ef99ee689ec3d1fbdc1L31-R32) [[2]](diffhunk://#diff-50a7a1c27464f0f16e2778da18ab6cdefb94fab27dc01ef99ee689ec3d1fbdc1L70-R70) [[3]](diffhunk://#diff-50a7a1c27464f0f16e2778da18ab6cdefb94fab27dc01ef99ee689ec3d1fbdc1L93-R93) [[4]](diffhunk://#diff-50a7a1c27464f0f16e2778da18ab6cdefb94fab27dc01ef99ee689ec3d1fbdc1L140-R141) [[5]](diffhunk://#diff-50a7a1c27464f0f16e2778da18ab6cdefb94fab27dc01ef99ee689ec3d1fbdc1L157-R157) [[6]](diffhunk://#diff-50a7a1c27464f0f16e2778da18ab6cdefb94fab27dc01ef99ee689ec3d1fbdc1L176-R177) [[7]](diffhunk://#diff-50a7a1c27464f0f16e2778da18ab6cdefb94fab27dc01ef99ee689ec3d1fbdc1L205-R205)

### Improvements to listener configuration docs:

* Reorganized the listener configuration section to clarify key concepts, such as defining listeners, advertising addresses, and supporting multiple configurations. Simplified explanations and added examples for better comprehension.
* Enhanced descriptions of listener properties, including the importance of using valid hostnames or IPs for advertised addresses and ensuring compatibility with TLS certificates.
* Added examples for advanced configurations, such as multiple listeners, TLS listeners, and mixed-mode authentication, to support a variety of use cases.

## Page previews

- https://deploy-preview-1082--redpanda-docs-preview.netlify.app/current/console/config/connect-to-redpanda/#configure-a-connection-to-the-kafka-api
- https://deploy-preview-1082--redpanda-docs-preview.netlify.app/current/manage/security/listener-configuration/#multiple-listeners

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
