### PR TITLE
Fix CLI flags

### DIFF
--- a/modules/shared/attachments/redpanda-console-config.yaml
+++ b/modules/shared/attachments/redpanda-console-config.yaml
@@ -221,7 +221,7 @@ serde:
       # basicAuth:
         # enabled: true
         # username: token
-        # Password can also be set using the via the --serde.protobuf.git.basic-auth.password flag.
+        # Password can also be set using the --serde.protobuf.git.basic-auth.password flag.
         # password:
       # You can pass the private key file directly using a flag on the command line, or you can specify it in the
       # yaml configuration file. Another alternative is to provide the filepath to a mounted key

--- a/modules/shared/attachments/redpanda-console-config.yaml
+++ b/modules/shared/attachments/redpanda-console-config.yaml
@@ -221,7 +221,7 @@ serde:
       # basicAuth:
         # enabled: true
         # username: token
-        # Password can also be set using the via the --git.basic-auth.password flag.
+        # Password can also be set using the via the --serde.protobuf.git.basic-auth.password flag.
         # password:
       # You can pass the private key file directly using a flag on the command line, or you can specify it in the
       # yaml configuration file. Another alternative is to provide the filepath to a mounted key
@@ -229,10 +229,10 @@ serde:
       # ssh:
         # enabled: false
         # username:
-        # privateKey can also be set using the --git.ssh.private-key flag.
+        # privateKey can also be set using the --serde.protobuf.git.ssh.private-key flag.
         # privateKey:
         # privateKeyFilepath:
-        # Passphrase can also be set using the --git.ssh.passphrase flag.
+        # Passphrase can also be set using the --serde.protobuf.git.ssh.passphrase flag.
         # passphrase:
   # messagePack:
     # enabled: false


### PR DESCRIPTION
## Description

Fixes https://github.com/redpanda-data/docs/issues/1144
Review deadline: 2 June

This pull request updates the configuration comments in the `redpanda-console-config.yaml` file to reflect the correct flag paths for setting authentication details under the `serde` configuration.

Configuration updates:

* Updated the flag paths for setting the `password`, `privateKey`, and `passphrase` fields under the `serde.protobuf.git` configuration. These changes ensure the comments specify the correct flags for authentication-related settings.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
