### PR TITLE
Call out supported Iceberg catalogs

### DIFF
--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -30,7 +30,7 @@ The following matrix shows the current status of Iceberg integrations across dif
 |===
 | |Databricks Unity Catalog |Snowflake Open Catalog |Dremio Nessie
 
-|AWS |GA |Beta |Beta
+|AWS |Beta |Beta |Beta
 |Azure |Beta |Beta |Beta
 |GCP |Beta |Beta |Beta
 |===

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -54,24 +54,6 @@ The following shows the current status of Iceberg catalog integrations. Check th
 |===
 endif::[]
 
-ifndef::env-cloud[]
-=== Limitations
-
-The Iceberg integration for Redpanda Self-Managed supports multiple Iceberg catalogs, with progressive levels of release maturity. Each catalog integration is tested and released independently.
-
-The following shows the current status of Iceberg catalog integrations. Check this list regularly as Redpanda continues to expand GA coverage for Iceberg topics.
-
-|===
-|Catalog service | Status
-
-|Databricks Unity Catalog |GA
-|Snowflake Open Catalog |Beta
-|AWS Glue |Beta 
-|Dremio Nessie |Beta
-
-|===
-endif::[]
-
 === Set cluster properties
 
 To connect to a REST catalog, set the following cluster configuration properties:

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -20,6 +20,38 @@ For BYOVPC clusters, you must:
 +
 Secrets management is enabled by default for AWS if you follow the guide to xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc[creating a new BYOVPC cluster]. For GCP, follow the guides to enable secrets management for a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[new BYOVPC cluster] or an xref:get-started:cluster-types/byoc/gcp/enable-secrets-byovpc-gcp.adoc[existing BYOVPC cluster].
 . Ensure that your network security settings allow egress traffic from the Redpanda network to the catalog service endpoints.
+
+=== Limitations
+
+The Iceberg integration for Redpanda Cloud supports multiple Iceberg catalogs across different cloud platforms, with progressive levels of release maturity. Each combination of cloud provider and catalog integration is tested and released independently.
+
+The following matrix shows the current status of Iceberg integrations across different cloud providers and catalogs. Check this matrix regularly as Redpanda Cloud continues to expand GA coverage for Iceberg topics.
+
+|===
+| |Databricks Unity Catalog |Snowflake Open Catalog |AWS Glue |Dremio Nessie
+
+|AWS |Beta |GA |Beta |GA
+|Azure |Beta |Beta |Beta |Beta
+|GCP |Beta |Beta |Beta |Beta
+|===
+endif::[]
+
+ifndef::env-cloud[]
+=== Limitations
+
+The Iceberg integration for Redpanda Self-Managed supports multiple Iceberg catalogs, with progressive levels of release maturity. Each catalog integration is tested and released independently.
+
+The following shows the current status of Iceberg catalog integrations. Check this list regularly as Redpanda continues to expand GA coverage for Iceberg topics.
+
+|===
+|Catalog service | Status
+
+|Databricks Unity Catalog |GA
+|Snowflake Open Catalog |Beta
+|AWS Glue |Beta 
+|Dremio Nessie |Beta
+
+|===
 endif::[]
 
 === Set cluster properties

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -46,7 +46,7 @@ The following shows the current status of Iceberg catalog integrations. Check th
 |===
 |Catalog service | Status
 
-|Databricks Unity Catalog |GA
+|Databricks Unity Catalog |Beta
 |Snowflake Open Catalog |Beta
 |Dremio Nessie |Beta
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -28,11 +28,11 @@ The Iceberg integration for Redpanda Cloud supports multiple Iceberg catalogs ac
 The following matrix shows the current status of Iceberg integrations across different cloud providers and catalogs. Check this matrix regularly as Redpanda Cloud continues to expand GA coverage for Iceberg topics.
 
 |===
-| |Databricks Unity Catalog |Snowflake Open Catalog |AWS Glue |Dremio Nessie
+| |Databricks Unity Catalog |Snowflake Open Catalog |Dremio Nessie
 
-|AWS |GA |Beta |Beta |Beta
-|Azure |Beta |Beta |Beta |Beta
-|GCP |Beta |Beta |Beta |Beta
+|AWS |GA |Beta |Beta
+|Azure |Beta |Beta |Beta
+|GCP |Beta |Beta |Beta
 |===
 endif::[]
 
@@ -48,7 +48,6 @@ The following shows the current status of Iceberg catalog integrations. Check th
 
 |Databricks Unity Catalog |GA
 |Snowflake Open Catalog |Beta
-|AWS Glue |Beta 
 |Dremio Nessie |Beta
 
 |===

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -46,9 +46,9 @@ The following shows the current status of Iceberg catalog integrations. Check th
 |===
 |Catalog service | Status
 
-|Databricks Unity Catalog |Beta
-|Snowflake Open Catalog |Beta
-|Dremio Nessie |Beta
+|Databricks Unity Catalog |Tested
+|Snowflake Open Catalog |Tested
+|Dremio Nessie |Tested
 
 |===
 endif::[]

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -54,6 +54,24 @@ The following shows the current status of Iceberg catalog integrations. Check th
 |===
 endif::[]
 
+ifndef::env-cloud[]
+=== Limitations
+
+The Iceberg integration for Redpanda Self-Managed supports multiple Iceberg catalogs, with progressive levels of release maturity. Each catalog integration is tested and released independently.
+
+The following shows the current status of Iceberg catalog integrations. Check this list regularly as Redpanda continues to expand GA coverage for Iceberg topics.
+
+|===
+|Catalog service | Status
+
+|Databricks Unity Catalog |GA
+|Snowflake Open Catalog |Beta
+|AWS Glue |Beta 
+|Dremio Nessie |Beta
+
+|===
+endif::[]
+
 === Set cluster properties
 
 To connect to a REST catalog, set the following cluster configuration properties:

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -30,7 +30,7 @@ The following matrix shows the current status of Iceberg integrations across dif
 |===
 | |Databricks Unity Catalog |Snowflake Open Catalog |AWS Glue |Dremio Nessie
 
-|AWS |Beta |GA |Beta |GA
+|AWS |GA |Beta |Beta |Beta
 |Azure |Beta |Beta |Beta |Beta
 |GCP |Beta |Beta |Beta |Beta
 |===


### PR DESCRIPTION
## Description

This pull request adds documentation to clarify the limitations and maturity levels of Iceberg catalog integrations for Redpanda Cloud and Redpanda Self-Managed environments. It also introduces a matrix and list to summarize the current status of integrations across various cloud providers and catalog services.

### Documentation Updates:

* [`modules/manage/partials/iceberg/use-iceberg-catalogs.adoc`](diffhunk://#diff-8a1d2144ab6d9a2c0149032efbcfcd9bade68a17cd3b60b8a1fd7027881db5f4R18-R54): Added separate sections for Redpanda Cloud and Redpanda Self-Managed environments, detailing the limitations and maturity levels of Iceberg catalog integrations. Included a matrix for Redpanda Cloud and a list for Redpanda Self-Managed to summarize the status of integrations with catalog services like Databricks Unity Catalog, Snowflake Open Catalog, AWS Glue, and Dremio Nessie.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 12 June

## Page previews

Cloud > Use Iceberg Catalogs > Connect to a REST catalog > [Limitations](https://deploy-preview-1151--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/use-iceberg-catalogs/#limitations)
Self-managed > Use Iceberg Catalogs > Connect to a REST catalog > [Limitations](https://deploy-preview-1151--redpanda-docs-preview.netlify.app/current/manage/iceberg/use-iceberg-catalogs/#limitations)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
