### PR TITLE
Add request body schema to PUT /v1/cluster_config

### DIFF
--- a/modules/ROOT/attachments/admin-api.yaml
+++ b/modules/ROOT/attachments/admin-api.yaml
@@ -148,6 +148,11 @@ paths:
           and return 400 on errors)
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/patch_cluster_config_request'
       responses:
         200:
           description: Success
@@ -4712,7 +4717,22 @@ components:
               #visibility: tunable
               #is_secret: false
               type: integer
-
+    patch_cluster_config_request:
+      type: object
+      properties:
+        upsert:
+          type: object
+          description: Cluster configuration property key-value pairs to add or update.
+          additionalProperties:
+            type: string
+        remove:
+          type: array
+          description: Cluster configuration property keys to reset to their default.
+          items:
+            type: string
+      required:
+        - upsert
+        - remove
     ntp:
       type: object
       description: Namespace, Topic, Partition ID tuple


### PR DESCRIPTION
## Description

This pull request introduces an enhancement to the `admin-api.yaml` file by adding support for a new `patch_cluster_config_request` schema. This schema enables the API to handle updates and removals of cluster configuration properties in a structured way. The changes include defining the new schema and integrating it into the request body of a specific API endpoint.

### Enhancements to API functionality:

* **Added `patch_cluster_config_request` schema**:
  - Defined a new schema under `components` to support updating (`upsert`) and resetting (`remove`) cluster configuration properties. The `upsert` property accepts key-value pairs, and the `remove` property accepts an array of keys. Both fields are required. (`modules/ROOT/attachments/admin-api.yaml`, [modules/ROOT/attachments/admin-api.yamlL4715-R4735](diffhunk://#diff-7b60b751908bd5ea8c33bdf12dea54174f7cdb13a1e47904d78346751db72cf3L4715-R4735))

* **Integrated `patch_cluster_config_request` into request body**:
  - Updated the `paths` section to include the new `patch_cluster_config_request` schema in the request body for the relevant API endpoint. (`modules/ROOT/attachments/admin-api.yaml`, [modules/ROOT/attachments/admin-api.yamlR151-R155](diffhunk://#diff-7b60b751908bd5ea8c33bdf12dea54174f7cdb13a1e47904d78346751db72cf3R151-R155))

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 18 April

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
