### PR TITLE
DOC-1282 rpk cluster config for cloud wasm

### DIFF
--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -31,12 +31,13 @@ Data transforms is disabled on all clusters by default. Before you can deploy da
 --
 . Set the `data_transforms_enabled` cluster property to `true`:
 +
-```bash
+[source,bash]
+----
 rpk cluster config set data_transforms_enabled true
-```
+----
 . Restart all brokers:
 +
-[,bash]
+[source,bash]
 ----
 rpk redpanda stop
 rpk redpanda start
@@ -48,7 +49,7 @@ Cloud API::
 --
 Use the Cloud API to set xref:ROOT:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] to `true`.
 
-[,bash]
+[source,bash]
 ----
 # Store your cluster ID in a variable
 export RP_CLUSTER_ID=<cluster-id>
@@ -497,6 +498,7 @@ JavaScript::
 +
 --
 The JavaScript SDK does not support writing records to a specific output topic.
+
 --
 ======
 

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -22,7 +22,7 @@ endif::[]
 ifdef::env-cloud[]
 == Enable data transforms
 
-Data transforms are disabled on all clusters by default. Before you can deploy data transforms to a cluster, you must first enable the feature with either `rpk` or the Cloud API.
+Data transforms are disabled on all clusters by default. Before you can deploy data transforms to a cluster, you must first enable the feature with either the `rpk` command-line tool or the Cloud API.
 
 [tabs]
 ======
@@ -37,7 +37,7 @@ rpk cluster config set data_transforms_enabled true
 ----
 
 
-NOTE: The `rpk cluster config` command returns the operation ID. Cluster configuration operations can take up to ten minutes to complete. 
+NOTE: The `rpk cluster config set` command returns the operation ID. Cluster configuration operations can take up to ten minutes to complete. 
 
 --
 Cloud API::

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -72,10 +72,11 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
 The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. The operation may take up to ten minutes to complete. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint.
 
 NOTE: You must restart your cluster if you change this configuration for a running cluster.
-endif::[]
 
 --
 ======
+
+endif::[]
 
 
 [[init]]

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -22,7 +22,7 @@ endif::[]
 ifdef::env-cloud[]
 == Enable data transforms
 
-Data transforms is disabled on all clusters by default. Before you can deploy data transforms to a cluster, you must first enable the feature with either `rpk` or the Cloud API:
+Data transforms are disabled on all clusters by default. Before you can deploy data transforms to a cluster, you must first enable the feature with either `rpk` or the Cloud API:
 
 [tabs]
 ======

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -37,7 +37,7 @@ rpk cluster config set data_transforms_enabled true
 ----
 
 
-NOTE: The `rpk cluster config set` command returns the operation ID. Cluster configuration operations can take up to ten minutes to complete. 
+NOTE: Some properties require a rolling restart, and it can take several minutes for the update to complete. The `rpk cluster config set` command returns the operation ID. 
 
 --
 Cloud API::
@@ -69,6 +69,7 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
 
 NOTE: This cluster configuration operation may take up to ten minutes to complete. The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the operation ID. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint. 
 
+NOTE: Some properties require a rolling restart for the update to take effect. This triggers a xref:manage:api/cloud-byoc-controlplane-api.adoc#lro[long-running operation] that can take several minutes to complete.
 
 --
 ======

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -22,32 +22,30 @@ endif::[]
 ifdef::env-cloud[]
 == Enable data transforms
 
-Data transforms are disabled on all clusters by default. Before you can deploy data transforms to a cluster, you must first enable the feature with either `rpk` or the Cloud API:
+Data transforms are disabled on all clusters by default. Before you can deploy data transforms to a cluster, you must first enable the feature with either `rpk` or the Cloud API.
 
 [tabs]
 ======
 `rpk`::
 +
 --
-. Set the `data_transforms_enabled` cluster property to `true`:
-+
+Set the `data_transforms_enabled` cluster property to `true`:
+
 [source,bash]
 ----
 rpk cluster config set data_transforms_enabled true
 ----
-. Restart all brokers:
-+
-[source,bash]
-----
-rpk redpanda stop
-rpk redpanda start
-----
+
+
+NOTE: The `rpk cluster config` command returns the operation ID. Cluster configuration operations can take up to ten minutes to complete. 
 
 --
 Cloud API::
 +
 --
-Use the Cloud API to set xref:ROOT:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] to `true`.
+Create a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /v1/clusters`] request. Edit `cluster_configuration` in the request body to set xref:ROOT:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] to `true`.
+
+Update a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request, passing the cluster ID as a parameter. For example:
 
 [source,bash]
 ----
@@ -69,9 +67,8 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
  -d '{"cluster_configuration":{"custom_properties": {"data_transforms_enabled":true}}}'
 ----
 
-The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. The operation may take up to ten minutes to complete. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint.
+NOTE: This cluster configuration operation may take up to ten minutes to complete. The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the operation ID. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint. 
 
-NOTE: You must restart your cluster if you change this configuration for a running cluster.
 
 --
 ======

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -22,8 +22,30 @@ endif::[]
 ifdef::env-cloud[]
 == Enable data transforms
 
-Data transforms is disabled on all clusters by default. Before you can deploy data transforms to a cluster, you must first enable the feature.
+Data transforms is disabled on all clusters by default. Before you can deploy data transforms to a cluster, you must first enable the feature with either `rpk` or the Cloud API:
 
+[tabs]
+======
+`rpk`::
++
+--
+. Set the `data_transforms_enabled` cluster property to `true`:
++
+```bash
+rpk cluster config set data_transforms_enabled true
+```
+. Restart all brokers:
++
+[,bash]
+----
+rpk redpanda stop
+rpk redpanda start
+----
+
+--
+Cloud API::
++
+--
 Use the Cloud API to set xref:ROOT:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] to `true`.
 
 [,bash]
@@ -50,6 +72,10 @@ The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`P
 
 NOTE: You must restart your cluster if you change this configuration for a running cluster.
 endif::[]
+
+--
+======
+
 
 [[init]]
 == Initialize a data transforms project

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -67,7 +67,7 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
  -d '{"cluster_configuration":{"custom_properties": {"data_transforms_enabled":true}}}'
 ----
 
-NOTE: This cluster configuration operation may take up to ten minutes to complete. The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the operation ID. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint. 
+The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the operation ID. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint. 
 
 NOTE: Some properties require a rolling restart for the update to take effect. This triggers a xref:manage:api/cloud-byoc-controlplane-api.adoc#lro[long-running operation] that can take several minutes to complete.
 


### PR DESCRIPTION
## Description
This pull request adds steps for enabling data transforms in Redpanda Cloud using `rpk`.

* **Enhanced instructions for enabling data transforms**: Added step-by-step guidance on how to enable the `data_transforms_enabled` cluster property using `rpk` or the Cloud API, including commands for setting the property and restarting brokers.
* **Improved structure and readability**: Introduced tabs for `rpk` and Cloud API instructions.

Resolves https://redpandadata.atlassian.net/browse/DOC-1282
Review deadline:

## Page previews
[Enable Data Transforms](https://deploy-preview-1092--redpanda-docs-preview.netlify.app/redpanda-cloud/develop/data-transforms/build/#enable-data-transforms) (in Redpanda Cloud)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded instructions for enabling data transforms on cloud clusters, now including both `rpk` CLI and Cloud API methods.
  - Added step-by-step guide for enabling via `rpk` with improved formatting using a tabbed interface.
  - Enhanced visual separation and clarity in the documentation for better user guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->