### PR TITLE
DOC-1324 SSD backed persistent volumes typo

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
@@ -52,16 +52,11 @@ redpanda2:~ sudo apt update; sudo apt install iperf3
 redpanda2:~ iperf3 -c redpanda1 -p 5201 -t 300
 Connecting to host redpanda1, port 5201
 [ ID] Interval Transfer Bitrate Retr Cwnd
-[ 5] 0.00-1.00 sec 1.11 GBytes 9.57 Gbits/sec 0 1.64
-MBytes
-[ 5] 1.00-2.00 sec 1.11 GBytes 9.53 Gbits/sec 0 1.64
-MBytes
-[ 5] 2.00-3.00 sec 1.11 GBytes 9.53 Gbits/sec 0 1.64
-MBytes
-[ 5] 3.00-4.00 sec 1.11 GBytes 9.53 Gbits/sec 0 1.72
-MBytes
-[ 5] 4.00-5.00 sec 1.11 GBytes 9.53 Gbits/sec 0 1.72
-MBytes
+[ 5] 0.00-1.00 sec 1.11 GBytes 9.57 Gbits/sec 0 1.64 MBytes
+[ 5] 1.00-2.00 sec 1.11 GBytes 9.53 Gbits/sec 0 1.64 MBytes
+[ 5] 2.00-3.00 sec 1.11 GBytes 9.53 Gbits/sec 0 1.64 MBytes
+[ 5] 3.00-4.00 sec 1.11 GBytes 9.53 Gbits/sec 0 1.72 MBytes
+[ 5] 4.00-5.00 sec 1.11 GBytes 9.53 Gbits/sec 0 1.72 MBytes
 ...
 ----
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
@@ -43,13 +43,13 @@ The following example uses https://iperf.fr/[iPerf3^] to test the network bandwi
 
 [,bash]
 ----
-redpanda1:~$ sudo apt -y update; sudo apt -y install iperf3
-redpanda1:~$ iperf3 -s
+redpanda1:~ sudo apt -y update; sudo apt -y install iperf3
+redpanda1:~ iperf3 -s
 -----------------------------------------------------------
 Server listening on 5201
 -----------------------------------------------------------
-redpanda2:~$ sudo apt update; sudo apt install iperf3
-redpanda2:~$ iperf3 -c redpanda1 -p 5201 -t 300
+redpanda2:~ sudo apt update; sudo apt install iperf3
+redpanda2:~ iperf3 -c redpanda1 -p 5201 -t 300
 Connecting to host redpanda1, port 5201
 [ ID] Interval Transfer Bitrate Retr Cwnd
 [ 5] 0.00-1.00 sec 1.11 GBytes 9.57 Gbits/sec 0 1.64

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
@@ -77,7 +77,7 @@ Redpanda is basically a distributed transaction log with well-understood access 
 
 Your best storage solution for your workload depends on your performance and data retention requirements.
 
-If high throughput and low latency is most important, then use locally attached NVMe SSD disks. This is also a good option in the cloud. Just remember that in the cloud, local disks are ephemeral, so data is wiped when an instance is restarted. An alternative in the cloud is to use SSD-backed object storage to persist data between instance restarts. Most cloud providers have options for guaranteeing throughput and provisioned IOPS performance of network-attached storage, although network-attached storage almost always exhibits slightly higher tail latencies than direct-attached storage.
+If high throughput and low latency is most important, then use locally attached NVMe SSD disks. This is also a good option in the cloud. Just remember that in the cloud, local disks are ephemeral, so data is wiped when an instance is restarted. An alternative in the cloud is to use SSD-backed persistent volumes to retain data between instance restarts. Most cloud providers have options for guaranteeing throughput and provisioned IOPS performance of network-attached storage, although network-attached storage almost always exhibits slightly higher tail latencies than direct-attached storage.
 
 For example, AWS io2 volumes offer up to 64,000 IOPS and 1,000 MB/sec throughput with single-digit millisecond latency. This is an expensive option, so if you can trade performance for cost, then AWS gp3 volumes are a good alternative. GCP has comparable options with high-end Extreme persistent disks and the lesser SSD persistent disks. Likewise, Azure has Ultra, Premium, and Standard persistent disk options for choosing the right balance of performance versus cost.
 
@@ -87,9 +87,9 @@ NOTE: Ensure that the fio job runs against the chosen block device. By default, 
 
 [,bash]
 ----
-$ sudo apt -y update; sudo apt -y install fio
-$ cd /var/lib/redpanda/data
-$ sudo cat > fio-seq-write.job << EOF
+sudo apt -y update; sudo apt -y install fio
+cd /var/lib/redpanda/data
+sudo cat > fio-seq-write.job << EOF
 [global]
 name=fio-seq-write
 filename=fio-seq-write
@@ -105,7 +105,7 @@ size=10G
 ioengine=libaio
 iodepth=16
 EOF
-$ sudo fio fio-seq-write.job
+sudo fio fio-seq-write.job
 ----
 
 Key performance metrics:

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
@@ -72,7 +72,7 @@ Redpanda is basically a distributed transaction log with well-understood access 
 
 Your best storage solution for your workload depends on your performance and data retention requirements.
 
-If high throughput and low latency is most important, then use locally attached NVMe SSD disks. This is also a good option in the cloud. Just remember that in the cloud, local disks are ephemeral, so data is wiped when an instance is restarted. An alternative in the cloud is to use SSD-backed persistent volumes to retain data between instance restarts. Most cloud providers have options for guaranteeing throughput and provisioned IOPS performance of network-attached storage, although network-attached storage almost always exhibits slightly higher tail latencies than direct-attached storage.
+If high throughput and low latency is most important, then use locally attached NVMe SSD disks. This is also a good option in the cloud. Just remember that in the cloud, local disks are ephemeral, so data is wiped when an instance is restarted. An alternative in the cloud is to use SSD-backed network-attached storage to persist data between instance restarts. Most cloud providers have options for guaranteeing throughput and provisioned IOPS performance of network-attached storage, although network-attached storage almost always exhibits slightly higher tail latencies than direct-attached storage.
 
 For example, AWS io2 volumes offer up to 64,000 IOPS and 1,000 MB/sec throughput with single-digit millisecond latency. This is an expensive option, so if you can trade performance for cost, then AWS gp3 volumes are a good alternative. GCP has comparable options with high-end Extreme persistent disks and the lesser SSD persistent disks. Likewise, Azure has Ultra, Premium, and Standard persistent disk options for choosing the right balance of performance versus cost.
 
@@ -84,7 +84,7 @@ NOTE: Ensure that the fio job runs against the chosen block device. By default, 
 ----
 sudo apt -y update; sudo apt -y install fio
 cd /var/lib/redpanda/data
-sudo cat > fio-seq-write.job << EOF
+sudo tee fio-seq-write.job >/dev/null << EOF
 [global]
 name=fio-seq-write
 filename=fio-seq-write


### PR DESCRIPTION
## Description
This pull request makes minor updates to the self-hosted deployment manual for Redpanda, improving clarity and consistency in the documentation. 

* Updated the description of cloud storage options to replace "SSD-backed object storage" with "SSD-backed persistent volumes to retain data" for better clarity and accuracy in describing data retention solutions. (`modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc`, [modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adocL80-R80](diffhunk://#diff-b419478a3d8714102e6df5124ff2b39e138f22527e6459ac7950095c9eaee2d2L80-R80))

* Removed redundant `sudo` prefixes from several commands to streamline the instructions and improve readability. (`modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc`, [[1]](diffhunk://#diff-b419478a3d8714102e6df5124ff2b39e138f22527e6459ac7950095c9eaee2d2L90-R92) [[2]](diffhunk://#diff-b419478a3d8714102e6df5124ff2b39e138f22527e6459ac7950095c9eaee2d2L108-R108)

Resolves https://redpandadata.atlassian.net/browse/DOC-1324
Review deadline:

## Page previews
https://deploy-preview-1112--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/manual/sizing/#storage

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
