### PR TITLE
DOC-859 Update FIPs installation documentation

### DIFF
--- a/modules/deploy/partials/linux/install-fips.adoc
+++ b/modules/deploy/partials/linux/install-fips.adoc
@@ -3,9 +3,8 @@
 [NOTE]
 ====
 include::shared:partial$enterprise-license.adoc[]
-====
 
-To run Redpanda in FIPS compliance mode, you must install the `redpanda-fips` package, which is separate from and dependent upon the `redpanda` install package already being installed. Install the following packages after installing `redpanda`:
+To run Redpanda in FIPS compliance mode, you must install the packages `redpanda-fips` and `redpanda-rpk-fips`. This automatically pulls in all required packages.
 
 `redpanda-fips`
 

--- a/modules/deploy/partials/linux/install-fips.adoc
+++ b/modules/deploy/partials/linux/install-fips.adoc
@@ -4,7 +4,7 @@
 ====
 include::shared:partial$enterprise-license.adoc[]
 
-To run Redpanda in FIPS compliance mode, you must install the packages `redpanda-fips` and `redpanda-rpk-fips`. This automatically pulls in all required packages.
+To install Redpanda for FIPS compliance, install the packages `redpanda-fips` and `redpanda-rpk-fips`, which automatically pull in all required dependencies.
 
 `redpanda-fips`
 

--- a/modules/deploy/partials/linux/install-fips.adoc
+++ b/modules/deploy/partials/linux/install-fips.adoc
@@ -3,6 +3,7 @@
 [NOTE]
 ====
 include::shared:partial$enterprise-license.adoc[]
+====
 
 To install Redpanda for FIPS compliance, install the packages `redpanda-fips` and `redpanda-rpk-fips`, which automatically pull in all required dependencies.
 


### PR DESCRIPTION
This pull request updates the documentation for installing Redpanda in FIPS compliance mode. The change simplifies the instructions and clarifies the package requirements.

This PR fixes [DOC-859](https://redpandadata.atlassian.net/browse/DOC-859).

Documentation updates:

* [`modules/deploy/partials/linux/install-fips.adoc`](diffhunk://#diff-15cb4e087161e0a523f8659c5891fbcda1f2c3d717fc48b9ba322cbc3e06db3fL6-R7): Updated the instructions to specify that both `redpanda-fips` and `redpanda-rpk-fips` packages must be installed, and clarified that these packages automatically pull in all required dependencies.## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews
[Preview](https://deploy-preview-1132--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/manual/production/production-deployment/#install-redpanda-for-fips-compliance)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)


[DOC-859]: https://redpandadata.atlassian.net/browse/DOC-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ