### PR TITLE
Fix duplicate headers in cluster properties reference

### DIFF
--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3266,7 +3266,9 @@ Leadership rebalancing idle timeout.
 
 === leader_balancer_mute_timeout
 
-Leadership rebalancing mute timeout.
+The length of time that a Raft group is muted after a leadership transfer. Any group that has been moved, regardless of whether the move succeeded or failed, undergoes a cooling-off period. This prevents Raft groups from repeatedly experiencing leadership transfers in a short time frame, which can lead to instability in the cluster.
+
+The leader balancer maintains a list of muted gruops and reevaluates muted status at the start of each balancing iteration. Muted groups still contribute to overall cluster balance calculations although they can't themselves be moved until the mute period is over. 
 
 *Unit:* milliseconds
 
@@ -3280,11 +3282,15 @@ Leadership rebalancing mute timeout.
 
 *Default:* `300000` (5min)
 
+*Related topics*:
+
+* xref:manage:cluster-maintenance/cluster-balancing.adoc[]
+
 ---
 
-=== leader_balancer_mute_timeout
+=== leader_balancer_node_mute_timeout
 
-Leadership rebalancing node mute timeout.
+The duration after which a broker that hasn't sent a heartbeat is considered muted. This timeout sets a threshold for identifying brokers that shouldn't be targeted for leadership transfers when the cluster rebalances, for example, because of unreliable network connectivity.
 
 *Unit:* milliseconds
 
@@ -3296,7 +3302,11 @@ Leadership rebalancing node mute timeout.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `20000`
+*Default:* `20000` (20s)
+
+*Related topics*:
+
+* xref:manage:cluster-maintenance/cluster-balancing.adoc[]
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3266,7 +3266,7 @@ Leadership rebalancing idle timeout.
 
 === leader_balancer_mute_timeout
 
-The length of time that a Raft group is muted after a leadership transfer. Any group that has been moved, regardless of whether the move succeeded or failed, undergoes a cooling-off period. This prevents Raft groups from repeatedly experiencing leadership transfers in a short time frame, which can lead to instability in the cluster.
+The length of time that a glossterm:Raft[] group is muted after a leadership transfer. Any group that has been moved, regardless of whether the move succeeded or failed, undergoes a cooling-off period. This prevents Raft groups from repeatedly experiencing leadership transfers in a short time frame, which can lead to instability in the cluster.
 
 The leader balancer maintains a list of muted gruops and reevaluates muted status at the start of each balancing iteration. Muted groups still contribute to overall cluster balance calculations although they can't themselves be moved until the mute period is over. 
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3266,7 +3266,7 @@ Leadership rebalancing idle timeout.
 
 === leader_balancer_mute_timeout
 
-The length of time that a glossterm:Raft[] group is muted after a leadership transfer. Any group that has been moved, regardless of whether the move succeeded or failed, undergoes a cooling-off period. This prevents Raft groups from repeatedly experiencing leadership transfers in a short time frame, which can lead to instability in the cluster.
+The length of time that a glossterm:Raft[] group is muted after a leadership rebalance operation. Any group that has been moved, regardless of whether the move succeeded or failed, undergoes a cooling-off period. This prevents Raft groups from repeatedly experiencing leadership rebalance operations in a short time frame, which can lead to instability in the cluster.
 
 The leader balancer maintains a list of muted groups and reevaluates muted status at the start of each balancing iteration. Muted groups still contribute to overall cluster balance calculations although they can't themselves be moved until the mute period is over. 
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -42,7 +42,7 @@ Interval, in milliseconds, at which Redpanda looks for inactive transactions and
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `10000` (10s)
+*Default:* `10000` (10 s)
 
 ---
 
@@ -106,7 +106,7 @@ The duration, in milliseconds, that Redpanda waits for the replication of entrie
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `5000` (5s)
+*Default:* `5000` (5 s)
 
 ---
 
@@ -449,7 +449,7 @@ This is an internal-only configuration and should be enabled only after consulti
 
 *Type:* number
 
-*Default:* `30000` (30s)
+*Default:* `30000` (30 s)
 
 ---
 
@@ -487,7 +487,7 @@ Interval between iterations of controller backend housekeeping loop.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `1000` (1s)
+*Default:* `1000` (1 s)
 
 ---
 
@@ -611,7 +611,7 @@ Interval, in milliseconds, between trigger and invocation of core balancing.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `10000` (10s)
+*Default:* `10000` (10 s)
 
 ---
 
@@ -1711,7 +1711,7 @@ Frequency rate at which the system should check for expired group offsets.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `600000` (10min)
+*Default:* `600000` (10 min)
 
 ---
 
@@ -1767,7 +1767,7 @@ How often the health manager runs.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `180000` (3min)
+*Default:* `180000` (3 min)
 
 ---
 
@@ -3260,7 +3260,7 @@ Leadership rebalancing idle timeout.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `120000` (2min)
+*Default:* `120000` (2 min)
 
 ---
 
@@ -3280,7 +3280,7 @@ The leader balancer maintains a list of muted groups and reevaluates muted statu
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `300000` (5min)
+*Default:* `300000` (5 min)
 
 *Related topics*:
 
@@ -3302,7 +3302,7 @@ The duration after which a broker that hasn't sent a heartbeat is considered mut
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `20000` (20s)
+*Default:* `20000` (20 s)
 
 *Related topics*:
 
@@ -3481,7 +3481,7 @@ Threshold in milliseconds for alerting on messages with a timestamp after the br
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `7200000` (2h)
+*Default:* `7200000` (2 h)
 
 ---
 
@@ -3604,7 +3604,7 @@ Lower bound on topic `segment.ms`: lower values will be clamped to this value.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `600000` (10min)
+*Default:* `600000` (10 min)
 
 ---
 
@@ -3799,7 +3799,7 @@ Time between members backend reconciliation loop retries.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `5000` (5s)
+*Default:* `5000` (5 s)
 
 ---
 
@@ -3918,7 +3918,7 @@ Cluster metrics reporter tick interval.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `60000` (1min)
+*Default:* `60000` (1 min)
 
 ---
 
@@ -4009,7 +4009,7 @@ Timeout for executing node management operations.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `5000` (5s)
+*Default:* `5000` (5 s)
 
 ---
 
@@ -4253,7 +4253,7 @@ When a node is unavailable for at least this timeout duration, it triggers Redpa
 
 *Accepted values:* [`-17179869184`, `17179869183`]
 
-*Default:* `900` (15min)
+*Default:* `900` (15 min)
 
 *Related topics*:
 
@@ -4275,7 +4275,7 @@ Partition autobalancer tick interval.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `30000` (30s)
+*Default:* `30000` (30 s)
 
 ---
 
@@ -4361,7 +4361,7 @@ Quota manager GC frequency in milliseconds.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `30000` (30s)
+*Default:* `30000` (30 s)
 
 ---
 
@@ -5012,7 +5012,7 @@ The period during which disk usage is checked for disk pressure, and data is opt
 
 *Accepted values:* [`0`, `17592186044415`]
 
-*Default:* `30000` (30s)
+*Default:* `30000` (30 s)
 
 ---
 
@@ -5345,7 +5345,7 @@ Maximum delay until buffered data is written.
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `1000` (1s)
+*Default:* `1000` (1 s)
 
 ---
 
@@ -5880,7 +5880,7 @@ Delete segments older than this age. To ensure transaction state is retained as 
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `604800000` (10080min)
+*Default:* `604800000` (10080 min)
 
 ---
 
@@ -5897,7 +5897,7 @@ The size (in bytes) each log segment should be.
 
 *Accepted values:* [`0`, `18446744073709551615`]
 
-*Default:* `1073741824` (1Gb)
+*Default:* `1073741824` (1 GB)
 
 ---
 
@@ -5954,7 +5954,7 @@ Expiration time of producer IDs. Measured starting from the time of the last wri
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
-*Default:* `604800000` (10080min)
+*Default:* `604800000` (10080 min)
 
 ---
 
@@ -6005,7 +6005,7 @@ The interval in which all usage stats are written to disk.
 
 *Accepted values:* [`-17179869184`, `17179869183`]
 
-*Default:* `300` (5min)
+*Default:* `300` (5 min)
 
 ---
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3268,7 +3268,7 @@ Leadership rebalancing idle timeout.
 
 The length of time that a glossterm:Raft[] group is muted after a leadership transfer. Any group that has been moved, regardless of whether the move succeeded or failed, undergoes a cooling-off period. This prevents Raft groups from repeatedly experiencing leadership transfers in a short time frame, which can lead to instability in the cluster.
 
-The leader balancer maintains a list of muted gruops and reevaluates muted status at the start of each balancing iteration. Muted groups still contribute to overall cluster balance calculations although they can't themselves be moved until the mute period is over. 
+The leader balancer maintains a list of muted groups and reevaluates muted status at the start of each balancing iteration. Muted groups still contribute to overall cluster balance calculations although they can't themselves be moved until the mute period is over. 
 
 *Unit:* milliseconds
 


### PR DESCRIPTION
## Description

This pull request updates the documentation for cluster properties related to leadership rebalancing. It clarifies the behavior of mute timeouts and adds related references to improve usability.

### Updates to leadership rebalancing mute timeout documentation:

* [`modules/reference/pages/properties/cluster-properties.adoc`](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9L3269-R3271): Enhanced the description of `leader_balancer_mute_timeout` to explain the cooling-off period for Raft groups after leadership transfers, including its role in maintaining cluster stability.
* [`modules/reference/pages/properties/cluster-properties.adoc`](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R3285-R3293): Added related topics linking to `cluster-balancing.adoc` for better context.

### Updates to leadership rebalancing node mute timeout documentation:

* [`modules/reference/pages/properties/cluster-properties.adoc`](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R3285-R3293): Improved the explanation of `leader_balancer_node_mute_timeout` to specify its purpose in identifying brokers with unreliable connectivity during rebalancing.
* [`modules/reference/pages/properties/cluster-properties.adoc`](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9L3299-R3309): Updated the default value description to include units and added related topics linking to `cluster-balancing.adoc`.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

https://deploy-preview-1194--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/#leader_balancer_mute_timeout

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
