### PR TITLE
Add `mkfsParams: "-i nrext64=0"` to StorageClass

### DIFF
--- a/modules/deploy/partials/kubernetes/guides/create-storageclass.adoc
+++ b/modules/deploy/partials/kubernetes/guides/create-storageclass.adoc
@@ -45,7 +45,7 @@ XFS (dm-0): Superblock has unknown incompatible features (0x20) enabled.
 . Create the StorageClass:
 +
 .`csi-driver-lvm-striped-xfs.yaml`
-[,yaml,lines=5-8+10-11]
+[,yaml,lines=5-8+10-12]
 ----
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/modules/deploy/partials/kubernetes/guides/create-storageclass.adoc
+++ b/modules/deploy/partials/kubernetes/guides/create-storageclass.adoc
@@ -58,6 +58,7 @@ allowVolumeExpansion: true
 parameters:
   type: "striped"
   csi.storage.k8s.io/fstype: xfs
+  mkfsParams: "-i nrext64=0"
 ----
 +
 - `provisioner`: The LVM CSI driver responsible for provisioning the volume.
@@ -66,6 +67,7 @@ parameters:
 - `allowVolumeExpansion`: Allows the volume to be expanded after it has been provisioned.
 - `parameters.type`: Combines multiple physical volumes to create a single logical volume. In a striped setup, data is spread across the physical volumes in a way that distributes the I/O load evenly, improving performance by allowing parallel disk I/O operations.
 - `parameters.csi.storage.k8s.io/fstype`: Formats the volumes with the XFS file system. Redpanda Data recommends XFS for its enhanced performance with Redpanda workloads.
+- `parameters.mkfsParams`: Disables the nrext64 feature to ensure compatibility with older kernels.
 
 . Apply the StorageClass:
 +


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1427
Review deadline: June 10

@masapanda discovered that on newer versions of Kubernetes, this extra parameter is required to work with the LVM CSI driver.

This pull request updates the documentation for creating a Kubernetes StorageClass to include a new parameter and its explanation. The changes improve clarity and provide additional configuration details for users.

### Documentation updates for StorageClass creation:

* [`modules/deploy/partials/kubernetes/guides/create-storageclass.adoc`](diffhunk://#diff-c4bf31351307235b44c9ca664a1015a0f75ba9e7eac6a29d6616d79e69b82beeR61): Added a new parameter, `mkfsParams`, with the value `"-i nrext64=0"`, to disable the `nrext64` feature for compatibility with older kernels. This ensures broader compatibility for systems using the StorageClass. [[1]](diffhunk://#diff-c4bf31351307235b44c9ca664a1015a0f75ba9e7eac6a29d6616d79e69b82beeR61) [[2]](diffhunk://#diff-c4bf31351307235b44c9ca664a1015a0f75ba9e7eac6a29d6616d79e69b82beeR70)

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
