### PR TITLE
Partition evolution supported in Unity Catalog

### DIFF
--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -27,13 +27,9 @@ endif::[]
 * Workspace admin privileges to complete the steps to create a Unity Catalog storage credential and external location that connects your cluster's Tiered Storage bucket to Databricks.
 
 == Limitations
+ 
+The following data types are not currently supported for managed Iceberg tables:
 
-* Databricks Managed Iceberg tables do not currently support partition evolution. If you define a xref:manage:iceberg/about-iceberg-topics.adoc#use-custom-partitioning[custom partitioning] scheme for an Iceberg topic, you must not change it later. 
-+
-The cluster property config_ref:iceberg_default_partition_spec,true,properties/cluster-properties[`iceberg_default_partition_spec`] defines the cluster-wide partitioning scheme, by default configured to `(hour(redpanda.timestamp))`. To use a different cluster-wide default, configure this property before creating any Iceberg-enabled topics. You must only override the default partitioning scheme on the topic level for new Iceberg topics that do not yet contain data.  
-* The following data types are not currently supported for managed Iceberg tables:
-+
---
 |===
 | Iceberg type | Equivalent Avro type
 
@@ -42,8 +38,7 @@ The cluster property config_ref:iceberg_default_partition_spec,true,properties/c
 | time | time-millis, time-micros
 
 |===
---
-+
+
 There are no limitations for Protobuf types.
 
 == Create a Unity Catalog storage credential

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -60,6 +60,11 @@ To connect to a REST catalog, set the following cluster configuration properties
 * config_ref:iceberg_catalog_type,true,properties/cluster-properties[`iceberg_catalog_type`]: `rest`
 * config_ref:iceberg_rest_catalog_endpoint,true,properties/cluster-properties[`iceberg_rest_catalog_endpoint`]: The endpoint URL for your Iceberg catalog, which you either manage directly, or is managed by an external catalog service.
 * config_ref:iceberg_rest_catalog_authentication_mode,true,properties/cluster-properties[`iceberg_rest_catalog_authentication_mode`]: The authentication mode to use for the REST catalog. Choose from `oauth2`, `bearer`, or `none` (default).
+ifdef::env-cloud[]
++
+Redpanda recommends using `oauth2`.
+
+endif::[]
 ** For `oauth2`, also configure the following properties:
 +
 --
@@ -111,6 +116,11 @@ Run the following `rpk` command:
 ----
 rpk security secret create --name <secret-name> --value <secret-value> --scopes redpanda_cluster
 ----
+
+Replace the placeholders with your own values:
+
+- `<secret-name>`: The name of the secret you want to add. The secret name is also its ID. Use only the following characters: `^[A-Z][A-Z0-9_]*$`.
+- `<secret-value>`: The value of the secret.
 --
 
 Cloud API::

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2068,6 +2068,10 @@ endif::[]
 
 The authentication mode for client requests made to the Iceberg catalog. Choose from: `none`, `bearer`, and `oauth2`. In `bearer` mode, the token specified in `iceberg_rest_catalog_token` is used unconditionally, and no attempts are made to refresh the token. In `oauth2` mode, the credentials specified in `iceberg_rest_catalog_client_id` and `iceberg_rest_catalog_client_secret` are used to obtain a bearer token from the URI defined by `iceberg_rest_catalog_oauth2_server_uri.`.
 
+ifdef::env-cloud[]
+Redpanda recommends using `oauth2`.
+endif::[]
+
 *Requires restart:* Yes
 
 *Visibility:* `user`

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2066,7 +2066,7 @@ endif::[]
 // tag::iceberg_rest_catalog_authentication_mode[]
 === iceberg_rest_catalog_authentication_mode
 
-The authentication mode for client requests made to the Iceberg catalog. Choose from: `none`, `bearer`, and `oauth2`. In `bearer` mode, the token specified in `iceberg_rest_catalog_token` is used unconditionally, and no attempts are made to refresh the token. In `oauth2` mode, the credentials specified in `iceberg_rest_catalog_client_id` and `iceberg_rest_catalog_client_secret` are used to obtain a bearer token from the URI defined by `iceberg_rest_catalog_oauth2_server_uri.`.
+The authentication mode for client requests made to the Iceberg catalog. Choose from: `none`, `bearer`, and `oauth2`. In `oauth2` mode, the credentials specified in `iceberg_rest_catalog_client_id` and `iceberg_rest_catalog_client_secret` are used to obtain a bearer token from the URI defined by `iceberg_rest_catalog_oauth2_server_uri.`. In `bearer` mode, the token specified in `iceberg_rest_catalog_token` is used unconditionally, and no attempts are made to refresh the token. 
 
 ifdef::env-cloud[]
 Redpanda recommends using `oauth2`.

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -544,6 +544,7 @@ Enable the Iceberg integration for the topic. You can choose one of four modes.
 
 **Related topics**:
 
+- xref:manage:iceberg/choose-iceberg-mode.adoc[]
 - xref:manage:iceberg/about-iceberg-topics.adoc[]
 
 ---
@@ -553,18 +554,6 @@ Enable the Iceberg integration for the topic. You can choose one of four modes.
 Whether the corresponding Iceberg table is deleted upon deleting the topic.
 
 **Default**: `true`
-
-**Related topics**:
-
-- xref:manage:iceberg/about-iceberg-topics.adoc[]
-
----
-
-==== redpanda.iceberg.partition.spec
-
-The https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] specification for the Iceberg table.
-
-**Default**: `(hour(redpanda.timestamp))`
 
 **Related topics**:
 
@@ -582,6 +571,30 @@ Whether to write invalid records to a dead-letter queue (DLQ).
 
 - `drop`: Disable the DLQ and drop invalid records.
 - `dlq_table`: Write invalid records to a separate DLQ Iceberg table.
+
+**Related topics**:
+
+- xref:manage:iceberg/about-iceberg-topics.adoc#manage-dead-letter-queue[Manage dead-letter queue]
+
+---
+
+==== redpanda.iceberg.partition.spec
+
+The https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] specification for the Iceberg table.
+
+**Default**: `(hour(redpanda.timestamp))`
+
+**Related topics**:
+
+- xref:manage:iceberg/about-iceberg-topics.adoc#use-custom-partitioning[Use custom partitioning]
+
+---
+
+==== redpanda.iceberg.target.lag.ms
+
+Controls how often the data in the Iceberg table is refreshed with new data from the topic. Redpanda attempts to commit all data produced to the topic within the lag target, subject to resource availability.
+
+**Default**: `60000`
 
 **Related topics**:
 


### PR DESCRIPTION
## Description

This pull request introduces documentation updates for Redpanda's Iceberg integration, focusing on partitioning, authentication modes, dead-letter queues, and topic properties. The updates aim to improve clarity and provide additional guidance for users configuring Iceberg-related features.

### Iceberg Partitioning and Configuration Updates:
* Partition evolution is supported in Unity Catalog for external Iceberg engines such as Redpanda: https://docs.databricks.com/gcp/en/iceberg/#iceberg-table-limitations

### Authentication Recommendations:
* Added a recommendation to use `oauth2` as the preferred authentication mode for REST catalogs in cloud environments. (`modules/manage/partials/iceberg/use-iceberg-catalogs.adoc`, [[1]](diffhunk://#diff-8a1d2144ab6d9a2c0149032efbcfcd9bade68a17cd3b60b8a1fd7027881db5f4R63-R67); `modules/reference/pages/properties/cluster-properties.adoc`, [[2]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2071-R2074)

### Dead-Letter Queue (DLQ) Configuration:
* Documented the `redpanda.iceberg.invalid.record.action` topic property, explaining options for handling invalid records with a dead-letter queue (`dlq_table`) or dropping them (`drop`). (`modules/reference/pages/properties/topic-properties.adoc`, [modules/reference/pages/properties/topic-properties.adocR564-R580](diffhunk://#diff-54adcda7d96062c2fb7992aa97d14d18a505c71c20412a89e8a777609a2179daR564-R580))

### Topic Refresh Lag Configuration:
* Added documentation for the `redpanda.iceberg.target.lag.ms` property, which controls the frequency of data refreshes in Iceberg tables, with a default value of 60,000 milliseconds. (`modules/reference/pages/properties/topic-properties.adoc`, [modules/reference/pages/properties/topic-properties.adocL571-R597](diffhunk://#diff-54adcda7d96062c2fb7992aa97d14d18a505c71c20412a89e8a777609a2179daL571-R597))

### Cross-Reference Improvements:
* Enhanced cross-references in topic properties documentation to guide users to relevant sections, such as managing dead-letter queues and custom partitioning. (`modules/reference/pages/properties/topic-properties.adoc`, [[1]](diffhunk://#diff-54adcda7d96062c2fb7992aa97d14d18a505c71c20412a89e8a777609a2179daR547); [[2]](diffhunk://#diff-54adcda7d96062c2fb7992aa97d14d18a505c71c20412a89e8a777609a2179daL571-R597)

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

Query Iceberg Topics with Databricks Unity Catalog > [Limitations](https://deploy-preview-1163--redpanda-docs-preview.netlify.app/current/manage/iceberg/iceberg-topics-databricks-unity/#limitations)
Topic Configuration Properties > [redpanda.iceberg.target.lag.ms](https://deploy-preview-1163--redpanda-docs-preview.netlify.app/current/reference/properties/topic-properties/#redpanda-iceberg-target-lag-ms)
Cloud > Use Iceberg Catalogs > Connect to REST Catalog > [Set cluster properties](https://deploy-preview-1163--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/use-iceberg-catalogs/#set-cluster-properties)
Cloud > Cluster Properties > [iceberg_rest_catalog_authentication_mode](https://deploy-preview-1163--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/properties/cluster-properties/#iceberg_rest_catalog_authentication_mode)


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
