### PR TITLE
Query Iceberg topics with Databricks Unity

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1045-cloud-databricks-ga'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1045-cloud-databricks-ga'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -174,6 +174,7 @@
 *** xref:manage:iceberg/choose-iceberg-mode.adoc[Choose Iceberg Mode]
 *** xref:manage:iceberg/use-iceberg-catalogs.adoc[Use Iceberg Catalogs]
 *** xref:manage:iceberg/query-iceberg-topics.adoc[Query Iceberg Topics]
+*** xref:manage:iceberg/iceberg-topics-databricks-unity.adoc[Query Iceberg Topics with Databricks Unity Catalog]
 *** xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[Query Iceberg Topics with Snowflake]
 ** xref:manage:schema-reg/index.adoc[Schema Registry]
 *** xref:manage:schema-reg/schema-reg-overview.adoc[Overview]

--- a/modules/manage/pages/iceberg/choose-iceberg-mode.adoc
+++ b/modules/manage/pages/iceberg/choose-iceberg-mode.adoc
@@ -219,6 +219,7 @@ Protobuf::
 | string | string
 | bytes | binary
 | map | map
+| message | struct
 |===
 
 There are some cases where the Protobuf type does not map directly to an Iceberg type and Redpanda applies the following transformations:
@@ -227,8 +228,7 @@ There are some cases where the Protobuf type does not map directly to an Iceberg
 * Enums are translated into Iceberg `int` types based on the integer value of the enumerated type.
 * `uint32` and `fixed32` are translated into Iceberg `long` types as that is the existing semantic for unsigned 32-bit values in Iceberg.
 * `uint64` and `fixed64` values are translated into their Base-10 string representation.
-* The `timestamp` type in Protobuf is translated into `timestamp` in Iceberg.
-* Messages are converted into Iceberg structs.
+* `google.protobuf.Timestamp` is translated into `timestamp` in Iceberg.
 
 Recursive types are not supported.
 --

--- a/modules/manage/pages/iceberg/choose-iceberg-mode.adoc
+++ b/modules/manage/pages/iceberg/choose-iceberg-mode.adoc
@@ -175,22 +175,29 @@ Avro::
 | string | string
 | record | struct
 | array | list
-| maps | list
-| fixed | fixed
+| maps | map
+| fixed | fixed*
 | decimal | decimal
-| uuid | uuid
+| uuid | uuid*
 | date | date
-| time | time
+| time | time*
 | timestamp | timestamp
 |===
+
+*These types are not currently supported in Unity Catalog managed Iceberg tables.
+
+There are some cases where the Avro type does not map directly to an Iceberg type and Redpanda applies the following transformations:
 
 * Different flavors of time (such as `time-millis`) and timestamp (such as `timestamp-millis`) types are translated to the same Iceberg `time` and `timestamp` types, respectively.
 * Avro unions are flattened to Iceberg structs with optional fields. For example:
 ** The union `["int", "long", "float"]` is represented as an Iceberg struct `struct<0 INT NULLABLE, 1 LONG  NULLABLE, 2 FLOAT NULLABLE>`.
 ** The union `["int", null, "float"]` is represented as an Iceberg struct `struct<0 INT NULLABLE, 1 FLOAT NULLABLE>`.
 * All fields are required by default. (Avro always sets a default in binary representation.)
-* The Avro duration logical type is ignored.
-* The Avro null type is ignored and not represented in the Iceberg schema.
+
+Some Avro types are not supported:
+
+* The Avro `duration` logical type is ignored.
+* The Avro `null` type is ignored and not represented in the Iceberg schema.
 * Recursive types are not supported.
 --
 
@@ -208,11 +215,13 @@ Protobuf::
 | int64 | long
 | sint64 | long
 | sfixed32 | int
-| sfixed64 | int
+| sfixed64 | long
 | string | string
 | bytes | binary
 | map | map
 |===
+
+There are some cases where the Protobuf type does not map directly to an Iceberg type and Redpanda applies the following transformations:
 
 * Repeated values are translated into Iceberg `array` types.
 * Enums are translated into Iceberg `int` types based on the integer value of the enumerated type.
@@ -220,7 +229,8 @@ Protobuf::
 * `uint64` and `fixed64` values are translated into their Base-10 string representation.
 * The `timestamp` type in Protobuf is translated into `timestamp` in Iceberg.
 * Messages are converted into Iceberg structs.
-* Recursive types are not supported.
+
+Recursive types are not supported.
 --
 ======
 

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -21,7 +21,7 @@ ifndef::env-cloud[]
 You need the AWS S3 bucket URI, so you can configure it as an external location in Unity Catalog.
 endif::[]
 * A Databricks workspace in the same region as your S3 bucket. See the https://docs.databricks.com/aws/en/resources/supported-regions#supported-regions-list[list of supported AWS regions^].
-* Unity Catalog enabled in your Databricks workspace. See the https://docs.databricks.com/aws/en/data-governance/unity-catalog/get-started[official Databricks documentation^] to set up Unity Catalog for your workspace.
+* Unity Catalog enabled in your Databricks workspace. See the https://docs.databricks.com/aws/en/data-governance/unity-catalog/get-started[Databricks documentation^] to set up Unity Catalog for your workspace.
 * https://docs.databricks.com/aws/en/optimizations/predictive-optimization#enable-predictive-optimization[Predictive optimization^] enabled for Unity Catalog.
 * https://docs.databricks.com/aws/en/external-access/admin[External data access^] enabled in your metastore.
 * Workspace admin privileges to complete the steps to create a Unity Catalog storage credential and external location that connects your cluster's Tiered Storage bucket to Databricks.
@@ -50,7 +50,7 @@ There are no limitations for Protobuf types.
 
 A storage credential is a Databricks object that controls access to external object storage, in this case S3. You associate a storage credential with an AWS IAM role that defines what actions Unity Catalog can perform in the S3 bucket.
 
-Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/storage-credentials[official Databricks documentation^] to create an AWS IAM role that has the required permissions for the bucket. When you have completed these steps, you should have the following configured in AWS and Databricks:
+Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/storage-credentials[Databricks documentation^] to create an AWS IAM role that has the required permissions for the bucket. When you have completed these steps, you should have the following configured in AWS and Databricks:
 
 * A self-assuming IAM role, meaning you've defined the role trust policy so the role trusts itself.
 * Two IAM policies attached to the IAM role. The first policy grants Unity Catalog read and write access to the bucket. The second policy allows Unity Catalog to configure file events.
@@ -64,7 +64,7 @@ ifdef::env-cloud[]
 For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`, where `<cluster-id>` is the ID of your Redpanda cluster.
 endif::[]
 
-Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/external-locations[official Databricks documentation] to *manually* create an external location. You can create the external location in the Catalog Explorer, or using SQL. You must create the external location manually because the location needs to be associated with the existing Tiered Storage bucket URL, `s3://<bucket-name>`.
+Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/external-locations[Databricks documentation] to *manually* create an external location. You can create the external location in the Catalog Explorer or with SQL. You must create the external location manually because the location needs to be associated with the existing Tiered Storage bucket URL, `s3://<bucket-name>`.
 
 == Create a new catalog
 
@@ -76,7 +76,7 @@ You use the catalog name when you set the Iceberg cluster configuration properti
 
 Redpanda recommends using OAuth for service principals to grant Redpanda access to Unity Catalog. 
 
-. Follow the steps in the https://docs.databricks.com/aws/en/dev-tools/auth/oauth-m2m[official Databricks documentation] to create a service principal, and then generate an OAuth secret. You use the client ID and secret to set Iceberg cluster configuration properties in Redpanda in the next step.
+. Follow the steps in the https://docs.databricks.com/aws/en/dev-tools/auth/oauth-m2m[Databricks documentation] to create a service principal, and then generate an OAuth secret. You use the client ID and secret to set Iceberg cluster configuration properties in Redpanda in the next step.
 . Open your catalog in the Catalog Explorer, then click *Permissions*.
 . Click *Grant* to grant the service principal the following permissions on the catalog:
 +
@@ -109,7 +109,7 @@ iceberg_disable_snapshot_tagging: true
 ----
 endif::[]
 ifdef::env-cloud[]
-Use `rpk` like in the following example, or the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
+Use `rpk` like in the following example, or use the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
 +
 To reference a secret in a cluster property, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value]. 
 +
@@ -136,7 +136,7 @@ endif::[]
 Use your own values for the following placeholders:
 +
 --
-- `<workspace-instance>`: The URL of your https://docs.databricks.com/aws/en/workspace/workspace-details#workspace-instance-names-urls-and-ids[Databricks workspace instance^], for example, `cust-success.cloud.databricks.com`.
+- `<workspace-instance>`: The URL of your https://docs.databricks.com/aws/en/workspace/workspace-details#workspace-instance-names-urls-and-ids[Databricks workspace instance^]; for example, `cust-success.cloud.databricks.com`.
 - `<service-principal-client-id>`: The client ID of the service principal you created in an earlier step.
 ifndef::env-cloud[]
 - `<service-principal-client-secret>`: The client secret of the service principal you created in an earlier step.
@@ -186,12 +186,12 @@ You should see the topic as a table with data in Unity Catalog. The data may tak
 
 == Query Iceberg table using Databricks SQL
 
-You can query the Iceberg table using different engines, such as Databricks SQL, PyIceberg, or Apache Spark. To query the table or view the table data in Catalog Explorer, ensure that your account has the necessary permissions to read the table. Review the official Databricks documentation on https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/?language=SQL#grant-permissions-on-objects-in-a-unity-catalog-metastore[granting permissions to objects^] and https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/privileges[Unity Catalog privileges^] for details.
+You can query the Iceberg table using different engines, such as Databricks SQL, PyIceberg, or Apache Spark. To query the table or view the table data in Catalog Explorer, ensure that your account has the necessary permissions to read the table. Review the Databricks documentation on https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/?language=SQL#grant-permissions-on-objects-in-a-unity-catalog-metastore[granting permissions to objects^] and https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/privileges[Unity Catalog privileges^] for details.
 
 The following example shows how to query the Iceberg table using SQL in Databricks SQL.
 
 . In the Databricks console, open *SQL Editor*.
-. In the query editor, run the following:
+. In the query editor, run:
 +
 [,sql]
 ----

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -156,7 +156,7 @@ ifndef::env-cloud[]
 . You must restart your cluster if you change the configuration for a running cluster. 
 endif::[]
 
-. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic or alter the configuration for an existing topic and set the Iceberg mode to `key_value`:  
+. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic or alter the configuration for an existing topic and set the Iceberg mode to `key_value`. The `key_value` mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/choose-iceberg-mode.adoc[] for more details on Iceberg modes.  
 +
 .Create a new topic and set `redpanda.iceberg.mode`:
 [,bash]
@@ -168,9 +168,7 @@ rpk topic create <topic-name> --topic-config=redpanda.iceberg.mode=key_value
 [,bash]
 ----
 rpk topic alter-config <topic-name> --set redpanda.iceberg.mode=key_value
-----
-+
-Th `key_value` mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/choose-iceberg-mode.adoc[] for more details on Iceberg modes. 
+---- 
 
 . Produce to the topic. For example, 
 +

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -4,25 +4,25 @@
 
 // tag::single-source[]
 
+ifndef::env-cloud[]
 [NOTE]
 ====
 include::shared:partial$enterprise-license.adoc[]
 ====
+endif::[]
 
 This guide walks you through querying Redpanda topics as managed Iceberg tables in Databricks, with AWS S3 as object storage and a catalog integration using https://docs.databricks.com/aws/en/data-governance/unity-catalog[Unity Catalog^]. For general information about Iceberg catalog integrations in Redpanda, see xref:manage:iceberg/use-iceberg-catalogs.adoc[].
 
 == Prerequisites
 
+ifndef::env-cloud[]
 * xref:manage:tiered-storage.adoc#configure-object-storage[Object storage configured] for your cluster and xref:manage:tiered-storage.adoc#enable-tiered-storage[Tiered Storage enabled] for the topics for which you want to generate Iceberg tables.
 +
 You need the AWS S3 bucket URI, so you can configure it as an external location in Unity Catalog.
-ifdef::env-cloud[]
-+
-For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`, where `<cluster-id>` is the ID of your Redpanda cluster.
 endif::[]
 * A Databricks workspace in the same region as your S3 bucket. See the https://docs.databricks.com/aws/en/resources/supported-regions#supported-regions-list[list of supported AWS regions^].
 * Unity Catalog enabled in your Databricks workspace. See the https://docs.databricks.com/aws/en/data-governance/unity-catalog/get-started[official Databricks documentation^] to set up Unity Catalog for your workspace.
-* Predictive optimization enabled.
+* Predictive optimization enabled for Unity Catalog.
 * External data access enabled in your metastore.
 * Workspace admin privileges to complete the steps to create a Unity Catalog storage credential and external location that connects your Tiered Storage bucket to Databricks.
 
@@ -46,7 +46,11 @@ Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog
 
 == Create a Unity Catalog external location
 
-The external location points to the location of the Iceberg data in your S3 bucket. 
+The external location points to the location of the Iceberg data in your cluster's S3 bucket. 
+
+ifdef::env-cloud[]
+For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`, where `<cluster-id>` is the ID of your Redpanda cluster.
+endif::[]
 
 Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/external-locations[official Databricks documentation] to *manually* create an external location. You can create the external location in the Catalog Explorer, or using SQL. You must create the external location manually because the location needs to be associated with the existing Tiered Storage bucket URL, `s3://<bucket-name>`.
 
@@ -96,9 +100,9 @@ iceberg_disable_snapshot_tagging: true
 ----
 endif::[]
 ifdef::env-cloud[]
-Use `rpk` or the Data Plane API to update these properties. Cluster property updates might take several minutes to complete.
+Use `rpk` like in the following example, or the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
 +
-To reference a secret in a cluster property like in the following example, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value]. 
+To reference a secret in a cluster property, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value]. 
 +
 [,bash]
 ----
@@ -139,9 +143,11 @@ endif::[]
 Successfully updated configuration. New configuration version is 2.
 ----
 
+ifndef::env-cloud[]
 . You must restart your cluster if you change the configuration for a running cluster. 
+endif::[]
 
-. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. This mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/topic-iceberg-integration.adoc#enable-iceberg-integration[Enable Iceberg integration] for more details on Iceberg modes. The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic, or alter the configuration for an existing topic, to set the Iceberg mode to `key_value`:  
+. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. This mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for more details on Iceberg modes. The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic, or alter the configuration for an existing topic, to set the Iceberg mode to `key_value`:  
 +
 .Create a new topic and set `redpanda.iceberg.mode`:
 [,bash]

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -117,7 +117,7 @@ To reference a secret in a cluster property, you must first xref:manage:iceberg/
 ----
 rpk cloud login
 
-rpk profile create  --from-cloud <cluster-id>
+rpk profile create --from-cloud <cluster-id>
 
 rpk cluster config set \
   iceberg_enabled=true \
@@ -204,12 +204,12 @@ Your query results should look like the following:
 [,sql,role="no-copy no-wrap"]
 ----
 -- Example for redpanda.iceberg.mode=key_value with 1 record produced to topic
-+----------------------------------------------------------------------+------------+-------------------------+
-| redpanda                                                                 | value      | redpanda.timestamp_hour |
-+----------------------------------------------------------------------+------------+-------------------------+
-| {"partition":0,"offset":"0","timestamp":"2025-04-02T18:57:11.127Z",      | 776f726c64 | 2025-04-02-18           |
-| "headers":null,"key":"68656c6c6f"}                                       |            |                         |
-+----------------------------------------------------------------------+------------+-------------------------+
++----------------------------------------------------------------------+------------+
+| redpanda                                                             | value      |
++----------------------------------------------------------------------+------------+
+| {"partition":0,"offset":"0","timestamp":"2025-04-02T18:57:11.127Z",  | 776f726c64 |
+| "headers":null,"key":"68656c6c6f"}                                   |            |
++----------------------------------------------------------------------+------------+
 ----
 
 == See also

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -1,0 +1,199 @@
+= Query Iceberg Topics using Databricks and Unity Catalog
+:description: Add Redpanda topics as Iceberg tables that you can query in Databricks managed by Unity Catalog.
+:page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
+:page-beta: true
+
+[NOTE]
+====
+include::shared:partial$enterprise-license.adoc[]
+====
+
+This guide walks you through querying Redpanda topics as managed Iceberg tables in Databricks, with AWS S3 as object storage and a catalog integration using https://docs.databricks.com/aws/en/data-governance/unity-catalog[Unity Catalog^]. For general information about Iceberg catalog integrations in Redpanda, see xref:manage:iceberg/use-iceberg-catalogs.adoc[].
+
+== Prerequisites
+
+* xref:manage:tiered-storage.adoc#configure-object-storage[Object storage configured] for your cluster and xref:manage:tiered-storage.adoc#enable-tiered-storage[Tiered Storage enabled] for the topics for which you want to generate Iceberg tables.
++
+You need the AWS S3 bucket URI, so you can configure it as an external location in Unity Catalog.
+ifdef::env-cloud[]
++
+For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`, where `<cluster-id>` is the ID of your Redpanda cluster.
+endif::[]
+* A Databricks workspace in the same region as your S3 bucket. See the https://docs.databricks.com/aws/en/resources/supported-regions#supported-regions-list[list of supported AWS regions^].
+* Unity Catalog enabled in your Databricks workspace. See the https://docs.databricks.com/aws/en/data-governance/unity-catalog/get-started[official Databricks documentation^] to set up Unity Catalog for your workspace.
+* Predictive optimization enabled.
+* External data access enabled in your metastore.
+* Workspace admin privileges to complete the steps to create a Unity Catalog storage credential and external location that connects your Tiered Storage bucket to Databricks.
+
+== Limitations
+
+* The Managed Iceberg Tables feature in Databricks does not currently support partition evolution. This means that when you define a xref:manage:iceberg/about-iceberg-topics.adoc#use-custom-partitioning[custom partitioning] scheme for an Iceberg topic, you cannot change it later. You must create a new topic with the desired new partitioning and migrate the topic data.
+* The following data types are not currently supported for managed Iceberg tables:
+** UUID
+** Fixed(L)
+** Time
+
+== Create a Unity Catalog storage credential
+
+A storage credential is a Databricks object that controls access to external object storage, in this case S3. You associate a storage credential with an AWS IAM role that defines what actions Unity Catalog can perform in the S3 bucket.
+
+Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/storage-credentials[official Databricks documentation^] to create an AWS IAM role that has the required permissions for the bucket. When you have completed these steps, you should have the following configured in AWS and Databricks:
+
+* A self-assuming IAM role, meaning you've defined the role trust policy so the role trusts itself.
+* Two IAM policies attached to the IAM role. The first policy grants Unity Catalog read and write access to the bucket. The second policy allows Unity Catalog to configure file events.
+* A storage credential in Databricks associated with the IAM role, using the role's ARN. You also use the storage credential's external ID in the role's trust relationship policy to make the role self-assuming.
+
+== Create a Unity Catalog external location
+
+The external location points to the location of the Iceberg data in your S3 bucket. 
+
+Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/external-locations[official Databricks documentation] to *manually* create an external location. You can create the external location in the Catalog Explorer, or using SQL. You must create the external location manually because the location needs to be associated with the existing Tiered Storage bucket URL, `s3://<bucket-name>`.
+
+== Create a new catalog
+
+Follow the steps in the official Databricks documentation to https://docs.databricks.com/aws/en/catalogs/create-catalog[create a standard catalog^]. When you create the catalog, specify the following as the storage location:
+
+* The external location you created in the previous step.
+* In the subpath field, enter `redpanda-iceberg-catalog`.
+
+You use the catalog name when you set the Iceberg cluster configuration properties in Redpanda in a later step.
+
+== Authorize access to Unity Catalog
+
+Redpanda recommends using OAuth for service principals to grant Redpanda access to Unity Catalog. 
+
+. Follow the steps in the https://docs.databricks.com/aws/en/dev-tools/auth/oauth-m2m[official Databricks documentation] to create a service principal, and then generate an OAuth secret. You use the client ID and secret to set Iceberg cluster configuration properties in Redpanda in the next step.
+. Open your catalog in the Catalog Explorer, then click *Permissions*.
+. Click *Grant* to grant the service principal the following permissions on the catalog:
++
+* `ALL PRIVILEGES`
+* `EXTERNAL USE SCHEMA`
+
+The Iceberg integration for Redpanda also supports using bearer tokens.
+
+== Update cluster configuration
+
+To configure your Redpanda cluster to enable Iceberg on a topic and integrate with Unity Catalog:
+
+. Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below.
+ifndef::env-cloud[]
++
+Run `rpk cluster config edit` to update these properties:
++
+[,bash]
+----
+iceberg_enabled: true 
+iceberg_catalog_type: rest
+iceberg_rest_catalog_endpoint: https://<workspace-instance>/api/2.1/unity-catalog/iceberg-rest
+iceberg_rest_catalog_authentication_mode: oauth2
+iceberg_rest_catalog_oauth2_server_uri: https://<workspace-instance>/oidc/v1/token
+iceberg_rest_catalog_oauth2_scope: all-apis
+iceberg_rest_catalog_client_id: <service-principal-client-id>
+iceberg_rest_catalog_client_secret: <service-principal-client-secret>
+iceberg_rest_catalog_warehouse: <unity-catalog-name>
+iceberg_disable_snapshot_tagging: true
+----
+endif::[]
+ifdef::env-cloud[]
+Use `rpk` or the Data Plane API to update these properties. Cluster property updates might take several minutes to complete.
++
+To reference a secret in a cluster property like in the following example, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value]. 
++
+[,bash]
+----
+rpk cloud login
+
+rpk profile create  --from-cloud <cluster-id>
+
+rpk cluster config set \
+  iceberg_enabled=true \
+  iceberg_catalog_type=rest \
+  iceberg_rest_catalog_endpoint=https://<workspace-instance>/api/2.1/unity-catalog/iceberg-rest \
+  iceberg_rest_catalog_authentication_mode=oauth2 \
+  iceberg_rest_catalog_oauth2_server_uri=https://<workspace-instance>/oidc/v1/token \
+  iceberg_rest_catalog_oauth2_scope=all-apis \
+  iceberg_rest_catalog_client_id=<service-principal-client-id> \
+  iceberg_rest_catalog_client_secret=${secrets.<service-principal-client-secret-name>} \
+  iceberg_rest_catalog_warehouse=<unity-catalog-name> \
+  iceberg_disable_snapshot_tagging=true
+----
+endif::[]
++
+Use your own values for the following placeholders:
++
+--
+- `<workspace-instance>`: The URL of your https://docs.databricks.com/aws/en/workspace/workspace-details#workspace-instance-names-urls-and-ids[Databricks workspace instance^], for example, `cust-success.cloud.databricks.com`.
+- `<service-principal-client-id>`: The client ID of the service principal you created in an earlier step.
+ifndef::env-cloud[]
+- `<service-principal-client-secret>`: The client secret of the service principal you created in an earlier step.
+endif::[]
+ifdef::env-cloud[]
+- `<service-principal-client-secret-name>`: The name of the client secret of the service principal you created in an earlier step.
+endif::[]
+- `<unity-catalog-name>`: The name of your catalog in Unity Catalog.
+--
++
+[,bash,role=no-copy]
+----
+Successfully updated configuration. New configuration version is 2.
+----
+
+. You must restart your cluster if you change the configuration for a running cluster. 
+
+. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. This mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/topic-iceberg-integration.adoc#enable-iceberg-integration[Enable Iceberg integration] for more details on Iceberg modes. The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic, or alter the configuration for an existing topic, to set the Iceberg mode to `key_value`:  
++
+.Create a new topic and set `redpanda.iceberg.mode`:
+[,bash]
+----
+rpk topic create <topic-name> --topic-config=redpanda.iceberg.mode=key_value
+----
++
+.Set `redpanda.iceberg.mode` for an existing topic:
+[,bash]
+----
+rpk topic alter-config <topic-name> --set redpanda.iceberg.mode=key_value
+----
+
+. Produce to the topic. For example, 
++
+[,bash]
+----
+echo "hello world\nfoo bar\nbaz qux" | rpk topic produce <topic-name> --format='%k %v\n'
+----
+
+You should see the topic as a table in Unity Catalog.
+
+. In Catalog Explorer, open your catalog. You should see a `redpanda` schema, in addition to `default` and `information_schema`.
+. The `redpanda` schema and the table residing within this schema are automatically added for you. The table name is the same as the topic name. 
+
+== Query Iceberg table using Databricks SQL
+
+You can query the Iceberg table using different engines, such as Databricks SQL, PyIceberg, or Apache Spark. To query the table or view the table data in Catalog Explorer, ensure that your account has the necessary permissions to read the table. Review the official Databricks documentation on https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/?language=SQL#grant-permissions-on-objects-in-a-unity-catalog-metastore[granting permissions to objects^] and https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/privileges[Unity Catalog privileges^] for details.
+
+The following example shows how to query the Iceberg table using SQL in Databricks SQL.
+
+. In the Databricks console, open *SQL Editor*.
+. In the query editor, run the following:
++
+[,sql]
+----
+-- Ensure that the catalog and table name are correctly parsed in case they contain special characters
+SELECT * FROM `<catalog-name>`.redpanda.`<table-name>`;
+----
++
+Your query results should look like the following:
++
+[,sql,role="no-copy no-wrap"]
+----
+# Example for redpanda.iceberg.mode=key_value with 1 record produced to topic
++----------------------------------------------------------------------+------------+-------------------------+
+| redpanda                                                                 | value      | redpanda.timestamp_hour |
++----------------------------------------------------------------------+------------+-------------------------+
+| {"partition":0,"offset":"0","timestamp":"2025-04-02T18:57:11.127Z",      | 776f726c64 | 2025-04-02-18           |
+| "headers":null,"key":"68656c6c6f"}                                       |            |                         |
++----------------------------------------------------------------------+------------+-------------------------+
+----
+
+== See also
+
+- xref:manage:iceberg/query-iceberg-topics.adoc[]

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -68,7 +68,7 @@ Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog
 
 == Create a new catalog
 
-Follow the steps in the official Databricks documentation to https://docs.databricks.com/aws/en/catalogs/create-catalog[create a standard catalog^]. When you create the catalog, specify the external location you created in the previous step as the storage location.
+Follow the steps in the Databricks documentation to https://docs.databricks.com/aws/en/catalogs/create-catalog[create a standard catalog^]. When you create the catalog, specify the external location you created in the previous step as the storage location.
 
 You use the catalog name when you set the Iceberg cluster configuration properties in Redpanda in a later step.
 

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -22,17 +22,29 @@ You need the AWS S3 bucket URI, so you can configure it as an external location 
 endif::[]
 * A Databricks workspace in the same region as your S3 bucket. See the https://docs.databricks.com/aws/en/resources/supported-regions#supported-regions-list[list of supported AWS regions^].
 * Unity Catalog enabled in your Databricks workspace. See the https://docs.databricks.com/aws/en/data-governance/unity-catalog/get-started[official Databricks documentation^] to set up Unity Catalog for your workspace.
-* Predictive optimization enabled for Unity Catalog.
-* External data access enabled in your metastore.
-* Workspace admin privileges to complete the steps to create a Unity Catalog storage credential and external location that connects your Tiered Storage bucket to Databricks.
+* https://docs.databricks.com/aws/en/optimizations/predictive-optimization#enable-predictive-optimization[Predictive optimization^] enabled for Unity Catalog.
+* https://docs.databricks.com/aws/en/external-access/admin[External data access^] enabled in your metastore.
+* Workspace admin privileges to complete the steps to create a Unity Catalog storage credential and external location that connects your cluster's Tiered Storage bucket to Databricks.
 
 == Limitations
 
-* The Managed Iceberg Tables feature in Databricks does not currently support partition evolution. This means that when you define a xref:manage:iceberg/about-iceberg-topics.adoc#use-custom-partitioning[custom partitioning] scheme for an Iceberg topic, you cannot change it later. You must create a new topic with the desired new partitioning and migrate the topic data.
+* Databricks Managed Iceberg tables do not currently support partition evolution. If you define a xref:manage:iceberg/about-iceberg-topics.adoc#use-custom-partitioning[custom partitioning] scheme for an Iceberg topic, you must not change it later. 
++
+The cluster property config_ref:iceberg_default_partition_spec,true,properties/cluster-properties[`iceberg_default_partition_spec`] defines the cluster-wide partitioning scheme, by default configured to `(hour(redpanda.timestamp))`. To use a different cluster-wide default, configure this property before creating any Iceberg-enabled topics. You must only override the default partitioning scheme on the topic level for new Iceberg topics that do not yet contain data.  
 * The following data types are not currently supported for managed Iceberg tables:
-** UUID
-** Fixed(L)
-** Time
++
+--
+|===
+| Iceberg type | Equivalent Avro type
+
+| uuid | uuid
+| fixed(L) | fixed
+| time | time-millis, time-micros
+
+|===
+--
++
+There are no limitations for Protobuf types.
 
 == Create a Unity Catalog storage credential
 
@@ -46,7 +58,7 @@ Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog
 
 == Create a Unity Catalog external location
 
-The external location points to the location of the Iceberg data in your cluster's S3 bucket. 
+The external location stores the Unity Catalog-managed Iceberg metadata, and the Iceberg data written by Redpanda. You must use the same bucket configured for glossterm:Tiered Storage[] for your Redpanda cluster.
 
 ifdef::env-cloud[]
 For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`, where `<cluster-id>` is the ID of your Redpanda cluster.
@@ -56,10 +68,7 @@ Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog
 
 == Create a new catalog
 
-Follow the steps in the official Databricks documentation to https://docs.databricks.com/aws/en/catalogs/create-catalog[create a standard catalog^]. When you create the catalog, specify the following as the storage location:
-
-* The external location you created in the previous step.
-* In the subpath field, enter `redpanda-iceberg-catalog`.
+Follow the steps in the official Databricks documentation to https://docs.databricks.com/aws/en/catalogs/create-catalog[create a standard catalog^]. When you create the catalog, specify the external location you created in the previous step as the storage location.
 
 You use the catalog name when you set the Iceberg cluster configuration properties in Redpanda in a later step.
 
@@ -147,7 +156,7 @@ ifndef::env-cloud[]
 . You must restart your cluster if you change the configuration for a running cluster. 
 endif::[]
 
-. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. This mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for more details on Iceberg modes. The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic, or alter the configuration for an existing topic, to set the Iceberg mode to `key_value`:  
+. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic or alter the configuration for an existing topic and set the Iceberg mode to `key_value`:  
 +
 .Create a new topic and set `redpanda.iceberg.mode`:
 [,bash]
@@ -160,6 +169,8 @@ rpk topic create <topic-name> --topic-config=redpanda.iceberg.mode=key_value
 ----
 rpk topic alter-config <topic-name> --set redpanda.iceberg.mode=key_value
 ----
++
+Th `key_value` mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/choose-iceberg-mode.adoc[] for more details on Iceberg modes. 
 
 . Produce to the topic. For example, 
 +
@@ -168,7 +179,7 @@ rpk topic alter-config <topic-name> --set redpanda.iceberg.mode=key_value
 echo "hello world\nfoo bar\nbaz qux" | rpk topic produce <topic-name> --format='%k %v\n'
 ----
 
-You should see the topic as a table in Unity Catalog.
+You should see the topic as a table with data in Unity Catalog. The data may take some time to become visible, depending on your config_ref:iceberg_target_lag_ms,true,properties/cluster-properties[`iceberg_target_lag_ms`] setting.
 
 . In Catalog Explorer, open your catalog. You should see a `redpanda` schema, in addition to `default` and `information_schema`.
 . The `redpanda` schema and the table residing within this schema are automatically added for you. The table name is the same as the topic name. 
@@ -192,7 +203,7 @@ Your query results should look like the following:
 +
 [,sql,role="no-copy no-wrap"]
 ----
-# Example for redpanda.iceberg.mode=key_value with 1 record produced to topic
+-- Example for redpanda.iceberg.mode=key_value with 1 record produced to topic
 +----------------------------------------------------------------------+------------+-------------------------+
 | redpanda                                                                 | value      | redpanda.timestamp_hour |
 +----------------------------------------------------------------------+------------+-------------------------+

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -1,7 +1,8 @@
 = Query Iceberg Topics using Databricks and Unity Catalog
 :description: Add Redpanda topics as Iceberg tables that you can query in Databricks managed by Unity Catalog.
 :page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
-:page-beta: true
+
+// tag::single-source[]
 
 [NOTE]
 ====
@@ -197,3 +198,5 @@ Your query results should look like the following:
 == See also
 
 - xref:manage:iceberg/query-iceberg-topics.adoc[]
+
+// end::single-source[]

--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -66,6 +66,22 @@ endif::[]
 . Set the `iceberg_enabled` configuration option on your cluster to `true`. 
 ifdef::env-cloud[]
 +
+[tabs]
+=====
+rpk::
++
+--
+[,bash]
+----
+rpk cloud login
+rpk profile create  --from-cloud <CLUSTER ID>
+rpk cluster config set iceberg_enabled true
+----
+--
+
+Cloud API::
++
+--
 [,bash]
 ----
 # Store your cluster ID in a variable
@@ -85,8 +101,10 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
  -H 'content-type: application/json' \
  -d '{"cluster_configuration":{"custom_properties": {"iceberg_enabled":true}}}'
 ----
-+ 
+
 The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. The operation may take up to ten minutes to complete. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint.
+--
+=====
 endif::[]
 ifndef::env-cloud[]
 +

--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -63,7 +63,7 @@ ifdef::env-cloud[]
 To create an Iceberg table for a Redpanda topic, you must set the cluster configuration property config_ref:iceberg_enabled,true,properties/cluster-properties[`iceberg_enabled`] to `true`, and also configure the topic property `redpanda.iceberg.mode`. You can choose to provide a schema if you need the Iceberg table to be structured with defined columns.
 endif::[]
 
-. Set the `iceberg_enabled` configuration option on your cluster to `true`. You must restart your cluster if you change this configuration for a running cluster. 
+. Set the `iceberg_enabled` configuration option on your cluster to `true`. 
 ifdef::env-cloud[]
 +
 [,bash]
@@ -99,6 +99,8 @@ rpk cluster config set iceberg_enabled true
 ----
 Successfully updated configuration. New configuration version is 2.
 ----
++
+You must restart your cluster if you change this configuration for a running cluster.
 endif::[]
 
 . (Optional) Create a new topic.

--- a/modules/manage/partials/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/query-iceberg-topics.adoc
@@ -40,7 +40,7 @@ NOTE: Redpanda automatically removes expired snapshots on a periodic basis. Snap
 == Query examples
 
 ifndef::env-cloud[]
-To follow along with the examples on this page, suppose you produce the same stream of events to a topic `ClickEvent`, which uses a schema, and another topic `ClickEvent_key_value`, which uses the key-value mode. The topics have glossterm:tiered-storage[] configured to an AWS S3 bucket. A sample record contains the following data:
+To follow along with the examples on this page, suppose you produce the same stream of events to a topic `ClickEvent`, which uses a schema, and another topic `ClickEvent_key_value`, which uses the key-value mode. The topics have glossterm:Tiered Storage[] configured to an AWS S3 bucket. A sample record contains the following data:
 endif::[]
 
 ifdef::env-cloud[]


### PR DESCRIPTION
## Description

Related PR to add Databricks doc in Cloud: https://github.com/redpanda-data/cloud-docs/pull/321

This PR adds a Databricks Unity integration doc, one version for [Self-managed](https://deploy-preview-1154--redpanda-docs-preview.netlify.app/current/manage/iceberg/iceberg-topics-databricks-unity/) and one for [Cloud](https://deploy-preview-1154--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/iceberg-topics-databricks-unity/). Conditional tags `ifdef::env-cloud[]` and `ifndef::env-cloud[]` control when content is displayed for the Cloud version or Self-managed version of the doc respectively.

This pull request introduces several updates to the documentation for Redpanda's Iceberg integration, with a focus on Databricks Unity Catalog support, data type mappings, and navigation enhancements. The most significant changes include adding a new guide for querying Iceberg topics with Databricks Unity Catalog, updating data type mappings for Avro and Protobuf, and modifying navigation to include the new Databricks Unity Catalog documentation.

### Databricks Unity Catalog Integration:
* [`modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc`](diffhunk://#diff-a8cc69134db34c0afe324812dbe0c1c9ec51c399f09a25e0c32d137913f81791R1-R208): Added a comprehensive guide on integrating Redpanda Iceberg topics with Databricks Unity Catalog, detailing prerequisites, limitations, configuration steps, and querying examples.

### Data Type Mapping Updates:
* [`modules/manage/pages/iceberg/choose-iceberg-mode.adoc`](diffhunk://#diff-5076fb238fceeabc4117ed4246fd8815832779df3ff7f6eff2784d01d4fcdf6cL178-R200): Updated Avro type mappings to clarify unsupported types and added notes on transformations for time, timestamp, and union types.  
* [`modules/manage/pages/iceberg/choose-iceberg-mode.adoc`](diffhunk://#diff-5076fb238fceeabc4117ed4246fd8815832779df3ff7f6eff2784d01d4fcdf6cL211-R233): Updated Protobuf type mappings, correcting `sfixed64` mapping to `long` and adding notes on transformations for repeated values, enums, and timestamp types.

### Navigation Enhancements:
* [`modules/ROOT/nav.adoc`](diffhunk://#diff-5daf5a85fd51578ad9fc545388bf62176bcea32094ee97b5e30c2eea044e4193R177): Added a new navigation link for the Databricks Unity Catalog integration guide under the Iceberg section.

### Minor Updates:
* [`local-antora-playbook.yml`](diffhunk://#diff-430ed78ec72afb78849cef359188c9b20a3dde4623593958cba0dfb974cb2ac9L20-R20): Changed the branch for `cloud-docs` to reflect the Databricks GA documentation (`DOC-1045-cloud-databricks-ga`).
* [`modules/manage/partials/iceberg/query-iceberg-topics.adoc`](diffhunk://#diff-ad35e9a1826487725ec6e9250fb2a9925cf842c7ab4f7efdd31823823eb188f1L43-R43): Corrected terminology from "tiered-storage" to "Tiered Storage" for consistency.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 11 June

## Page previews

Cloud: Manage > Iceberg > [Query Iceberg Topics with Databricks Unity Catalog](https://deploy-preview-1154--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/iceberg-topics-databricks-unity/)
Self-managed: Manage > Iceberg > [Query Iceberg Topics with Databricks Unity Catalog](https://deploy-preview-1154--redpanda-docs-preview.netlify.app/current/manage/iceberg/iceberg-topics-databricks-unity/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
