### PR TITLE
Fix indentation for secretRef in authentication docs

### DIFF
--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -753,7 +753,7 @@ spec:
     auth:
       sasl:
         enabled: true
-      secretRef: redpanda-superusers
+        secretRef: redpanda-superusers
     config:
       cluster:
         sasl_mechanisms:
@@ -779,7 +779,7 @@ Helm::
 auth:
   sasl:
     enabled: true
-  secretRef: redpanda-superusers
+    secretRef: redpanda-superusers
 config:
   cluster:
     sasl_mechanisms:
@@ -942,7 +942,7 @@ spec:
     auth:
       sasl:
         enabled: true
-      secretRef: redpanda-superusers
+        secretRef: redpanda-superusers
     config:
       cluster:
         sasl_mechanisms:
@@ -974,7 +974,7 @@ Helm::
 auth:
   sasl:
     enabled: true
-  secretRef: redpanda-superusers
+    secretRef: redpanda-superusers
 config:
   cluster:
     sasl_mechanisms:
@@ -1393,7 +1393,7 @@ spec:
     auth:
       sasl:
         enabled: true
-      secretRef: redpanda-superusers
+        secretRef: redpanda-superusers
     config:
       cluster:
         admin_api_require_auth: true


### PR DESCRIPTION
## Description

The indentation for the `secretRef` in few examples in the [Kubernetes authentication docs page](https://docs.redpanda.com/current/manage/kubernetes/security/authentication/k-authentication) is broken. The `secretRef` key should be under `auth.sasl` and not `auth` (See [helm values](https://github.com/redpanda-data/helm-charts/blob/d16c638447ac045eadd07a57bb2de5f20d8d3f93/charts/redpanda/values.yaml#L162)). There are other examples in the page that have the right reference.

This PR fixes the indentation for `secretRef`s which are under `auth` instead of `auth.sasl`

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
