### PR TITLE
DOC-1342 conditionalize glossary links

### DIFF
--- a/modules/terms/partials/acl.adoc
+++ b/modules/terms/partials/acl.adoc
@@ -3,4 +3,6 @@
 :hover-text: A security feature used to define and enforce granular permissions to resources, ensuring only authorized users or applications can perform specific operations. ACLs act on principals. 
 :category: Redpanda security
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:security/authorization.adoc[].
+endif::[]

--- a/modules/terms/partials/acl.adoc
+++ b/modules/terms/partials/acl.adoc
@@ -6,3 +6,7 @@
 ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:security/authorization.adoc[].
 endif::[]
+
+ifdef::env-cloud[]
+For more information, see xref:security:authorization/cloud-authorization.adoc[].
+endif::[]

--- a/modules/terms/partials/admin-api.adoc
+++ b/modules/terms/partials/admin-api.adoc
@@ -1,8 +1,10 @@
 === Admin API
 :term-name: Admin API
-:hover-text: A REST API used to manage and monitor Redpanda clusters. It uses the default port 9644.
+:hover-text: A REST API used to manage and monitor Redpanda Self-Managed clusters. It uses the default port 9644.
 :category: Redpanda features
 
+ifndef::env-cloud[]
 For more information about using this API with Self-Managed Redpanda, see xref:api:ROOT:admin-api.adoc[].
+endif::[]
 
 Note: The Redpanda Admin API is different from the https://kafka.apache.org/documentation/#adminapi[Kafka Admin API]. 

--- a/modules/terms/partials/authentication.adoc
+++ b/modules/terms/partials/authentication.adoc
@@ -7,3 +7,7 @@ ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:security/authentication.adoc[].
 endif::[]
 
+ifdef::env-cloud[]
+For more information, see xref:security/cloud-authentication.adoc[].
+endif::[]
+

--- a/modules/terms/partials/authentication.adoc
+++ b/modules/terms/partials/authentication.adoc
@@ -3,4 +3,7 @@
 :hover-text: The process of verifying the identity of a principal, user, or service account. 
 :category: Redpanda security
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:security/authentication.adoc[].
+endif::[]
+

--- a/modules/terms/partials/authorization.adoc
+++ b/modules/terms/partials/authorization.adoc
@@ -6,3 +6,7 @@
 ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:security/authorization.adoc[].
 endif::[]
+
+ifdef::env-cloud[]
+For more information, see xref:security:authorization/cloud-authorization.adoc[].
+endif::[]

--- a/modules/terms/partials/authorization.adoc
+++ b/modules/terms/partials/authorization.adoc
@@ -3,4 +3,6 @@
 :hover-text: The process of specifying access rights to resources. Access rights are enforced through roles or access-control lists (ACLs).
 :category: Redpanda security
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:security/authorization.adoc[].
+endif::[]

--- a/modules/terms/partials/bearer-token.adoc
+++ b/modules/terms/partials/bearer-token.adoc
@@ -6,3 +6,7 @@
 ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:security/authentication.adoc[].
 endif::[]
+
+ifdef::env-cloud[]
+For more information, see xref:security:cloud-authentication.adoc[].
+endif::[]

--- a/modules/terms/partials/bearer-token.adoc
+++ b/modules/terms/partials/bearer-token.adoc
@@ -3,4 +3,6 @@
 :hover-text: An access token used for authentication and authorization in web applications and APIs. It holds user credentials, usually in the form of random strings of characters. 
 :category: Redpanda security
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:security/authentication.adoc[].
+endif::[]

--- a/modules/terms/partials/compaction.adoc
+++ b/modules/terms/partials/compaction.adoc
@@ -3,4 +3,6 @@
 :hover-text: Feature that retains the latest value for each key within a partition while discarding older values. 
 :category: Redpanda features
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:cluster-maintenance/compaction-settings.adoc[].
+endif::[]

--- a/modules/terms/partials/data-transforms.adoc
+++ b/modules/terms/partials/data-transforms.adoc
@@ -3,4 +3,5 @@
 :hover-text: Framework to manipulate or enrich data written to Redpanda topics. You can develop custom data functions, which run asynchronously using a WebAssembly (Wasm) engine inside a Redpanda broker. 
 :category: Redpanda features
 
-For more information, see xref:ROOT:develop:data-transforms/index.adoc[].
+
+For more information, see xref:develop:data-transforms/index.adoc[].

--- a/modules/terms/partials/helm.adoc
+++ b/modules/terms/partials/helm.adoc
@@ -3,4 +3,6 @@
 :hover-text: Generates and applies all the manifest files you need for deploying Redpanda in Kubernetes. 
 :category: Redpanda in Kubernetes
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:deploy:deployment-option/self-hosted/kubernetes/kubernetes-production-deployment.adoc[].
+endif::[]

--- a/modules/terms/partials/learner.adoc
+++ b/modules/terms/partials/learner.adoc
@@ -5,4 +5,6 @@
 
 In a Raft group, a broker can be in learner status. Learners are followers that cannot vote and so do not count towards quorum (the majority). They cannot be elected to leader nor can they trigger leader elections. Brokers can be promoted or demoted between learner and voter. New Raft group members start as learners. 
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:raft-group-reconfiguration.adoc[].
+endif::[]

--- a/modules/terms/partials/listener.adoc
+++ b/modules/terms/partials/listener.adoc
@@ -3,4 +3,6 @@
 :hover-text: Configuration on a broker that defines how it should accept client or inter-broker connections. Each listener is associated with a specific protocol, hostname, and port combination. The listener defines where the broker should listen for incoming connections.
 :category: Redpanda core
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:security/listener-configuration.adoc[].
+endif::[]

--- a/modules/terms/partials/maintenance-mode.adoc
+++ b/modules/terms/partials/maintenance-mode.adoc
@@ -3,4 +3,6 @@
 :hover-text: A state where a Redpanda broker temporarily doesn't take any partition leaderships. It continues to store data as a follower. This is usually done for system maintenance or a rolling upgrade.
 :category: Redpanda features
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:node-management.adoc[].
+endif::[]

--- a/modules/terms/partials/operator.adoc
+++ b/modules/terms/partials/operator.adoc
@@ -3,4 +3,6 @@
 :hover-text: Extends Kubernetes with custom resource definitions (CRDs), which allow Redpanda clusters to be treated as native Kubernetes resources. 
 :category: Redpanda in Kubernetes
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:deploy:deployment-option/self-hosted/kubernetes/kubernetes-production-deployment.adoc[].
+endif::[]

--- a/modules/terms/partials/producer.adoc
+++ b/modules/terms/partials/producer.adoc
@@ -3,4 +3,5 @@
 :hover-text: A client application that writes events to Redpanda. Redpanda stores these events in sequence and organizes them into topics.
 :category: Redpanda core
 
-For more information, see xref:ROOT:develop:produce-data/configure-producers.adoc[].
+
+For more information, see xref:develop:produce-data/configure-producers.adoc[].

--- a/modules/terms/partials/rack-awareness.adoc
+++ b/modules/terms/partials/rack-awareness.adoc
@@ -3,4 +3,6 @@
 :hover-text: Feature that lets you distribute replicas of the same partition across different racks to minimize data loss and improve fault tolerance in the event of a rack failure. 
 :category: Redpanda features
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:rack-awareness.adoc[].
+endif::[]

--- a/modules/terms/partials/rebalancing.adoc
+++ b/modules/terms/partials/rebalancing.adoc
@@ -7,6 +7,8 @@ Redpanda provides various topic-aware tools to balance clusters for best perform
 
 - Leadership balancing changes where data is written to first, but it does not involve any data transfer. The partition leader regularly sends heartbeats to its followers. If a follower does not receive a heartbeat within a timeout, it triggers a new leader election. Redpanda also provides leadership balancing when brokers are added or decommissioned.
 - Partition replica balancing moves partition replicas to alleviate disk pressure and to honor the configured replication factor across brokers and the additional redundancy across failure domains (such as racks). Redpanda provides partition replica rebalancing when brokers are added or decommissioned. 
+ifndef::env-cloud[]
 - With an Enterprise license, you can additionally enable Continuous Data Balancing to continuously monitor broker and rack availability and disk usage.
 
 For more information, see xref:ROOT:manage:cluster-maintenance/cluster-balancing.adoc[].
+endif::[]

--- a/modules/terms/partials/retention.adoc
+++ b/modules/terms/partials/retention.adoc
@@ -3,4 +3,6 @@
 :hover-text: The mechanism for determining how long Redpanda stores data on local disk or in object storage before purging it.
 :category: Redpanda core
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:cluster-maintenance/disk-utilization.adoc[].
+endif::[]

--- a/modules/terms/partials/rolling-upgrade.adoc
+++ b/modules/terms/partials/rolling-upgrade.adoc
@@ -3,4 +3,6 @@
 :hover-text: The process of upgrading each broker in a Redpanda cluster, one at a time, to minimize disruption and ensure continuous availability.
 :category: Redpanda features
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:upgrade:rolling-upgrade.adoc[].
+endif::[]

--- a/modules/terms/partials/tiered-storage.adoc
+++ b/modules/terms/partials/tiered-storage.adoc
@@ -3,4 +3,6 @@
 :hover-text: Feature that lets you offload log segments to object storage in near real-time, providing long-term data retention and topic recovery.
 :category: Redpanda features
 
+ifndef::env-cloud[]
 For more information, see xref:ROOT:manage:tiered-storage.adoc[].
+endif::[]


### PR DESCRIPTION
## Description
This pull request adds conditionalizes out links to multiple glossary files in the `modules/terms/partials` directory, ensuring that the glossary in Cloud docs does not link to Self-Managed docs. Additionally, it updates some existing links to improve consistency. 

Resolves https://redpandadata.atlassian.net/browse/DOC-1342
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
