### PR TITLE
Remove outdated Tiered Storage notice

### DIFF
--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -16,11 +16,6 @@ The following image illustrates the Tiered Storage architecture: remote write up
 
 image::shared:tiered_storage1.png[Tiered Storage architecture]
 
-[IMPORTANT]
-====
-When upgrading Redpanda, uploads to object storage are paused until all brokers in the cluster are upgraded. If the cluster gets stuck while upgrading, roll it back to the original version. In a mixed-version state, the cluster could run out of disk space. If you need to force a mixed-version cluster to upload, move partition leadership to brokers running the original version.
-====
-
 == Prerequisites
 
 include::shared:partial$enterprise-license.adoc[]


### PR DESCRIPTION
## Description

This pull request removes a warning note from the intro section of the Tiered Storage documentation. The removed note provided guidance on handling object storage uploads during Redpanda upgrades.

Documentation update:

* [`modules/manage/partials/tiered-storage.adoc`](diffhunk://#diff-8e053dde88b9dfc92939a73598f0d06dd718f88b36c08f136745e3cf97bcb061L19-L23): Removed a warning about uploads being paused during Redpanda upgrades and instructions for handling mixed-version clusters. This simplifies the documentation and removes potentially outdated or unnecessary information.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

https://deploy-preview-1089--redpanda-docs-preview.netlify.app/current/manage/tiered-storage/#prerequisites

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed a note regarding upload behavior to object storage during upgrades, including information about upload pauses, disk space risks, and recommendations for resolving upgrade issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->