### PR TITLE
DOC-1288 Remove limitation on reducing core count

### DIFF
--- a/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
+++ b/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
@@ -4,20 +4,18 @@
 :page-categories: Management, Scaling
 :env-kubernetes: true
 
-You can scale a cluster both vertically, by increasing or decreasing the resources available to existing brokers, and horizontally, by increasing or decreasing the number of brokers in the cluster.
+You can scale a cluster both vertically, by increasing or decreasing the resources available to existing brokers, and horizontally, by adding or removing brokers from the cluster.
 
 == Vertical scaling
 
-Vertical scaling involves increasing the amount of resources available to Redpanda brokers (scaling up) or decreasing the amount of resources (scaling down). Resources include the amount of hardware available to Redpanda brokers, such as CPU cores, memory, and storage.
+Vertical scaling involves increasing or decreasing the amount of resources available to Redpanda brokers, referred to as scaling up or scaling down. Resources include the amount of hardware available to Redpanda brokers, such as CPU cores, memory, and storage.
 
 To scale a Redpanda cluster vertically, see xref:./k-manage-resources.adoc[Manage Pod Resources in Kubernetes].
-
-IMPORTANT: You cannot decrease the number of CPU cores in a running cluster.
 
 If your existing worker nodes have either too many resources or not enough resources, you may need to move Redpanda brokers to new worker nodes that meet your resource requirements. This process involves:
 
 - Making sure the new worker nodes are available.
-- Deleting each worker node one by one.
+- Deleting each worker node individually.
 - Deleting the Pod's PersistentVolumeClaim (PVC).
 - Ensuring that the PersistentVolume's (PV) reclaim policy is set to `Retain` to make sure that you can roll back to the original worker node without losing data.
 
@@ -29,11 +27,11 @@ Horizontal scaling involves modifying the number of brokers in your cluster, eit
 
 :caution-caption: Do not use autoscalers
 
-CAUTION: Redpanda does not support Kubernetes autoscalers. Autoscalers rely on CPU and memory metrics for scaling decisions, which do not fully capture the complexities involved in scaling Redpanda clusters. Always manually scale your Redpanda clusters as described in this topic.
+CAUTION: Redpanda does not support Kubernetes autoscalers. Autoscalers rely on CPU and memory metrics for scaling decisions, which do not fully capture the complexities involved in scaling Redpanda clusters. You should always manually scale your Redpanda clusters as described in this topic.
 
 :caution-caption: Caution
 
-While you should not rely on Kubernetes autoscalers to scale your Redpanda brokers, you can prevent infrastructure-level autoscalers like Karpenter from terminating nodes that run Redpanda Pods. For example, you can set the xref:reference:k-redpanda-helm-spec.adoc#statefulset-podtemplate-annotations[`statefulset.podTemplate.annotations`] field in the Redpanda Helm values, or the xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-podtemplate[`statefulset.podTemplate.annotations`] field in the Redpanda custom resource to include:
+While you should not rely on Kubernetes autoscalers to scale your Redpanda brokers, you can prevent infrastructure-level autoscalers, such as Karpenter, from terminating nodes that run Redpanda Pods. For example, you can set the xref:reference:k-redpanda-helm-spec.adoc#statefulset-podtemplate-annotations[`statefulset.podTemplate.annotations`] field in the Redpanda Helm values, or the xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-podtemplate[`statefulset.podTemplate.annotations`] field in the Redpanda custom resource to include:
 
 [,yaml]
 ----
@@ -44,7 +42,7 @@ This annotation tells Karpenter not to disrupt the node on which the annotated P
 
 === Scale out
 
-Scaling out is the process of adding more brokers to your Redpanda cluster. You may want to add more brokers for increased throughput, high availability, and fault tolerance. Adding more brokers allows for better distribution of data across the cluster. This can be particularly important when dealing with large data sets.
+Scaling out involves adding more brokers to your Redpanda cluster. You may want to add more brokers to increase throughput, enhance high availability, and improve fault tolerance. Adding more brokers enables a more effective distribution of data across the cluster. This is particularly important when dealing with large datasets.
 
 To add Redpanda brokers to your cluster:
 

--- a/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
+++ b/modules/manage/pages/kubernetes/k-scale-redpanda.adoc
@@ -4,11 +4,11 @@
 :page-categories: Management, Scaling
 :env-kubernetes: true
 
-You can scale a cluster both vertically, by increasing or decreasing the resources available to existing brokers, and horizontally, by adding or removing brokers from the cluster.
+You can scale a cluster both vertically (by increasing or decreasing the resources available to existing brokers) and horizontally (by adding or removing brokers from the cluster).
 
 == Vertical scaling
 
-Vertical scaling involves increasing or decreasing the amount of resources available to Redpanda brokers, referred to as scaling up or scaling down. Resources include the amount of hardware available to Redpanda brokers, such as CPU cores, memory, and storage.
+Vertical scaling involves increasing or decreasing the amount of resources available to Redpanda brokers, referred to as scaling up or scaling down. Resources include hardware resources such as CPU cores, memory, and storage.
 
 To scale a Redpanda cluster vertically, see xref:./k-manage-resources.adoc[Manage Pod Resources in Kubernetes].
 
@@ -27,11 +27,11 @@ Horizontal scaling involves modifying the number of brokers in your cluster, eit
 
 :caution-caption: Do not use autoscalers
 
-CAUTION: Redpanda does not support Kubernetes autoscalers. Autoscalers rely on CPU and memory metrics for scaling decisions, which do not fully capture the complexities involved in scaling Redpanda clusters. You should always manually scale your Redpanda clusters as described in this topic.
+CAUTION: Redpanda does not support Kubernetes autoscalers. Autoscalers rely on CPU and memory metrics for scaling decisions, which do not fully capture the complexities involved in scaling Redpanda clusters. Always manually scale your Redpanda clusters as described in this topic.
 
 :caution-caption: Caution
 
-While you should not rely on Kubernetes autoscalers to scale your Redpanda brokers, you can prevent infrastructure-level autoscalers, such as Karpenter, from terminating nodes that run Redpanda Pods. For example, you can set the xref:reference:k-redpanda-helm-spec.adoc#statefulset-podtemplate-annotations[`statefulset.podTemplate.annotations`] field in the Redpanda Helm values, or the xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-podtemplate[`statefulset.podTemplate.annotations`] field in the Redpanda custom resource to include:
+Do not rely on Kubernetes autoscalers to scale your Redpanda brokers. Instead, prevent infrastructure-level autoscalers, such as Karpenter, from terminating nodes that host Redpanda Pods. For example, you can set the xref:reference:k-redpanda-helm-spec.adoc#statefulset-podtemplate-annotations[`statefulset.podTemplate.annotations`] field in the Redpanda Helm values, or the xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-podtemplate[`statefulset.podTemplate.annotations`] field in the Redpanda custom resource to include:
 
 [,yaml]
 ----


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1288
Review deadline: April 29

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Documentation**
  - Improved clarity and consistency in the scaling instructions for Redpanda clusters on Kubernetes.
  - Updated terminology for horizontal and vertical scaling.
  - Enhanced explanations of scaling benefits and autoscaler usage.
  - Refined wording throughout for better readability and precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->