### PR TITLE
DOC-1308 change redpanda-tuners to redpanda-tuner

### DIFF
--- a/modules/manage/pages/security/fips-compliance.adoc
+++ b/modules/manage/pages/security/fips-compliance.adoc
@@ -68,7 +68,7 @@ You must specify the following SSL configurations for brokers you want to run in
 +
 The following configuration starts Redpanda in FIPS mode: 
 +
-```bash
+```yaml
 redpanda:
   # ....
   fips_mode: enabled

--- a/modules/manage/pages/security/fips-compliance.adoc
+++ b/modules/manage/pages/security/fips-compliance.adoc
@@ -44,7 +44,7 @@ Redpanda logs an error and exits immediately if:
 
 To place a broker in FIPS compliance mode, enable xref:reference:properties/broker-properties.adoc#fips_mode[`fips_mode`] in the Redpanda broker configuration file (typically located in `/etc/redpanda/redpanda.yaml`). All fields are within the `redpanda` object:
 
-```bash
+```yaml
 redpanda:
   # ....
   fips_mode: enabled

--- a/modules/manage/pages/security/fips-compliance.adoc
+++ b/modules/manage/pages/security/fips-compliance.adoc
@@ -18,7 +18,7 @@ rpk cluster license info
 
 == Prerequisites
 
-Before configuring brokers to run in FIPS compliance mode (FIPS mode), check to make sure the `redpanda-rpk-fips` and `redpanda-fips` packages are xref:deploy:deployment-option/self-hosted/manual/production/production-deployment.adoc#install-redpanda-for-fips-compliance[installed]. These packages are required by both the `redpanda` and `redpanda-tuners` install packages.
+Before configuring brokers to run in FIPS compliance mode (FIPS mode), check to make sure the `redpanda-rpk-fips` and `redpanda-fips` packages are xref:deploy:deployment-option/self-hosted/manual/production/production-deployment.adoc#install-redpanda-for-fips-compliance[installed]. These packages are required by both the `redpanda` and `redpanda-tuner` install packages.
 
 == Limitations
 


### PR DESCRIPTION
## Description
This pull request includes a minor documentation fix to the `modules/manage/pages/security/fips-compliance.adoc` file. The change corrects a typo in the package name.

Documentation fix:

* Corrected the package name from `redpanda-tuners` to `redpanda-tuner` in the prerequisites section for configuring brokers in FIPS compliance mode.

Resolves https://redpandadata.atlassian.net/browse/DOC-1308
Review deadline:

## Page previews
https://deploy-preview-1105--redpanda-docs-preview.netlify.app/current/manage/security/fips-compliance/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
