### PR TITLE
Clarify that `serde.protobuf` should not be configured when using Schema Registry

### DIFF
--- a/modules/console/pages/config/deserialization.adoc
+++ b/modules/console/pages/config/deserialization.adoc
@@ -21,18 +21,9 @@ Most Kafka clients that serialize Protobuf messages put the serialized byte arra
 [[sr-protobuf]]
 === Use Schema Registry for Protobuf
 
-If you use a Schema Registry for Protobuf deserialization, Redpanda Console can automatically fetch and use the required schemas without the need for <<topic-mapping, manual topic mappings>>. Because the schema information (including which Protobuf message type to use) is embedded in the messages, you do not need to manually configure mappings for each topic. The Schema Registry provides the necessary schema information to deserialize the messages.
+If you use a Schema Registry for Protobuf deserialization, Redpanda Console can automatically fetch and use the required schemas without the need for manual topic mappings or additional configuration.
 
-To configure Protobuf deserialization using Schema Registry, add the following to your configuration file in addition to the <<sr, `schemaRegistry` configuration>>:
-
-[,yaml]
-----
-serde:
-  protobuf:
-    enabled: true
-----
-
-- `serde.protobuf.enabled`: Set to `true` to enable Protobuf deserialization.
+When using Schema Registry for Protobuf, you should not configure `serde.protobuf`. Redpanda Console detects and uses the Protobuf schemas from the Schema Registry automatically.
 
 When using Schema Registry for Protobuf, you do not need to provide specific topic mappings, as the schemas will be fetched dynamically.
 
@@ -73,6 +64,7 @@ serde:
       # keyProtoType: Not specified because the key is a plain string
 ----
 
+* `serde.protobuf.enabled`: Set to `true` to enable Protobuf deserialization.
 * `serde.protobuf.mappings.topicName`: The name of the Kafka topic.
 * `serde.protobuf.mappings.valueProtoType`: The fully-qualified Protobuf type for the message value.
 * `serde.protobuf.mappings.keyProtoType`: Specify the key Protobuf type if the key is not a plain string.
@@ -101,6 +93,7 @@ serde:
         - /etc/protos
 ----
 
+* `serde.protobuf.enabled`: Set to `true` to enable Protobuf deserialization.
 * `serde.protobuf.fileSystem.paths`: Paths to directories where Protobuf files are stored.
 * `serde.protobuf.fileSystem.refreshInterval`: The frequency at which Redpanda Console checks for updates to these files.
 
@@ -131,6 +124,7 @@ serde:
         password: redacted
 ----
 
+* `serde.protobuf.enabled`: Set to `true` to enable Protobuf deserialization.
 * `serde.protobuf.git.repository.url`: The URL of the GitHub repository containing your Protobuf files.
 * `serde.protobuf.git.basicAuth`: Basic authentication credentials, often an API token for private repositories.
 * `serde.protobuf.git.refreshInterval`: Frequency at which the repository is polled for updates.

--- a/modules/console/pages/config/deserialization.adoc
+++ b/modules/console/pages/config/deserialization.adoc
@@ -23,7 +23,9 @@ Most Kafka clients that serialize Protobuf messages put the serialized byte arra
 
 If you use a Schema Registry for Protobuf deserialization, Redpanda Console can automatically fetch and use the required schemas without the need for manual topic mappings or additional configuration.
 
-When using Schema Registry for Protobuf, you should not configure `serde.protobuf`. Redpanda Console detects and uses the Protobuf schemas from the Schema Registry automatically.
+When using Schema Registry for Protobuf, you must not configure `serde.protobuf`. Redpanda Console detects and uses the Protobuf schemas from the Schema Registry automatically.
+
+If you configure `serde.protobuf`, it enables manual deserialization mode, which requires you to specify topic mappings and source providers. Without those, Redpanda Console fails to start due to validation errors.
 
 When using Schema Registry for Protobuf, you do not need to provide specific topic mappings, as the schemas will be fetched dynamically.
 


### PR DESCRIPTION
Update the "Use Schema Registry for Protobuf" section to reflect that enabling serde.protobuf triggers manual deserialization mode, which requires source providers and topic mappings. When using Schema Registry, this block should be omitted to avoid validation errors and allow dynamic schema fetching.

## Description

Resolves https://github.com/redpanda-data/console/issues/1804
Review deadline: June 20

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
