### PR TITLE
Update install-redpanda.adoc

### DIFF
--- a/modules/deploy/partials/linux/install-redpanda.adoc
+++ b/modules/deploy/partials/linux/install-redpanda.adoc
@@ -7,14 +7,14 @@ Unless you intend to run Redpanda in FIPS-compliance mode, the following package
 `redpanda`
 
 - Contains the Redpanda application and all supporting libraries
-- Depends on `redpanda-tuners` and either `redpanda-rpk` or `redpanda-rpk-fips`
+- Depends on `redpanda-tuner` and either `redpanda-rpk` or `redpanda-rpk-fips`
 
 `redpanda-rpk`
 
 - Contains the pure GoLang compiled `rpk` application
 - If you wish to use `rpk` only, then this is the only required install package
 
-`redpanda-tuners`
+`redpanda-tuner`
 
 - Contains the files used to run Redpanda tuners
 - Depends on `redpanda-rpk` or `redpanda-rpk-fips`


### PR DESCRIPTION
Fixes name of `redpanda-tuner` package in Linux install page.

## Description

Just a small typo I noticed and wanted to fix.

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
