### PR TITLE
Iceberg data retention

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -175,7 +175,7 @@
 *** xref:manage:iceberg/use-iceberg-catalogs.adoc[Use Iceberg Catalogs]
 *** xref:manage:iceberg/query-iceberg-topics.adoc[Query Iceberg Topics]
 *** xref:manage:iceberg/iceberg-topics-databricks-unity.adoc[Query Iceberg Topics with Databricks Unity Catalog]
-*** xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[Query Iceberg Topics with Snowflake]
+*** xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[Query Iceberg Topics with Snowflake and Open Catalog]
 ** xref:manage:schema-reg/index.adoc[Schema Registry]
 *** xref:manage:schema-reg/schema-reg-overview.adoc[Overview]
 *** xref:manage:schema-reg/manage-schema-reg.adoc[]

--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -1,4 +1,5 @@
-:schema-id-val-doc: manage:schema-reg/schema-id-validation.adoc
+ifdef::env-cloud[:manage-topic-doc: get-started:create-topic.adoc]
+ifndef::env-cloud[:manage-topic-doc: manage:cluster-maintenance/disk-utilization.adoc]
 
 The Apache Iceberg integration for Redpanda allows you to store topic data in the cloud in the Iceberg open table format. This makes your streaming data immediately available in downstream analytical systems, including data warehouses like Snowflake, Databricks, ClickHouse, and Redshift, without setting up and maintaining additional ETL pipelines. You can also integrate your data directly into commonly-used big data processing frameworks, such as Apache Spark and Flink, standardizing and simplifying the consumption of streams as tables in a wide variety of data analytics pipelines.
 
@@ -222,9 +223,9 @@ As you produce records to the topic, the data also becomes available in object s
 
 See also: xref:manage:iceberg/choose-iceberg-mode.adoc#schema-types-translation[Schema types translation].
 
-=== Iceberg topic retention
+=== Iceberg data retention
 
-Data in Iceberg-enabled topics remains queryable as Iceberg tables indefinitely. The generated Iceberg table does not follow the configured retention policies for the Redpanda topic itself. The Iceberg table persists unless you:
+Data in an Iceberg-enabled topic is consumable from Kafka based on the configured xref:{manage-topic-doc}[topic retention policy]. Conversely, data written to Iceberg remains queryable as Iceberg tables indefinitely. The Iceberg table persists unless you:
 
 - Delete the Redpanda topic associated with the Iceberg table. This is the default behavior set by the config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] cluster property and the `redpanda.iceberg.delete` topic property. If you set this property to `false`, the Iceberg table remains even after you delete the topic.
 - Explicitly delete data from the Iceberg table using a query engine.

--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -226,7 +226,7 @@ See also: xref:manage:iceberg/choose-iceberg-mode.adoc#schema-types-translation[
 
 Data in Iceberg-enabled topics remains queryable as Iceberg tables indefinitely. The generated Iceberg table do not follow the configured retention policies for the Redpanda topic itself. The Iceberg table persists unless you:
 
-- Delete the Redpanda topic associated with the Iceberg table. This is the default behavior set by the config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] cluster property or the `redpanda.iceberg.delete` topic property. If you set this property to `false`, the Iceberg table remains even after you delete the topic.
+- Delete the Redpanda topic associated with the Iceberg table. This is the default behavior set by the config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] cluster property and the `redpanda.iceberg.delete` topic property. If you set this property to `false`, the Iceberg table remains even after you delete the topic.
 - Explicitly delete data from the Iceberg table using a query engine.
 - Disable the Iceberg integration for the topic and delete the Parquet files in object storage.
 

--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -222,6 +222,14 @@ As you produce records to the topic, the data also becomes available in object s
 
 See also: xref:manage:iceberg/choose-iceberg-mode.adoc#schema-types-translation[Schema types translation].
 
+=== Iceberg topic retention
+
+Data in Iceberg-enabled topics remains queryable as Iceberg tables indefinitely. The generated Iceberg table do not follow the configured retention policies for the Redpanda topic itself. The Iceberg table persists unless you:
+
+- Delete the Redpanda topic associated with the Iceberg table. This is the default behavior set by the config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] cluster property or the `redpanda.iceberg.delete` topic property. If you set this property to `false`, the Iceberg table remains even after you delete the topic.
+- Explicitly delete data from the Iceberg table using a query engine.
+- Disable the Iceberg integration for the topic and delete the Parquet files in object storage.
+
 == Schema evolution
 
 Redpanda supports schema evolution for Avro and Protobuf schemas in accordance with the https://iceberg.apache.org/spec/#schema-evolution[Iceberg specification^]. Permitted schema evolutions include reordering fields and promoting field types. When you update the schema in Schema Registry, Redpanda automatically updates the Iceberg table schema to match the new schema.

--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -224,7 +224,7 @@ See also: xref:manage:iceberg/choose-iceberg-mode.adoc#schema-types-translation[
 
 === Iceberg topic retention
 
-Data in Iceberg-enabled topics remains queryable as Iceberg tables indefinitely. The generated Iceberg table do not follow the configured retention policies for the Redpanda topic itself. The Iceberg table persists unless you:
+Data in Iceberg-enabled topics remains queryable as Iceberg tables indefinitely. The generated Iceberg table does not follow the configured retention policies for the Redpanda topic itself. The Iceberg table persists unless you:
 
 - Delete the Redpanda topic associated with the Iceberg table. This is the default behavior set by the config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] cluster property and the `redpanda.iceberg.delete` topic property. If you set this property to `false`, the Iceberg table remains even after you delete the topic.
 - Explicitly delete data from the Iceberg table using a query engine.


### PR DESCRIPTION
## Description

This pull request updates documentation for Iceberg-related features, including clarifying catalog usage and adding a new section on Iceberg topic retention. These changes improve the accuracy and comprehensiveness of the documentation.

### Updates to Iceberg documentation:

* **Navigation Update**: Updated the link label in `modules/ROOT/nav.adoc` for consistency with other catalog integration docs.
* **Iceberg Topic Retention**: Added a new section in `modules/manage/partials/iceberg/about-iceberg-topics.adoc` explaining the retention behavior of Iceberg-enabled topics. This includes details on how Iceberg tables persist beyond the configured retention policies of Redpanda topics and the conditions under which they can be deleted.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

About Iceberg Topics > Enable Iceberg integration > [Iceberg data retention](https://deploy-preview-1171--redpanda-docs-preview.netlify.app/current/manage/iceberg/about-iceberg-topics/#iceberg-data-retention)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
