### PR TITLE
DOC-1340 fix single sourcing in docs repo

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1339-fix-single-sourcing'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/get-started/pages/intro-to-rpk.adoc
+++ b/modules/get-started/pages/intro-to-rpk.adoc
@@ -14,9 +14,11 @@ After you install `rpk`, you can use it to:
 See also:
 
 * xref:get-started:rpk-install.adoc[]
-* xref:get-started:config-rpk-profile.adoc[]
-// This topic is not available in our Cloud docs.
+ifdef::env-cloud[]
+* xref:manage:rpk/config-rpk-profile.adoc[]
+endif::[]
 ifndef::env-cloud[]
+* xref:get-started:config-rpk-profile.adoc[]
 * xref:get-started:rpk-quickstart.adoc[]
 endif::[]
 
@@ -24,7 +26,12 @@ endif::[]
 
 You can specify `rpk` command properties in the following ways:
 
+ifdef::env-cloud[]
+* Create an xref:manage:rpk/config-rpk-profile.adoc[`rpk profile`].
+endif::[]
+ifndef::env-cloud[]
 * Create an xref:get-started:config-rpk-profile.adoc[`rpk profile`].
+endif::[]
 * Specify the appropriate flag on the command line.
 * Define the corresponding environment variables.
 +


### PR DESCRIPTION
## Description
This pull request updates branch references in the Antora playbook and improves conditional content handling in the "Intro to rpk" documentation. The changes ensure better alignment with the current development workflow and enhance the documentation's adaptability for different environments.

* Modified conditional content in `intro-to-rpk.adoc` to include environment-specific links for the `config-rpk-profile` topic. This ensures the correct content is displayed based on whether the environment is `cloud` or not.

Resolves https://redpandadata.atlassian.net/browse/DOC-1340
Review deadline:

## Page previews
[Intro to rpk - SM](https://deploy-preview-1119--redpanda-docs-preview.netlify.app/current/get-started/intro-to-rpk/)
[Intro to rpk - Cloud](https://deploy-preview-1119--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/rpk/intro-to-rpk/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
