### PR TITLE
Fix syntax description in rpk cluster partitions transfer-leadership

### DIFF
--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc
@@ -30,7 +30,7 @@ rpk cluster partitions transfer-leadership --partition test-topic/0:2
 
 In this case, the name of the topic is `test-topic` and the partition ID is `0`.
 
-The preceding examples transfer leadership for the partition `kafka/test-topic/0`. The command assumes the `kafka` namespace by default, but you can also specify an internal namespace using the `+{namespace}/+` prefix.
+The preceding examples transfer leadership for the partition `kafka/test-topic/0`. The command behavior is based on the assumption that the default namespace is `kafka`, but you can also specify an internal namespace using the `+{namespace}/+` prefix.
 
 == Flags
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc
@@ -39,7 +39,7 @@ rpk cluster partitions transfer-leadership --partition foo/0:2
 
 |-h, --help |- |Help for transfer-leadership.
 
-|-p, --partition |string |Specify which partition's leadership to transfer and the location of the new leader. Use the syntax `-p A:B` where A is the partition ID and B is the new leader broker. 
+|-p, --partition |string |Specify which partition's leadership to transfer and the location of the new leader. Use the syntax `-p <partition-ID>:<new-leader-broker-ID>`. 
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc
@@ -39,7 +39,7 @@ rpk cluster partitions transfer-leadership --partition foo/0:2
 
 |-h, --help |- |Help for transfer-leadership.
 
-|-p, --partition |string |The topic partition to which to transfer leadership and specify the new leader location. Syntax `-p A:B` where A is the partition leader and B will be the new leader. See <<examples>> for how to use it. 
+|-p, --partition |string |Specify which partition's leadership to transfer and the location of the new leader. Use the syntax `-p A:B` where A is the partition ID and B is the new leader broker. 
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc
@@ -1,10 +1,11 @@
 = rpk cluster partitions transfer-leadership
 
-Transfer partition leadership between brokers.
+Transfer partition leadership between brokers. This command supports transferring only one partition leader at a time.
 
-You can transfer only one partition leader at a time.
-
-WARNING: Redpanda tries to balance leadership distribution across brokers by default. If the distribution of leaders becomes uneven as a result of transferring leadership across brokers, the cluster may move leadership back to the original brokers automatically.
+NOTE: Redpanda tries to balance leadership distribution across brokers by default.
+If the distribution of leaders becomes uneven as a result of transferring leadership
+across brokers, the cluster may move leadership back to the original
+brokers automatically.
 
 == Usage
 
@@ -15,19 +16,21 @@ rpk cluster partitions transfer-leadership [flags]
 
 == Examples
 
-Transfer partition leadership:
+To transfer partition leadership for a partition `0` to a broker ID `2`, run:
 
 ```bash
 rpk cluster partitions transfer-leadership foo --partition 0:2
 ```
 
-The preceding example shows how to transfer leadership for the partition `kafka/foo/0` to broker 2. By default, it uses the `kafka` namespace, but you can specify an internal namespace using the `+{namespace}/+` prefix.
-
-Equivalent command using different syntax:
+The `--partition` flag accepts a value `<A>:<B>`, where `A` is a topic-partition and `B` is the ID of the broker to which you want to transfer leadership. To specify a topic-partition, you can use just the partition ID (`0`) or also use the topic name together with the partition using the following syntax:
 
 ```bash
-rpk cluster partitions transfer-leadership --partition foo/0:2
+rpk cluster partitions transfer-leadership --partition test-topic/0:2
 ```
+
+In this case, the name of the topic is `test-topic` and the partition ID is `0`.
+
+The preceding examples transfer leadership for the partition `kafka/test-topic/0`. The command assumes the `kafka` namespace by default, but you can also specify an internal namespace using the `+{namespace}/+` prefix.
 
 == Flags
 
@@ -39,7 +42,7 @@ rpk cluster partitions transfer-leadership --partition foo/0:2
 
 |-h, --help |- |Help for transfer-leadership.
 
-|-p, --partition |string |Specify which partition's leadership to transfer and the location of the new leader. Use the syntax `-p <partition-ID>:<new-leader-broker-ID>`. 
+|-p, --partition |string |Specify the topic-partition's leadership to transfer and the location of the new leader. Use the syntax `-p <topic-partition>:<new-leader-broker-ID>`. 
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 


### PR DESCRIPTION
## Description

This pull request includes a minor update to the documentation for the `rpk cluster partitions transfer-leadership` command. The description of the `--partition` flag has been clarified.

Documentation update:

* [`modules/reference/pages/rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership.adoc`](diffhunk://#diff-6b0fa9945cbdb8f1dd515d0e27185ed26621bae37b91b0eb0f3d865a2c373875L42-R42): Updated the description of the `-p, --partition` flag to clarify that `A` refers to the partition ID and `B` refers to the new leader broker.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

https://deploy-preview-1125--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-partitions-transfer-leadership/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
