### PR TITLE
DOC-1407 single source additions for Cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1404-Document-new-configurable-property'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -241,7 +241,10 @@ Aggregates the lag across all partitions, providing an overall view of data cons
 To enable these dedicated gauges, you must enable consumer group metrics in your cluster properties. Add the following to your Redpanda configuration:
 
 - xref:reference:properties/cluster-properties.adoc#enable_consumer_group_metrics[`enable_consumer_group_metrics`]: A list of properties to enable for consumer group metrics. You must add the `consumer_lag` property to enable consumer group lag metrics.
+ifndef::env-cloud[]
+[,bash]
 - xref:reference:properties/cluster-properties.adoc#consumer_group_lag_collection_interval_sec[`consumer_group_lag_collection_interval_sec`] (optional): The interval in seconds for collecting consumer group lag metrics. The default is 60 seconds.
+endif::[]
 +
 Set this value equal to the scrape interval of your metrics collection system. Aligning these intervals ensures synchronized data collection, reducing the likelihood of missing or misaligned lag measurements.
 

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -1,4 +1,5 @@
 == Monitor for performance and health
+// tag::single-source[]
 
 This section provides guidelines and example queries using Redpanda's public metrics to optimize your system's performance and monitor its health.
 
@@ -237,10 +238,12 @@ Reports the maximum lag observed among all partitions for a consumer group. This
 - xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_lag_sum[`redpanda_kafka_consumer_group_lag_sum`]:
 Aggregates the lag across all partitions, providing an overall view of data consumption delay for the consumer group.
 
-To enable these dedicated gauges, you must enable consumer group metrics in your cluster properties. Add the following settings to your Redpanda configuration:
+To enable these dedicated gauges, you must enable consumer group metrics in your cluster properties. Add the following to your Redpanda configuration:
 
 - xref:reference:properties/cluster-properties.adoc#enable_consumer_group_metrics[`enable_consumer_group_metrics`]: A list of properties to enable for consumer group metrics. You must add the `consumer_lag` property to enable consumer group lag metrics.
+ifndef::env-cloud[]
 - xref:reference:properties/cluster-properties.adoc#consumer_group_lag_collection_interval_sec[`consumer_group_lag_collection_interval_sec`] (optional): The interval in seconds for collecting consumer group lag metrics. The default is 60 seconds.
+endif::[]
 +
 Set this value equal to the scrape interval of your metrics collection system. Aligning these intervals ensures synchronized data collection, reducing the likelihood of missing or misaligned lag measurements.
 
@@ -394,3 +397,6 @@ rate(redpanda_rest_proxy_request_errors_total[5m])
 === Data transforms
 
 See xref:develop:data-transforms/monitor.adoc[].
+
+// end::single-source[]
+

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -241,9 +241,7 @@ Aggregates the lag across all partitions, providing an overall view of data cons
 To enable these dedicated gauges, you must enable consumer group metrics in your cluster properties. Add the following to your Redpanda configuration:
 
 - xref:reference:properties/cluster-properties.adoc#enable_consumer_group_metrics[`enable_consumer_group_metrics`]: A list of properties to enable for consumer group metrics. You must add the `consumer_lag` property to enable consumer group lag metrics.
-ifndef::env-cloud[]
 - xref:reference:properties/cluster-properties.adoc#consumer_group_lag_collection_interval_sec[`consumer_group_lag_collection_interval_sec`] (optional): The interval in seconds for collecting consumer group lag metrics. The default is 60 seconds.
-endif::[]
 +
 Set this value equal to the scrape interval of your metrics collection system. Aligning these intervals ensures synchronized data collection, reducing the likelihood of missing or misaligned lag measurements.
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -1236,6 +1236,10 @@ ifdef::env-cloud[]
 - `consumer_lag`: Enables the `redpanda_kafka_consumer_group_lag_max` and `redpanda_kafka_consumer_group_lag_sum` metrics
 +
 Enabling `consumer_lag` may add a small amount of additional processing overhead to the brokers, especially in environments with a high number of consumer groups or partitions.
+
+*Related topics*:
+
+- xref:manage:monitor-cloud.adoc#consumers[Monitor consumer group lag]
 endif::[]
 
 *Requires restart:* No

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -1220,26 +1220,14 @@ Enables cluster metadata uploads. Required for xref:manage:whole-cluster-restore
 
 List of enabled consumer group metrics. Accepted values include:
 
-ifndef::env-cloud[]
 - `group`: Enables the xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_consumers[`redpanda_kafka_consumer_group_consumers`] and xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_topics[`redpanda_kafka_consumer_group_topics`] metrics.
 - `partition`: Enables the xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_committed_offset[`redpanda_kafka_consumer_group_committed_offset`] metric.
 - `consumer_lag`: Enables the xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_lag_max[`redpanda_kafka_consumer_group_lag_max`] and xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_lag_sum[`redpanda_kafka_consumer_group_lag_sum`] metrics
 +
 Enabling `consumer_lag` may add a small amount of additional processing overhead to the brokers, especially in environments with a high number of consumer groups or partitions.
 +
+ifndef::env-cloud[]
 Use the xref:reference:properties/cluster-properties.adoc#consumer_group_lag_collection_interval_sec[`consumer_group_lag_collection_interval_sec`] property to control the frequency of consumer lag metric collection.
-endif::[]
-
-ifdef::env-cloud[]
-- `group`: Enables the `redpanda_kafka_consumer_group_consumers` and `redpanda_kafka_consumer_group_topics` metrics.
-- `partition`: Enables the `redpanda_kafka_consumer_group_committed_offset` metric.
-- `consumer_lag`: Enables the `redpanda_kafka_consumer_group_lag_max` and `redpanda_kafka_consumer_group_lag_sum` metrics
-+
-Enabling `consumer_lag` may add a small amount of additional processing overhead to the brokers, especially in environments with a high number of consumer groups or partitions.
-
-*Related topics*:
-
-- xref:manage:monitor-cloud.adoc#consumers[Monitor consumer group lag]
 endif::[]
 
 *Requires restart:* No
@@ -1254,6 +1242,12 @@ ifndef::env-cloud[]
 *Related topics*:
 
 - xref:manage:monitoring.adoc#consumers[Monitor consumer group lag]
+endif::[]
+
+ifdef::env-cloud[]
+*Related topics*:
+
+- xref:manage:monitor-cloud.adoc#consumers[Monitor consumer group lag]
 endif::[]
 
 ---

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -1215,10 +1215,12 @@ Enables cluster metadata uploads. Required for xref:manage:whole-cluster-restore
 
 ---
 
+// tag::enable_consumer_group_metrics[]
 === enable_consumer_group_metrics
 
 List of enabled consumer group metrics. Accepted values include:
 
+ifndef::env-cloud[]
 - `group`: Enables the xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_consumers[`redpanda_kafka_consumer_group_consumers`] and xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_topics[`redpanda_kafka_consumer_group_topics`] metrics.
 - `partition`: Enables the xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_committed_offset[`redpanda_kafka_consumer_group_committed_offset`] metric.
 - `consumer_lag`: Enables the xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_lag_max[`redpanda_kafka_consumer_group_lag_max`] and xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_lag_sum[`redpanda_kafka_consumer_group_lag_sum`] metrics
@@ -1226,6 +1228,15 @@ List of enabled consumer group metrics. Accepted values include:
 Enabling `consumer_lag` may add a small amount of additional processing overhead to the brokers, especially in environments with a high number of consumer groups or partitions.
 +
 Use the xref:reference:properties/cluster-properties.adoc#consumer_group_lag_collection_interval_sec[`consumer_group_lag_collection_interval_sec`] property to control the frequency of consumer lag metric collection.
+endif::[]
+
+ifdef::env-cloud[]
+- `group`: Enables the `redpanda_kafka_consumer_group_consumers` and `redpanda_kafka_consumer_group_topics` metrics.
+- `partition`: Enables the `redpanda_kafka_consumer_group_committed_offset` metric.
+- `consumer_lag`: Enables the `redpanda_kafka_consumer_group_lag_max` and `redpanda_kafka_consumer_group_lag_sum` metrics
++
+Enabling `consumer_lag` may add a small amount of additional processing overhead to the brokers, especially in environments with a high number of consumer groups or partitions.
+endif::[]
 
 *Requires restart:* No
 
@@ -1233,12 +1244,16 @@ Use the xref:reference:properties/cluster-properties.adoc#consumer_group_lag_col
 
 *Type:* array
 
+ifndef::env-cloud[]
 *Default:* `["group", "partition"]`
 
 *Related topics*:
 
 - xref:manage:monitoring.adoc#consumers[Monitor consumer group lag]
+endif::[]
+
 ---
+// end::enable_consumer_group_metrics[]
 
 === enable_controller_log_rate_limiting
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-get.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-get.adoc
@@ -1,4 +1,5 @@
 = rpk cluster config get
+// tag::single-source[]
 
 Get a cluster configuration property.
 
@@ -30,3 +31,5 @@ rpk cluster config get <key> [flags]
 
 |-v, --verbose |- |Enable verbose logging.
 |===
+
+// end::single-source[]


### PR DESCRIPTION
## Description
This pull request tags `enable_consumer_group_metrics`, `rpk cluster config get`, and part of the monitoring page for single sourcing in Cloud docs. Related PR = https://github.com/redpanda-data/cloud-docs/pull/311.

### Documentation Updates:

* **Consumer Group Metrics Documentation**:
  - Added detailed tags (`enable_consumer_group_metrics`) to describe consumer group metrics and their behavior for both cloud and non-cloud environments. 
* **`rpk cluster config get` Documentation**:
  - Introduced tags (`single-source`) to structure the documentation for retrieving cluster configuration properties, improving readability and organization. [[1]](diffhunk://#diff-8f6c1440fc65d7de9b29bb82f91f77ec8db3300d6a4b3723d307804a2eda7736R2) [[2]](diffhunk://#diff-8f6c1440fc65d7de9b29bb82f91f77ec8db3300d6a4b3723d307804a2eda7736R34-R35)

### Configuration Updates:

* **Branch Reference Update in `local-antora-playbook.yml`**:
  - Updated the branch reference for the `redpanda-data/cloud-docs` repository from `'main'` to `'DOC-1404-Document-new-configurable-property'` to reflect the new documentation branch.

Resolves https://redpandadata.atlassian.net/browse/DOC-1407
Review deadline:

## Page previews
[enable_consumer_group_metrics in Cloud](https://deploy-preview-1139--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/properties/cluster-properties/#enable_consumer_group_metrics) 
[enable_consumer_group_metrics in SM](https://deploy-preview-1139--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/#enable_consumer_group_metrics)
[rpk cluster config get in Cloud](https://deploy-preview-1139--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-cluster/rpk-cluster-config-get/)
[Monitor Redpanda Cloud](https://deploy-preview-1139--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/monitor-cloud/#monitor-for-health-and-performance)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
