### PR TITLE
Support for PCF in Avro

### DIFF
--- a/modules/manage/pages/schema-reg/schema-reg-overview.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-overview.adoc
@@ -23,6 +23,10 @@ The Schema Registry is built directly into the Redpanda binary. It runs out of t
 
 **Normalization**: Normalization is the process of converting a schema into a canonical form. When a schema is normalized, it can be compared and considered equivalent to another schema that may contain minor syntactic differences. Schema normalization allows you to more easily manage schema versions and compatibility by prioritizing meaningful logical changes. Normalization is supported for Avro, JSON, and Protobuf formats during both schema registration and lookup for a subject.
 
+=== Avro normalization
+
+When normalizing an Avro schema, Redpanda transforms the schema into Parsing Canonical Form as defined in the https://avro.apache.org/docs/++version++/specification/#transforming-into-parsing-canonical-form[Avro specification], with the exception that it does not apply the STRIP transformation.
+
 == Redpanda design overview
 
 Every broker allows mutating REST calls, so there's no need to configure leadership or failover strategies. Schemas are stored in a compacted topic, and the registry uses optimistic concurrency control at the topic level to detect and avoid collisions.

--- a/modules/manage/pages/schema-reg/schema-reg-overview.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-overview.adoc
@@ -25,7 +25,7 @@ The Schema Registry is built directly into the Redpanda binary. It runs out of t
 
 === Avro normalization
 
-When normalizing an Avro schema, Redpanda transforms the schema into Parsing Canonical Form as defined in the https://avro.apache.org/docs/++version++/specification/#transforming-into-parsing-canonical-form[Avro specification], with the exception that it does not apply the STRIP transformation.
+When normalizing an Avro schema, Redpanda transforms the schema into Parsing Canonical Form as defined in the https://avro.apache.org/docs/++version++/specification/#transforming-into-parsing-canonical-form[Avro specification^], with the exception that it does not apply the STRIP transformation.
 
 == Redpanda design overview
 


### PR DESCRIPTION
## Description

This pull request adds a new section to the Schema Registry documentation to explain how Avro normalization is handled in Redpanda. The update clarifies the transformation process and references the Avro specification.

Support for PCF was added in RP version 23.2.

### Documentation updates:

* [`modules/manage/pages/schema-reg/schema-reg-overview.adoc`](diffhunk://#diff-e9f6a4c1fd662ee69a453b3de821c432b638537c19a6e81b20e826924e1d6abfR26-R29): Added a new subsection titled "Avro normalization" to describe how Redpanda transforms Avro schemas into Parsing Canonical Form, with a note that the STRIP transformation is not applied. A link to the relevant section of the Avro specification is included.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 29 Apr 

## Page previews

https://deploy-preview-1091--redpanda-docs-preview.netlify.app/current/manage/schema-reg/schema-reg-overview/#avro-normalization

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new "Avro normalization" subsection to clarify how Avro schemas are normalized, specifying the use of Parsing Canonical Form and noting the exception regarding the STRIP transformation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->