### PR TITLE
Add a link to the masterclass

### DIFF
--- a/modules/upgrade/pages/k-rolling-upgrade.adoc
+++ b/modules/upgrade/pages/k-rolling-upgrade.adoc
@@ -7,18 +7,18 @@
 
 To benefit from Redpanda's new features and enhancements, upgrade to the latest version. New features are available after all brokers in the cluster are upgraded and restarted.
 
-include::partial$versioning.adoc[]
+include::upgrade:partial$versioning.adoc[]
 
-include::partial$rolling-upgrades/upgrade-limitations.adoc[]
+include::upgrade:partial$rolling-upgrades/upgrade-limitations.adoc[]
 
 == Prerequisites
 
 * xref:deploy:deployment-option/self-hosted/kubernetes/index.adoc[A Redpanda cluster running in Kubernetes].
 * The default xref:reference:k-redpanda-helm-spec.adoc#statefulset-updatestrategy-type[RollingUpdate strategy] configured in the Helm values.
 
-include::partial$incompat-changes.adoc[]
+include::upgrade:partial$incompat-changes.adoc[]
 
-include::partial$rolling-upgrades/restart-impact.adoc[leveloffset=+1]
+include::upgrade:partial$rolling-upgrades/restart-impact.adoc[leveloffset=+1]
 
 == Check your current Redpanda version
 

--- a/modules/upgrade/pages/k-upgrade-kubernetes.adoc
+++ b/modules/upgrade/pages/k-upgrade-kubernetes.adoc
@@ -4,7 +4,13 @@
 :page-categories: Management, Upgrades
 :env-kubernetes: true
 
+:tip-caption: Try an interactive tutorial
+
 This topic outlines a safe procedure for migrating your Redpanda cluster to a new node pool. This is especially useful when you need to change node instance types, perform vertical scaling, or upgrade Kubernetes. The process ensures that your cluster remains fault tolerant and data safe throughout the migration.
+
+TIP: To run through the process in a sandbox, try the https://play.instruqt.com/redpanda/invite/mfav52vtowq8[masterclass^].
+
+:tip-caption: Tip
 
 == Prerequisites
 
@@ -25,7 +31,7 @@ When replacing Kubernetes nodes under a running Redpanda cluster, consider the f
 
 == Upgrade the Redpanda Helm chart
 
-Before upgrading Kubernetes, always upgrade your Redpanda Helm chart or Redpanda CRD to the latest version. This ensures that any deprecated Kubernetes resources (e.g. the `v1beta1` PodDisruptionBudget in Kubernetes 1.25) are replaced with updated ones. If you skip this step, you may see errors during or after the Kubernetes upgrade.
+Before upgrading Kubernetes, always upgrade your Redpanda Helm chart or Redpanda CRD to the latest version. This ensures that any deprecated Kubernetes resources, such as the `v1beta1` PodDisruptionBudget in Kubernetes 1.25, are replaced with updated ones. If you skip this step, you may see errors during or after the Kubernetes upgrade.
 
 For more details, see xref:upgrade:k-rolling-upgrade.adoc[].
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1408
Review deadline: July 3

This pull request includes updates to documentation for Redpanda's upgrade process. The most important changes involve adding interactive tutorial links, and refining language for better readability.

### Documentation restructuring:

* Updated file references in `modules/upgrade/pages/k-rolling-upgrade.adoc` to use the `upgrade:` prefix for partial includes, improving modularity and clarity in the documentation structure.

### User engagement enhancements:

* Added a tip caption and an interactive tutorial link to `modules/upgrade/pages/k-upgrade-kubernetes.adoc`, encouraging users to try a sandboxed masterclass for hands-on learning.

### Language improvements:

* Refined language in `modules/upgrade/pages/k-upgrade-kubernetes.adoc` to enhance readability, such as clarifying the description of deprecated Kubernetes resources (e.g., `v1beta1` PodDisruptionBudget).


## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
