### PR TITLE
DOC-1326 update metadata in docs single sourcing

### DIFF
--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -1,8 +1,8 @@
 = Manage Topics
 :page-context-links: [{"name": "Linux", "to": "develop:config-topics.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-manage-topics.adoc" } ]
 :page-categories: Clients, Development
-// tag::single-source[]
 :description: Learn how to create topics, update topic configurations, and delete topics or records.
+// tag::single-source[]
 
 include::develop:partial$topic-defaults.adoc[]
 

--- a/modules/develop/pages/consume-data/consumer-offsets.adoc
+++ b/modules/develop/pages/consume-data/consumer-offsets.adoc
@@ -1,8 +1,8 @@
 = Consumer Offsets
 :page-aliases: introduction:consumer-offsets.adoc, development:consumer-offsets.adoc
 :page-categories: Clients, Development
-// tag::single-source[]
 :description: pass:q[Redpanda uses an internal topic, `__consumer_offsets`, to store committed offsets from each Kafka consumer that is attached to Redpanda.]
+// tag::single-source[]
 
 
 In Redpanda, all messages are organized by glossterm:topic[] and distributed across multiple partitions, based on a https://www.redpanda.com/guides/kafka-tutorial-kafka-partition-strategy[partition strategy^]. For example, when using the round robin strategy, a producer writing to a topic with five partitions would distribute approximately 20% of the messages to each glossterm:partition[].

--- a/modules/develop/pages/consume-data/follower-fetching.adoc
+++ b/modules/develop/pages/consume-data/follower-fetching.adoc
@@ -1,7 +1,7 @@
 = Follower Fetching
 :page-categories: Clients, Development
-// tag::single-source[]
 :description: Learn about follower fetching and how to configure a Redpanda consumer to fetch records from the closest replica.
+// tag::single-source[]
 :url-kip392: https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica
 
 Learn about follower fetching and how to configure a Redpanda consumer to fetch records from the closest replica.

--- a/modules/develop/pages/http-proxy.adoc
+++ b/modules/develop/pages/http-proxy.adoc
@@ -2,8 +2,8 @@
 :env-core: true
 :page-aliases: development:http-proxy.adoc
 :page-categories: Clients, Development
-// tag::single-source[]
 :description: HTTP Proxy exposes a REST API to list topics, produce events, and subscribe to events from topics using consumer groups.
+// tag::single-source[]
 
 include::develop:partial$http-proxy.adoc[]
 

--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -2,8 +2,8 @@
 :page-aliases: development:kafka-clients.adoc
 :page-categories: Clients, Development, Kafka Compatibility
 :pp: {plus}{plus}
-// tag::single-source[]
 :description: Kafka clients, version 0.11 or later, are compatible with Redpanda. Validations and exceptions are listed.
+// tag::single-source[]
 
 Redpanda is compatible with Apache Kafka versions 0.11 and later, with specific exceptions noted on this page.
 

--- a/modules/develop/pages/produce-data/configure-producers.adoc
+++ b/modules/develop/pages/produce-data/configure-producers.adoc
@@ -1,8 +1,8 @@
 = Configure Producers
 :page-aliases: development:configure-producers.adoc
 :page-categories: Clients, Development
-// tag::single-source[]
 :description: Learn about configuration options for producers, including write caching and acknowledgment settings.
+// tag::single-source[]
 
 Producers are client applications that write data to Redpanda
 in the form of events. Producers communicate with Redpanda through the Kafka API. 

--- a/modules/develop/pages/produce-data/idempotent-producers.adoc
+++ b/modules/develop/pages/produce-data/idempotent-producers.adoc
@@ -1,8 +1,8 @@
 = Idempotent producers
 :page-aliases: development:idempotent-producers.adoc
 :page-categories: Clients, Development
-// tag::single-source[]
 :description: Idempotent producers assign a unique ID to every write request, guaranteeing that each message is recorded only once in the order in which it was sent.
+// tag::single-source[]
 
 When a producer writes messages to a topic, each message should be recorded only once in the order in which it was sent. However, network issues such as a connection failure can result in a timeout, which prevents a write request from succeeding. In such cases, the client retries the write request until one of these events occurs:
 

--- a/modules/develop/pages/produce-data/leader-pinning.adoc
+++ b/modules/develop/pages/produce-data/leader-pinning.adoc
@@ -1,6 +1,6 @@
 = Leader Pinning
-// tag::single-source[]
 :description: Learn about leader pinning and how to configure a preferred partition leader location based on cloud availability zones or regions.
+// tag::single-source[]
 
 Produce requests that write data to Redpanda topics go through the topic partition leader, which syncs messages across its follower replicas. For a Redpanda cluster deployed across multiple availability zones (AZs), leader pinning ensures that a topic's partition leaders are geographically closer to clients, which helps decrease networking costs and guarantees lower latency.
 

--- a/modules/develop/pages/transactions.adoc
+++ b/modules/develop/pages/transactions.adoc
@@ -1,8 +1,8 @@
 = Transactions
 :page-aliases: development:transactions.adoc
 :page-categories: Clients, Development
-// tag::single-source[]
 :description: Learn how to use transactions; for example, you can fetch messages starting from the last consumed offset and transactionally process them one by one, updating the last consumed offset and producing events at the same time.
+// tag::single-source[]
 
 Redpanda supports Apache Kafka®-compatible transaction semantics and APIs. For example, you can fetch messages starting from the last consumed offset and transactionally process them one by one, updating the last consumed offset and producing events at the same time.
 

--- a/modules/get-started/pages/architecture.adoc
+++ b/modules/get-started/pages/architecture.adoc
@@ -1,8 +1,8 @@
 = How Redpanda Works
-// tag::single-source[]
 :page-aliases: introduction:architecture.adoc
 :page-categories: Architecture
 :description: Learn specifics about Redpanda architecture.
+// tag::single-source[]
 
 At its core, Redpanda is a fault-tolerant transaction log for storing event streams. Producers and consumers interact with Redpanda using the Kafka API. To achieve high scalability, producers and consumers are fully decoupled. Redpanda provides strong guarantees to producers that events are stored durably within the system, and consumers can subscribe to Redpanda and read the events asynchronously.
 

--- a/modules/get-started/pages/broker-admin.adoc
+++ b/modules/get-started/pages/broker-admin.adoc
@@ -1,8 +1,8 @@
 = Specify Broker Addresses for rpk
 :page-categories: rpk
+:description: pass:q[Learn how and when to specify Redpanda broker addresses for `rpk` commands, so `rpk` knows where to run Kafka-related commands.]
 // tag::single-source[]
 ifdef::env-cloud[:page-aliases: get-started:broker-admin.adoc]
-:description: pass:q[Learn how and when to specify Redpanda broker addresses for `rpk` commands, so `rpk` knows where to run Kafka-related commands.]
 
 For `rpk` to know where to run Kafka-related commands, you must provide the broker addresses for each broker of a Redpanda cluster. You can specify these addresses as IP addresses or as hostnames, using any of these methods:
 

--- a/modules/get-started/pages/config-rpk-profile.adoc
+++ b/modules/get-started/pages/config-rpk-profile.adoc
@@ -1,8 +1,8 @@
 = rpk Profiles
 :page-categories: rpk
+:description: pass:q[Use `rpk profile` to simplify your development experience with multiple Redpanda clusters by saving and reusing configurations for different clusters.]
 // tag::single-source[]
 ifdef::env-cloud[:page-aliases: get-started:config-rpk-profile.adoc]
-:description: pass:q[Use `rpk profile` to simplify your development experience with multiple Redpanda clusters by saving and reusing configurations for different clusters.]
 
 Use rpk profiles to simplify your development experience using `rpk` with multiple Redpanda clusters by saving and reusing configurations for different clusters.
 

--- a/modules/get-started/pages/intro-to-events.adoc
+++ b/modules/get-started/pages/intro-to-events.adoc
@@ -1,8 +1,8 @@
 = Introduction to Redpanda
-// tag::single-source[]
 :pp: {plus}{plus}
 :page-aliases: features:intro-to-events.adoc, introduction:intro-to-events.adoc
 :description: Learn about Redpanda event streaming.
+// tag::single-source[]
 
 Distributed systems often require data and system updates to happen as quickly as possible. In software architecture, these updates can be handled with either messages or events.
 

--- a/modules/get-started/pages/intro-to-rpk.adoc
+++ b/modules/get-started/pages/intro-to-rpk.adoc
@@ -1,7 +1,7 @@
 = Introduction to rpk
 :page-categories: rpk
-// tag::single-source[]
 :description: pass:q[Learn about `rpk` and how to use it to interact with your Redpanda cluster.]
+// tag::single-source[]
 
 The `rpk` command line interface tool is designed to manage your entire Redpanda cluster, without the need to run a separate script for each function, as with Apache Kafka. The `rpk` commands handle everything from configuring brokers to high-level general Redpanda tasks. For example, you can use `rpk` to monitor your cluster's health, perform tuning, and implement access control lists (ACLs) and other security features. You can also use `rpk` to perform basic streaming tasks, such as creating topics, producing to topics, and consuming from topics.
 

--- a/modules/get-started/pages/partner-integration.adoc
+++ b/modules/get-started/pages/partner-integration.adoc
@@ -1,7 +1,7 @@
 = Partner Integrations
 :page-aliases: reference:partner-integration.adoc
-// tag::single-source[]
 :description: Learn about Redpanda integrations built and supported by our partners.
+// tag::single-source[]
 
 Learn about Redpanda integrations built and supported by our partners.
 

--- a/modules/get-started/pages/rpk-install.adoc
+++ b/modules/get-started/pages/rpk-install.adoc
@@ -1,9 +1,9 @@
 = Install or Update rpk
 :page-aliases: quickstart:rpk-install.adoc
 :page-categories: rpk
+:description: pass:q[Install or update `rpk` to interact with Redpanda from the command line.]
 // Do not put page aliases in the single-sourced content
 // tag::single-source[]
-:description: pass:q[Install or update `rpk` to interact with Redpanda from the command line.]
 
 The `rpk` tool is a single binary application that provides a way to interact with your Redpanda clusters from the command line. For example, you can use `rpk` to do the following:
 

--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -1,7 +1,7 @@
 = Use the Schema Registry API
 :page-categories: Management, Schema Registry
-// tag::single-source[]
 :description: Perform common Schema Registry management operations with the API.
+// tag::single-source[]
 
 Schemas provide human-readable documentation for an API. They verify that data conforms to an API, support the generation of serializers for data, and manage the compatibility of evolving APIs, allowing new versions of services to be rolled out independently.
 

--- a/modules/manage/pages/schema-reg/schema-reg-overview.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-overview.adoc
@@ -1,8 +1,8 @@
 = Redpanda Schema Registry
 :page-aliases: console:features/schema-registry.adoc
 :page-categories: Management, Schema Registry
-// tag::single-source[]
 :description: Redpanda's Schema Registry provides the interface to store and manage event schemas.
+// tag::single-source[]
 
 In Redpanda, the messages exchanged between producers and consumers contain raw bytes. Schemas enable producers and consumers to share the information needed to serialize and deserialize those messages. They register and retrieve the schemas they use in the Schema Registry to ensure data verification.
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -1,6 +1,6 @@
 = Public Metrics
-// tag::single-source[]
 :description: Public metrics to create your system dashboard.
+// tag::single-source[]
 
 This section provides reference descriptions for the public metrics exported from Redpanda's `/public_metrics` endpoint.
 


### PR DESCRIPTION
## Description
This pull request standardizes the placement of the `// tag::single-source[]` comment across multiple documentation files. The comment was moved to immediately follow the `:description:` attribute in all affected files. Single sourcing correction in cloud-docs is done in https://github.com/redpanda-data/cloud-docs/pull/284.

Resolves https://redpandadata.atlassian.net/browse/DOC-1326
Review deadline:

## Page previews
https://deploy-preview-1114--redpanda-docs-preview.netlify.app/current/develop/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
