### PR TITLE
DOC-1287 hide defaults in cloud cluster properties

### DIFF
--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -155,7 +155,9 @@ Enables or disables audit logging. When you set this to true, Redpanda checks fo
 
 *Enterprise license required*: `true`
 
+ifndef::env-cloud[]
 *Default:* `false`
+endif::[]
 
 ---
 
@@ -188,7 +190,9 @@ List of user principals to exclude from auditing.
 
 *Type:* array
 
+ifndef::env-cloud[]
 *Default:* `null`
+endif::[]
 
 ---
 
@@ -206,7 +210,9 @@ List of topics to exclude from auditing.
 
 *Type:* array
 
+ifndef::env-cloud[]
 *Default:* `null`
+endif::[]
 
 ---
 
@@ -226,7 +232,9 @@ Defines the number of partitions used by a newly-created audit topic. This confi
 
 *Accepted values:* [`-2147483648`, `2147483647`]
 
+ifndef::env-cloud[]
 *Default:* `12`
+endif::[]
 
 ---
 
@@ -704,7 +712,9 @@ Enables WebAssembly-powered data transforms directly in the broker. When `data_t
 
 *Type:* boolean
 
+ifndef::env-cloud[]
 *Default:* `false`
+endif::[]
 
 ---
 
@@ -758,7 +768,9 @@ Transform log lines truncate to this length. Truncation occurs after any charact
 
 *Type:* integer
 
+ifndef::env-cloud[]
 *Default:* `1024`
+endif::[]
 
 ---
 
@@ -774,7 +786,9 @@ The amount of memory to reserve per core for data transform (Wasm) virtual machi
 
 *Type:* integer
 
+ifndef::env-cloud[]
 *Default:* `20971520`
+endif::[]
 
 ---
 
@@ -1814,7 +1828,9 @@ Iceberg catalog type that Redpanda will use to commit table metadata updates. Su
 
 *Accepted values:* `rest`, `object_storage`
 
+ifndef::env-cloud[]
 *Default:* `object_storage`
+endif::[]
 
 **Related topics**:
 
@@ -1841,9 +1857,11 @@ endif::[]
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `(hour(redpanda.timestamp))`
 
 Partitions the topic by extracting the hour from `redpanda.timestamp`, grouping records by hour to optimize queries.
+endif::[]
 
 **Related topics**:
 
@@ -1864,7 +1882,9 @@ Default value for the `redpanda.iceberg.delete` topic property that determines i
 
 *Type:* boolean
 
+ifndef::env-cloud[]
 *Default:* `true`
+endif::[]
 
 **Related topics**:
 
@@ -1923,7 +1943,9 @@ endif::[]
 
 *Type:* boolean
 
+ifndef::env-cloud[]
 *Default:* `false`
+endif::[]
 
 **Related topics**:
 
@@ -1948,7 +1970,9 @@ endif::[]
 
 *Visibility:* `user`
 
+ifndef::env-cloud[]
 *Default:* `dlq_table`
+endif::[]
 
 **Related topics**:
 
@@ -1967,7 +1991,9 @@ The authentication mode for client requests made to the Iceberg catalog. Choose 
 
 *Visibility:* `user`
 
+ifndef::env-cloud[]
 *Default:* `none`
+endif::[]
 
 **Related topics**:
 
@@ -1988,7 +2014,9 @@ The client ID used to query the REST catalog API for the OAuth token. Required i
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `null`
+endif::[]
 
 **Related topics**:
 
@@ -2009,7 +2037,9 @@ Secret used with the client ID to query the OAuth token endpoint for Iceberg RES
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `null`
+endif::[]
 
 **Related topics**:
 
@@ -2030,7 +2060,9 @@ The contents of a certificate revocation list for `iceberg_rest_catalog_trust`. 
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `null`
+endif::[]
 
 ---
 
@@ -2065,7 +2097,9 @@ URL of Iceberg REST catalog endpoint.
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `null`
+endif::[]
 
 **Related topics**:
 
@@ -2086,7 +2120,9 @@ The OAuth URI used to retrieve access tokens for Iceberg REST catalog authentica
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `null`
+endif::[]
 
 **Related topics**:
 
@@ -2107,7 +2143,9 @@ The OAuth scope used to retrieve access tokens for Iceberg catalog authenticatio
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `principal_role:all`
+endif::[]
 
 **Related topics**:
 
@@ -2128,7 +2166,9 @@ Prefix part of the Iceberg REST catalog URL. Prefix is appended to the catalog p
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `null`
+endif::[]
 
 **Related topics**:
 
@@ -2153,7 +2193,9 @@ Maximum length of time that Redpanda waits for a response from the REST catalog 
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
+ifndef::env-cloud[]
 *Default:* `10000`
+endif::[]
 
 **Related topics**:
 
@@ -2176,7 +2218,9 @@ Required if <<iceberg_rest_catalog_authentication_mode, `iceberg_rest_catalog_au
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `null`
+endif::[]
 
 **Related topics**:
 
@@ -2201,7 +2245,9 @@ endif::[]
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `null`
+endif::[]
 
 ---
 
@@ -2268,7 +2314,9 @@ endif::[]
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
+ifndef::env-cloud[]
 *Default:* `60000`
+endif::[]
 
 **Related topics**:
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -153,9 +153,9 @@ Enables or disables audit logging. When you set this to true, Redpanda checks fo
 
 *Type:* boolean
 
+ifndef::env-cloud[]
 *Enterprise license required*: `true`
 
-ifndef::env-cloud[]
 *Default:* `false`
 endif::[]
 
@@ -1865,7 +1865,7 @@ endif::[]
 
 **Related topics**:
 
-- xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg]
+- xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration]
 
 ---
 
@@ -2233,9 +2233,9 @@ endif::[]
 // tag::iceberg_rest_catalog_trust[]
 === iceberg_rest_catalog_trust
 
-The contents of a certificate chain to trust for the REST Iceberg catalog. 
+The contents of a certificate chain to trust for the REST Iceberg catalog.
 
-ifndef::end-cloud[]
+ifndef::env-cloud[]
 Takes precedence over <<iceberg_rest_catalog_trust_file, `iceberg_rest_catalog_trust_file`>>.
 endif::[]
 


### PR DESCRIPTION
## Description
This pull request updates the `modules/reference/pages/properties/cluster-properties.adoc` file to conditionally exclude default property values in Cloud docs. Specifically, it wraps default values in `ifndef::env-cloud[]` blocks to exclude them when the `env-cloud` environment is active. 

### Conditional Default Value Updates:

* Added `ifndef::env-cloud[]` blocks around default values for various cluster properties, such as audit logging, WebAssembly-powered data transforms, Iceberg catalog configurations, and more. These blocks exclude default values from the documentation when the `env-cloud` environment is active. [[1]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R158-R160) [[2]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R193-R195) [[3]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R213-R215) [[4]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R235-R237) [[5]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R715-R717) [[6]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R771-R773) [[7]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R789-R791) [[8]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R1831-R1833) [[9]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R1860-R1864) [[10]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R1885-R1887) [[11]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R1946-R1948) [[12]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R1973-R1975) [[13]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R1994-R1996) [[14]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2017-R2019) [[15]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2040-R2042) [[16]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2063-R2065) [[17]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2100-R2102) [[18]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2123-R2125) [[19]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2146-R2148) [[20]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2169-R2171) [[21]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2196-R2198) [[22]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2221-R2223) [[23]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2248-R2250) [[24]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2317-R2319)

Resolves https://redpandadata.atlassian.net/browse/DOC-1287
Review deadline:

## Page previews
[Cluster config properties in Cloud](https://deploy-preview-1107--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/properties/cluster-properties/)
[Cluster config properties in Self-Managed](https://deploy-preview-1107--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
