### PR TITLE
Add required version for cluster restore

### DIFF
--- a/modules/manage/partials/whole-cluster-restore.adoc
+++ b/modules/manage/partials/whole-cluster-restore.adoc
@@ -69,7 +69,7 @@ ifdef::env-kubernetes[. <<Verify that the cluster restore is complete>>.]
 
 You must have the following:
 
-- Redpanda v23.3 or later.
+- Redpanda v23.3 or later on both source and target clusters.
 - xref:{link-tiered-storage}[Tiered Storage] enabled on the source cluster.
 - Physical or virtual machines on which to deploy the target cluster.
 

--- a/modules/manage/partials/whole-cluster-restore.adoc
+++ b/modules/manage/partials/whole-cluster-restore.adoc
@@ -69,6 +69,7 @@ ifdef::env-kubernetes[. <<Verify that the cluster restore is complete>>.]
 
 You must have the following:
 
+- Redpanda v23.3 or later.
 - xref:{link-tiered-storage}[Tiered Storage] enabled on the source cluster.
 - Physical or virtual machines on which to deploy the target cluster.
 


### PR DESCRIPTION
## Description

This pull request updates the documentation for whole-cluster restore in `modules/manage/partials/whole-cluster-restore.adoc` to include a new prerequisite.

Documentation update:

* Added a requirement for Redpanda v23.3 or later to the list of prerequisites for performing a whole-cluster restore.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

https://deploy-preview-1096--redpanda-docs-preview.netlify.app/current/manage/whole-cluster-restore/#prerequisites

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
