### PR TITLE
Doc-748 Correct RHEL cmds for FIPS

### DIFF
--- a/modules/deploy/partials/linux/install-fips.adoc
+++ b/modules/deploy/partials/linux/install-fips.adoc
@@ -27,10 +27,11 @@ To install Redpanda for FIPS compliance, run:
 
 [,bash]
 ----
-sudo apt install -y redpanda-rpk-fips redpanda-fips
+curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.rpm.sh' | \
+sudo -E bash && sudo yum install redpanda -y
 ----
 
-NOTE: Alternatively, you could run `sudo apt install -y redpanda-fips`, which also picks up and includes the `redpanda` install package.
+NOTE: Alternatively, you could run `sudo yum install -y redpanda-fips`, which also picks up and includes the `redpanda` install package.
 
 If you wish to only use `rpk` on a FIPS host, run:
 


### PR DESCRIPTION
This pull request updates the installation instructions for Redpanda with FIPS compliance on Linux. The changes replace the use of `apt` with `yum` for package installation and update the corresponding commands and notes.

Changes to installation instructions:

* [`modules/deploy/partials/linux/install-fips.adoc`](diffhunk://#diff-15cb4e087161e0a523f8659c5891fbcda1f2c3d717fc48b9ba322cbc3e06db3fL30-R34): Updated the installation command to use `curl` and `yum` for setting up Redpanda with FIPS compliance, replacing the previous `apt`-based instructions. The alternative installation note was also updated to reflect the use of `yum`.## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-748
Review deadline: **Tuesday April 22**

## Page previews

[Install Redpanda for FIPS compliance](https://deploy-preview-1084--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/manual/production/production-deployment/#install-redpanda-for-fips-compliance)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions for RHEL-based systems to use `yum` instead of `apt`, providing clearer steps for Redpanda installation on RPM-based distributions. Debian/Ubuntu instructions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->