### PR TITLE
Test spam prevention form submissions

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -25,7 +25,7 @@ content:
     branches: main
 ui:
   bundle:
-    url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip
+    url: https://github.com/redpanda-data/docs-ui/releases/download/spam-test/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:


### PR DESCRIPTION
## Description

This PR is a test for our new spam prevention techniques in doc feedback forms.

Currently, we're being redirected to the default Netlify success message. We need to make sure that we override that behavior.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
