### PR TITLE
DOC-1394 iceberg_disable_snapshot_tagging in Cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1398-single-source-iceberg_disable_snapshot_tagging'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1398-single-source-iceberg_disable_snapshot_tagging'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -1971,9 +1971,10 @@ Whether to disable automatic Iceberg snapshot expiry. This property may be usefu
 
 ---
 
+// tag::iceberg_disable_snapshot_tagging[]
 === iceberg_disable_snapshot_tagging
 
-Whether to disable tagging of Iceberg snapshots. These tags are used to ensure that the snapshots that Redpanda writes are retained during snapshot removal, which in turn, helps Redpanda ensure exactly-once delivery of records. Disabling tags is therefore not recommended, but may be useful if the Iceberg catalog does not support tags.
+Whether to disable tagging of Iceberg snapshots. These tags are used to ensure that the snapshots that Redpanda writes are retained during snapshot removal, which in turn, helps Redpanda ensure exactly-once delivery of records. Disabling tags is therefore not recommended, but it may be useful if the Iceberg catalog does not support tags.
 
 *Requires restart:* No
 
@@ -1981,13 +1982,17 @@ Whether to disable tagging of Iceberg snapshots. These tags are used to ensure t
 
 *Type:* boolean
 
+ifndef::env-cloud[]
 *Default:* `false`
+endif::[]
 
 **Related topics**:
 
 - xref:manage:iceberg/about-iceberg-topics.adoc[]
 
 ---
+
+// end::iceberg_disable_snapshot_tagging[] 
 
 // tag::iceberg_enabled[] 
 === iceberg_enabled

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -135,9 +135,9 @@ endif::[]
 
 *Supported versions*: Redpanda v23.1 or later
 
-// end::cloud_storage_azure_container[]
-
 ---
+
+// end::cloud_storage_azure_container[]
 
 === cloud_storage_azure_hierarchical_namespace_enabled
 
@@ -210,9 +210,9 @@ The name of the Azure storage account to use with Tiered Storage. If `null`, the
 
 *Default:* `null`
 
-// end::cloud_storage_azure_storage_account[]
-
 ---
+
+// end::cloud_storage_azure_storage_account[]
 
 === cloud_storage_backend
 


### PR DESCRIPTION
## Description
This pull request includes updates to documentation for Redpanda's configuration properties, tagging `iceberg_disable_snapshot_tagging` for single sourcing in Cloud.

### Iceberg Snapshot Tagging Documentation:

* Improved the description of the `iceberg_disable_snapshot_tagging` property to clarify its purpose and usage, ensuring better readability.
* Added conditional visibility for the default value of the `iceberg_disable_snapshot_tagging` property to exclude it from cloud environments.

### Object Storage Properties Documentation:

* Corrected the placement of the `// end::cloud_storage_azure_container[]` tag for better alignment with the documentation structure.
* Adjusted the `// end::cloud_storage_azure_storage_account[]` tag to improve consistency in the object storage properties section.

Resolves https://redpandadata.atlassian.net/browse/DOC-1394
Review deadline:

## Page previews
https://deploy-preview-1133--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/properties/cluster-properties/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
