### PR TITLE
Fix minor typo in object-storage-properties.adoc

### DIFF
--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -562,7 +562,7 @@ To authenticate using access keys, see <<cloud_storage_access_key,`cloud_storage
 
 *Gets restored during cluster restore:* No
 
-*Accepted values*: `config_file`, `aws_instance_metadata`, `sts, gcp_instance_metadata`, `azure_vm_instance_metadata`, `azure_aks_oidc_federation`
+*Accepted values*: [`config_file`, `aws_instance_metadata`, `sts`, `gcp_instance_metadata`, `azure_vm_instance_metadata`, `azure_aks_oidc_federation`]
 
 *Visibility:* `user`
 


### PR DESCRIPTION
## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the list of accepted values for the `cloud_storage_credentials_source` property to clearly list `sts` and `gcp_instance_metadata` as separate options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->