### PR TITLE
DOC-1265 Make _schema topic modification unsupported

### DIFF
--- a/modules/manage/pages/schema-reg/schema-reg-overview.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-overview.adoc
@@ -29,7 +29,7 @@ Every broker allows mutating REST calls, so there's no need to configure leaders
 
 [IMPORTANT]
 ====
-The Schema Registry publishes an internal topic, `_schemas`, as its backend store. This internal topic is reserved strictly for schema metadata and support purposes. *Do not directly edit or manipulate the `_schemas` topic.*
+The Schema Registry publishes an internal topic, `_schemas`, as its backend store. This internal topic is reserved strictly for schema metadata and support purposes. *Do not directly edit or manipulate the `_schemas` topic unless directed to do so by Redpanda Support.*
 ifndef::env-cloud[]
 See the xref:reference:cluster-properties.adoc#kafka_nodelete_topics[kafka_nodelete_topics] cluster property.
 

--- a/modules/manage/pages/schema-reg/schema-reg-overview.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-overview.adoc
@@ -27,7 +27,8 @@ The Schema Registry is built directly into the Redpanda binary. It runs out of t
 
 Every broker allows mutating REST calls, so there's no need to configure leadership or failover strategies. Schemas are stored in a compacted topic, and the registry uses optimistic concurrency control at the topic level to detect and avoid collisions.
 
-The Schema Registry publishes record metadata to an internal topic, `_schemas`, as its backend store. By default, `_schemas` is protected from deletion and configuration changes by Kafka clients.
+The Schema Registry publishes record metadata to an internal topic, `_schemas`, as its backend store. By default, `_schemas` is protected from deletion and configuration changes by Kafka clients, and is for support purposes only. *Do not edit or manipulate this topic directly.*
+
 ifndef::env-cloud[]
 See the xref:reference:cluster-properties.adoc#kafka_nodelete_topics[kafka_nodelete_topics] cluster property.
 

--- a/modules/manage/pages/schema-reg/schema-reg-overview.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-overview.adoc
@@ -27,12 +27,14 @@ The Schema Registry is built directly into the Redpanda binary. It runs out of t
 
 Every broker allows mutating REST calls, so there's no need to configure leadership or failover strategies. Schemas are stored in a compacted topic, and the registry uses optimistic concurrency control at the topic level to detect and avoid collisions.
 
-The Schema Registry publishes record metadata to an internal topic, `_schemas`, as its backend store. By default, `_schemas` is protected from deletion and configuration changes by Kafka clients, and is for support purposes only. *Do not edit or manipulate this topic directly.*
-
+[IMPORTANT]
+====
+The Schema Registry publishes an internal topic, `_schemas`, as its backend store. This internal topic is reserved strictly for schema metadata and support purposes. *Do not directly edit or manipulate the `_schemas` topic.*
 ifndef::env-cloud[]
 See the xref:reference:cluster-properties.adoc#kafka_nodelete_topics[kafka_nodelete_topics] cluster property.
 
 endif::[]
+====
 
 Redpanda Schema Registry uses the default port 8081.
 


### PR DESCRIPTION
## Description

Resolves (https://redpandadata.atlassian.net/browse/DOC-1265)
Review deadline: **Friday, May 30**

## Page previews

[Schema Registry overview](https://deploy-preview-1142--redpanda-docs-preview.netlify.app/current/manage/schema-reg/schema-reg-overview/#redpanda-design-overview)
[Cloud Schema Registry design overview](https://deploy-preview-1142--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/schema-reg/schema-reg-overview/#redpanda-design-overview)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
