### PR TITLE
DOC-1378: Compaction robustness

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [main, v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1404-Document-new-configurable-property'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [main, v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1404-Document-new-configurable-property'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -62,6 +62,14 @@ Where:
 | Cluster
 | Compaction frequency in milliseconds.
 
+| xref:reference:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`]
+| Cluster
+| The maximum amount of time in milliseconds that a message remains ineligible for compaction. Use to guarantee the maximum delay between the time a message is written and the time the message becomes eligible for compaction. This setting is useful for ensuring that messages are compacted within a predictable timeframe.
+
+| xref:reference:cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`]
+| Cluster
+| The minimum time in milliseconds that a message remains uncompacted in the log. Use to guarantee the minimum length of time that must pass after a message is written before it could be compacted. For example, to provide a lower bound on how long each message will remain in the (uncompacted) head.
+
 | xref:reference:properties/topic-properties.adoc#max.compaction.lag.ms[`max.compaction.lag.ms`]
 | Topic
 | The maximum amount of time in milliseconds that a message remains ineligible for compaction. Use to guarantee the maximum delay between the time a message is written and the time the message becomes eligible for compaction.

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -64,11 +64,11 @@ Where:
 
 | xref:reference:properties/topic-properties.adoc#max.compaction.lag.ms[`max.compaction.lag.ms`]
 | Topic
-| The maximum amount of time in milliseconds that a message remains ineligible for compaction.
+| The maximum amount of time in milliseconds that a message remains ineligible for compaction. Use to guarantee the maximum delay between the time a message is written and the time the message becomes eligible for compaction.
 
 | xref:reference:properties/topic-properties.adoc#min.compaction.lag.ms[`min.compaction.lag.ms`]
 | Topic
-| The minimum time in milliseconds that a message remains uncompacted in the log.
+| The minimum time in milliseconds that a message remains uncompacted in the log. Use to guarantee the minimum length of time that must pass after a message is written before it could be compacted. For example, to provide a lower bound on how long each message will remain in the (uncompacted) head.
 |===
 
 Redpanda runs a scan every `log_compaction_interval_ms`. During each scan:

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -61,6 +61,14 @@ Where:
 | xref:reference:cluster-properties.adoc#log_compaction_interval_ms[`log_compaction_interval_ms`]
 | Cluster
 | Compaction frequency in milliseconds.
+
+| xref:reference:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`]
+| Topic
+| The maximum amount of time in milliseconds that a message remains ineligible for compaction. Do not set lower than `segment.ms`.
+
+| xref:reference:cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`]
+| Topic
+| The minimum time in milliseconds that a message remains uncompacted in the log.
 |===
 
 Redpanda runs a scan every `log_compaction_interval_ms`. During each scan:

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -64,7 +64,7 @@ Where:
 
 | xref:reference:properties/topic-properties.adoc#max.compaction.lag.ms[`max.compaction.lag.ms`]
 | Topic
-| The maximum amount of time in milliseconds that a message remains ineligible for compaction. Do not set lower than `segment.ms`.
+| The maximum amount of time in milliseconds that a message remains ineligible for compaction.
 
 | xref:reference:properties/topic-properties.adoc#min.compaction.lag.ms[`min.compaction.lag.ms`]
 | Topic

--- a/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
+++ b/modules/manage/pages/cluster-maintenance/compaction-settings.adoc
@@ -62,11 +62,11 @@ Where:
 | Cluster
 | Compaction frequency in milliseconds.
 
-| xref:reference:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`]
+| xref:reference:properties/topic-properties.adoc#max.compaction.lag.ms[`max.compaction.lag.ms`]
 | Topic
 | The maximum amount of time in milliseconds that a message remains ineligible for compaction. Do not set lower than `segment.ms`.
 
-| xref:reference:cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`]
+| xref:reference:properties/topic-properties.adoc#min.compaction.lag.ms[`min.compaction.lag.ms`]
 | Topic
 | The minimum time in milliseconds that a message remains uncompacted in the log.
 |===

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3707,20 +3707,19 @@ Maximum compacted segment size after consolidation.
 
 === max_compaction_lag_ms
 
-For a compacted topic, the maximum time a message remains ineligible for compaction.
-The topic property xref:reference:properties/topic-properties.adoc#max.compaction.lag.ms[max.compaction.lag.ms] overrides this property.
+For a compacted topic, the maximum time a message remains ineligible for compaction. The topic property `max.compaction.lag.ms` overrides this property.
 
-*Unit:* milliseconds
+**Unit:** milliseconds
 
-*Requires restart:* No
+**Requires restart:** No
 
-*Visibility:* `user`
+**Visibility:** `user`
 
-*Type:* integer
+**Type:** integer
 
-*Accepted values:* [`1`, `9223372036854`]
+**Accepted values:** [`1`, `9223372036854`]
 
-*Default:* `9223372036854`
+**Default:** `9223372036854`
 
 ---
 
@@ -3969,9 +3968,9 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 
 ---
 
-=== min_compaction_lag_ms
+==== min_compaction_lag_ms
 
-For a compacted topic, the minimum time a message remains uncompacted in the log. The topic property xref:reference:properties/topic-properties.adoc#min.compaction.lag.ms[min.compaction.lag.ms] overrides this property.
+The minimum amount of time (in ms) that a log segment must remain unaltered before it can be compacted in a compact topic.
 
 *Unit:* milliseconds
 
@@ -3985,10 +3984,14 @@ For a compacted topic, the minimum time a message remains uncompacted in the log
 
 *Default:* `0`
 
+**Related topics**:
+
+- xref:manage:cluster-maintenance/compaction-settings.adoc#configure-min-compaction-lag[Configure minimum compaction lag]
+
 ---
 
-// tag::minimum_topic_replications[]
-=== minimum_topic_replications
+[[minimum_topic_replications]]
+==== minimum_topic_replications
 
 ifdef::env-cloud[]
 NOTE: This property is read-only in Redpanda Cloud.

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3988,7 +3988,7 @@ The minimum amount of time (in ms) that a log segment must remain unaltered befo
 
 *Related topics*:
 
-- xref:reference:properties/topic-properties.adoc#min.compaction.lag[Configure minimum compaction lag]
+- xref:reference:properties/topic-properties.adoc#min.compaction.lag.ms[`min.compaction.lag.ms`]
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3718,7 +3718,7 @@ The topic property `max.compaction.lag.ms` overrides this property.
 
 *Type:* integer
 
-*Accepted values:* [`1,...`]
+*Accepted values:* [`1, 9223372036854`]
 
 *Default:* `9223372036854`
 
@@ -3981,7 +3981,7 @@ For a compacted topic, the minimum time a message remains uncompacted in the log
 
 *Type:* integer
 
-*Accepted values:* [`0,...`]
+*Accepted values:* [`0,9223372036854`]
 
 *Default:* `9223372036854`
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3991,7 +3991,7 @@ The minimum amount of time (in ms) that a log segment must remain unaltered befo
 ---
 
 [[minimum_topic_replications]]
-==== minimum_topic_replications
+=== minimum_topic_replications
 
 ifdef::env-cloud[]
 NOTE: This property is read-only in Redpanda Cloud.

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3981,7 +3981,7 @@ For a compacted topic, the minimum time a message remains uncompacted in the log
 
 *Type:* integer
 
-*Accepted values:* [`0,...`]]
+*Accepted values:* [`0,...`]
 
 *Default:* `9223372036854`
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3983,7 +3983,7 @@ For a compacted topic, the minimum time a message remains uncompacted in the log
 
 *Accepted values:* [`0,9223372036854`]
 
-*Default:* `9223372036854`
+*Default:* `0`
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3968,7 +3968,7 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 
 ---
 
-==== min_compaction_lag_ms
+=== min_compaction_lag_ms
 
 The minimum amount of time (in ms) that a log segment must remain unaltered before it can be compacted in a compact topic.
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3709,17 +3709,17 @@ Maximum compacted segment size after consolidation.
 
 For a compacted topic, the maximum time a message remains ineligible for compaction. The topic property `max.compaction.lag.ms` overrides this property.
 
-**Unit:** milliseconds
+*Unit:* milliseconds
 
-**Requires restart:** No
+*Requires restart:* No
 
-**Visibility:** `user`
+*Visibility:* `user`
 
-**Type:** integer
+*Type:* integer
 
-**Accepted values:** [`1`, `9223372036854`]
+*Accepted values:* [`1`, `9223372036854`]
 
-**Default:** `9223372036854`
+*Default:* `9223372036854`
 
 ---
 
@@ -3984,7 +3984,7 @@ The minimum amount of time (in ms) that a log segment must remain unaltered befo
 
 *Default:* `0`
 
-**Related topics**:
+*Related topics*:
 
 - xref:manage:cluster-maintenance/compaction-settings.adoc#configure-min-compaction-lag[Configure minimum compaction lag]
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3721,6 +3721,8 @@ For a compacted topic, the maximum time a message remains ineligible for compact
 
 *Default:* `9223372036854`
 
+*Related topics*: xref:reference:properties/topic-properties.adoc#max.compaction.lag.ms[`max.compaction.lag.ms`]
+
 ---
 
 === max_concurrent_producer_ids
@@ -3986,7 +3988,7 @@ The minimum amount of time (in ms) that a log segment must remain unaltered befo
 
 *Related topics*:
 
-- xref:manage:cluster-maintenance/compaction-settings.adoc#configure-min-compaction-lag[Configure minimum compaction lag]
+- xref:reference:properties/topic-properties.adoc#min.compaction.lag[Configure minimum compaction lag]
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3705,9 +3705,28 @@ Maximum compacted segment size after consolidation.
 
 ---
 
+=== max_compaction_lag_ms
+
+For a compacted topic, the maximum time a message remains ineligible for compaction.
+The topic property `max.compaction.lag.ms` overrides this property.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`1,...`]
+
+*Default:* `9223372036854`
+
+---
+
 === max_concurrent_producer_ids
 
-Maximum number of active producer sessions. When the threshold is passed, Redpanda terminates old sessions. When an idle producer corresponding to the terminated session wakes up and produces, its message batches are rejected, and an out of order sequence error is emitted. Consumers don't affect this setting.
+Maximum number of active producer sessions. When the threshold is passed, Redpanda terminates old sessions. When an idle producer corresponding to the terminated session wakes up and produces, its message batches are rejected, and an out of order sequence error is emitted. Consumers don't affect this setting. Do not set this value lower than `segment.ms`.
 
 *Requires restart:* No
 
@@ -3947,6 +3966,24 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 *Type:* number
 
 *Default:* `0.5`
+
+---
+
+=== min_compaction_lag_ms
+
+For a compacted topic, the minimum time a message remains uncompacted in the log. The topic property `min.compaction.lag.ms` overrides this property.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`0,...`]]
+
+*Default:* `9223372036854`
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3726,7 +3726,7 @@ The topic property `max.compaction.lag.ms` overrides this property.
 
 === max_concurrent_producer_ids
 
-Maximum number of active producer sessions. When the threshold is passed, Redpanda terminates old sessions. When an idle producer corresponding to the terminated session wakes up and produces, its message batches are rejected, and an out of order sequence error is emitted. Consumers don't affect this setting. Do not set this value lower than `segment.ms`.
+Maximum number of active producer sessions. When the threshold is passed, Redpanda terminates old sessions. When an idle producer corresponding to the terminated session wakes up and produces, its message batches are rejected, and an out of order sequence error is emitted. Consumers don't affect this setting. Do not set this value lower than xref:reference:properties/cluster-properties.adoc#log_segment_ms[`segment.ms`].
 
 *Requires restart:* No
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3726,7 +3726,7 @@ The topic property `max.compaction.lag.ms` overrides this property.
 
 === max_concurrent_producer_ids
 
-Maximum number of active producer sessions. When the threshold is passed, Redpanda terminates old sessions. When an idle producer corresponding to the terminated session wakes up and produces, its message batches are rejected, and an out of order sequence error is emitted. Consumers don't affect this setting. Do not set this value lower than xref:reference:properties/cluster-properties.adoc#log_segment_ms[`segment.ms`].
+Maximum number of active producer sessions. When the threshold is passed, Redpanda terminates old sessions. When an idle producer corresponding to the terminated session wakes up and produces, its message batches are rejected, and an out of order sequence error is emitted. Consumers don't affect this setting.
 
 *Requires restart:* No
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3718,7 +3718,7 @@ The topic property xref:reference:properties/topic-properties.adoc#max.compactio
 
 *Type:* integer
 
-*Accepted values:* [`1, 9223372036854`]
+*Accepted values:* [`1`, `9223372036854`]
 
 *Default:* `9223372036854`
 
@@ -3981,7 +3981,7 @@ For a compacted topic, the minimum time a message remains uncompacted in the log
 
 *Type:* integer
 
-*Accepted values:* [`0,9223372036854`]
+*Accepted values:* [`0`, `9223372036854`]
 
 *Default:* `0`
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3708,7 +3708,7 @@ Maximum compacted segment size after consolidation.
 === max_compaction_lag_ms
 
 For a compacted topic, the maximum time a message remains ineligible for compaction.
-The topic property `max.compaction.lag.ms` overrides this property.
+The topic property (xref:reference:properties/topic-properties.adoc#max.compaction.lag.ms)[max.compaction.lag.ms] overrides this property.
 
 *Unit:* milliseconds
 
@@ -3971,7 +3971,7 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 
 === min_compaction_lag_ms
 
-For a compacted topic, the minimum time a message remains uncompacted in the log. The topic property `min.compaction.lag.ms` overrides this property.
+For a compacted topic, the minimum time a message remains uncompacted in the log. The topic property (xref:reference:properties/topic-properties.adoc#min.compaction.lag.ms)[min.compaction.lag.ms] overrides this property.
 
 *Unit:* milliseconds
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3708,7 +3708,7 @@ Maximum compacted segment size after consolidation.
 === max_compaction_lag_ms
 
 For a compacted topic, the maximum time a message remains ineligible for compaction.
-The topic property (xref:reference:properties/topic-properties.adoc#max.compaction.lag.ms)[max.compaction.lag.ms] overrides this property.
+The topic property xref:reference:properties/topic-properties.adoc#max.compaction.lag.ms[max.compaction.lag.ms] overrides this property.
 
 *Unit:* milliseconds
 
@@ -3971,7 +3971,7 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 
 === min_compaction_lag_ms
 
-For a compacted topic, the minimum time a message remains uncompacted in the log. The topic property (xref:reference:properties/topic-properties.adoc#min.compaction.lag.ms)[min.compaction.lag.ms] overrides this property.
+For a compacted topic, the minimum time a message remains uncompacted in the log. The topic property xref:reference:properties/topic-properties.adoc#min.compaction.lag.ms[min.compaction.lag.ms] overrides this property.
 
 *Unit:* milliseconds
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -162,6 +162,7 @@ kubectl exec <pod-name> -- rpk topic alter-config <topic-name> --set retention.m
 Configure properties to manage the disk space used by a topic:
 
 - Clean up log segments by deletion and/or compaction (<<cleanuppolicy, `cleanup.policy`>>).
+- Control compaction timing with maximum and minimum lag settings (<<max.compaction.lag.ms, `max.compaction.lag.ms`>> and <<min.compaction.lag.ms, `min.compaction.lag.ms`>>).
 - Retain logs up to a maximum size per partition before cleanup (<<retentionbytes, `retention.bytes`>>).
 - Retain logs for a maximum duration before cleanup (<<retentionms, `retention.ms`>>).
 - Periodically close an active log segment (<<segmentms, `segment.ms`>>).

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -157,11 +157,7 @@ kubectl exec <pod-name> -- rpk topic alter-config <topic-name> --set retention.m
 --
 ====
 
-== Properties
-
-This section describes all supported topic-level properties.
-
-=== Disk space properties
+== Disk space properties
 
 Configure properties to manage the disk space used by a topic:
 
@@ -175,7 +171,7 @@ Configure properties to manage the disk space used by a topic:
 ---
 
 [[cleanuppolicy]]
-==== cleanup.policy
+=== cleanup.policy
 
 The cleanup policy to apply for log segments of a topic.
 
@@ -201,7 +197,7 @@ include::develop:partial$topic-properties-warning.adoc[]
 ---
 
 [[flushms]]
-==== flush.ms
+=== flush.ms
 
 The maximum delay (in ms) between two subsequent fsyncs. After this delay, the log is automatically fsynced.
 
@@ -214,7 +210,7 @@ The maximum delay (in ms) between two subsequent fsyncs. After this delay, the l
 ---
 
 [[flushbytes]]
-==== flush.bytes
+=== flush.bytes
 
 The maximum bytes not fsynced per partition. If this configured threshold is reached, the log is automatically fsynced, even though it wasn't explicitly requested.
 
@@ -227,7 +223,7 @@ The maximum bytes not fsynced per partition. If this configured threshold is rea
 ---
 
 [[mincleanabledirtyratio]]
-==== min.cleanable.dirty.ratio
+=== min.cleanable.dirty.ratio
 
 The minimum ratio between the number of bytes in dirty segments and the total number of bytes in closed segments that must be reached before a partition's log is eligible for compaction in a compact topic.
 
@@ -240,7 +236,7 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 ---
 
 [[max.compaction.lag.ms]]
-==== max.compaction.lag.ms
+=== max.compaction.lag.ms
 
 The maximum amount of time (in ms) that a log segment can remain unaltered before it is eligible for compaction in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`] for the topic.
 
@@ -263,7 +259,7 @@ The maximum amount of time (in ms) that a log segment can remain unaltered befor
 ---
 
 [[min.compaction.lag.ms]]
-==== min.compaction.lag.ms
+=== min.compaction.lag.ms
 
 The minimum amount of time (in ms) that a log segment must remain unaltered before it can be compacted in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`] for the topic.
 
@@ -286,7 +282,7 @@ The minimum amount of time (in ms) that a log segment must remain unaltered befo
 ---
 
 [[retentionbytes]]
-==== retention.bytes
+=== retention.bytes
 
 A size-based retention limit that configures the maximum size that a topic partition can grow before becoming eligible for cleanup.
 
@@ -303,7 +299,7 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 ---
 
 [[retentionms]]
-==== retention.ms
+=== retention.ms
 
 A time-based retention limit that configures the maximum duration that a log's segment file for a topic is retained before it becomes eligible to be cleaned up. To consume all data, a consumer of the topic must read from a segment before its `retention.ms` elapses, otherwise the segment may be compacted and/or deleted. If a non-positive value, no per-topic limit is applied.
 
@@ -320,7 +316,7 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 ---
 
 [[segmentms]]
-==== segment.ms
+=== segment.ms
 
 The maximum duration that a log segment of a topic is active (open for writes and not deletable). A periodic event, with `segment.ms` as its period, forcibly closes the active segment and transitions, or rolls, to a new active segment. The closed (inactive) segment is then eligible to be cleaned up according to cleanup and retention properties.
 
@@ -335,7 +331,7 @@ If set to a positive duration, `segment.ms` overrides the cluster property xref:
 ---
 
 [[segmentbytes]]
-==== segment.bytes
+=== segment.bytes
 
 The maximum size of an active log segment for a topic. When the size of an active segment exceeds `segment.bytes`, the segment is closed and a new active segment is created. The closed, inactive segment is then eligible to be cleaned up according to retention properties.
 
@@ -352,7 +348,7 @@ When `segment.bytes` is set to a positive value, it overrides the cluster proper
 ---
 
 [[writecaching]]
-==== write.caching
+=== write.caching
 
 The write caching mode to apply to a topic. 
 
@@ -371,7 +367,7 @@ When `write.caching` is set, it overrides the cluster property xref:cluster-prop
 
 ---
 
-=== Message properties
+== Message properties
 
 Configure properties for the messages of a topic:
 
@@ -380,7 +376,7 @@ Configure properties for the messages of a topic:
 - Set the maximum size of a message (<<maxmessagebytes, `max.message.bytes`>>).
 
 [[compressiontype]]
-==== compression.type
+=== compression.type
 
 The type of compression algorithm to apply for all messages of a topic. When a compression type is set for a topic, producers compress and send messages, nodes (brokers) store and send compressed messages, and consumers receive and uncompress messages.
 
@@ -409,7 +405,7 @@ NOTE: The valid values of `compression.type` are taken from `log_compression_typ
 ---
 
 [[messagetimestamptype]]
-==== message.timestamp.type
+=== message.timestamp.type
 
 The source of a message's timestamp: either the message's creation time or its log append time.
 
@@ -425,7 +421,7 @@ When `message.timestamp.type` is set, it overrides the cluster property xref:./c
 ---
 
 [[maxmessagebytes]]
-==== max.message.bytes
+=== max.message.bytes
 
 The maximum size of a message or batch of a topic. If a compression type is enabled, `max.message.bytes` sets the maximum size of the compressed message or batch.
 
@@ -439,7 +435,7 @@ If `max.message.bytes` is set to a positive value, it overrides the cluster prop
 
 ---
 
-=== Tiered Storage properties
+== Tiered Storage properties
 
 Configure properties to manage topics for xref:manage:tiered-storage.adoc[Tiered Storage]:
 
@@ -449,7 +445,7 @@ Configure properties to manage topics for xref:manage:tiered-storage.adoc[Tiered
 - Delete data from object storage for a topic when it's deleted from local storage (<<redpandaremotedelete, `redpanda.remote.delete`>>).
 
 [[redpandaremotewrite]]
-==== redpanda.remote.write
+=== redpanda.remote.write
 
 A flag for enabling Redpanda to upload data for a topic from local storage to object storage. When set to `true` together with <<redpandaremoteread, `redpanda.remote.read`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
 
@@ -462,7 +458,7 @@ A flag for enabling Redpanda to upload data for a topic from local storage to ob
 ---
 
 [[redpandaremoteread]]
-==== redpanda.remote.read
+=== redpanda.remote.read
 
 A flag for enabling Redpanda to fetch data for a topic from object storage to local storage. When set to `true` together with <<redpandaremotewrite, `redpanda.remote.write`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
 
@@ -475,7 +471,7 @@ A flag for enabling Redpanda to fetch data for a topic from object storage to lo
 ---
 
 [[initialretentionlocaltargetbytes]]
-==== initial.retention.local.target.bytes
+=== initial.retention.local.target.bytes
 
 A size-based initial retention limit for Tiered Storage that determines how much data in local storage is transferred to a partition replica when a cluster is resized. If `null` (default), all locally retained data is transferred.
 
@@ -488,7 +484,7 @@ A size-based initial retention limit for Tiered Storage that determines how much
 ---
 
 [[initialretentionlocaltargetms]]
-==== initial.retention.local.target.ms
+=== initial.retention.local.target.ms
 
 A time-based initial retention limit for Tiered Storage that determines how much data in local storage is transferred to a partition replica when a cluster is resized. If `null` (default), all locally retained data is transferred.
 
@@ -501,7 +497,7 @@ A time-based initial retention limit for Tiered Storage that determines how much
 ---
 
 [[retentionlocaltargetbytes]]
-==== retention.local.target.bytes
+=== retention.local.target.bytes
 
 A size-based retention limit for Tiered Storage that configures the maximum size that a topic partition in local storage can grow before becoming eligible for cleanup. It applies per partition and is equivalent to <<retentionbytes, `retention.bytes`>> without Tiered Storage.
 
@@ -514,7 +510,7 @@ A size-based retention limit for Tiered Storage that configures the maximum size
 ---
 
 [[retentionlocaltargetms]]
-==== retention.local.target.ms
+=== retention.local.target.ms
 
 A time-based retention limit for Tiered Storage that sets the maximum duration that a log's segment file for a topic is retained in local storage before it's eligible for cleanup. This property is equivalent to <<retentionms, `retention.ms`>> without Tiered Storage.
 
@@ -527,7 +523,7 @@ A time-based retention limit for Tiered Storage that sets the maximum duration t
 ---
 
 [[redpandaremoterecovery]]
-==== redpanda.remote.recovery
+=== redpanda.remote.recovery
 
 A flag that enables the recovery or reproduction of a topic from object storage for Tiered Storage. The recovered data is saved in local storage, and the maximum amount of recovered data is determined by the local storage retention limits of the topic.
 
@@ -542,7 +538,7 @@ TIP: You can only configure `redpanda.remote.recovery` when you create a topic. 
 ---
 
 [[redpandaremotedelete]]
-==== redpanda.remote.delete
+=== redpanda.remote.delete
 
 A flag that enables deletion of data from object storage for Tiered Storage when it's deleted from local storage for a topic.
 
@@ -559,11 +555,11 @@ NOTE: `redpanda.remote.delete` doesn't apply to Remote Read Replica topics: a Re
 
 ---
 
-=== Remote Read Replica properties
+== Remote Read Replica properties
 
 Configure properties to manage topics for xref:manage:remote-read-replicas.adoc[Remote Read Replicas].
 
-==== redpanda.remote.readreplica
+=== redpanda.remote.readreplica
 
 The name of the object storage bucket for a Remote Read Replica topic.
 
@@ -577,11 +573,11 @@ CAUTION: Setting `redpanda.remote.readreplica` together with either `redpanda.re
 
 ---
 
-=== Apache Iceberg integration properties
+== Apache Iceberg integration properties
 
 Integrate Redpanda topics as Iceberg tables.
 
-==== redpanda.iceberg.mode
+=== redpanda.iceberg.mode
 
 Enable the Iceberg integration for the topic. You can choose one of four modes.
 
@@ -601,7 +597,7 @@ Enable the Iceberg integration for the topic. You can choose one of four modes.
 
 ---
 
-==== redpanda.iceberg.delete
+=== redpanda.iceberg.delete
 
 Whether the corresponding Iceberg table is deleted upon deleting the topic.
 
@@ -613,7 +609,7 @@ Whether the corresponding Iceberg table is deleted upon deleting the topic.
 
 ---
 
-==== redpanda.iceberg.invalid.record.action
+=== redpanda.iceberg.invalid.record.action
 
 Whether to write invalid records to a dead-letter queue (DLQ).
 
@@ -630,7 +626,7 @@ Whether to write invalid records to a dead-letter queue (DLQ).
 
 ---
 
-==== redpanda.iceberg.partition.spec
+=== redpanda.iceberg.partition.spec
 
 The https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] specification for the Iceberg table.
 
@@ -642,7 +638,7 @@ The https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] specifi
 
 ---
 
-==== redpanda.iceberg.target.lag.ms
+=== redpanda.iceberg.target.lag.ms
 
 Controls how often the data in the Iceberg table is refreshed with new data from the topic. Redpanda attempts to commit all data produced to the topic within the lag target, subject to resource availability.
 
@@ -654,14 +650,14 @@ Controls how often the data in the Iceberg table is refreshed with new data from
 
 ---
 
-=== Redpanda topic properties
+== Redpanda topic properties
 
 Configure Redpanda-specific topic properties.
 
 ---
 
 [[deleteretentionms]]
-==== delete.retention.ms
+=== delete.retention.ms
 
 The retention time for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
 
@@ -680,7 +676,7 @@ If both `delete.retention.ms` and the cluster property config_ref:tombstone_rete
 ---
 
 [[redpandaleaderspreference]]
-==== redpanda.leaders.preference
+=== redpanda.leaders.preference
 
 The preferred location (rack) for partition leaders of a topic.
 
@@ -701,7 +697,7 @@ If the cluster configuration property config_ref:enable_rack_awareness,true,prop
 
 ---
 
-==== replication.factor
+=== replication.factor
 
 The number of replicas of a topic to save in different nodes (brokers) of a cluster.
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -42,6 +42,12 @@ NOTE: All topic properties take effect immediately after being set.
 | <<compressiontype,`compression.type`>>
 | xref:./cluster-properties.adoc#log_compression_type[`log_compression_type`]
 
+| <<max.compaction.lag.ms,`max.compaction.lag.ms`>>
+| xref:./cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`]
+
+| <<min.compaction.lag.ms,`min.compaction.lag.ms`>>
+| xref:./cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`]
+
 | <<messagetimestamptype,`message.timestamp.type`>>
 | xref:./cluster-properties.adoc#log_message_timestamp_type[`log_message_timestamp_type`]
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -612,6 +612,73 @@ Controls how often the data in the Iceberg table is refreshed with new data from
 
 Configure Redpanda-specific topic properties.
 
+---
+
+[[deleteretentionms]]
+==== delete.retention.ms
+
+The retention time for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
+
+If you have enabled Tiered Storage and set <<redpandaremoteread,`redpanda.remote.read`>> or <<redpandaremotewrite,`redpanda.remote.write`>> for the topic, you cannot enable tombstone removal. 
+
+If both `delete.retention.ms` and the cluster property config_ref:tombstone_retention_ms,true,properties/cluster-properties[] are set, `delete.retention.ms` overrides the cluster level tombstone retention for an individual topic.
+
+*Unit:* milliseconds
+
+**Default**: null
+
+**Related topics**:
+
+- xref:manage:cluster-maintenance/compaction-settings.adoc#tombstone-record-removal[Tombstone record removal]
+
+---
+
+[[max.compaction.lag.ms]]
+==== max.compaction.lag.ms
+
+The maximum amount of time (in ms) that a log segment can remain unaltered before it is eligible for compaction in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`] for the topic.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`1`, `9223372036854`]
+
+*Default:* `9223372036854`
+
+**Related topics**:
+
+- xref:manage:cluster-maintenance/compaction-settings.adoc#configure-max-compaction-lag[Configure maximum compaction lag]
+
+---
+
+[[min.compaction.lag.ms]]
+==== min.compaction.lag.ms
+
+The minimum amount of time (in ms) that a log segment must remain unaltered before it can be compacted in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`] for the topic.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `9223372036854`]
+
+*Default:* `0`
+
+**Related topics**:
+
+- xref:manage:cluster-maintenance/compaction-settings.adoc#configure-min-compaction-lag[Configure minimum compaction lag]
+
+---
+
 [[redpandaleaderspreference]]
 ==== redpanda.leaders.preference
 
@@ -651,24 +718,7 @@ NOTE: Although `replication.factor` isn't returned or displayed by xref:referenc
 
 ---
 
-[[deleteretentionms]]
-==== delete.retention.ms
 
-The retention time for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
-
-If you have enabled Tiered Storage and set <<redpandaremoteread,`redpanda.remote.read`>> or <<redpandaremotewrite,`redpanda.remote.write`>> for the topic, you cannot enable tombstone removal. 
-
-If both `delete.retention.ms` and the cluster property config_ref:tombstone_retention_ms,true,properties/cluster-properties[] are set, `delete.retention.ms` overrides the cluster level tombstone retention for an individual topic.
-
-*Unit:* milliseconds
-
-**Default**: null
-
-**Related topics**:
-
-- xref:manage:cluster-maintenance/compaction-settings.adoc#tombstone-record-removal[Tombstone record removal]
-
----
 
 == Related topics
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -239,6 +239,52 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 
 ---
 
+[[min.compaction.lag.ms]]
+==== min.compaction.lag.ms
+
+The minimum amount of time (in ms) that a log segment must remain unaltered before it can be compacted in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`] for the topic.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`0`, `9223372036854`]
+
+*Default:* `0`
+
+**Related topics**:
+
+- xref:manage:cluster-maintenance/compaction-settings.adoc#configure-min-compaction-lag[Configure minimum compaction lag]
+
+---
+
+[[max.compaction.lag.ms]]
+==== max.compaction.lag.ms
+
+The maximum amount of time (in ms) that a log segment can remain unaltered before it is eligible for compaction in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`] for the topic.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`1`, `9223372036854`]
+
+*Default:* `9223372036854`
+
+**Related topics**:
+
+- xref:manage:cluster-maintenance/compaction-settings.adoc#configure-max-compaction-lag[Configure maximum compaction lag]
+
+---
+
 [[retentionbytes]]
 ==== retention.bytes
 
@@ -630,52 +676,6 @@ If both `delete.retention.ms` and the cluster property config_ref:tombstone_rete
 **Related topics**:
 
 - xref:manage:cluster-maintenance/compaction-settings.adoc#tombstone-record-removal[Tombstone record removal]
-
----
-
-[[max.compaction.lag.ms]]
-==== max.compaction.lag.ms
-
-The maximum amount of time (in ms) that a log segment can remain unaltered before it is eligible for compaction in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`] for the topic.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Visibility:* `user`
-
-*Type:* integer
-
-*Accepted values:* [`1`, `9223372036854`]
-
-*Default:* `9223372036854`
-
-**Related topics**:
-
-- xref:manage:cluster-maintenance/compaction-settings.adoc#configure-max-compaction-lag[Configure maximum compaction lag]
-
----
-
-[[min.compaction.lag.ms]]
-==== min.compaction.lag.ms
-
-The minimum amount of time (in ms) that a log segment must remain unaltered before it can be compacted in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`] for the topic.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Visibility:* `user`
-
-*Type:* integer
-
-*Accepted values:* [`0`, `9223372036854`]
-
-*Default:* `0`
-
-**Related topics**:
-
-- xref:manage:cluster-maintenance/compaction-settings.adoc#configure-min-compaction-lag[Configure minimum compaction lag]
 
 ---
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -239,6 +239,29 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 
 ---
 
+[[max.compaction.lag.ms]]
+==== max.compaction.lag.ms
+
+The maximum amount of time (in ms) that a log segment can remain unaltered before it is eligible for compaction in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`] for the topic.
+
+*Unit:* milliseconds
+
+*Requires restart:* No
+
+*Visibility:* `user`
+
+*Type:* integer
+
+*Accepted values:* [`1`, `9223372036854`]
+
+*Default:* `9223372036854`
+
+**Related topics**:
+
+- xref:manage:cluster-maintenance/compaction-settings.adoc#configuration-options[Configure maximum compaction lag]
+
+---
+
 [[min.compaction.lag.ms]]
 ==== min.compaction.lag.ms
 
@@ -259,29 +282,6 @@ The minimum amount of time (in ms) that a log segment must remain unaltered befo
 **Related topics**:
 
 - xref:manage:cluster-maintenance/compaction-settings.adoc#configure-min-compaction-lag[Configure minimum compaction lag]
-
----
-
-[[max.compaction.lag.ms]]
-==== max.compaction.lag.ms
-
-The maximum amount of time (in ms) that a log segment can remain unaltered before it is eligible for compaction in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`] for the topic.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Visibility:* `user`
-
-*Type:* integer
-
-*Accepted values:* [`1`, `9223372036854`]
-
-*Default:* `9223372036854`
-
-**Related topics**:
-
-- xref:manage:cluster-maintenance/compaction-settings.adoc#configure-max-compaction-lag[Configure maximum compaction lag]
 
 ---
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -241,12 +241,6 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 
 The maximum amount of time (in ms) that a log segment can remain unaltered before it is eligible for compaction in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`] for the topic.
 
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Visibility:* `user`
-
 *Type:* integer
 
 *Accepted values:* [`1`, `9223372036854`]
@@ -263,12 +257,6 @@ The maximum amount of time (in ms) that a log segment can remain unaltered befor
 === min.compaction.lag.ms
 
 The minimum amount of time (in ms) that a log segment must remain unaltered before it can be compacted in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`] for the topic.
-
-*Unit:* milliseconds
-
-*Requires restart:* No
-
-*Visibility:* `user`
 
 *Type:* integer
 


### PR DESCRIPTION
## Description
This pull request introduces documentation updates to include new configurable properties for message compaction in Redpanda. These changes add details about `max_compaction_lag_ms` and `min_compaction_lag_ms` at both the cluster and topic levels, enhancing clarity and usability for users configuring compaction settings.

### Updates to compaction-related properties:

**Cluster-level properties:**
* Added documentation for `max_compaction_lag_ms` in `modules/reference/pages/properties/cluster-properties.adoc`. This property specifies the maximum time a message remains ineligible for compaction, with details on units, accepted values, and default settings.
* Added documentation for `min_compaction_lag_ms` in `modules/reference/pages/properties/cluster-properties.adoc`. This property defines the minimum time a message remains uncompacted in the log, including its units, accepted values, and default settings.

**Topic-level properties:**
* Updated `modules/reference/pages/properties/topic-properties.adoc` to include cross-references for `max.compaction.lag.ms` and `min.compaction.lag.ms`, linking them to their corresponding cluster-level properties.

### Updates to compaction settings documentation:
* Enhanced `modules/manage/pages/cluster-maintenance/compaction-settings.adoc` with detailed descriptions of `max_compaction_lag_ms` and `min_compaction_lag_ms` for both cluster and topic levels, explaining their purpose and use cases.

### Playbook configuration update:
* Modified `local-antora-playbook.yml` to track the `DOC-1404-Document-new-configurable-property` branch in the `cloud-docs` repository, ensuring the documentation aligns with the latest updates.

Resolves https://redpandadata.atlassian.net/browse/DOC-1378
Review deadline:

## Page previews

[Topic Properties](https://deploy-preview-1153--redpanda-docs-preview.netlify.app/25.2/reference/properties/topic-properties/)

[max_compaction_lag_ms](https://deploy-preview-1153--redpanda-docs-preview.netlify.app/25.2/reference/properties/cluster-properties/#max_compaction_lag_ms)

[min_compaction_lag_ms](https://deploy-preview-1153--redpanda-docs-preview.netlify.app/25.2/reference/properties/cluster-properties/#min_compaction_lag_ms)

[Compaction settings - configuration options](https://deploy-preview-1153--redpanda-docs-preview.netlify.app/25.2/manage/cluster-maintenance/compaction-settings/#configuration-options)



## Checks

- [ X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
