### PR TITLE
Update k-compatibility.adoc - small changes to 25.1.1-beta versions

### DIFF
--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -49,9 +49,9 @@ Redpanda Core has no direct dependency on Kubernetes. Compatibility is influence
 // |1.30.x - 1.33.x
 
 |25.1.x
-|25.1.1-beta1, 5.10.x, 5.9.x
-|25.1.1-beta1, 0.4.41, 0.4.36
-|25.1.1-beta1, 2.4.x, 2.3.x
+|25.1.1-betaX, 5.10.x, 5.9.x
+|25.1.1-betaX, 0.4.41, 0.4.36
+|25.1.1-betaX, 2.4.x, 2.3.x
 |3.12+
 // d (default) here is required to get footnotes to appear at the bottom of the page
 // instead of inside the table cell.
@@ -59,9 +59,9 @@ Redpanda Core has no direct dependency on Kubernetes. Compatibility is influence
 d|1.28.x - 1.32.x{fn-k8s-compatibility}
 
 |24.3.x
-|25.1-k8s-beta, 5.9.x
-|25.1-k8s-beta, 0.4.41, 0.4.36, 0.4.29
-|25.1-k8s-beta, 2.4.x, 2.3.x, 2.2.x
+|25.1.1-betaX, 5.9.x
+|25.1.1-beta, 0.4.41, 0.4.36, 0.4.29
+|25.1.1-beta, 2.4.x, 2.3.x, 2.2.x
 |3.11+
 d|1.28.x - 1.31.x{fn-k8s-compatibility}
 


### PR DESCRIPTION
## Description

Small changes to make sure beta versions are accurate. Also changed the version of beta (i.e. beta1) to betaX. 

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
