### PR TITLE
Rpk cluster config edits

### DIFF
--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-edit.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-edit.adoc
@@ -4,16 +4,15 @@ Edit cluster-wide configuration properties.
 
 This command opens a text editor to modify the cluster's configuration.
 
-Cluster properties are redpanda settings which apply to all nodes in
-the cluster. These are separate to node properties, which are set with
-`rpk redpanda config`.
+Cluster properties are Redpanda settings that apply to all brokers in
+the cluster. These are separate from broker properties, which you can set with `rpk redpanda config`.
 
-Modified values are written back when the file is saved and the editor
-is closed. Properties which are deleted are reset to their default
-values.
+Modified values are saved after the file is saved and the editor
+is closed. If you delete a property, Redpanda resets it to its default
+value.
 
-By default, low level tunables are excluded: use the `--all` flag
-to edit all properties including these tunables.
+By default, low-level tunables are excluded. Use the `--all` flag
+to edit all properties including tunables.
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-export.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-export.adoc
@@ -7,7 +7,7 @@ suitable for editing and later applying with the corresponding `import`
 command.
 
 By default, low-level tunables are excluded. Use the `--all` flag
-to edit all properties including these tunables.
+to edit all properties, including these tunables.
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-export.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-export.adoc
@@ -6,8 +6,8 @@ Writes out a YAML representation of the cluster configuration to a file,
 suitable for editing and later applying with the corresponding `import`
 command.
 
-By default, low level tunables are excluded: use the `--all` flag
-to include all properties including these low level tunables.
+By default, low-level tunables are excluded. Use the `--all` flag
+to edit all properties including these tunables.
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-export.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-export.adoc
@@ -22,7 +22,7 @@ rpk cluster config export [flags]
 |===
 |*Value* |*Type* |*Description*
 
-|-f, --filename |string |path to file to export to, e.g. './config.yml'.
+|-f, --filename |string |Path to file to export to; for example, `./config.yml`.
 
 |-h, --help |- |Help for export.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-force-reset.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-force-reset.adoc
@@ -2,14 +2,14 @@
 
 Forcibly clear a cluster configuration property on a broker.
 
-Do not use this command for general changes to cluster configuration. Use `force-reset` only when Redpanda does not start due to a configuration issue, for example when a property is set to an invalid value or when a property is missing that Redpanda requires to start.
+Do not use this command for general changes to cluster configuration. Use `force-reset` only when Redpanda does not start due to a configuration issue; for example, when a property is set to an invalid value or when a property is missing that Redpanda requires to start.
 
 This command erases the named property from an internal cache of the cluster configuration on the local broker, so that on next startup Redpanda treats
 the property as if it was set to the default.
 
 If your cluster is working properly and you want to reset a property
-to its default, either use the `set` command with an empty string, or
-the `edit` command and delete the line containing the property.
+to its default value, either use the `set` command with an empty string, or
+use the `edit` command and delete the line containing the property.
 
 WARNING: Use this command only when Redpanda isn't running.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-force-reset.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-force-reset.adoc
@@ -1,17 +1,15 @@
 = rpk cluster config force-reset
 
-Forcibly clear a cluster configuration property on this node.
+Forcibly clear a cluster configuration property on a broker.
 
-This command is not for general changes to cluster configuration: use this only
-when redpanda will not start due to a configuration issue.
+Do not use this command for general changes to cluster configuration. Use `force-reset` only when Redpanda does not start due to a configuration issue, for example when a property is set to an invalid value or when a property is missing that Redpanda requires to start.
 
-If your cluster is working properly and you would like to reset a property
-to its default, you may use the `set` command with an empty string, or
-use the `edit` command and delete the property`s line.
+This command erases the named property from an internal cache of the cluster configuration on the local broker, so that on next startup Redpanda treats
+the property as if it was set to the default.
 
-This command erases a named property from an internal cache of the cluster
-configuration on the local node, so that on next startup redpanda will treat
-the setting as if it was set to the default.
+If your cluster is working properly and you want to reset a property
+to its default, either use the `set` command with an empty string, or
+the `edit` command and delete the line containing the property.
 
 WARNING: Use this command only when Redpanda isn't running.
 
@@ -28,8 +26,8 @@ rpk cluster config force-reset [PROPERTY...] [flags]
 |===
 |*Value* |*Type* |*Description*
 
-|--cache-file |string |location of configuration cache file (defaults to
-redpanda data directory).
+|--cache-file |string |Location of configuration cache file (defaults to
+Redpanda `data` directory).
 
 |-h, --help |- |Help for force-reset.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-get.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-get.adoc
@@ -2,8 +2,10 @@
 
 Get a cluster configuration property.
 
+ifndef::env-cloud[]
 This command is provided for use in scripts. For interactive editing, or bulk
 output, use the `edit` and `export` commands respectively.
+endif::[]
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-import.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-import.adoc
@@ -20,7 +20,7 @@ rpk cluster config import [flags]
 |*Value* |*Type* |*Description*
 
 |-f, --filename |string |Full path to file to import; for example,
-'/tmp/config.yml'.
+`/tmp/config.yml`.
 
 |-h, --help |- |Help for import.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-import.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-import.adoc
@@ -4,11 +4,7 @@ CAUTION: Redpanda does not support importing cluster-specific identification (su
 
 Import cluster configuration from a file.
 
-Import configuration from a YAML file, usually generated with
-corresponding `export` command. This downloads the current cluster
-configuration, calculates the difference with the YAML file, and
-updates any properties that were changed. If a property is removed
-from the YAML file, it is reset to its default value.
+This command imports a cluster configuration from a YAML file, typically generated with the `export` command. The command first retrieves the current cluster configuration, compares it with the specified YAML file, and then updates any properties that were changed. If a property exists in the current configuration but is absent from the YAML file, that property is reset to its default value.
 
 == Usage
 
@@ -23,7 +19,7 @@ rpk cluster config import [flags]
 |===
 |*Value* |*Type* |*Description*
 
-|-f, --filename |string |full path to file to import, e.g.
+|-f, --filename |string |Full path to file to import, e.g.
 '/tmp/config.yml'.
 
 |-h, --help |- |Help for import.

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-import.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-import.adoc
@@ -19,7 +19,7 @@ rpk cluster config import [flags]
 |===
 |*Value* |*Type* |*Description*
 
-|-f, --filename |string |Full path to file to import, e.g.
+|-f, --filename |string |Full path to file to import; for example,
 '/tmp/config.yml'.
 
 |-h, --help |- |Help for import.

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-lint.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-lint.adoc
@@ -2,7 +2,7 @@
 
 Remove any deprecated content from `redpanda.yaml`.
 
-Deprecated content includes properties which were set via `redpanda.yaml`
+Deprecated content includes properties that were set in the `redpanda.yaml` file. 
 in earlier versions but are now managed through Redpanda's central configuration store and through `rpk cluster config edit`.
 
 == Usage

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-lint.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-lint.adoc
@@ -3,7 +3,7 @@
 Remove any deprecated content from `redpanda.yaml`.
 
 Deprecated content includes properties which were set via `redpanda.yaml`
-in earlier versions but are now managed via Redpanda`s central configuration store (and via `rpk cluster config edit`).
+in earlier versions but are now managed through Redpanda`s central configuration store and through `rpk cluster config edit`.
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-lint.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-lint.adoc
@@ -3,7 +3,7 @@
 Remove any deprecated content from `redpanda.yaml`.
 
 Deprecated content includes properties which were set via `redpanda.yaml`
-in earlier versions but are now managed through Redpanda`s central configuration store and through `rpk cluster config edit`.
+in earlier versions but are now managed through Redpanda's central configuration store and through `rpk cluster config edit`.
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-lint.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-lint.adoc
@@ -2,7 +2,7 @@
 
 Remove any deprecated content from `redpanda.yaml`.
 
-Deprecated content includes properties that were set in the `redpanda.yaml` file. 
+Deprecated content includes properties that were set in the `redpanda.yaml` file 
 in earlier versions but are now managed through Redpanda's central configuration store and through `rpk cluster config edit`.
 
 == Usage


### PR DESCRIPTION
## Description

This pull request focuses on improving the clarity and consistency of documentation for various `rpk cluster config` commands in the Redpanda CLI. Key changes include rephrasing for better readability, standardizing terminology, and enhancing descriptions of command behavior and options.

### Documentation Improvements:

* **General clarity and terminology updates:**
  - Updated descriptions to replace "nodes" with "brokers" for consistency and clarified the distinction between cluster and broker properties in `rpk-cluster-config-edit.adoc`.
  - Improved phrasing in `rpk-cluster-config-force-reset.adoc` to emphasize the specific use case for the `force-reset` command and clarified its behavior.

* **Consistency in flag descriptions:**
  - Standardized the description for the `--all` flag across `rpk-cluster-config-edit.adoc` and `rpk-cluster-config-export.adoc` to ensure uniformity in explaining low-level tunables. [[1]](diffhunk://#diff-55cba3e7886787d50931621815f4ced64b88c04cfd4bfc92bcdbb9cce43cac71L7-R15) [[2]](diffhunk://#diff-fe735cce72f0e4266cc4132441dad98a68cfbe9a4b4a219114215469362db40fL9-R10)

* **Enhanced command option descriptions:**
  - Refined the explanation of the `--cache-file` option in `rpk-cluster-config-force-reset.adoc` to improve clarity and align with Redpanda's terminology.

* **Additional contextual improvements:**
  - Added a conditional block for cloud environments in `rpk-cluster-config-get.adoc` to guide users toward appropriate commands for interactive or bulk operations.
  - Reworded the description of deprecated content handling in `rpk-cluster-config-lint.adoc` for better readability.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

[edit](https://deploy-preview-1143--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-config-edit/)
[export](https://deploy-preview-1143--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-config-export/)
[get](https://deploy-preview-1143--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-config-get/)
[force-reset](https://deploy-preview-1143--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-config-force-reset/)
[import](https://deploy-preview-1143--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-config-import/)
[lint](https://deploy-preview-1143--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-config-lint/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
