### PR TITLE
`tests:` Deploy Redpanda Self-Managed quickstart fix

### DIFF
--- a/tests/docker-compose/docker-compose.yml
+++ b/tests/docker-compose/docker-compose.yml
@@ -389,7 +389,7 @@ services:
       - AWS_REGION=local
     entrypoint: >
       /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 minio redpandaTieredStorage7) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set minio http://minio:9000 minio redpandaTieredStorage7) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc mb minio/redpanda;
       /usr/bin/mc policy set public minio/redpanda;
       tail -f /dev/null

--- a/tests/docker-compose/docker-compose.yml
+++ b/tests/docker-compose/docker-compose.yml
@@ -379,7 +379,7 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    image: minio/mc
+    image: minio/mc:RELEASE.2025-05-21T01-59-54Z
     container_name: mc
     networks:
       - redpanda_network


### PR DESCRIPTION
## Description

https://docs.redpanda.com/current/get-started/quick-start/#deploy-redpanda-self-managed

Relevant Slack thread: https://redpandadata.slack.com/archives/C01ND4SVB6Z/p1748908368606149.

Our quick-start guide was failing previously, due to use of `mc config host add`.  

```
$ docker logs mc
> mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag.
> ...waiting...
```
Since we are pulling the latest image of `mc` and this command seems to be deprecated,  this would result in the `redpanda` bucket never being created in the `minIO` container, and the `redpanda` container would fail with the following log lines:

```
2025-06-02 15:32:41.231 | ERROR 2025-06-02 22:32:41,231 [shard 0:main] s3 - s3_client.cc:516 - The specified S3 bucket, redpanda, could not be found. Ensure that your bucket exists and that the cloud_storage_bucket and cloud_storage_region cluster configs are correct.
2025-06-02 15:32:41.231 | ERROR 2025-06-02 22:32:41,231 [shard 0:main] s3 - s3_client.cc:637 - Couldn't reach S3 storage with either path style or virtual_host style requests.
2025-06-02 15:32:41.231 | ERROR 2025-06-02 22:32:41,231 [shard 0:main] client_pool - client_pool.cc:81 - Self configuration of the cloud storage client failed. This indicates a misconfiguration of Redpanda. Aborting start-up ...
```

## Page previews

N/A

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
