### PR TITLE
DOC-1422 update Azure instance types for self-hosted

### DIFF
--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -220,16 +220,11 @@ ifdef::env-kubernetes[EKS defaults to the ext4 file system. Use XFS instead wher
 
 ifdef::env-kubernetes[AKS often defaults to the ext4 file system. Use XFS instead where possible.]
 
-- Memory optimized: Memory-optimized VM sizes offer a high memory-to-CPU ratio.
+- General purpose: General purpose VM sizes provide balanced CPU-to-memory ratio. Ideal for testing and development, small to medium databases, and low to medium traffic web servers.	
 
-** https://learn.microsoft.com/en-us/azure/virtual-machines/ebdsv5-ebsv5-series[Ebsv5 series (NVMe)^]
-** https://learn.microsoft.com/en-us/azure/virtual-machines/ebdsv5-ebsv5-series[Ebdsv5 series (NVMe)^]
-
-- Storage optimized: Storage-optimized virtual machine (VM) sizes offer high disk throughput and IO.
-
-** https://learn.microsoft.com/en-us/azure/virtual-machines/lsv2-series[Lsv2 series^]
-** https://learn.microsoft.com/en-us/azure/virtual-machines/lsv3-series[Lsv3 series^]
-** https://learn.microsoft.com/en-us/azure/virtual-machines/lasv3-series[Lasv3 series^]
+** https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/ddv5-series?tabs=sizebasic[Standard_D2d_v5^]
+** https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/ddv5-series?tabs=sizebasic[Standard_D4d_v5^]	
+** https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/ddv5-series?tabs=sizebasic[Standard_D32d_v5^]	
 
 === Google
 


### PR DESCRIPTION
## Description
This pull request updates the `modules/deploy/partials/requirements.adoc` file to revise the guidance on Azure VM sizes, focusing on general-purpose VMs instead of memory-optimized or storage-optimized VMs.

Updates to VM size recommendations:

* Replaced the description of memory-optimized and storage-optimized VM sizes with a description of general-purpose VM sizes, highlighting their balanced CPU-to-memory ratio and suitability for testing, development, small to medium databases, and low to medium traffic web servers.
* Updated the list of recommended VM series to include `Standard_D2d_v5`, `Standard_D4d_v5`, and `Standard_D32d_v5` series, linking to their respective documentation.

Resolves https://redpandadata.atlassian.net/browse/DOC-1422
Review deadline:

## Page previews
[Cloud instance types: Azure](https://deploy-preview-1152--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/manual/production/requirements/#azure)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
