### PR TITLE
Document `kafka.sasl.oauth.tokenFilepath`

### DIFF
--- a/modules/console/pages/config/configure-console.adoc
+++ b/modules/console/pages/config/configure-console.adoc
@@ -14,7 +14,7 @@ Environment variables and YAML configurations can overwrite input that is set on
 
 The recommended configuration source is a YAML file. You can specify the path to the configuration file by setting either
 the `-config.filepath` flag or the `CONFIG_FILEPATH` environment variable.
-A reference configuration file is provided under <<Example Redpanda Console configuration file>>.
+A reference configuration file is provided under <<Complete configuration file example>>.
 
 In Linux package installations, this file is located in `/etc/redpanda/redpanda-console-config.yaml` by default and Redpanda Console is configured to read from this file path.
 

--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -81,18 +81,7 @@ Redpanda Console supports enabling both OIDC and basic authentication simultaneo
 
 === Enable OIDC authentication
 
-To configure OIDC, choose one of two modes:
-
-* *Runtime acquisition mode:* Redpanda Console obtains a token from the IdP.
-* *Static token mode:* You provide a pre-acquired OIDC token.
-
 Redpanda and Redpanda Console require OAuth 2.0-compliant JWT tokens for user authentication. When using OIDC, your IdP must issue JWTs. Redpanda Console uses these tokens to authenticate to Redpanda APIs through SASL/OAUTHBEARER or Bearer headers.
-
-include::manage:partial$security/oidc/limitations.adoc[leveloffset=+2]
-
-IMPORTANT: For any secret values, xref:console:config/configure-console.adoc[use environment variables] instead of hardcoding them in the configuration file. For example, use `AUTHENTICATION_OIDC_CLIENTSECRET` for the client secret.
-
-==== Enable runtime acquisition mode
 
 [,yaml]
 ----
@@ -129,26 +118,9 @@ authentication:
 <10> Optional. Controls whether a refresh token is requested. A value of `offline` (default) requests a refresh token for long-lived sessions. Set it to `online` if you don't want a refresh token.
 <11> Optional. Determines how the authorization prompt is displayed. Use `consent` (default) to force the consent screen to appear even if the user has previously authorized the application. Alternatives include `none` (no prompt) or `select_account` to allow the user to choose an account. Some IdPs require `consent` to issue a refresh token.
 
-==== Enable static token mode
+IMPORTANT: For any secret values, xref:console:config/configure-console.adoc[use environment variables] instead of hardcoding them in the configuration file. For example, use `AUTHENTICATION_OIDC_CLIENTSECRET` for the client secret.
 
-[,yaml]
-----
-authentication:
-  jwtSigningKey: "<secret-key>"
-  useSecureCookies: true
-  oidc:
-    enabled: true
-    issuerUrl: "https://accounts.google.com"
-    token: "<static-token>" # <1>
-    issuerTls:
-      enabled: true
-      caFilepath: "/path/to/ca.pem"
-    redirectUrl: "http://localhost:8080/auth/callbacks/oidc"
-    accessType: "offline"
-    prompt: "consent"
-----
-
-<1> A pre-acquired OIDC token. Keep this secure. You can also use the `AUTHENTICATION_OIDC_TOKEN` environment variable.
+include::manage:partial$security/oidc/limitations.adoc[leveloffset=+2]
 
 ==== Supported identity providers
 
@@ -239,7 +211,7 @@ TIP: Redpanda Data recommends user impersonation so that access control is fine-
 
 [NOTE]
 ====
-When using OIDC with static credentials, Redpanda Console authenticates to Redpanda as the OIDC client itself (usually a service principal). In this case, Redpanda evaluates access based on the `sub` claim in the token. Be sure to set `oidc_principal_mapping: "$.sub"` in your Redpanda configuration and grant ACLs for that value. For detailed steps to create ACLs, see xref:manage:security/authorization/acl.adoc[]
+When using OIDC with static credentials, Redpanda Console authenticates to Redpanda as the OIDC client itself (usually a service principal). In this case, Redpanda evaluates access based on the `sub` claim in the token. Ensure you grant ACLs for your principals. For help creating ACLs, see xref:manage:security/authorization/acl.adoc[]
 ====
 
 === Kafka API examples

--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -81,6 +81,8 @@ Redpanda Console supports enabling both OIDC and basic authentication simultaneo
 
 === Enable OIDC authentication
 
+When you enable OIDC authentication, Redpanda Console uses an external IdP to authenticate users. This allows for single sign-on (SSO) and centralized user management.
+
 Redpanda and Redpanda Console require OAuth 2.0-compliant JWT tokens for user authentication. When using OIDC, your IdP must issue JWTs. Redpanda Console uses these tokens to authenticate to Redpanda APIs through SASL/OAUTHBEARER or Bearer headers.
 
 [,yaml]

--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -237,9 +237,19 @@ Choose one method per API:
 
 TIP: Redpanda Data recommends user impersonation so that access control is fine-grained and centralized within Redpanda. This way, audit logs are also more accurate, as they reflect the actual user identity.
 
+[NOTE]
+====
+When using OIDC with static credentials, Redpanda Console authenticates to Redpanda as the OIDC client itself (usually a service principal). In this case, Redpanda evaluates access based on the `sub` claim in the token. Be sure to set `oidc_principal_mapping: "$.sub"` in your Redpanda configuration and grant ACLs for that value. For detailed steps to create ACLs, see xref:manage:security/authorization/acl.adoc[]
+====
+
 === Kafka API examples
 
-.User impersonation
+This section provides examples of how to configure authentication for communicating with the Kafka API from Redpanda Console. You can choose between user impersonation or static credentials.
+
+==== User impersonation
+
+This option is useful when you want to use the same credentials you log in with to authenticate Kafka API requests in Redpanda. This ensures accurate audit logs and unified identity enforcement.
+
 [,yaml]
 ----
 kafka:
@@ -249,7 +259,10 @@ kafka:
     impersonateUser: true
 ----
 
-.Static credentials with SCRAM
+==== Static credentials with SCRAM
+
+This option is useful when you want to use basic authentication. Redpanda Console uses the provided credentials for authentication.
+
 [,yaml]
 ----
 kafka:
@@ -268,7 +281,10 @@ authorization:
         name: "matt"
 ----
 
-.Static credentials with OIDC
+==== Static credentials with OIDC (token acquired at runtime)
+
+This option is useful when you want to use OIDC. This configuration instructs Redpanda Console to fetch an OAuth 2.0 access token at runtime using the client credentials grant flow.
+
 [,yaml]
 ----
 kafka:
@@ -278,26 +294,60 @@ kafka:
     impersonateUser: false
     mechanism: OAUTHBEARER
     oauth:
-      clientId: "<oidc-client-id>"
-      clientSecret: "<oidc-client-secret>"
-      tokenEndpoint: "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token"
-      scope: "api://<oidc-client-id>/.default"
-authorization:
-  roleBindings:
-  - roleName: viewer
-    users:
-      - loginType: oidc
-        name: "<sub-from-token>" # such as "ae775e64-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      clientId: "<oidc-client-id>" # <1>
+      clientSecret: "<oidc-client-secret>" # <2>
+      tokenEndpoint: "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token" # <3>
+      scope: "api://<oidc-client-id>/.default" # <4>
 ----
+<1> Client ID registered with the identity provider (IdP).
+<2> Client secret associated with the client ID. Store securely using an environment variable such as `KAFKA_SASL_OAUTH_CLIENTSECRET`.
+<3> OAuth 2.0 token endpoint URL provided by the IdP.
+<4> Requested scope to authorize access. Required by some IdPs such as Azure Entra ID.
 
-[NOTE]
-====
-When using OIDC without impersonation, Redpanda Console authenticates to Redpanda as the OIDC client itself (usually a service principal). In this case, Redpanda evaluates access based on the `sub` claim in the token. Be sure to set `oidc_principal_mapping: "$.sub"` in your Redpanda configuration and grant ACLs for that value. For detailed steps to create ACLs, see xref:manage:security/authorization/acl.adoc[]
-====
+==== Static credentials with OIDC (pre-acquired token)
+
+This option is suitable when a token is issued externally and injected into the environment (for example, through CI/CD, Vault, or other automation workflows). Redpanda Console does not attempt to refresh or renew the token.
+
+[,yaml]
+----
+kafka:
+  brokers: ["broker1:9092"]
+  sasl:
+    enabled: true
+    impersonateUser: false
+    mechanism: OAUTHBEARER
+    oauth:
+      token: "<static-jwt-token>" # <1>
+----
+<1> A valid OAuth 2.0 JWT token. Redpanda Console uses this token when authenticating to Kafka. To avoid hardcoding sensitive data, provide this value using the `KAFKA_SASL_OAUTH_TOKEN` environment variable.
+
+==== Static credentials with OIDC (token from file)
+
+This option is useful when running Redpanda Console in Kubernetes, where a service account token is mounted to the Pod filesystem. Redpanda Console reads this token at startup and uses it for authentication.
+
+Redpanda Console does not monitor the token file for changes after startup. To ensure the token is refreshed, restart the Console periodically or implement a sidecar that triggers restarts on token rotation.
+
+[,yaml]
+----
+kafka:
+  brokers: ["broker1:9092"]
+  sasl:
+    enabled: true
+    impersonateUser: false
+    mechanism: OAUTHBEARER
+    oauth:
+      tokenFilepath: "/var/run/secrets/kafka/serviceaccount/token" # <1>
+----
+<1> Path to a file containing a valid OAuth 2.0 JWT token. Redpanda Console reads this file at startup and uses its contents as the access token.
 
 === Schema Registry API examples
 
-.User impersonation
+This section provides examples of how to configure authentication for communicating with the Schema Registry API from Redpanda Console. You can choose between user impersonation or static credentials.
+
+==== User impersonation
+
+This option is useful when you want to use the same credentials you log in with to authenticate API requests in the Schema Registry. This ensures accurate audit logs and unified identity enforcement.
+
 [,yaml]
 ----
 schemaRegistry:
@@ -307,7 +357,10 @@ schemaRegistry:
     impersonateUser: true
 ----
 
-.Static credentials with basic auth
+==== Static credentials with basic auth
+
+This option is useful when you want to use basic authentication. Redpanda Console uses the provided credentials for authentication.
+
 [,yaml]
 ----
 schemaRegistry:
@@ -326,7 +379,10 @@ authorization:
         name: "matt"
 ----
 
-.Static credentials with OIDC bearer token
+==== Static credentials with OIDC bearer token
+
+This option is useful when you want to use OIDC but do not want to implement a custom token refresh mechanism. Redpanda Console uses a pre-fetched token for authentication.
+
 [,yaml]
 ----
 schemaRegistry:
@@ -350,7 +406,12 @@ You can supply a static bearer token here, but this token must be refreshed manu
 
 === Admin API examples
 
-.User impersonation
+This section provides examples of how to configure authentication for communicating with the Admin API from Redpanda Console. You can choose between user impersonation or static credentials.
+
+==== User impersonation
+
+This option is useful when you want to use the same credentials you log in with to authenticate API requests in the Admin API. This ensures accurate audit logs and unified identity enforcement.
+
 [,yaml]
 ----
 redpanda:
@@ -361,7 +422,10 @@ redpanda:
       impersonateUser: true
 ----
 
-.Static credentials with basic auth
+==== Static credentials with basic auth
+
+This option is useful when you want to use basic authentication. Redpanda Console uses the provided credentials for authentication.
+
 [,yaml]
 ----
 redpanda:
@@ -381,7 +445,10 @@ authorization:
         name: "matt"
 ----
 
-.Static credentials with OIDC bearer token
+==== Static credentials with OIDC bearer token
+
+This option is useful when you want to use OIDC but do not want to implement a custom token refresh mechanism. Redpanda Console uses a pre-fetched token for authentication.
+
 [,yaml]
 ----
 redpanda:
@@ -399,14 +466,9 @@ authorization:
         name: "<sub-from-token>"
 ----
 
-[NOTE]
-====
-When impersonation is disabled, Redpanda Console executes Admin API requests as the service identity represented in the token. This is typically the `sub` from the client credentials flow, and must match an ACL or RBAC binding.
-====
-
 == Authorization overview
 
-Authentication allows users to log in, but authorization determines what they can do once authenticated.
+Authentication allows users to log in, but authorization determines what they can do when they're authenticated.
 
 Redpanda Console supports role-based access control (RBAC) through two modes:
 

--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -293,7 +293,7 @@ kafka:
     oauth:
       token: "<static-jwt-token>" # <1>
 ----
-<1> A valid OAuth 2.0 JWT token. Redpanda Console uses this token when authenticating to Kafka. To avoid hardcoding sensitive data, provide this value using the `KAFKA_SASL_OAUTH_TOKEN` environment variable.
+<1> A valid OAuth 2.0 JWT. Redpanda Console uses this token when authenticating to Kafka. To avoid hardcoding sensitive data, provide this value using the `KAFKA_SASL_OAUTH_TOKEN` environment variable.
 
 ==== Static credentials with OIDC (token from file)
 

--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -213,7 +213,7 @@ TIP: Redpanda Data recommends user impersonation so that access control is fine-
 
 [NOTE]
 ====
-When using OIDC with static credentials, Redpanda Console authenticates to Redpanda as the OIDC client itself (usually a service principal). In this case, Redpanda evaluates access based on the `sub` claim in the token. Ensure you grant ACLs for your principals. For help creating ACLs, see xref:manage:security/authorization/acl.adoc[]
+When using OIDC with static credentials, Redpanda Console authenticates to Redpanda as the OIDC client itself (usually a service principal). In this case, Redpanda evaluates access based on the `sub` claim in the token. Ensure you grant ACLs for your principals. For help creating ACLs, see xref:manage:security/authorization/acl.adoc[].
 ====
 
 === Kafka API examples
@@ -222,7 +222,7 @@ This section provides examples of how to configure authentication for communicat
 
 ==== User impersonation
 
-This option is useful when you want to use the same credentials you log in with to authenticate Kafka API requests in Redpanda. This ensures accurate audit logs and unified identity enforcement.
+This option is useful when you want to use the same login credentials to authenticate Kafka API requests in Redpanda. This ensures accurate audit logs and enforces unified identity.
 
 [,yaml]
 ----
@@ -274,9 +274,9 @@ kafka:
       scope: "api://<oidc-client-id>/.default" # <4>
 ----
 <1> Client ID registered with the identity provider (IdP).
-<2> Client secret associated with the client ID. Store securely using an environment variable such as `KAFKA_SASL_OAUTH_CLIENTSECRET`.
+<2> Client secret associated with the client ID. Store securely using an environment variable, such as `KAFKA_SASL_OAUTH_CLIENTSECRET`.
 <3> OAuth 2.0 token endpoint URL provided by the IdP.
-<4> Requested scope to authorize access. Required by some IdPs such as Azure Entra ID.
+<4> Requested scope to authorize access. Required by some IdPs, such as Azure Entra ID.
 
 ==== Static credentials with OIDC (pre-acquired token)
 
@@ -320,7 +320,7 @@ This section provides examples of how to configure authentication for communicat
 
 ==== User impersonation
 
-This option is useful when you want to use the same credentials you log in with to authenticate API requests in the Schema Registry. This ensures accurate audit logs and unified identity enforcement.
+This option is useful when you want to use the same login credentials to authenticate API requests in the Schema Registry. This ensures accurate audit logs and enforces unified identity.
 
 [,yaml]
 ----
@@ -384,7 +384,7 @@ This section provides examples of how to configure authentication for communicat
 
 ==== User impersonation
 
-This option is useful when you want to use the same credentials you log in with to authenticate API requests in the Admin API. This ensures accurate audit logs and unified identity enforcement.
+This option is useful when you want to use the same login credentials to authenticate API requests in the Admin API. This ensures accurate audit logs and enforces unified identity.
 
 [,yaml]
 ----

--- a/modules/shared/attachments/redpanda-console-config.yaml
+++ b/modules/shared/attachments/redpanda-console-config.yaml
@@ -27,6 +27,7 @@ kafka:
       # clientId: "example-client-id"
       # clientSecret: "example-client-secret"
       # tokenEndpoint: "https://accounts.google.com/token"
+      # tokenFilepath: "/var/run/secrets/kafka/serviceaccount/token"
       # scope: "openid"
     # Example for basic authentication (uncomment to use):
     # username: "your-username"


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1304
Review deadline: June 12

This pull request updates the Redpanda Console documentation to provide detailed examples and guidance for configuring authentication with various methods, including user impersonation, static credentials, and OIDC. The changes enhance clarity, add new configuration options, and improve usability for administrators setting up secure access to Redpanda services.

### Authentication Configuration Enhancements:

* **OIDC with Static Credentials**:
  - Added guidance for configuring OIDC with static credentials, including runtime token acquisition, pre-acquired tokens, and tokens from files. Each method includes detailed YAML examples and explanations for configuration parameters. [[1]](diffhunk://#diff-dcbd0b62522d079543df3fcf768c3a70f48179666d1073a06ee77482a60e85e3R240-R252) [[2]](diffhunk://#diff-dcbd0b62522d079543df3fcf768c3a70f48179666d1073a06ee77482a60e85e3L281-R350)
  - Introduced notes on securely storing sensitive information, such as client secrets and tokens, using environment variables.

### General Improvements:

* **Example Configuration Updates**:
  - Updated the shared example configuration file to include the `tokenFilepath` option for Kubernetes environments.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
