### PR TITLE
Update Iceberg catalog doc for Cloud (single source)

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1216-Document-how-to-pass-in-secrets-when-configuring-iceberg'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1216-Document-how-to-pass-in-secrets-when-configuring-iceberg'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -41,7 +41,9 @@ See xref:reference:properties/cluster-properties.adoc[Cluster Configuration Prop
 ifdef::env-cloud[]
 === Store a secret for REST catalog authentication
 
-To store a secret that you can reference in your catalog authentication cluster properties, you must create the secret using `rpk` or the Data Plane API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime.
+To store a secret that you can reference in your catalog authentication cluster properties, you must create the secret using `rpk` or the Cloud API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime. 
+
+To learn more about `rpk` and the Cloud API, see xref:manage:rpk/intro-to-rpk.adoc[] and xref:manage:api/cloud-api-overview.adoc[].
 
 Store secrets for the following properties:
 
@@ -63,10 +65,10 @@ rpk security secret create --name <secret-name> --value <secret-value> --scopes 
 ----
 --
 
-Data Plane API::
+Cloud API::
 +
 --
-. xref:manage:api/cloud-api-quickstart.adoc#try-the-cloud-api[Authenticate and get the base URL] for the Data Plane API.
+. Authenticate and make a `GET /v1/clusters/\{id}` request to xref:manage:api/cloud-dataplane-api.adoc#get-data-plane-api-url[retrieve the Data Plane API URL] for your cluster.
 . Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/secrets[`POST /v1/secrets`]. You must use a Base64-encoded secret.
 +
 [,bash]
@@ -111,10 +113,10 @@ rpk cluster config set iceberg_rest_catalog_client_secret <secret-name>
 ----
 --
 
-Control Plane API::
+Cloud API::
 +
 --
-Make a request to xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/<cluster-id>`].
+Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/<cluster-id>`] endpoint of the Control Plane API.
 
 [,bash]
 ----

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -86,7 +86,7 @@ You must include the following values:
 
 - `<dataplane-api-url>`: The base URL for the Data Plane API.
 - `<token>`: The API key you generated during authentication.
-- `<secret-name>`: The ID or name of the secret you want to add. Use only the following characters: `^[A-Z][A-Z0-9_]*$`.
+- `<secret-name>`: The name of the secret you want to add. The secret name is also its ID. Use only the following characters: `^[A-Z][A-Z0-9_]*$`.
 - `<secret-value>`: The Base64-encoded secret.
 - This scope: `"SCOPE_REDPANDA_CLUSTER"`.
 
@@ -138,7 +138,7 @@ You must include the following values:
 
 - `<cluster-id>`: The ID of the Redpanda cluster.
 - `<token>`: The API key you generated during authentication.
-- `<secret-name>`: The name of the secret you created earlier. The secret name is also its ID.
+- `<secret-name>`: The name of the secret you created earlier.
 --
 =====
 endif::[]

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -11,7 +11,8 @@ For production deployments, Redpanda recommends using an external REST catalog t
 
 After you have selected a catalog type at the cluster level and xref:{about-iceberg-doc}#enable-iceberg-integration[enabled the Iceberg integration] for a topic, you cannot switch to another catalog type.
 
-ifndef::env-cloud[]
+//ifndef::env-cloud[]
+// tag::single-source-rest[]
 == Connect to a REST catalog
 
 Connect to an Iceberg REST catalog using the standard https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml[REST API^] supported by many catalog providers. Use this catalog integration type with REST-enabled Iceberg catalog services, such as https://docs.databricks.com/en/data-governance/unity-catalog/index.html[Databricks Unity^] and https://other-docs.snowflake.com/en/opencatalog/overview[Snowflake Open Catalog^].
@@ -79,8 +80,11 @@ SELECT * FROM streaming.redpanda.<table-name>;
 The Iceberg table name is the name of your Redpanda topic. Redpanda puts the Iceberg table into a namespace called `redpanda`, creating the namespace if necessary. 
 
 TIP: You may need to explicitly create a table for the Iceberg data in your query engine. For an example, see xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[].
-endif::[]
 
+// end::single-source-rest[]
+//endif::[]
+
+// tag::single-source-object-storage[]
 == Integrate filesystem-based catalog (`object_storage`)
 
 By default, Iceberg topics use the filesystem-based catalog (config_ref:iceberg_catalog_type,true,properties/cluster-properties[`iceberg_catalog_type`] cluster property set to `object_storage`). Redpanda stores the table metadata in https://iceberg.apache.org/docs/latest/java-api-quickstart/#using-a-hadoop-catalog[HadoopCatalog^] format in the same object storage bucket or container as the data files.
@@ -122,3 +126,5 @@ endif::[]
 ifdef::env-cloud[]
 The base path for the filesystem-based catalog if using the `object_storage` catalog type is `redpanda-iceberg-catalog`. 
 endif::[]
+
+// end::single-source-object-storage[]

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -41,9 +41,15 @@ See xref:reference:properties/cluster-properties.adoc[Cluster Configuration Prop
 ifdef::env-cloud[]
 === Store a secret for REST authentication
 
-To store secrets for authentication that are referenced in your cloud cluster properties, you must add the secrets using `rpk` or the Data Plane API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime. 
+To store a secret that you can reference in your catalog authentication cluster properties, you must create the secret using `rpk` or the Data Plane API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime.
 
-To store a new secret, run the following:
+Store secrets for the following properties:
+* `iceberg_rest_catalog_client_secret`
+* `iceberg_rest_catalog_crl`
+* `iceberg_rest_catalog_token`
+* `iceberg_rest_catalog_trust`
+
+To create a new secret, run the following:
 
 [tabs]
 =====
@@ -59,10 +65,8 @@ rpk security secret create --name <secret-name> --value <secret-value> --scopes 
 Data Plane API::
 +
 --
-You must use a Base64-encoded secret.
-
 . xref:manage:api/cloud-api-quickstart.adoc#try-the-cloud-api[Authenticate and get the base URL] for the Data Plane API.
-. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/secrets[`POST /v1/secrets`].
+. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/secrets[`POST /v1/secrets`]. You must use a Base64-encoded secret.
 +
 [,bash]
 ----
@@ -84,14 +88,14 @@ You must include the following values:
 +
 The response returns the name of the secret and the scope `"SCOPE_REDPANDA_CLUSTER"`.
 
-You can now <<add-a-secret-to-cluster-configuration,add the secret to your cluster configuration>>.
+You can now <<use-a-secret-in-cluster-configuration,reference the secret in your cluster configuration>>.
 
 --
 =====
 
-=== Add a secret to cluster configuration
+=== Use a secret in cluster configuration
 
-To update the cluster property with the value of the secret, use `rpk` or the Control Plane API.
+To set the cluster property to use the value of the secret, use `rpk` or the Control Plane API.
 
 For example, to use a secret for the `iceberg_rest_catalog_client_secret` property, run the following:
 
@@ -129,14 +133,14 @@ You must include the following values:
 
 - `<cluster-id>`: The ID of the Redpanda cluster.
 - `<token>`: The API key you generated during authentication.
-- `<secret-name>`: The ID or name of the secret you created earlier.
+- `<secret-name>`: The name of the secret you created earlier. The secret name is also its ID.
 --
 =====
 endif::[]
 
 === Example REST catalog configuration
 
-For example, if you have Redpanda cluster configuration properties set to connect to a REST catalog:
+Suppose you configure the following Redpanda cluster properties for connecting to a REST catalog:
 
 [,yaml]
 ----
@@ -147,7 +151,7 @@ iceberg_rest_catalog_client_id: <rest-connection-id>
 iceberg_rest_catalog_client_secret: <rest-connection-secret>
 ----
 
-And you use Apache Spark as a processing engine, configured to use a catalog named `streaming`:
+If you use Apache Spark as a processing engine, your Spark configuration might look like the following. This example uses a catalog named `streaming`:
 
 [,spark]
 ----

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -52,13 +52,15 @@ Store secrets for the following properties:
 * `iceberg_rest_catalog_token`
 * `iceberg_rest_catalog_trust`
 
-To create a new secret, run the following:
+To create a new secret, follow these steps:
 
 [tabs]
 =====
 rpk::
 +
 --
+Run the following `rpk` command:
+
 [,bash]
 ----
 rpk security secret create --name <secret-name> --value <secret-value> --scopes redpanda_cluster

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -39,7 +39,7 @@ For REST catalogs that use self-signed certificates, also configure these proper
 See xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties] for the full list of cluster properties to configure for a catalog integration.
 
 ifdef::env-cloud[]
-=== Store a secret for REST authentication
+=== Store a secret for REST catalog authentication
 
 To store a secret that you can reference in your catalog authentication cluster properties, you must create the secret using `rpk` or the Data Plane API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime.
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -33,19 +33,25 @@ Redpanda uses the bearer token unconditionally and does not attempt to refresh t
 
 For REST catalogs that use self-signed certificates, also configure these properties:
 
-* config_ref:iceberg_rest_catalog_trust_file,true,properties/cluster-properties[`iceberg_rest_catalog_trust_file`]: The path to a file containing a certificate chain to trust for the REST catalog.
-* config_ref:iceberg_rest_catalog_crl_file,true,properties/cluster-properties[`iceberg_rest_catalog_crl_file`]: The path to the certificate revocation list for the specified trust file.
+* config_ref:iceberg_rest_catalog_trust,true,properties/cluster-properties[`iceberg_rest_catalog_trust`]: The contents of a certificate chain to trust for the REST catalog. 
+ifndef::env-cloud[]
+** Or, use config_ref:iceberg_rest_catalog_trust_file,true,properties/cluster-properties[`iceberg_rest_catalog_trust_file`] to specify the path to the certificate chain file.
+endif::[]
+* config_ref:iceberg_rest_catalog_crl,true,properties/cluster-properties[`iceberg_rest_catalog_crl`]: The contents of a certificate revocation list for `iceberg_rest_catalog_trust`.
+ifndef::env-cloud[]
+** Or, use config_ref:iceberg_rest_catalog_crl_file,true,properties/cluster-properties[`iceberg_rest_catalog_crl_file`] to specify the path to the certificate revocation list file.
+endif::[]
 
 See xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties] for the full list of cluster properties to configure for a catalog integration.
 
 ifdef::env-cloud[]
 === Store a secret for REST catalog authentication
 
-To store a secret that you can reference in your catalog authentication cluster properties, you must create the secret using `rpk` or the Cloud API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime. 
+To store a secret that you can reference in your catalog authentication cluster properties, you must create the secret using `rpk` or the Data Plane API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime. 
 
 To learn more about `rpk` and the Cloud API, see xref:manage:rpk/intro-to-rpk.adoc[] and xref:manage:api/cloud-api-overview.adoc[].
 
-Store secrets for the following properties:
+If you need to configure any of the following properties, you must set their values using secrets:
 
 * `iceberg_rest_catalog_client_secret`
 * `iceberg_rest_catalog_crl`
@@ -91,7 +97,7 @@ You must include the following values:
 - This scope: `"SCOPE_REDPANDA_CLUSTER"`.
 
 +
-The response returns the name of the secret and the scope `"SCOPE_REDPANDA_CLUSTER"`.
+The response returns the name and scope of the secret.
 
 You can now <<use-a-secret-in-cluster-configuration,reference the secret in your cluster configuration>>.
 
@@ -100,7 +106,7 @@ You can now <<use-a-secret-in-cluster-configuration,reference the secret in your
 
 === Use a secret in cluster configuration
 
-To set the cluster property to use the value of the secret, use `rpk` or the Cloud API.
+To set the cluster property to use the value of the secret, use `rpk` or the Control Plane API.
 
 For example, to use a secret for the `iceberg_rest_catalog_client_secret` property, run the following:
 
@@ -111,7 +117,7 @@ rpk::
 --
 [,bash]
 ----
-rpk cluster config set iceberg_rest_catalog_client_secret <secret-name>
+rpk cluster config set iceberg_rest_catalog_client_secret ${secrets.<secret-name>}
 ----
 --
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -100,7 +100,7 @@ You can now <<use-a-secret-in-cluster-configuration,reference the secret in your
 
 === Use a secret in cluster configuration
 
-To set the cluster property to use the value of the secret, use `rpk` or the Control Plane API.
+To set the cluster property to use the value of the secret, use `rpk` or the Cloud API.
 
 For example, to use a secret for the `iceberg_rest_catalog_client_secret` property, run the following:
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -49,7 +49,7 @@ ifdef::env-cloud[]
 
 To store a secret that you can reference in your catalog authentication cluster properties, you must create the secret using `rpk` or the Data Plane API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime. 
 
-To learn more about `rpk` and the Cloud API, see xref:manage:rpk/intro-to-rpk.adoc[] and xref:manage:api/cloud-api-overview.adoc[].
+For more information, see xref:manage:rpk/intro-to-rpk.adoc[] and xref:manage:api/cloud-api-overview.adoc[].
 
 If you need to configure any of the following properties, you must set their values using secrets:
 
@@ -58,7 +58,7 @@ If you need to configure any of the following properties, you must set their val
 * `iceberg_rest_catalog_token`
 * `iceberg_rest_catalog_trust`
 
-To create a new secret, follow these steps:
+To create a new secret:
 
 [tabs]
 =====
@@ -108,7 +108,7 @@ You can now <<use-a-secret-in-cluster-configuration,reference the secret in your
 
 To set the cluster property to use the value of the secret, use `rpk` or the Control Plane API.
 
-For example, to use a secret for the `iceberg_rest_catalog_client_secret` property, run the following:
+For example, to use a secret for the `iceberg_rest_catalog_client_secret` property, run:
 
 [tabs]
 =====

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -44,6 +44,7 @@ ifdef::env-cloud[]
 To store a secret that you can reference in your catalog authentication cluster properties, you must create the secret using `rpk` or the Data Plane API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime.
 
 Store secrets for the following properties:
+
 * `iceberg_rest_catalog_client_secret`
 * `iceberg_rest_catalog_crl`
 * `iceberg_rest_catalog_token`
@@ -123,7 +124,7 @@ curl -H "Authorization: Bearer <token>" -X PATCH \
 -H 'content-type: application/json' \
 -d '{"cluster_configuration": {
         "custom_properties": {
-            "iceberg_rest_catalog_client_secret": <secret-name>
+            "iceberg_rest_catalog_client_secret": "${secrets.<secret-name>}"
             }
         }
     }'

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -12,7 +12,6 @@ For production deployments, Redpanda recommends using an external REST catalog t
 After you have selected a catalog type at the cluster level and xref:{about-iceberg-doc}#enable-iceberg-integration[enabled the Iceberg integration] for a topic, you cannot switch to another catalog type.
 
 //ifndef::env-cloud[]
-// tag::single-source-rest[]
 == Connect to a REST catalog
 
 Connect to an Iceberg REST catalog using the standard https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml[REST API^] supported by many catalog providers. Use this catalog integration type with REST-enabled Iceberg catalog services, such as https://docs.databricks.com/en/data-governance/unity-catalog/index.html[Databricks Unity^] and https://other-docs.snowflake.com/en/opencatalog/overview[Snowflake Open Catalog^].
@@ -39,6 +38,102 @@ For REST catalogs that use self-signed certificates, also configure these proper
 * config_ref:iceberg_rest_catalog_crl_file,true,properties/cluster-properties[`iceberg_rest_catalog_crl_file`]: The path to the certificate revocation list for the specified trust file.
 
 See xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties] for the full list of cluster properties to configure for a catalog integration.
+
+ifdef::env-cloud[]
+=== Store a secret for REST authentication
+
+To store secrets for authentication that are referenced in your cloud cluster properties, you must add the secrets using `rpk` or the Data Plane API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime. 
+
+To store a new secret, run the following:
+
+[tabs]
+=====
+rpk::
++
+--
+[,bash]
+----
+rpk security secret create --name <secret-name> --value <secret-value> --scopes redpanda_cluster
+----
+--
+
+Data Plane API::
++
+--
+You must use a Base64-encoded secret.
+
+. xref:manage:api/cloud-api-quickstart.adoc#try-the-cloud-api[Authenticate and get the base URL] for the Data Plane API.
+. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/secrets[`POST /v1/secrets`].
++
+[,bash]
+----
+curl -X POST "https://<dataplane-api-url>/v1/secrets" \
+ -H 'accept: application/json'\
+ -H 'authorization: Bearer <token>'\
+ -H 'content-type: application/json' \
+ -d '{"id":"<secret-name>","scopes":["SCOPE_REDPANDA_CLUSTER"],"secret_data":"<secret-value>"}' 
+----
++
+You must include the following values:
+
+- `<dataplane-api-url>`: The base URL for the Data Plane API.
+- `<token>`: The API key you generated during authentication.
+- `<secret-name>`: The ID or name of the secret you want to add. Use only the following characters: `^[A-Z][A-Z0-9_]*$`.
+- `<secret-value>`: The Base64-encoded secret.
+- This scope: `"SCOPE_REDPANDA_CLUSTER"`.
+
++
+The response returns the name of the secret and the scope `"SCOPE_REDPANDA_CLUSTER"`.
+
+You can now <<add-a-secret-to-cluster-configuration,add the secret to your cluster configuration>>.
+
+--
+=====
+
+=== Add a secret to cluster configuration
+
+To update the cluster property with the value of the secret, use `rpk` or the Control Plane API.
+
+For example, to use a secret for the `iceberg_rest_catalog_client_secret` property, run the following:
+
+[tabs]
+=====
+rpk::
++
+--
+[,bash]
+----
+rpk
+----
+--
+
+Control Plane API::
++
+--
+Make a request to xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/<cluster-id>`].
+
+[,bash]
+----
+curl -H "Authorization: Bearer <token>" -X PATCH \
+"https://api.cloud.redpanda.com/v1/clusters/<cluster-id>" \
+-H 'accept: application/json'\
+-H 'content-type: application/json' \
+-d '{"cluster_configuration": {
+        "custom_properties": {
+            "iceberg_rest_catalog_client_secret": <secret-name>
+            }
+        }
+    }'
+----
+
+You must include the following values:
+
+- `<cluster-id>`: The ID of the Redpanda cluster.
+- `<token>`: The API key you generated during authentication.
+- `<secret-name>`: The ID or name of the secret you created earlier.
+--
+=====
+endif::[]
 
 === Example REST catalog configuration
 
@@ -81,10 +176,7 @@ The Iceberg table name is the name of your Redpanda topic. Redpanda puts the Ice
 
 TIP: You may need to explicitly create a table for the Iceberg data in your query engine. For an example, see xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[].
 
-// end::single-source-rest[]
-//endif::[]
 
-// tag::single-source-object-storage[]
 == Integrate filesystem-based catalog (`object_storage`)
 
 By default, Iceberg topics use the filesystem-based catalog (config_ref:iceberg_catalog_type,true,properties/cluster-properties[`iceberg_catalog_type`] cluster property set to `object_storage`). Redpanda stores the table metadata in https://iceberg.apache.org/docs/latest/java-api-quickstart/#using-a-hadoop-catalog[HadoopCatalog^] format in the same object storage bucket or container as the data files.
@@ -126,5 +218,3 @@ endif::[]
 ifdef::env-cloud[]
 The base path for the filesystem-based catalog if using the `object_storage` catalog type is `redpanda-iceberg-catalog`. 
 endif::[]
-
-// end::single-source-object-storage[]

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -11,7 +11,6 @@ For production deployments, Redpanda recommends using an external REST catalog t
 
 After you have selected a catalog type at the cluster level and xref:{about-iceberg-doc}#enable-iceberg-integration[enabled the Iceberg integration] for a topic, you cannot switch to another catalog type.
 
-//ifndef::env-cloud[]
 == Connect to a REST catalog
 
 Connect to an Iceberg REST catalog using the standard https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml[REST API^] supported by many catalog providers. Use this catalog integration type with REST-enabled Iceberg catalog services, such as https://docs.databricks.com/en/data-governance/unity-catalog/index.html[Databricks Unity^] and https://other-docs.snowflake.com/en/opencatalog/overview[Snowflake Open Catalog^].
@@ -103,7 +102,7 @@ rpk::
 --
 [,bash]
 ----
-rpk
+rpk cluster config set iceberg_rest_catalog_client_secret <secret-name>
 ----
 --
 
@@ -174,8 +173,10 @@ SELECT * FROM streaming.redpanda.<table-name>;
 
 The Iceberg table name is the name of your Redpanda topic. Redpanda puts the Iceberg table into a namespace called `redpanda`, creating the namespace if necessary. 
 
+// Hide section in Cloud until Snowflake doc is single sourced
+ifndef::env-cloud[]
 TIP: You may need to explicitly create a table for the Iceberg data in your query engine. For an example, see xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[].
-
+endif::[]
 
 == Integrate filesystem-based catalog (`object_storage`)
 


### PR DESCRIPTION
## Description

This pull request introduces updates to the documentation for configuring Iceberg catalog integrations in Redpanda, with a focus on adding instructions for passing secrets in cloud environments. Key changes include updating branch references in the Antora playbook, adding detailed steps for secret management, and refining content visibility based on the environment.

### Documentation Updates for Iceberg Catalog Integration:

* **Secret Management for Cloud Environments**:
  - Added a new section on storing and using secrets for REST authentication in cloud environments. This includes instructions for using `rpk` and the Data Plane API to create secrets and update cluster configurations.

* **Environment-Specific Visibility**:
  - Introduced conditional visibility for certain sections of the documentation, such as hiding tips for Snowflake integration in cloud environments.

### Antora Playbook Configuration:

* **Branch Update for `cloud-docs` Repository**:
  - Changed the branch reference for the `cloud-docs` repository to `DOC-1216-Document-how-to-pass-in-secrets-when-configuring-iceberg`.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 9 May

## Page previews

Self-managed > [Use Iceberg Catalogs](https://deploy-preview-1113--redpanda-docs-preview.netlify.app/current/manage/iceberg/use-iceberg-catalogs/#connect-to-a-rest-catalog)
Cloud > Use Iceberg Catalogs > [Store a secret for REST catalog authentication](https://deploy-preview-1113--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/use-iceberg-catalogs/#store-a-secret-for-rest-catalog-authentication)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
