### PR TITLE
Add BYOVPC support for Iceberg REST catalogs in single-sourced docs

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1222-Document-feature-Iceberg-on-Cloud-BYOVPC-GA-AWS-GCP'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1222-Document-feature-Iceberg-on-Cloud-BYOVPC-GA-AWS-GCP'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -174,7 +174,7 @@ The Redpanda cluster ID is also used as the container name (ID) and the storage 
 
 |===
 
-For Azure clusters, you must add the public IP addresses or ranges from the REST catalog service or other clients requiring access to the Iceberg data to your cluster's allow list. Alternatively, add subnet IDs to the allow list if the requests originate from the same Azure region.
+For Azure clusters, you must add the public IP addresses or ranges from the REST catalog service, or other clients requiring access to the Iceberg data, to your cluster's allow list. Alternatively, add subnet IDs to the allow list if the requests originate from the same Azure region.
 
 For example, to add subnet IDs to the allow list through the Control Plane API xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/<cluster-id>`] endpoint, run:
 

--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -150,6 +150,28 @@ SUBJECT          VERSION   ID   TYPE
 ----
 
 ifdef::env-cloud[]
+For Azure clusters, you will need to add subnet IDs from the REST catalog service or other clients requiring access to the Iceberg data to your cluster's allow list.
+
+Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/<cluster-id>`] request to add the subnet IDs to the allow list:
+
+[,bash]
+----
+curl -X PATCH https://api.cloud.redpanda.com/v1/clusters/<cluster-id> \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" \
+  -d @- << EOF
+{
+  "cloud_storage": {
+    "azure": {
+      "allowed_subnet_ids": [
+         <list-of-subnet-ids>
+      ]
+    }
+  }
+}
+EOF
+----
+
 To query the Iceberg table, you need access to the object storage bucket or container where the Iceberg data is stored. For BYOC clusters, the bucket name and table location are as follows:
 
 |===
@@ -170,6 +192,7 @@ The Redpanda cluster ID is also used as the container name (ID) and the storage 
 
 
 |===
+
 endif::[]
 
 As you produce records to the topic, the data also becomes available in object storage for Iceberg-compatible clients to consume. You can use the same analytical tools to xref:manage:iceberg/query-iceberg-topics.adoc[read the Iceberg topic data] in a data lake as you would for a relational database.

--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -150,27 +150,8 @@ SUBJECT          VERSION   ID   TYPE
 ----
 
 ifdef::env-cloud[]
-For Azure clusters, you will need to add subnet IDs from the REST catalog service or other clients requiring access to the Iceberg data to your cluster's allow list.
 
-Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/<cluster-id>`] request to add the subnet IDs to the allow list:
-
-[,bash]
-----
-curl -X PATCH https://api.cloud.redpanda.com/v1/clusters/<cluster-id> \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" \
-  -d @- << EOF
-{
-  "cloud_storage": {
-    "azure": {
-      "allowed_subnet_ids": [
-         <list-of-subnet-ids>
-      ]
-    }
-  }
-}
-EOF
-----
+=== Access Iceberg data
 
 To query the Iceberg table, you need access to the object storage bucket or container where the Iceberg data is stored. For BYOC clusters, the bucket name and table location are as follows:
 
@@ -192,6 +173,28 @@ The Redpanda cluster ID is also used as the container name (ID) and the storage 
 
 
 |===
+
+For Azure clusters, you must add the public IP addresses or ranges from the REST catalog service or other clients requiring access to the Iceberg data to your cluster's allow list. Alternatively, add subnet IDs to the allow list if the requests originate from the same Azure region.
+
+For example, to add subnet IDs to the allow list through the Control Plane API xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/<cluster-id>`] endpoint, run:
+
+[,bash]
+----
+curl -X PATCH https://api.cloud.redpanda.com/v1/clusters/<cluster-id> \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" \
+  -d @- << EOF
+{
+  "cloud_storage": {
+    "azure": {
+      "allowed_subnet_ids": [
+         <list-of-subnet-ids>
+      ]
+    }
+  }
+}
+EOF
+----
 
 endif::[]
 

--- a/modules/manage/partials/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/query-iceberg-topics.adoc
@@ -26,7 +26,7 @@ The Redpanda cluster ID is also used as the container name (ID) and the storage 
 
 |===
 
-For Azure clusters, you must add the public IP addresses or ranges from the REST catalog service or other clients requiring access to the Iceberg data to your cluster's allow list. Alternatively, add subnet IDs to the allow list if the requests originate from the same Azure region.
+For Azure clusters, you must add the public IP addresses or ranges from the REST catalog service, or other clients requiring access to the Iceberg data, to your cluster's allow list. Alternatively, add subnet IDs to the allow list if the requests originate from the same Azure region.
 
 For example, to add subnet IDs to the allow list through the Control Plane API xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/<cluster-id>`] endpoint, run:
 

--- a/modules/manage/partials/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/query-iceberg-topics.adoc
@@ -26,27 +26,6 @@ The Redpanda cluster ID is also used as the container name (ID) and the storage 
 
 |===
 
-NOTE: For Azure clusters, you will need to add subnet IDs from the REST catalog service or other clients requiring access to the Iceberg data to your cluster's allow list.
-
-Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-id-[`PATCH /v1/clusters/<cluster-id>`] request to add the subnet IDs to the allow list:
-
-[,bash]
-----
-curl -X PATCH https://api.cloud.redpanda.com/v1/clusters/<cluster-id> \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <token>" \
-  -d @- << EOF
-{
-  "cloud_storage": {
-    "azure": {
-      "allowed_subnet_ids": [
-         <list-of-subnet-ids>
-      ]
-    }
-  }
-}
-EOF
-----
 endif::[]
 
 If your engine needs the full JSON metadata path, use the following:

--- a/modules/manage/partials/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/query-iceberg-topics.adoc
@@ -25,6 +25,28 @@ The Redpanda cluster ID is also used as the container name (ID) and the storage 
 | `redpanda-cloud-storage-<cluster-id>`
 
 |===
+
+NOTE: For Azure clusters, you will need to add subnet IDs from the REST catalog service or other clients requiring access to the Iceberg data to your cluster's allow list.
+
+Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-id-[`PATCH /v1/clusters/<cluster-id>`] request to add the subnet IDs to the allow list:
+
+[,bash]
+----
+curl -X PATCH https://api.cloud.redpanda.com/v1/clusters/<cluster-id> \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d @- << EOF
+{
+  "cloud_storage": {
+    "azure": {
+      "allowed_subnet_ids": [
+         <list-of-subnet-ids>
+      ]
+    }
+  }
+}
+EOF
+----
 endif::[]
 
 If your engine needs the full JSON metadata path, use the following:

--- a/modules/manage/partials/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/query-iceberg-topics.adoc
@@ -26,6 +26,28 @@ The Redpanda cluster ID is also used as the container name (ID) and the storage 
 
 |===
 
+For Azure clusters, you must add the public IP addresses or ranges from the REST catalog service or other clients requiring access to the Iceberg data to your cluster's allow list. Alternatively, add subnet IDs to the allow list if the requests originate from the same Azure region.
+
+For example, to add subnet IDs to the allow list through the Control Plane API xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/<cluster-id>`] endpoint, run:
+
+[,bash]
+----
+curl -X PATCH https://api.cloud.redpanda.com/v1/clusters/<cluster-id> \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" \
+  -d @- << EOF
+{
+  "cloud_storage": {
+    "azure": {
+      "allowed_subnet_ids": [
+         <list-of-subnet-ids>
+      ]
+    }
+  }
+}
+EOF
+----
+
 endif::[]
 
 If your engine needs the full JSON metadata path, use the following:

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -21,7 +21,7 @@ For BYOVPC clusters, you must:
 Secrets management is enabled by default for AWS if you follow the guide to xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc[creating a new BYOVPC cluster]. For GCP, follow the guides to enable secrets management for a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[new BYOVPC cluster] or an xref:get-started:cluster-types/byoc/gcp/enable-secrets-byovpc-gcp.adoc[existing BYOVPC cluster].
 . Ensure that your network security settings allow egress traffic from the Redpanda network to the catalog service endpoints.
 
-NOTE: If your cluster is on a private network, Redpanda recommends creating a VPC peering connection to the catalog service. See the steps to create a peering connection for xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc[AWS] or for xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[GCP].
+NOTE: If your cluster is on a private network, Redpanda recommends creating a VPC peering connection to the catalog service. See the steps to create a peering connection for xref:networking:byoc/aws/vpc-peering-aws.adoc[AWS] or for xref:networking:byoc/gcp/vpc-peering-gcp.adoc[GCP].
 endif::[]
 
 === Set cluster properties

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -11,6 +11,15 @@ After you have selected a catalog type at the cluster level and xref:{about-iceb
 
 Connect to an Iceberg REST catalog using the standard https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml[REST API^] supported by many catalog providers. Use this catalog integration type with REST-enabled Iceberg catalog services, such as https://docs.databricks.com/en/data-governance/unity-catalog/index.html[Databricks Unity^] and https://other-docs.snowflake.com/en/opencatalog/overview[Snowflake Open Catalog^].
 
+ifndef::env-cloud[]
+[NOTE]
+====
+For BYOVPC clusters, you must enable secrets management, which allows you to store and use secrets in your cluster's Iceberg catalog authentication properties. 
+
+Secrets management is enabled by default for AWS if you follow the guide to xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc[creating a new BYOVPC cluster]. For GCP, follow the guides to enable secrets management for a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[new BYOVPC cluster] or an xref:get-started:cluster-types/byoc/gcp/enable-secrets-byovpc-gcp.adoc[existing BYOVPC cluster].
+====
+endif::[]
+
 To connect to a REST catalog, set the following cluster configuration properties:
 
 * config_ref:iceberg_catalog_type,true,properties/cluster-properties[`iceberg_catalog_type`]: `rest`

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -7,19 +7,24 @@ For production deployments, Redpanda recommends using an external REST catalog t
 
 After you have selected a catalog type at the cluster level and xref:{about-iceberg-doc}#enable-iceberg-integration[enabled the Iceberg integration] for a topic, you cannot switch to another catalog type.
 
+== Connect to a REST catalog
+
+Connect to an Iceberg REST catalog using the standard https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml[REST API^] supported by many catalog providers. Use this catalog integration type with REST-enabled Iceberg catalog services, such as https://docs.databricks.com/en/data-governance/unity-catalog/index.html[Databricks Unity^] and https://other-docs.snowflake.com/en/opencatalog/overview[Snowflake Open Catalog^].
+
 ifdef::env-cloud[]
-== Prerequisites
+=== Prerequisites
+
 For BYOVPC clusters, you must:
 
 . Enable secrets management, which allows you to store and use secrets in your cluster's Iceberg catalog authentication properties. 
 +
 Secrets management is enabled by default for AWS if you follow the guide to xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc[creating a new BYOVPC cluster]. For GCP, follow the guides to enable secrets management for a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[new BYOVPC cluster] or an xref:get-started:cluster-types/byoc/gcp/enable-secrets-byovpc-gcp.adoc[existing BYOVPC cluster].
-. Allow egress traffic from the Redpanda network to the catalog service.
+. Ensure that your network security settings allow egress traffic from the Redpanda network to the catalog service endpoints.
+
+NOTE: If your cluster is on a private network, Redpanda recommends creating a VPC peering connection to the catalog service. See the steps to create a peering connection for xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc[AWS] or for xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[GCP].
 endif::[]
 
-== Connect to a REST catalog
-
-Connect to an Iceberg REST catalog using the standard https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml[REST API^] supported by many catalog providers. Use this catalog integration type with REST-enabled Iceberg catalog services, such as https://docs.databricks.com/en/data-governance/unity-catalog/index.html[Databricks Unity^] and https://other-docs.snowflake.com/en/opencatalog/overview[Snowflake Open Catalog^].
+=== Set cluster properties
 
 To connect to a REST catalog, set the following cluster configuration properties:
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -20,8 +20,6 @@ For BYOVPC clusters, you must:
 +
 Secrets management is enabled by default for AWS if you follow the guide to xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc[creating a new BYOVPC cluster]. For GCP, follow the guides to enable secrets management for a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[new BYOVPC cluster] or an xref:get-started:cluster-types/byoc/gcp/enable-secrets-byovpc-gcp.adoc[existing BYOVPC cluster].
 . Ensure that your network security settings allow egress traffic from the Redpanda network to the catalog service endpoints.
-
-NOTE: If your cluster is on a private network, Redpanda recommends creating a VPC peering connection to the catalog service. See the steps to create a peering connection for xref:networking:byoc/aws/vpc-peering-aws.adoc[AWS] or for xref:networking:byoc/gcp/vpc-peering-gcp.adoc[GCP].
 endif::[]
 
 === Set cluster properties

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -7,18 +7,19 @@ For production deployments, Redpanda recommends using an external REST catalog t
 
 After you have selected a catalog type at the cluster level and xref:{about-iceberg-doc}#enable-iceberg-integration[enabled the Iceberg integration] for a topic, you cannot switch to another catalog type.
 
+ifdef::env-cloud[]
+== Prerequisites
+For BYOVPC clusters, you must:
+
+. Enable secrets management, which allows you to store and use secrets in your cluster's Iceberg catalog authentication properties. 
++
+Secrets management is enabled by default for AWS if you follow the guide to xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc[creating a new BYOVPC cluster]. For GCP, follow the guides to enable secrets management for a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[new BYOVPC cluster] or an xref:get-started:cluster-types/byoc/gcp/enable-secrets-byovpc-gcp.adoc[existing BYOVPC cluster].
+. Allow egress traffic from the Redpanda network to the catalog service.
+endif::[]
+
 == Connect to a REST catalog
 
 Connect to an Iceberg REST catalog using the standard https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml[REST API^] supported by many catalog providers. Use this catalog integration type with REST-enabled Iceberg catalog services, such as https://docs.databricks.com/en/data-governance/unity-catalog/index.html[Databricks Unity^] and https://other-docs.snowflake.com/en/opencatalog/overview[Snowflake Open Catalog^].
-
-ifdef::env-cloud[]
-[NOTE]
-====
-For BYOVPC clusters, you must enable secrets management, which allows you to store and use secrets in your cluster's Iceberg catalog authentication properties. 
-
-Secrets management is enabled by default for AWS if you follow the guide to xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc[creating a new BYOVPC cluster]. For GCP, follow the guides to enable secrets management for a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[new BYOVPC cluster] or an xref:get-started:cluster-types/byoc/gcp/enable-secrets-byovpc-gcp.adoc[existing BYOVPC cluster].
-====
-endif::[]
 
 To connect to a REST catalog, set the following cluster configuration properties:
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -11,7 +11,7 @@ After you have selected a catalog type at the cluster level and xref:{about-iceb
 
 Connect to an Iceberg REST catalog using the standard https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml[REST API^] supported by many catalog providers. Use this catalog integration type with REST-enabled Iceberg catalog services, such as https://docs.databricks.com/en/data-governance/unity-catalog/index.html[Databricks Unity^] and https://other-docs.snowflake.com/en/opencatalog/overview[Snowflake Open Catalog^].
 
-ifndef::env-cloud[]
+ifdef::env-cloud[]
 [NOTE]
 ====
 For BYOVPC clusters, you must enable secrets management, which allows you to store and use secrets in your cluster's Iceberg catalog authentication properties. 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -3,10 +3,6 @@ ifndef::env-cloud[:about-iceberg-doc: manage:iceberg/topic-iceberg-integration.a
 
 To read from the Redpanda-generated xref:{about-iceberg-doc}[Iceberg table], your Iceberg-compatible client or tool needs access to the catalog to retrieve the table metadata and know the current state of the table. The catalog provides the current table metadata, which includes locations for all the table's data files. You can configure Redpanda to either connect to a REST-based catalog, or use a filesystem-based catalog. 
 
-ifdef::env-cloud[]
-NOTE: The Iceberg integration for Redpanda Cloud is a beta feature. It is not supported for production deployments. To configure REST catalog authentication for use with Iceberg topics in your cloud cluster, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
-endif::[]
-
 For production deployments, Redpanda recommends using an external REST catalog to manage Iceberg metadata. This enables built-in table maintenance, safely handles multiple engines and tools accessing tables at the same time, facilitates data governance, and maximizes data discovery. However, if it is not possible to use a REST catalog, you may use the filesystem-based catalog (`object_storage` catalog type), which does not require you to maintain a separate service to access the Iceberg data. In either case, you use the catalog to load, query, or refresh the Iceberg table as you produce to the Redpanda topic. See the documentation for your query engine or Iceberg-compatible tool for specific guidance on adding the Iceberg tables to your data warehouse or lakehouse using the catalog. 
 
 After you have selected a catalog type at the cluster level and xref:{about-iceberg-doc}#enable-iceberg-integration[enabled the Iceberg integration] for a topic, you cannot switch to another catalog type.


### PR DESCRIPTION
## Description

Related PR: https://github.com/redpanda-data/cloud-docs/pull/313

This pull request introduces updates to Redpanda's documentation, focusing on Iceberg integration and related configurations. The changes include updates to branch references, new instructions for Azure cluster configurations, and removal of outdated beta feature notes for Iceberg in Redpanda Cloud. Below are the most important changes grouped by theme:

### Documentation Updates for Iceberg Integration:

* **Branch Reference Update**: Updated the branch reference for `redpanda-data/cloud-docs` in `local-antora-playbook.yml` to reflect the `DOC-1222-Document-feature-Iceberg-on-Cloud-BYOVPC-GA-AWS-GCP` branch.

* **New Azure Configuration Instructions**: Added detailed steps for adding public IPs or subnet IDs to the allow list for Azure clusters. This includes a `curl` command example for using the Control Plane API to configure subnet IDs. [[1]](diffhunk://#diff-ea5033692607173dad8ffa11b9e530bac4ee1d40279f0f826c446e7e75582c12R176-R198) [[2]](diffhunk://#diff-ad35e9a1826487725ec6e9250fb2a9925cf842c7ab4f7efdd31823823eb188f1R28-R50)

### Removal of Deprecated Information:

* **Beta Feature Note Removal**: Removed the note indicating that Iceberg integration for Redpanda Cloud is a beta feature and not supported for production deployments. This reflects the feature's readiness for production.

### Configuration Prerequisites:

* **Prerequisites for BYOVPC Clusters**: Added a new section outlining prerequisites for BYOVPC clusters, including enabling secrets management and ensuring proper network security settings for connecting to Iceberg REST catalogs.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 30 May

## Page previews

Use Iceberg Catalogs > [Prerequisites](https://deploy-preview-1140--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/use-iceberg-catalogs/#prerequisites)
About Iceberg Topics > [Access Iceberg data](https://deploy-preview-1140--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/about-iceberg-topics/#access-iceberg-data)
Query Iceberg Topics > [Access Iceberg tables](https://deploy-preview-1140--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/query-iceberg-topics/#access-iceberg-tables)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
