### PR TITLE
Iceberg on Cloud (single source): GA Databricks/Unity+AWS

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1043-document-feature-iceberg-on-cloud-byoc-ga'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -4,6 +4,10 @@
 
 // tag::single-source[]
 
+ifdef::env-cloud[]
+NOTE: Unity Catalog support is generally available for AWS clusters, and is in beta for Azure and GCP.
+endif::[]
+
 ifndef::env-cloud[]
 [NOTE]
 ====
@@ -28,12 +32,8 @@ endif::[]
 
 == Limitations
 
-* Databricks Managed Iceberg tables do not currently support partition evolution. If you define a xref:manage:iceberg/about-iceberg-topics.adoc#use-custom-partitioning[custom partitioning] scheme for an Iceberg topic, you must not change it later. 
-+
-The cluster property config_ref:iceberg_default_partition_spec,true,properties/cluster-properties[`iceberg_default_partition_spec`] defines the cluster-wide partitioning scheme, by default configured to `(hour(redpanda.timestamp))`. To use a different cluster-wide default, configure this property before creating any Iceberg-enabled topics. You must only override the default partitioning scheme on the topic level for new Iceberg topics that do not yet contain data.  
-* The following data types are not currently supported for managed Iceberg tables:
-+
---
+The following data types are not currently supported for managed Iceberg tables:
+
 |===
 | Iceberg type | Equivalent Avro type
 
@@ -42,8 +42,7 @@ The cluster property config_ref:iceberg_default_partition_spec,true,properties/c
 | time | time-millis, time-micros
 
 |===
---
-+
+
 There are no limitations for Protobuf types.
 
 == Create a Unity Catalog storage credential

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -120,7 +120,7 @@ rpk security secret create --name <secret-name> --value <secret-value> --scopes 
 Replace the placeholders with your own values:
 
 - `<secret-name>`: The name of the secret you want to add. The secret name is also its ID. Use only the following characters: `^[A-Z][A-Z0-9_]*$`.
-- `<secret-value>`: The Base64-encoded secret.
+- `<secret-value>`: The value of the secret.
 --
 
 Cloud API::

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -59,7 +59,12 @@ To connect to a REST catalog, set the following cluster configuration properties
 
 * config_ref:iceberg_catalog_type,true,properties/cluster-properties[`iceberg_catalog_type`]: `rest`
 * config_ref:iceberg_rest_catalog_endpoint,true,properties/cluster-properties[`iceberg_rest_catalog_endpoint`]: The endpoint URL for your Iceberg catalog, which you either manage directly, or is managed by an external catalog service.
-* config_ref:iceberg_rest_catalog_authentication_mode,true,properties/cluster-properties[`iceberg_rest_catalog_authentication_mode`]: The authentication mode to use for the REST catalog. Choose from `oauth2`, `bearer`, or `none` (default).
+* config_ref:iceberg_rest_catalog_authentication_mode,true,properties/cluster-properties[`iceberg_rest_catalog_authentication_mode`]: The authentication mode to use for the REST catalog. Choose from `oauth2`, `bearer`, or `none` (default). 
+ifdef::env-cloud[]
++
+Redpanda recommends using `oauth2`.
+
+endif::[]
 ** For `oauth2`, also configure the following properties:
 +
 --
@@ -111,6 +116,11 @@ Run the following `rpk` command:
 ----
 rpk security secret create --name <secret-name> --value <secret-value> --scopes redpanda_cluster
 ----
+
+Replace the placeholders with your own values:
+
+- `<secret-name>`: The name of the secret you want to add. The secret name is also its ID. Use only the following characters: `^[A-Z][A-Z0-9_]*$`.
+- `<secret-value>`: The Base64-encoded secret.
 --
 
 Cloud API::

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2055,6 +2055,10 @@ endif::[]
 
 The authentication mode for client requests made to the Iceberg catalog. Choose from: `none`, `bearer`, and `oauth2`. In `bearer` mode, the token specified in `iceberg_rest_catalog_token` is used unconditionally, and no attempts are made to refresh the token. In `oauth2` mode, the credentials specified in `iceberg_rest_catalog_client_id` and `iceberg_rest_catalog_client_secret` are used to obtain a bearer token from the URI defined by `iceberg_rest_catalog_oauth2_server_uri.`.
 
+ifdef::env-cloud[]
+Redpanda recommends using `oauth2`.
+endif::[]
+
 *Requires restart:* Yes
 
 *Visibility:* `user`

--- a/modules/reference/partials/rpk-security/rpk-security-secret-create.adoc
+++ b/modules/reference/partials/rpk-security/rpk-security-secret-create.adoc
@@ -52,7 +52,7 @@ rpk security secret create --name NETT2 --value value --scopes "redpanda_connect
 
 |--scopes |stringArray |Scope(s) of the secret, for example, `redpanda_connect` (required).
 
-|--value |string |Value of the secret (required).
+|--value |string |Value of the secret (required). You must use a Base64-encoded value.
 
 |--config |string |Redpanda or rpk config file. Default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 

--- a/modules/reference/partials/rpk-security/rpk-security-secret-create.adoc
+++ b/modules/reference/partials/rpk-security/rpk-security-secret-create.adoc
@@ -52,7 +52,7 @@ rpk security secret create --name NETT2 --value value --scopes "redpanda_connect
 
 |--scopes |stringArray |Scope(s) of the secret, for example, `redpanda_connect` (required).
 
-|--value |string |Value of the secret (required). You must use a Base64-encoded value.
+|--value |string |Value of the secret (required).
 
 |--config |string |Redpanda or rpk config file. Default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 


### PR DESCRIPTION
## Description

This pull request introduces updates to documentation related to Iceberg integration and cluster configurations, as well as changes to the Antora playbook for documentation branches. The most significant changes include adding environment-specific notes, clarifying limitations and supported data types, and enhancing instructions for configuring Iceberg catalogs and secrets.

### Updates to Iceberg Documentation:

* **Environment-specific notes for Unity Catalog support**: Added a note indicating that Unity Catalog support is generally available for AWS clusters and is in beta for Azure and GCP. (`modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc`, [modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adocR7-R10](diffhunk://#diff-a8cc69134db34c0afe324812dbe0c1c9ec51c399f09a25e0c32d137913f81791R7-R10))
* **Clarifications on limitations and supported data types**: Removed outdated information about partition evolution and clarified unsupported data types for managed Iceberg tables. (`modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc`, [[1]](diffhunk://#diff-a8cc69134db34c0afe324812dbe0c1c9ec51c399f09a25e0c32d137913f81791L31-R36) [[2]](diffhunk://#diff-a8cc69134db34c0afe324812dbe0c1c9ec51c399f09a25e0c32d137913f81791L45-R45)

### Enhancements to Iceberg Catalog Configuration:

* **Recommendation for authentication mode**: Added a recommendation to use `oauth2` for REST catalog authentication in cloud environments. (`modules/manage/partials/iceberg/use-iceberg-catalogs.adoc`, [[1]](diffhunk://#diff-8a1d2144ab6d9a2c0149032efbcfcd9bade68a17cd3b60b8a1fd7027881db5f4R63-R67); `modules/reference/pages/properties/cluster-properties.adoc`, [[2]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2058-R2061)
* **Improved instructions for secret creation**: Provided detailed explanations for placeholder values in the `rpk security secret create` command. (`modules/manage/partials/iceberg/use-iceberg-catalogs.adoc`, [modules/manage/partials/iceberg/use-iceberg-catalogs.adocR119-R123](diffhunk://#diff-8a1d2144ab6d9a2c0149032efbcfcd9bade68a17cd3b60b8a1fd7027881db5f4R119-R123))

### Antora Playbook Update:

* **Branch configuration update**: Changed the branch name for the `cloud-docs` repository to `DOC-1043-document-feature-iceberg-on-cloud-byoc-ga`. (`local-antora-playbook.yml`, [local-antora-playbook.ymlL20-R20](diffhunk://#diff-430ed78ec72afb78849cef359188c9b20a3dde4623593958cba0dfb974cb2ac9L20-R20))

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
