### PR TITLE
DOC-1443 remove tab for Cloud api to enable WASM

### DIFF
--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -22,57 +22,14 @@ endif::[]
 ifdef::env-cloud[]
 == Enable data transforms
 
-Data transforms are disabled on all clusters by default. Before you can deploy data transforms to a cluster, you must first enable the feature with either the `rpk` command-line tool or the Cloud API.
-
-[tabs]
-======
-`rpk`::
-+
---
-Set the `data_transforms_enabled` cluster property to `true`:
+Data transforms are disabled on all clusters by default. Before you can deploy data transforms to a cluster, you must first enable the feature with the `rpk` command-line tool. To enable data transforms, set the xref:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] cluster property to `true`:
 
 [source,bash]
 ----
 rpk cluster config set data_transforms_enabled true
 ----
 
-
-NOTE: Some properties require a rolling restart, and it can take several minutes for the update to complete. The `rpk cluster config set` command returns the operation ID. 
-
---
-Cloud API::
-+
---
-Create a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /v1/clusters`] request. Edit `cluster_configuration` in the request body to set xref:ROOT:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] to `true`.
-
-Update a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request, passing the cluster ID as a parameter. For example:
-
-[source,bash]
-----
-# Store your cluster ID in a variable
-export RP_CLUSTER_ID=<cluster-id>
-
-# Retrieve a Redpanda Cloud access token
-export RP_CLOUD_TOKEN=`curl -X POST "https://auth.prd.cloud.redpanda.com/oauth/token" \
-    -H "content-type: application/x-www-form-urlencoded" \
-    -d "grant_type=client_credentials" \
-    -d "client_id=<client-id>" \
-    -d "client_secret=<client-secret>"`
-
-# Update cluster configuration to enable data transforms
-curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
-  "https://api.cloud.redpanda.com/v1/clusters/${RP_CLUSTER_ID}" \
- -H 'accept: application/json'\
- -H 'content-type: application/json' \
- -d '{"cluster_configuration":{"custom_properties": {"data_transforms_enabled":true}}}'
-----
-
-The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the operation ID. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint. 
-
-NOTE: Some properties require a rolling restart for the update to take effect. This triggers a xref:manage:api/cloud-byoc-controlplane-api.adoc#lro[long-running operation] that can take several minutes to complete.
-
---
-======
+NOTE: This property require a rolling restart, and it can take several minutes for the update to complete.
 
 endif::[]
 

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -29,7 +29,7 @@ Data transforms are disabled on all clusters by default. Before you can deploy d
 rpk cluster config set data_transforms_enabled true
 ----
 
-NOTE: This property require a rolling restart, and it can take several minutes for the update to complete.
+NOTE: This property requires a rolling restart, and it can take several minutes for the update to complete.
 
 endif::[]
 


### PR DESCRIPTION
## Description
This pull request simplifies the documentation for enabling data transforms in `modules/develop/pages/data-transforms/build.adoc`. The changes remove the Cloud API method and streamline instructions to focus solely on enabling the feature using the `rpk` command-line tool.

### Documentation simplification:

* Removed the Cloud API method for enabling data transforms, including detailed examples and API request instructions, to streamline the documentation. The focus is now solely on using the `rpk` command-line tool.
* Updated the `rpk` instructions to include a cross-reference to the cluster property documentation (`data_transforms_enabled`) for clarity.
* Simplified the note about rolling restarts, removing redundant explanations about operation IDs and long-running operations.

Resolves https://redpandadata.atlassian.net/browse/DOC-1443
Review deadline:

## Page previews
[Enable data transforms](https://deploy-preview-1156--redpanda-docs-preview.netlify.app/redpanda-cloud/develop/data-transforms/build/) (in Cloud)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [S] Small fix (typos, links, copyedits, etc)
