### PR TITLE
DOC-1449 revert playbook

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1404-Document-new-configurable-property'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']


### PR DESCRIPTION
## Description
This pull request updates the `local-antora-playbook.yml` file to ensure the correct branch is tracked for the `redpanda-data/cloud-docs` repository.

Branch updates:

* [`local-antora-playbook.yml`](diffhunk://#diff-430ed78ec72afb78849cef359188c9b20a3dde4623593958cba0dfb974cb2ac9L20-R20): Changed the tracked branch for `redpanda-data/cloud-docs` from `'DOC-1404-Document-new-configurable-property'` to `'main'`.

Resolves https://redpandadata.atlassian.net/browse/DOC-1449
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)
