### PR TITLE
Add deprecation notice in Cloud API reference

### DIFF
--- a/modules/ROOT/pages/cloud-controlplane/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud-controlplane/overview/overview.adoc
@@ -6,7 +6,7 @@ To familiarize yourself with Redpanda Cloud API basics, see the xref:redpanda-cl
 
 NOTE: To see the available endpoints for managing resources within your clusters, such as topics, users, access control lists (ACLs), and connectors, see the link:https://docs.redpanda.com/api/cloud-dataplane-api.html[Data Plane API Reference].
 
-IMPORTANT: The Control Plane API beta versions v1beta1 and v1beta2 are deprecated. v1beta1 and v1beta2 are still available, but they will be removed in a future release and are not recommended for use. See xref:redpanda-cloud:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+IMPORTANT: The Control Plane API versions v1beta1 and v1beta2 are deprecated. v1beta1 and v1beta2 are still available, but they will be removed in a future release and are not recommended for use. See xref:redpanda-cloud:manage:api/cloud-api-deprecation-policy.adoc[] for details.
 
 == Requirements
 

--- a/modules/ROOT/pages/cloud-controlplane/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud-controlplane/overview/overview.adoc
@@ -6,6 +6,8 @@ To familiarize yourself with Redpanda Cloud API basics, see the xref:redpanda-cl
 
 NOTE: To see the available endpoints for managing resources within your clusters, such as topics, users, access control lists (ACLs), and connectors, see the link:https://docs.redpanda.com/api/cloud-dataplane-api.html[Data Plane API Reference].
 
+IMPORTANT: The Control Plane API beta versions v1beta1 and v1beta2 are deprecated. v1beta1 and v1beta2 are still available, but they will be removed in a future release and are not recommended for use. See xref:redpanda-cloud:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+
 == Requirements
 
 To use the Control Plane API:

--- a/modules/ROOT/pages/cloud-controlplane/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud-controlplane/overview/overview.adoc
@@ -6,7 +6,18 @@ To familiarize yourself with Redpanda Cloud API basics, see the xref:redpanda-cl
 
 NOTE: To see the available endpoints for managing resources within your clusters, such as topics, users, access control lists (ACLs), and connectors, see the link:https://docs.redpanda.com/api/cloud-dataplane-api.html[Data Plane API Reference].
 
-IMPORTANT: The Control Plane API versions v1beta1 and v1beta2 are deprecated. v1beta1 and v1beta2 are still available, but they will be removed in a future release and are not recommended for use. See xref:redpanda-cloud:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+[IMPORTANT]
+====
+The Control Plane API versions v1beta1 and v1beta2 are deprecated. v1beta1 and v1beta2 are still available, but they will be removed in a future release and are not recommended for use. 
+
+The deprecation timeline is: 
+
+- Announcement date: May 27, 2025
+- End-of-support date: November 28, 2025
+- Retirement date: May 28, 2026
+
+See xref:redpanda-cloud:manage:api/cloud-api-deprecation-policy.adoc[] for more information.
+====
 
 == Requirements
 

--- a/modules/ROOT/pages/cloud-dataplane/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud-dataplane/overview/overview.adoc
@@ -6,6 +6,8 @@ To familiarize yourself with Redpanda Cloud API basics, see the xref:redpanda-cl
 
 NOTE: Redpanda Cloud uses a control plane and data plane architecture. To see the available endpoints for managing your clusters, networks, and resource groups, see the link:https://docs.redpanda.com/api/cloud-controlplane-api.html[Control Plane API Reference].
 
+IMPORTANT: The Data Plane API beta versions v1alpha1 and v1alpha2 are deprecated. v1alpha1 and v1alpha2 are still available, but they will be removed in a future release and are not recommended for use. See xref:redpanda-cloud:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+
 == Requirements
 
 To use the Data Plane APIs:

--- a/modules/ROOT/pages/cloud-dataplane/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud-dataplane/overview/overview.adoc
@@ -6,7 +6,18 @@ To familiarize yourself with Redpanda Cloud API basics, see the xref:redpanda-cl
 
 NOTE: Redpanda Cloud uses a control plane and data plane architecture. To see the available endpoints for managing your clusters, networks, and resource groups, see the link:https://docs.redpanda.com/api/cloud-controlplane-api.html[Control Plane API Reference].
 
-IMPORTANT: The Data Plane API versions v1alpha1 and v1alpha2 are deprecated. v1alpha1 and v1alpha2 are still available, but they will be removed in a future release and are not recommended for use. See xref:redpanda-cloud:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+[IMPORTANT]
+====
+The Data Plane API versions v1alpha1 and v1alpha2 are deprecated. v1alpha1 and v1alpha2 are still available, but they will be removed in a future release and are not recommended for use.
+
+The deprecation timeline is: 
+
+- Announcement date: May 27, 2025
+- End-of-support date: November 28, 2025
+- Retirement date: May 28, 2026
+
+See xref:redpanda-cloud:manage:api/cloud-api-deprecation-policy.adoc[] for more information.
+====
 
 == Requirements
 

--- a/modules/ROOT/pages/cloud-dataplane/overview/overview.adoc
+++ b/modules/ROOT/pages/cloud-dataplane/overview/overview.adoc
@@ -6,7 +6,7 @@ To familiarize yourself with Redpanda Cloud API basics, see the xref:redpanda-cl
 
 NOTE: Redpanda Cloud uses a control plane and data plane architecture. To see the available endpoints for managing your clusters, networks, and resource groups, see the link:https://docs.redpanda.com/api/cloud-controlplane-api.html[Control Plane API Reference].
 
-IMPORTANT: The Data Plane API beta versions v1alpha1 and v1alpha2 are deprecated. v1alpha1 and v1alpha2 are still available, but they will be removed in a future release and are not recommended for use. See xref:redpanda-cloud:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+IMPORTANT: The Data Plane API versions v1alpha1 and v1alpha2 are deprecated. v1alpha1 and v1alpha2 are still available, but they will be removed in a future release and are not recommended for use. See xref:redpanda-cloud:manage:api/cloud-api-deprecation-policy.adoc[] for details.
 
 == Requirements
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

[Control Plane API](https://deploy-preview-1134--redpanda-docs-preview.netlify.app/api/cloud-controlplane-api/#overview)
[Data Plane API](https://deploy-preview-1134--redpanda-docs-preview.netlify.app/api/cloud-dataplane-api/#overview)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
