### PR TITLE
Clarify the K8s compatibility guidelines

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -31,7 +31,7 @@ asciidoc:
     console-beta-version: '3.0.0-beta.1'
     console-beta-tag: 'v3.0.0-beta.1'
     # --
-    supported-kubernetes-version: 1.25.0-0
+    supported-kubernetes-version: 1.27.0-0
     supported-helm-version: 3.10.0
     supported-rhel-required: '8'
     supported-rhel-recommended: '9+'

--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -1,6 +1,7 @@
 = Kubernetes Compatibility
 :description: A compatibility matrix for versions of Redpanda, Redpanda Helm chart, and Redpanda Operator.
 :page-categories: Upgrades
+:fn-k8s-compatibility: footnote:fn-k8s-compatibility[These Kubernetes versions are are suggested ranges, based on testing and reported usage. Not every patch or minor version within these ranges is explicitly tested.]
 
 This topic describes the compatibility for versions of Redpanda, Redpanda Operator, and the Helm charts. The tables identify the version requirements and compatibility guidelines.
 
@@ -20,9 +21,19 @@ Starting from version v25.1.1-beta1, the Redpanda Operator and Redpanda Helm cha
 
 Each Redpanda Operator and Helm chart version supports the corresponding Redpanda core version plus one minor version above and one below. This approach ensures flexibility during upgrades. For example, Redpanda Operator version 25.1.1 supports Redpanda core versions 25.2.x, 25.1.x, and 24.3.x.
 
-Redpanda Operator and Helm chart versions are supported only while their associated Redpanda core version remains supported. If the core version reaches End-of-Life (EoL), the corresponding Operator and Helm chart versions also reach EoL.
+Redpanda Operator and Helm chart versions are supported only while their associated Redpanda core version remains supported. If the core version reaches end of life (EoL), the corresponding versions of the Redpanda Operator and Helm chart also reach EoL.
 
 NOTE: Beta versions are available only for testing and feedback. They are not supported by Redpanda and should not be used in production environments. To give feedback on beta releases, reach out to the Redpanda team in https://redpanda.com/slack[Redpanda Community Slack^].
+
+== Kubernetes version policy
+
+The minimum supported Kubernetes version is {supported-kubernetes-version}.
+
+The Kubernetes versions listed in the compatibility matrix are suggested ranges, based on testing and reported usage. Not every patch or minor version within these ranges is explicitly tested.
+
+To request compatibility testing of a Kubernetes version outside of the given ranges, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
+
+Redpanda Core has no direct dependency on Kubernetes. Compatibility is influenced indirectly by the Helm chart or Operator that you use.
 
 == Compatibility matrix
 
@@ -42,7 +53,7 @@ NOTE: Beta versions are available only for testing and feedback. They are not su
 |25.1.1-beta1, 0.4.41, 0.4.36
 |25.1.1-beta1, 2.4.x, 2.3.x
 |3.12+
-|1.29.x - 1.32.x
+|1.28.x - 1.32.x{fn-k8s-compatibility}
 
 |24.3.x
 |25.1-k8s-beta, 5.9.x
@@ -65,9 +76,11 @@ See the https://github.com/cert-manager/cert-manager/releases[cert-manager relea
 
 == Redpanda Console integration
 
-Redpanda Console is integrated as a subchart within the Redpanda Helm chart. Each version of the Redpanda Helm chart defines a range of versions of the Redpanda Console chart that it supports. The version of Redpanda Console that is installed depends on the version of the Redpanda Helm chart you choose to install.
+Redpanda Console is deployed through the Redpanda Helm chart. It is included as a subchart, and its version is determined by the version of the parent Helm chart.
 
-This interdependency is established when you add or update the Redpanda chart repository, linking a particular version of Redpanda Console with the corresponding version of the Redpanda Helm chart. As a result of this integration, any updates you apply to the Redpanda Helm chart might also lead to changes in the version of the Redpanda Console. This means that selecting a different version of the Redpanda Helm chart can automatically determine the version of the Console that gets installed or updated in your environment.
+The Redpanda Helm chart defines which Redpanda Console versions it supports. When you install or update the Helm chart, it automatically selects the appropriate Redpanda Console version.
+
+Upgrading the Helm chart may also upgrade Redpanda Console. Because of this built-in dependency, selecting a different Helm chart version can change the Redpanda Console version deployed in your environment.
 
 [cols="1a,1a,1a"]
 |===

--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -53,21 +53,24 @@ Redpanda Core has no direct dependency on Kubernetes. Compatibility is influence
 |25.1.1-beta1, 0.4.41, 0.4.36
 |25.1.1-beta1, 2.4.x, 2.3.x
 |3.12+
-|1.28.x - 1.32.x{fn-k8s-compatibility}
+// d (default) here is required to get footnotes to appear at the bottom of the page
+// instead of inside the table cell.
+// See https://github.com/asciidoctor/asciidoctor/issues/2350#issuecomment-546841684
+d|1.28.x - 1.32.x{fn-k8s-compatibility}
 
 |24.3.x
 |25.1-k8s-beta, 5.9.x
 |25.1-k8s-beta, 0.4.41, 0.4.36, 0.4.29
 |25.1-k8s-beta, 2.4.x, 2.3.x, 2.2.x
 |3.11+
-|1.28.x - 1.31.x
+d|1.28.x - 1.31.x{fn-k8s-compatibility}
 
 |24.2.x
 |5.9.x, 5.8.x
 |0.4.29
 |2.2.x
 |3.10+
-|1.27.x - 1.30.x
+d|1.27.x - 1.30.x{fn-k8s-compatibility}
 |===
 
 By default, the Redpanda Helm chart depends on cert-manager for enabling TLS.

--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -1,7 +1,7 @@
 = Kubernetes Compatibility
 :description: A compatibility matrix for versions of Redpanda, Redpanda Helm chart, and Redpanda Operator.
 :page-categories: Upgrades
-:fn-k8s-compatibility: footnote:fn-k8s-compatibility[These Kubernetes versions are are suggested ranges, based on testing and reported usage. Not every patch or minor version within these ranges is explicitly tested.]
+:fn-k8s-compatibility: footnote:fn-k8s-compatibility[These Kubernetes versions are suggested ranges, based on testing and reported usage. Not every patch or minor version within these ranges is explicitly tested.]
 
 This topic describes the compatibility for versions of Redpanda, Redpanda Operator, and the Helm charts. The tables identify the version requirements and compatibility guidelines.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1262
Review deadline: April 30

This pull request updates Kubernetes compatibility information and refines documentation around Redpanda Console integration. The changes include updating the supported Kubernetes version, adding a Kubernetes version policy section, and simplifying the description of Redpanda Console deployment.

### Kubernetes compatibility updates:
* Updated the `supported-kubernetes-version` in `antora.yml` to `1.27.0-0`.
* Added a footnote explaining the suggested Kubernetes version ranges in `k-compatibility.adoc`.
* Introduced a new "Kubernetes version policy" section in `k-compatibility.adoc`, detailing the minimum supported version and compatibility testing process.
* Adjusted the compatibility matrix to reflect the updated Kubernetes version range (`1.28.x - 1.32.x`).

### Redpanda Console documentation refinements:
* Simplified and clarified the description of how Redpanda Console is deployed and updated via the Helm chart in `k-compatibility.adoc`.

## Page previews

https://deploy-preview-1094--redpanda-docs-preview.netlify.app/current/upgrade/k-compatibility/

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the supported Kubernetes version to 1.27.0-0.
  - Added a footnote clarifying the suggested nature of Kubernetes version ranges.
  - Introduced a new "Kubernetes version policy" section with guidance on compatibility and support.
  - Improved clarity and consistency in descriptions of Redpanda Operator, Helm chart, and Redpanda Console integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->