### PR TITLE
Add beta tooltip text to global attributes

### DIFF
--- a/modules/ROOT/partials/global-attributes.yml
+++ b/modules/ROOT/partials/global-attributes.yml
@@ -21,3 +21,4 @@ badge-perf-storage: 'image:https://img.shields.io/badge/Performance-Storage-yell
 badge-deprecated: 'image:https://img.shields.io/badge/-Deprecated-red.svg[]'
 badge-tech-preview: 'image:https://img.shields.io/badge/Technical%20Preview-Version%2023.2.x-red.svg[Technical Preview]'
 badge-cloud-beta: 'image:https://img.shields.io/badge/Beta-red.svg[Beta]'
+page-beta-text: 'This feature is in beta. Features in beta are available for testing and feedback. They are not supported by Redpanda and should not be used in production environments.'

--- a/modules/ROOT/partials/global-attributes.yml
+++ b/modules/ROOT/partials/global-attributes.yml
@@ -21,4 +21,4 @@ badge-perf-storage: 'image:https://img.shields.io/badge/Performance-Storage-yell
 badge-deprecated: 'image:https://img.shields.io/badge/-Deprecated-red.svg[]'
 badge-tech-preview: 'image:https://img.shields.io/badge/Technical%20Preview-Version%2023.2.x-red.svg[Technical Preview]'
 badge-cloud-beta: 'image:https://img.shields.io/badge/Beta-red.svg[Beta]'
-page-beta-text: 'This feature is in beta. Features in beta are available for testing and feedback. They are not supported by Redpanda and should not be used in production environments.'
+page-beta-text: 'This is a beta feature. Beta features are available for testing and feedback. They are not supported by Redpanda and should not be used in production environments.'


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1440
Review deadline: June 25

This pull request introduces a new global attribute in `modules/ROOT/partials/global-attributes.yml` to clarify the status of beta features.

* [`modules/ROOT/partials/global-attributes.yml`](diffhunk://#diff-61cf951b1dbceb19c616f5f12172ea2a797b77b75a2121878ec5ef9550ff04f2R24): Added the `page-beta-text` attribute to provide a standardized message explaining that beta features are for testing and feedback purposes and are not suitable for production use.

The attribute is used to display tooltip text in our beta badges.

Related changes: https://github.com/redpanda-data/docs-ui/pull/304 and https://github.com/redpanda-data/docs-extensions-and-macros/pull/109

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
