### PR TITLE
Iceberg beta - Azure

### DIFF
--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -150,13 +150,24 @@ SUBJECT          VERSION   ID   TYPE
 ----
 
 ifdef::env-cloud[]
-To query the Iceberg table, you need access to the object storage bucket or container where the Iceberg data is stored. For BYOC clusters on AWS and GCP, the bucket name and table location are as follows:
+To query the Iceberg table, you need access to the object storage bucket or container where the Iceberg data is stored. For BYOC clusters, the bucket name and table location are as follows:
 
 |===
-| Bucket name | Iceberg table location
+| Cloud provider | Bucket or container name | Iceberg table location
 
+| AWS
 | `redpanda-cloud-storage-<cluster-id>`
-| `redpanda-iceberg-catalog/redpanda/<topic-name>`
+.3+a| `redpanda-iceberg-catalog/redpanda/<topic-name>`
+
+| Azure
+a| `<cluster-id>`
+
+The Redpanda cluster ID is also used as the container name (ID) and the storage account ID.
+
+
+| GCP
+| `redpanda-cloud-storage-<cluster-id>`
+
 
 |===
 endif::[]

--- a/modules/manage/partials/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/query-iceberg-topics.adoc
@@ -7,13 +7,22 @@ endif::[]
 ifdef::env-cloud[]
 Redpanda generates an Iceberg table with the same name as the topic. Depending on the processing engine and your Iceberg catalog implementation, you may also need to define the table (for example using `CREATE TABLE`) to point the data lakehouse to its location in the catalog.
 
-For BYOC clusters on AWS and GCP, the bucket name and table location are as follows:
+For BYOC clusters, the bucket name and table location are as follows:
 
 |===
-| Bucket name | Iceberg table location
+| Cloud provider | Bucket or container name | Iceberg table location
 
+| AWS
 | `redpanda-cloud-storage-<cluster-id>`
-| `redpanda-iceberg-catalog/redpanda/<topic-name>`
+.3+a| `redpanda-iceberg-catalog/redpanda/<topic-name>`
+
+| Azure
+a| `<cluster-id>`
+
+The Redpanda cluster ID is also used as the container name (ID) and the storage account ID.
+
+| GCP
+| `redpanda-cloud-storage-<cluster-id>`
 
 |===
 endif::[]


### PR DESCRIPTION
## Description

This pull request updates documentation for querying Iceberg tables in Redpanda by restructuring and expanding the details for bucket and table locations across different cloud providers. The changes improve clarity and provide additional information for Azure, which was previously not included.

### Documentation updates for Iceberg table queries:

* **Generalization of BYOC cluster instructions**:
  - Updated phrasing to remove specific mentions of AWS and GCP, making the instructions applicable to all BYOC clusters. (`modules/manage/partials/iceberg/about-iceberg-topics.adoc`, [[1]](diffhunk://#diff-ea5033692607173dad8ffa11b9e530bac4ee1d40279f0f826c446e7e75582c12L153-R170); `modules/manage/partials/iceberg/query-iceberg-topics.adoc`, [[2]](diffhunk://#diff-ad35e9a1826487725ec6e9250fb2a9925cf842c7ab4f7efdd31823823eb188f1L10-L16)

* **Addition of Azure-specific details**:
  - Introduced Azure as a supported cloud provider, specifying that the Redpanda cluster ID is used as both the container name and the storage account ID. (`modules/manage/partials/iceberg/about-iceberg-topics.adoc`, [[1]](diffhunk://#diff-ea5033692607173dad8ffa11b9e530bac4ee1d40279f0f826c446e7e75582c12L153-R170); `modules/manage/partials/iceberg/query-iceberg-topics.adoc`, [[2]](diffhunk://#diff-ad35e9a1826487725ec6e9250fb2a9925cf842c7ab4f7efdd31823823eb188f1L10-L16)

* **Table restructuring**:
  - Enhanced the table format to include a "Cloud provider" column, making it easier to differentiate instructions for AWS, Azure, and GCP. (`modules/manage/partials/iceberg/about-iceberg-topics.adoc`, [[1]](diffhunk://#diff-ea5033692607173dad8ffa11b9e530bac4ee1d40279f0f826c446e7e75582c12L153-R170); `modules/manage/partials/iceberg/query-iceberg-topics.adoc`, [[2]](diffhunk://#diff-ad35e9a1826487725ec6e9250fb2a9925cf842c7ab4f7efdd31823823eb188f1L10-L16)

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 14 May

## Page previews

About Iceberg Topics > [Enable Iceberg integration](https://deploy-preview-1123--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/about-iceberg-topics/#enable-iceberg-integration)
 Query Iceberg Topics > [Access Iceberg tables](https://deploy-preview-1123--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/query-iceberg-topics/#access-iceberg-tables)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
