### PR TITLE
DOC-1356 single source read-only properties in cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1356-single-source-read-only-properties-in-cloud'
+    branches: 'DOC-190-Document-feature-Expose-selected-cluster-configuration-properties-in-cloud-console'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-190-Document-feature-Expose-selected-cluster-configuration-properties-in-cloud-console'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1356-single-source-read-only-properties-in-cloud'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -202,10 +202,6 @@ endif::[]
 // tag::audit_excluded_topics[]
 === audit_excluded_topics
 
-ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
-endif::[]
-
 List of topics to exclude from auditing.
 
 *Requires restart:* No
@@ -226,7 +222,7 @@ endif::[]
 === audit_log_num_partitions
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 Defines the number of partitions used by a newly-created audit topic. This configuration applies only to the audit log topic and may be different from the cluster or other topic configurations. This cannot be altered for existing audit log topics.
@@ -319,7 +315,7 @@ If you produce to a topic that doesn't exist, the topic will be created with def
 === cluster_id
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 Cluster identifier.
@@ -692,7 +688,7 @@ Timeout, in milliseconds, to wait for new topic creation.
 === data_transforms_binary_max_size
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 The maximum size for a deployable WebAssembly binary that the broker can store.
@@ -807,7 +803,7 @@ endif::[]
 === data_transforms_per_core_memory_reservation
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 The amount of memory to reserve per core for data transform (Wasm) virtual machines. Memory is reserved on boot. The maximum number of functions that can be deployed to a cluster is equal to `data_transforms_per_core_memory_reservation` / `data_transforms_per_function_memory_limit`.
@@ -830,7 +826,7 @@ endif::[]
 === data_transforms_per_function_memory_limit
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 The amount of memory to give an instance of a data transform (Wasm) virtual machine. The maximum number of functions that can be deployed to a cluster is equal to `data_transforms_per_core_memory_reservation` / `data_transforms_per_function_memory_limit`.
@@ -1076,9 +1072,7 @@ Default number of partitions per topic.
 === default_topic_replications
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
-
-NOTE: In Redpanda Cloud, all new topics are created with a replication factor of 3.
+NOTE: This property is read-only in Redpanda Cloud. In Redpanda Cloud, all new topics are created with a replication factor of 3.
 endif::[]
 
 Default replication factor for new topics.
@@ -1790,7 +1784,7 @@ Maximum age of the metadata cached in the health monitor of a non-controller bro
 === http_authentication
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 ifndef::env-cloud[]
@@ -1842,7 +1836,7 @@ Proportional coefficient for the Iceberg backlog controller. Number of shares as
 === iceberg_catalog_base_location
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 Base path for the object-storage-backed Iceberg catalog. After Iceberg is enabled, do not change this value.
@@ -3514,7 +3508,7 @@ The amount of time to keep a log file before deleting it (in milliseconds). If s
 === log_segment_ms
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 Default lifetime of log segments. If `null`, the property is disabled, and no default lifetime is set. Any value under 60 seconds (60000 ms) is rejected. This property can also be set in the Kafka API using the Kafka-compatible alias, `log.roll.ms`.
@@ -3926,7 +3920,7 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 === minimum_topic_replications
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 Minimum allowable replication factor for topics in this cluster. The set value must be positive, odd, and equal to or less than the number of available brokers. Changing this parameter only restricts newly-created topics. Redpanda returns an `INVALID_REPLICATION_FACTOR` error on any attempt to create a topic with a replication factor less than this property.
@@ -4042,7 +4036,7 @@ The amount of time (in seconds) to allow for when validating the expiry claim in
 === oidc_discovery_url
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 The URL pointing to the well-known discovery endpoint for the OIDC provider.
@@ -4083,7 +4077,7 @@ The frequency of refreshing the JSON Web Keys (JWKS) used to validate access tok
 === oidc_principal_mapping
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 Rule for mapping JWT payload claim to a Redpanda user principal.
@@ -4106,7 +4100,7 @@ endif::[]
 === oidc_token_audience
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 A string representing the intended recipient of the token.
@@ -5255,7 +5249,7 @@ Rules for mapping Kerberos principal names to Redpanda user principals.
 === sasl_mechanisms
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 include::reference:partial$enterprise-licensed-property.adoc[]
@@ -5669,7 +5663,7 @@ TLS client-initiated renegotiation is considered unsafe and is disabled by defau
 === tls_min_version
 
 ifdef::env-cloud[]
-This property is read-only in Redpanda Cloud.
+NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
 The minimum TLS version that Redpanda clusters support. This property prevents client applications from negotiating a downgrade to the TLS version when they make a connection to a Redpanda cluster.

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3513,7 +3513,9 @@ endif::[]
 
 Default lifetime of log segments. If `null`, the property is disabled, and no default lifetime is set. Any value under 60 seconds (60000 ms) is rejected. This property can also be set in the Kafka API using the Kafka-compatible alias, `log.roll.ms`.
 
+ifndef::env-cloud[]
 The topic property xref:./topic-properties.adoc#segmentms[`segment.ms`] overrides the value of `log_segment_ms` at the topic level.
+endif::[]
 
 *Unit:* milliseconds
 
@@ -5252,7 +5254,9 @@ ifdef::env-cloud[]
 NOTE: This property is read-only in Redpanda Cloud.
 endif::[]
 
+ifndef::env-cloud[]
 include::reference:partial$enterprise-licensed-property.adoc[]
+endif::[]
 
 A list of supported SASL mechanisms. Accepted values: `SCRAM`, `GSSAPI`, `OAUTHBEARER`, `PLAIN`.  Note that in order to enable PLAIN, you must also enable SCRAM.
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -202,6 +202,10 @@ endif::[]
 // tag::audit_excluded_topics[]
 === audit_excluded_topics
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
 List of topics to exclude from auditing.
 
 *Requires restart:* No
@@ -220,6 +224,10 @@ endif::[]
 
 // tag::audit_log_num_partitions[]
 === audit_log_num_partitions
+
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
 
 Defines the number of partitions used by a newly-created audit topic. This configuration applies only to the audit log topic and may be different from the cluster or other topic configurations. This cannot be altered for existing audit log topics.
 
@@ -309,6 +317,10 @@ If you produce to a topic that doesn't exist, the topic will be created with def
 
 // tag::cluster_id[]
 === cluster_id
+
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
 
 Cluster identifier.
 
@@ -679,6 +691,10 @@ Timeout, in milliseconds, to wait for new topic creation.
 // tag::data_transforms_binary_max_size[]
 === data_transforms_binary_max_size
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
 The maximum size for a deployable WebAssembly binary that the broker can store.
 
 *Requires restart:* No
@@ -790,6 +806,10 @@ endif::[]
 // tag::data_transforms_per_core_memory_reservation[]
 === data_transforms_per_core_memory_reservation
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
 The amount of memory to reserve per core for data transform (Wasm) virtual machines. Memory is reserved on boot. The maximum number of functions that can be deployed to a cluster is equal to `data_transforms_per_core_memory_reservation` / `data_transforms_per_function_memory_limit`.
 
 *Requires restart:* Yes
@@ -808,6 +828,10 @@ endif::[]
 
 // tag::data_transforms_per_function_memory_limit[]
 === data_transforms_per_function_memory_limit
+
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
 
 The amount of memory to give an instance of a data transform (Wasm) virtual machine. The maximum number of functions that can be deployed to a cluster is equal to `data_transforms_per_core_memory_reservation` / `data_transforms_per_function_memory_limit`.
 
@@ -1051,6 +1075,12 @@ Default number of partitions per topic.
 // tag::default_topic_replications[]
 === default_topic_replications
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+
+NOTE: In Redpanda Cloud, all new topics are created with a replication factor of 3.
+endif::[]
+
 Default replication factor for new topics.
 
 *Requires restart:* No
@@ -1061,9 +1091,9 @@ Default replication factor for new topics.
 
 *Accepted values:* [`-32768`, `32767`]
 
+ifndef::env-cloud[]
 *Default:* `1`
-
-NOTE: In Redpanda Cloud, all new topics are created with a replication factor of 3.
+endif::[]
 
 ---
 
@@ -1759,7 +1789,13 @@ Maximum age of the metadata cached in the health monitor of a non-controller bro
 // tag::http_authentication[]
 === http_authentication
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
+ifndef::env-cloud[]
 include::reference:partial$enterprise-licensed-property.adoc[]
+endif::[]
 
 A list of supported HTTP authentication mechanisms. Accepted Values: `BASIC`, `OIDC`.
 
@@ -1771,9 +1807,11 @@ A list of supported HTTP authentication mechanisms. Accepted Values: `BASIC`, `O
 
 *Accepted Values:* `BASIC`, `OIDC`
 
+ifndef::env-cloud[]
 *Enterprise license required*: `OIDC`
 
 *Default:* `[basic]`
+endif::[]
 
 ---
 
@@ -1803,6 +1841,10 @@ Proportional coefficient for the Iceberg backlog controller. Number of shares as
 // tag::iceberg_catalog_base_location[]
 === iceberg_catalog_base_location
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
 Base path for the object-storage-backed Iceberg catalog. After Iceberg is enabled, do not change this value.
 
 *Requires restart:* Yes
@@ -1811,7 +1853,9 @@ Base path for the object-storage-backed Iceberg catalog. After Iceberg is enable
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `redpanda-iceberg-catalog`
+endif::[]
 
 **Related topics**:
 
@@ -3469,6 +3513,10 @@ The amount of time to keep a log file before deleting it (in milliseconds). If s
 // tag::log_segment_ms[]
 === log_segment_ms
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
 Default lifetime of log segments. If `null`, the property is disabled, and no default lifetime is set. Any value under 60 seconds (60000 ms) is rejected. This property can also be set in the Kafka API using the Kafka-compatible alias, `log.roll.ms`.
 
 The topic property xref:./topic-properties.adoc#segmentms[`segment.ms`] overrides the value of `log_segment_ms` at the topic level.
@@ -3483,12 +3531,14 @@ The topic property xref:./topic-properties.adoc#segmentms[`segment.ms`] override
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
+ifndef::env-cloud[]
 *Default:* `1209600000` (2 weeks)
 
 *Related properties*:
 
 * <<log_segment_ms_min,`log_segment_ms_min`>>
 * <<log_segment_ms_max,`log_segment_ms_max`>>
+endif::[]
 
 ---
 
@@ -3875,6 +3925,10 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 // tag::minimum_topic_replications[]
 === minimum_topic_replications
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
 Minimum allowable replication factor for topics in this cluster. The set value must be positive, odd, and equal to or less than the number of available brokers. Changing this parameter only restricts newly-created topics. Redpanda returns an `INVALID_REPLICATION_FACTOR` error on any attempt to create a topic with a replication factor less than this property.
 
 If you change the `minimum_topic_replications` setting, the replication factor of existing topics remains unchanged. However, Redpanda will log a warning on start-up with a list of any topics that have fewer replicas than this minimum. For example, you might see a message such as `Topic X has a replication factor less than specified minimum: 1 < 3`.
@@ -3889,7 +3943,9 @@ If you change the `minimum_topic_replications` setting, the replication factor o
 
 *Accepted values:* [`1`, `32767`]
 
+ifndef::env-cloud[]
 *Default:* `1`
+endif::[]
 
 ---
 
@@ -3985,6 +4041,10 @@ The amount of time (in seconds) to allow for when validating the expiry claim in
 // tag::oidc_discovery_url[]
 === oidc_discovery_url
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
 The URL pointing to the well-known discovery endpoint for the OIDC provider.
 
 *Requires restart:* No
@@ -3993,7 +4053,9 @@ The URL pointing to the well-known discovery endpoint for the OIDC provider.
 
 *Type:* string
 
+ifdef::env-cloud[]
 *Default:* `https://auth.prd.cloud.redpanda.com/.well-known/openid-configuration`
+endif::[]
 
 ---
 
@@ -4020,6 +4082,10 @@ The frequency of refreshing the JSON Web Keys (JWKS) used to validate access tok
 // tag::oidc_principal_mapping[]
 === oidc_principal_mapping
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
 Rule for mapping JWT payload claim to a Redpanda user principal.
 
 *Requires restart:* No
@@ -4028,7 +4094,9 @@ Rule for mapping JWT payload claim to a Redpanda user principal.
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `$.sub`
+endif::[]
 
 ---
 
@@ -4036,6 +4104,10 @@ Rule for mapping JWT payload claim to a Redpanda user principal.
 
 // tag::oidc_token_audience[]
 === oidc_token_audience
+
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
 
 A string representing the intended recipient of the token.
 
@@ -4045,7 +4117,9 @@ A string representing the intended recipient of the token.
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `redpanda`
+endif::[]
 
 ---
 
@@ -5180,6 +5254,10 @@ Rules for mapping Kerberos principal names to Redpanda user principals.
 // tag::sasl_mechanisms[]
 === sasl_mechanisms
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
 include::reference:partial$enterprise-licensed-property.adoc[]
 
 A list of supported SASL mechanisms. Accepted values: `SCRAM`, `GSSAPI`, `OAUTHBEARER`, `PLAIN`.  Note that in order to enable PLAIN, you must also enable SCRAM.
@@ -5192,9 +5270,11 @@ A list of supported SASL mechanisms. Accepted values: `SCRAM`, `GSSAPI`, `OAUTHB
 
 *Accepted values*: `SCRAM`, `GSSAPI`, `OAUTHBEARER`, `PLAIN`
 
+ifndef::env-cloud[]
 *Enterprise license required*:  `GSSAPI`, `OAUTHBEARER`
 
 *Default:* `[SCRAM]`
+endif::[]
 
 ---
 
@@ -5588,6 +5668,10 @@ TLS client-initiated renegotiation is considered unsafe and is disabled by defau
 // tag::tls_min_version[]
 === tls_min_version
 
+ifdef::env-cloud[]
+This property is read-only in Redpanda Cloud.
+endif::[]
+
 The minimum TLS version that Redpanda clusters support. This property prevents client applications from negotiating a downgrade to the TLS version when they make a connection to a Redpanda cluster.
 
 *Requires restart:* Yes
@@ -5598,7 +5682,9 @@ The minimum TLS version that Redpanda clusters support. This property prevents c
 
 *Type:* string
 
+ifndef::env-cloud[]
 *Default:* `v1.2`
+endif::[]
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -311,12 +311,9 @@ If you produce to a topic that doesn't exist, the topic will be created with def
 ---
 
 
-// tag::cluster_id[]
 === cluster_id
 
-ifdef::env-cloud[]
 NOTE: This property is read-only in Redpanda Cloud.
-endif::[]
 
 Cluster identifier.
 
@@ -332,7 +329,6 @@ Cluster identifier.
 
 ---
 
-// end::cluster_id[]
 
 // tag::compacted_log_segment_size[]
 === compacted_log_segment_size

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2,7 +2,7 @@
 :page-aliases: reference:tunable-properties.adoc, reference:cluster-properties.adoc
 :description: Reference of cluster configuration properties.
 
-Cluster configuration properties are the same for all brokers in a cluster, and are set at the cluster level.
+Cluster properties are configuration settings that control the behavior of a Redpanda cluster at a global level. Configuring cluster properties allows you to adapt Redpanda to specific workloads, optimize resource usage, and enable or disable features. 
 
 For information on how to edit cluster properties, see xref:manage:cluster-maintenance/cluster-property-configuration.adoc[] or xref:manage:kubernetes/k-cluster-property-configuration.adoc[].
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -218,6 +218,7 @@ endif::[]
 
 // end::audit_excluded_topics[]
 
+// tag::audit_log_num_partitions[]
 === audit_log_num_partitions
 
 Defines the number of partitions used by a newly-created audit topic. This configuration applies only to the audit log topic and may be different from the cluster or other topic configurations. This cannot be altered for existing audit log topics.
@@ -237,6 +238,8 @@ ifndef::env-cloud[]
 endif::[]
 
 ---
+
+// end::audit_log_num_partitions[]
 
 === audit_log_replication_factor
 
@@ -304,6 +307,7 @@ If you produce to a topic that doesn't exist, the topic will be created with def
 ---
 
 
+// tag::cluster_id[]
 === cluster_id
 
 Cluster identifier.
@@ -320,6 +324,9 @@ Cluster identifier.
 
 ---
 
+// end::cluster_id[]
+
+// tag::compacted_log_segment_size[]
 === compacted_log_segment_size
 
 Size (in bytes) for each compacted log segment.
@@ -335,6 +342,8 @@ Size (in bytes) for each compacted log segment.
 *Default:* `268435456`
 
 ---
+
+// end::compacted_log_segment_size[]
 
 === compaction_ctrl_backlog_size
 
@@ -667,6 +676,7 @@ Timeout, in milliseconds, to wait for new topic creation.
 ---
 
 
+// tag::data_transforms_binary_max_size[]
 === data_transforms_binary_max_size
 
 The maximum size for a deployable WebAssembly binary that the broker can store.
@@ -681,6 +691,7 @@ The maximum size for a deployable WebAssembly binary that the broker can store.
 
 ---
 
+// end::data_transforms_binary_max_size[]
 
 === data_transforms_commit_interval_ms
 
@@ -776,6 +787,7 @@ endif::[]
 
 // end::data_transforms_logging_line_max_bytes[]
 
+// tag::data_transforms_per_core_memory_reservation[]
 === data_transforms_per_core_memory_reservation
 
 The amount of memory to reserve per core for data transform (Wasm) virtual machines. Memory is reserved on boot. The maximum number of functions that can be deployed to a cluster is equal to `data_transforms_per_core_memory_reservation` / `data_transforms_per_function_memory_limit`.
@@ -792,6 +804,9 @@ endif::[]
 
 ---
 
+// end::data_transforms_per_core_memory_reservation[]
+
+// tag::data_transforms_per_function_memory_limit[]
 === data_transforms_per_function_memory_limit
 
 The amount of memory to give an instance of a data transform (Wasm) virtual machine. The maximum number of functions that can be deployed to a cluster is equal to `data_transforms_per_core_memory_reservation` / `data_transforms_per_function_memory_limit`.
@@ -805,6 +820,8 @@ The amount of memory to give an instance of a data transform (Wasm) virtual mach
 *Default:* `2097152`
 
 ---
+
+// end::data_transforms_per_function_memory_limit[]
 
 
 === data_transforms_read_buffer_memory_percentage
@@ -1031,6 +1048,7 @@ Default number of partitions per topic.
 ---
 
 
+// tag::default_topic_replications[]
 === default_topic_replications
 
 Default replication factor for new topics.
@@ -1048,6 +1066,8 @@ Default replication factor for new topics.
 NOTE: In Redpanda Cloud, all new topics are created with a replication factor of 3.
 
 ---
+
+// end::default_topic_replications[]
 
 === default_window_sec
 
@@ -1736,6 +1756,7 @@ Maximum age of the metadata cached in the health monitor of a non-controller bro
 
 ---
 
+// tag::http_authentication[]
 === http_authentication
 
 include::reference:partial$enterprise-licensed-property.adoc[]
@@ -1756,6 +1777,9 @@ A list of supported HTTP authentication mechanisms. Accepted Values: `BASIC`, `O
 
 ---
 
+// end::http_authentication[]
+
+// tag::iceberg_backlog_controller_p_coeff[]
 === iceberg_backlog_controller_p_coeff
 
 Proportional coefficient for the Iceberg backlog controller. Number of shares assigned to the datalake scheduling group will be proportional to the backlog size error. A negative value means larger and faster changes in the number of shares in the datalake scheduling group.
@@ -1774,6 +1798,9 @@ Proportional coefficient for the Iceberg backlog controller. Number of shares as
 
 ---
 
+// end::iceberg_backlog_controller_p_coeff[]
+
+// tag::iceberg_catalog_base_location[]
 === iceberg_catalog_base_location
 
 Base path for the object-storage-backed Iceberg catalog. After Iceberg is enabled, do not change this value.
@@ -1792,6 +1819,8 @@ Base path for the object-storage-backed Iceberg catalog. After Iceberg is enable
 - xref:manage:iceberg/about-iceberg-topics.adoc[]
 
 ---
+
+// end::iceberg_catalog_base_location[]
 
 
 === iceberg_catalog_commit_interval_ms
@@ -3437,6 +3466,7 @@ The amount of time to keep a log file before deleting it (in milliseconds). If s
 ---
 
 
+// tag::log_segment_ms[]
 === log_segment_ms
 
 Default lifetime of log segments. If `null`, the property is disabled, and no default lifetime is set. Any value under 60 seconds (60000 ms) is rejected. This property can also be set in the Kafka API using the Kafka-compatible alias, `log.roll.ms`.
@@ -3842,6 +3872,7 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 
 ---
 
+// tag::minimum_topic_replications[]
 === minimum_topic_replications
 
 Minimum allowable replication factor for topics in this cluster. The set value must be positive, odd, and equal to or less than the number of available brokers. Changing this parameter only restricts newly-created topics. Redpanda returns an `INVALID_REPLICATION_FACTOR` error on any attempt to create a topic with a replication factor less than this property.
@@ -3861,6 +3892,8 @@ If you change the `minimum_topic_replications` setting, the replication factor o
 *Default:* `1`
 
 ---
+
+// end::minimum_topic_replications[]
 
 === node_isolation_heartbeat_timeout
 
@@ -3949,6 +3982,7 @@ The amount of time (in seconds) to allow for when validating the expiry claim in
 
 ---
 
+// tag::oidc_discovery_url[]
 === oidc_discovery_url
 
 The URL pointing to the well-known discovery endpoint for the OIDC provider.
@@ -3962,6 +3996,8 @@ The URL pointing to the well-known discovery endpoint for the OIDC provider.
 *Default:* `https://auth.prd.cloud.redpanda.com/.well-known/openid-configuration`
 
 ---
+
+// end::oidc_discovery_url[]
 
 === oidc_keys_refresh_interval
 
@@ -3981,6 +4017,7 @@ The frequency of refreshing the JSON Web Keys (JWKS) used to validate access tok
 
 ---
 
+// tag::oidc_principal_mapping[]
 === oidc_principal_mapping
 
 Rule for mapping JWT payload claim to a Redpanda user principal.
@@ -3995,6 +4032,9 @@ Rule for mapping JWT payload claim to a Redpanda user principal.
 
 ---
 
+// end::oidc_principal_mapping[]
+
+// tag::oidc_token_audience[]
 === oidc_token_audience
 
 A string representing the intended recipient of the token.
@@ -4008,6 +4048,8 @@ A string representing the intended recipient of the token.
 *Default:* `redpanda`
 
 ---
+
+// end::oidc_token_audience[]
 
 === partition_autobalancing_concurrent_moves
 
@@ -5135,6 +5177,7 @@ Rules for mapping Kerberos principal names to Redpanda user principals.
 
 ---
 
+// tag::sasl_mechanisms[]
 === sasl_mechanisms
 
 include::reference:partial$enterprise-licensed-property.adoc[]
@@ -5154,6 +5197,8 @@ A list of supported SASL mechanisms. Accepted values: `SCRAM`, `GSSAPI`, `OAUTHB
 *Default:* `[SCRAM]`
 
 ---
+
+// end::sasl_mechanisms[]
 
 === schema_registry_normalize_on_startup
 
@@ -5540,6 +5585,7 @@ TLS client-initiated renegotiation is considered unsafe and is disabled by defau
 
 ---
 
+// tag::tls_min_version[]
 === tls_min_version
 
 The minimum TLS version that Redpanda clusters support. This property prevents client applications from negotiating a downgrade to the TLS version when they make a connection to a Redpanda cluster.
@@ -5555,6 +5601,8 @@ The minimum TLS version that Redpanda clusters support. This property prevents c
 *Default:* `v1.2`
 
 ---
+
+// end::tls_min_version[]
 
 === tm_sync_timeout_ms
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -8,7 +8,7 @@ For information on how to edit cluster properties, see xref:manage:cluster-maint
 
 NOTE: Some object storage properties require that you restart the cluster for any updates to take effect. See the specific property details to identify whether or not a restart is required.
 
-== Cloud configuration
+== Cluster configuration
 
 Object storage properties should only be set if you enable xref:manage:tiered-storage.adoc[Tiered Storage]. 
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -1,7 +1,9 @@
 = Object Storage Properties 
 :description: Reference of object storage properties. 
 
-Object storage properties are a type of cluster property. For information on how to edit cluster properties, see xref:manage:cluster-maintenance/cluster-property-configuration.adoc[]. 
+Object storage properties are a type of cluster property. Cluster properties are configuration settings that control the behavior of a Redpanda cluster at a global level. Configuring cluster properties allows you to adapt Redpanda to specific workloads, optimize resource usage, and enable or disable features. 
+
+For information on how to edit cluster properties, see xref:manage:cluster-maintenance/cluster-property-configuration.adoc[]. 
 
 NOTE: Some object storage properties require that you restart the cluster for any updates to take effect. See the specific property details to identify whether or not a restart is required.
 
@@ -113,6 +115,7 @@ Azure Data Lake Storage v2 port override. See also: <<cloud_storage_azure_adls_e
 
 ---
 
+// tag::cloud_storage_azure_container[]
 === cloud_storage_azure_container
 
 The name of the Azure container to use with Tiered Storage. If `null`, the property is disabled.
@@ -125,9 +128,13 @@ NOTE: The container must belong to <<cloud_storage_azure_storage_account,`cloud_
 
 *Type*: string
 
+ifndef::env-cloud[]
 *Default*: null
+endif::[]
 
 *Supported versions*: Redpanda v23.1 or later
+
+// end::cloud_storage_azure_container[]
 
 ---
 
@@ -179,12 +186,15 @@ NOTE: Redpanda expects this key string to be Base64 encoded.
 
 *Type*: string
 
+ifndef::env-cloud[]
 *Default*: null
+endif::[]
 
 *Supported versions*: Redpanda v23.1 or later
 
 ---
 
+// tag::cloud_storage_azure_storage_account[]
 === cloud_storage_azure_storage_account
 
 The name of the Azure storage account to use with Tiered Storage. If `null`, the property is disabled.
@@ -198,6 +208,8 @@ The name of the Azure storage account to use with Tiered Storage. If `null`, the
 *Type:* string
 
 *Default:* `null`
+
+// end::cloud_storage_azure_storage_account[]
 
 ---
 


### PR DESCRIPTION
## Description
This pull request tags cluster config properties for single sourcing them into Cloud docs (updated in https://github.com/redpanda-data/cloud-docs/pull/295)

Resolves https://redpandadata.atlassian.net/browse/DOC-1356
Review deadline: Monday May 19

## Page previews
[Cluster Configuration Properties Reference](https://deploy-preview-1128--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/properties/cluster-properties/) in Cloud
[Configure Cluster Properties](https://deploy-preview-1128--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/cluster-maintenance/config-cluster/) in Cloud

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
