### PR TITLE
Add metadata to cluster properties that don't get restored after a whole cluster restore procedure

### DIFF
--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -302,6 +302,8 @@ Cluster identifier.
 
 *Requires restart:* No
 
+*Gets restored during cluster restore:* No
+
 *Visibility:* `user`
 
 *Type:* string

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -161,7 +161,7 @@ The managed identity ID to use for access to the Azure storage account. To use A
 
 *Default*: null
 
-*Requires restart*: no
+*Requires restart*: No
 
 *Supported versions*: Redpanda v24.1 or later
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -119,7 +119,7 @@ The name of the Azure container to use with Tiered Storage. If `null`, the prope
 
 NOTE: The container must belong to <<cloud_storage_azure_storage_account,`cloud_storage_azure_storage_account`>>.
 
-*Restart required*: Yes
+*Requires restart*: Yes
 
 *Gets restored during cluster restore:* No
 
@@ -161,7 +161,7 @@ The managed identity ID to use for access to the Azure storage account. To use A
 
 *Default*: null
 
-*Restart required*: no
+*Requires restart*: no
 
 *Supported versions*: Redpanda v24.1 or later
 
@@ -173,7 +173,7 @@ The account access key to be used for Azure Shared Key authentication with the A
 
 NOTE: Redpanda expects this key string to be Base64 encoded.
 
-*Restart required*: Yes
+*Requires restart*: Yes
 
 *Gets restored during cluster restore:* No
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -35,6 +35,8 @@ Optional API endpoint. The only instance in which you must set this value is whe
 
 *Requires restart:* No
 
+*Gets restored during cluster restore:* No
+
 *Optional:* Yes (if not using a custom domain)
 
 *Visibility:* `user`
@@ -83,6 +85,8 @@ If not set, this is automatically generated using `dfs.core.windows.net` and <<c
 
 *Requires restart:* Yes
 
+*Gets restored during cluster restore:* No
+
 *Visibility:* `user`
 
 *Type:* string
@@ -96,6 +100,8 @@ If not set, this is automatically generated using `dfs.core.windows.net` and <<c
 Azure Data Lake Storage v2 port override. See also: <<cloud_storage_azure_adls_endpoint,`cloud_storage_azure_adls_endpoint`>>. Use when hierarchical namespaces are enabled on your storage account and you have set up a custom endpoint.
 
 *Requires restart:* Yes
+
+*Gets restored during cluster restore:* No
 
 *Visibility:* `user`
 
@@ -113,11 +119,13 @@ The name of the Azure container to use with Tiered Storage. If `null`, the prope
 
 NOTE: The container must belong to <<cloud_storage_azure_storage_account,`cloud_storage_azure_storage_account`>>.
 
+*Restart required*: Yes
+
+*Gets restored during cluster restore:* No
+
 *Type*: string
 
 *Default*: null
-
-*Restart required*: yes
 
 *Supported versions*: Redpanda v23.1 or later
 
@@ -165,11 +173,13 @@ The account access key to be used for Azure Shared Key authentication with the A
 
 NOTE: Redpanda expects this key string to be Base64 encoded.
 
+*Restart required*: Yes
+
+*Gets restored during cluster restore:* No
+
 *Type*: string
 
 *Default*: null
-
-*Restart required*: yes
 
 *Supported versions*: Redpanda v23.1 or later
 
@@ -180,6 +190,8 @@ NOTE: Redpanda expects this key string to be Base64 encoded.
 The name of the Azure storage account to use with Tiered Storage. If `null`, the property is disabled.
 
 *Requires restart:* Yes
+
+*Gets restored during cluster restore:* No
 
 *Visibility:* `user`
 
@@ -194,6 +206,8 @@ The name of the Azure storage account to use with Tiered Storage. If `null`, the
 Optional object storage backend variant used to select API capabilities. If not supplied, this will be inferred from other configuration properties.
 
 *Requires restart:* Yes
+
+*Gets restored during cluster restore:* No
 
 *Visibility:* `user`
 
@@ -226,6 +240,8 @@ AWS or GCP bucket that should be used to store data.
 WARNING: Modifying this property after writing data to a bucket could cause data loss.
 
 *Requires restart:* Yes
+
+*Gets restored during cluster restore:* No
 
 *Visibility:* `user`
 
@@ -331,9 +347,11 @@ This property works together with <<cloud_storage_cache_size_percent,`cloud_stor
 
 - `cloud_storage_cache_size` cannot be `0` while `cloud_storage_cache_size_percent` is `null`.
 
-*Unit*: bytes
-
 *Requires restart:* No
+
+*Gets restored during cluster restore:* No
+
+*Unit*: bytes
 
 *Visibility:* `user`
 
@@ -521,9 +539,11 @@ The hostname to connect to for retrieving role based credentials. Derived from <
 
 *Requires restart:* Yes
 
+*Gets restored during cluster restore:* No
+
 *Visibility:* `tunable`
 
-*Type:* 
+*Type:* string
 
 *Accepted values:* [`config_file`, `aws_instance_metadata`, `sts`, `gcp_instance_metadata`, `azure_aks_oidc_federation`, `azure_vm_instance_metadata`]
 
@@ -538,9 +558,11 @@ Required for AWS or GCP authentication with IAM roles.
 
 To authenticate using access keys, see <<cloud_storage_access_key,`cloud_storage_access_key`>>.
 
-*Accepted values*: `config_file`, `aws_instance_metadata`, `sts, gcp_instance_metadata`, `azure_vm_instance_metadata`, `azure_aks_oidc_federation`
-
 *Requires restart:* Yes
+
+*Gets restored during cluster restore:* No
+
+*Accepted values*: `config_file`, `aws_instance_metadata`, `sts, gcp_instance_metadata`, `azure_vm_instance_metadata`, `azure_aks_oidc_federation`
 
 *Visibility:* `user`
 
@@ -1357,6 +1379,8 @@ Cloud provider region that houses the bucket or container used for storage.
 
 *Requires restart:* Yes
 
+*Gets restored during cluster restore:* No
+
 *Visibility:* `user`
 
 *Type:* string
@@ -1406,6 +1430,8 @@ Jitter applied to the object storage scrubbing interval.
 Cloud provider secret key.
 
 *Requires restart:* Yes
+
+*Gets restored during cluster restore:* No
 
 *Visibility:* `user`
 
@@ -1548,6 +1574,8 @@ Grace period during which the purger refuses to purge the topic.
 Path to certificate that should be used to validate server certificate during TLS handshake.
 
 *Requires restart:* Yes
+
+*Gets restored during cluster restore:* No
 
 *Visibility:* `user`
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1285
Review deadline: April 30

This pull request updates documentation for cluster and object storage properties by adding a new attribute, "Gets restored during cluster restore," to clarify whether specific properties are restored during a cluster restore operation. Additionally, some formatting adjustments were made for consistency.

### Documentation Updates:

#### New Attribute Added:
* Added "*Gets restored during cluster restore:* No" to multiple properties in the `cluster-properties.adoc` and `object-storage-properties.adoc` files to indicate that these properties are not restored during a cluster restore. [[1]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R305-R306) [[2]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R38-R39) [[3]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R88-R89) [[4]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R104-R105) [[5]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R122-L121) [[6]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R176-L173) [[7]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R194-R195) [[8]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R210-R211) [[9]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R244-R245) [[10]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98L334-R355) [[11]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R542-R546) [[12]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98L541-R566) [[13]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R1382-R1383) [[14]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R1434-R1435) [[15]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R1578-R1579)

#### Formatting Adjustments:
* Moved the "*Restart required:* Yes" section in `object-storage-properties.adoc` to ensure consistent ordering of attributes. [[1]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R122-L121) [[2]](diffhunk://#diff-f25a8321223cd3b8aaaf2a00b85e24ca0e3fe9383aa39e657c2ff12d2e5e2e98R176-L173)

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated property documentation to indicate which cluster and object storage properties do not get restored during a cluster restore operation.
  - Added a new attribute to relevant properties for clearer behavior clarification during cluster restore.
  - Adjusted the order of some property attributes for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->