### PR TITLE
Rename extraClusterConfig to extraClusterConfiguration

### DIFF
--- a/modules/get-started/pages/release-notes/helm-charts.adoc
+++ b/modules/get-started/pages/release-notes/helm-charts.adoc
@@ -46,7 +46,7 @@ TIP: For a supported and scalable Kafka Connect alternative, consider using Redp
 
 === Reference Kubernetes Secrets and ConfigMaps for Redpanda cluster configuration
 
-You can now set any Redpanda cluster configuration property using the new `extraClusterConfig` field. This allows you to reference values from Kubernetes Secrets or ConfigMaps. For example, use this field to inject sensitive credentials or reuse shared configurations across features like Tiered Storage, Iceberg, and disaster recovery.
+You can now set any Redpanda cluster configuration property using the new `extraClusterConfiguration` field. This allows you to reference values from Kubernetes Secrets or ConfigMaps. For example, use this field to inject sensitive credentials or reuse shared configurations across features like Tiered Storage, Iceberg, and disaster recovery.
 
 This enhancement improves:
 

--- a/modules/get-started/pages/release-notes/operator.adoc
+++ b/modules/get-started/pages/release-notes/operator.adoc
@@ -74,7 +74,7 @@ TIP: For a supported and scalable Kafka Connect alternative, consider using Redp
 
 === Reference Kubernetes Secrets and ConfigMaps for Redpanda cluster configuration
 
-You can now set any Redpanda cluster configuration property using the new `extraClusterConfig` field. This allows you to reference values from Kubernetes Secrets or ConfigMaps. For example, use this field to inject sensitive credentials or reuse shared configurations across features like Tiered Storage, Iceberg, and disaster recovery.
+You can now set any Redpanda cluster configuration property using the new `extraClusterConfiguration` field. This allows you to reference values from Kubernetes Secrets or ConfigMaps. For example, use this field to inject sensitive credentials or reuse shared configurations across features like Tiered Storage, Iceberg, and disaster recovery.
 
 This enhancement improves:
 

--- a/modules/manage/pages/kubernetes/k-configure-helm-chart.adoc
+++ b/modules/manage/pages/kubernetes/k-configure-helm-chart.adoc
@@ -213,7 +213,7 @@ helm upgrade --install redpanda redpanda/redpanda \
 [[extra-cluster-config]]
 == Set Redpanda cluster properties from Kubernetes Secrets or ConfigMaps
 
-Starting in v25.1.1 of the Redpanda Operator and Redpanda Helm chart, you can set **any Redpanda cluster configuration property** by referencing Kubernetes Secrets or ConfigMaps using the `config.extraClusterConfig` field.
+Starting in v25.1.1 of the Redpanda Operator and Redpanda Helm chart, you can set **any Redpanda cluster configuration property** by referencing Kubernetes Secrets or ConfigMaps using the `config.extraClusterConfiguration` field.
 
 This feature provides a more secure, maintainable, and declarative way to manage sensitive or shared configuration values across your Redpanda deployment.
 
@@ -240,7 +240,7 @@ metadata:
 spec:
   clusterSpec:
     config:
-      extraClusterConfig:
+      extraClusterConfiguration:
         iceberg_rest_catalog_client_secret:
           secretRef:
             name: iceberg-config
@@ -263,7 +263,7 @@ Helm::
 [,yaml]
 ----
   config:
-    extraClusterConfig:
+    extraClusterConfiguration:
       iceberg_rest_catalog_client_secret:
         secretRef:
           name: iceberg-config
@@ -283,8 +283,8 @@ helm upgrade --install redpanda redpanda/redpanda \
 helm upgrade --install redpanda redpanda/redpanda \
   --namespace <namespace> \
   --create-namespace \
-  --set config.extraClusterConfig.iceberg_rest_catalog_client_secret.secretRef.name=iceberg-config \
-  --set config.extraClusterConfig.iceberg_rest_catalog_client_secret.secretRef.key=iceberg_rest_catalog_client_secret
+  --set config.extraClusterConfiguration.iceberg_rest_catalog_client_secret.secretRef.name=iceberg-config \
+  --set config.extraClusterConfiguration.iceberg_rest_catalog_client_secret.secretRef.key=iceberg_rest_catalog_client_secret
 ----
 
 ====

--- a/modules/manage/partials/kubernetes/extraclusterconfig.adoc
+++ b/modules/manage/partials/kubernetes/extraclusterconfig.adoc
@@ -1,6 +1,6 @@
 [TIP]
 ====
-Starting in Redpanda Operator v25.1.1, you can configure object storage settings using `extraClusterConfig`. This lets you securely reference sensitive values from Kubernetes Secrets or ConfigMaps, and reuse values like your bucket name across multiple features, such as Tiered Storage, Iceberg, and topic recovery.
+Starting in Redpanda Operator v25.1.1, you can configure object storage settings using `config.extraClusterConfiguration`. This lets you securely reference sensitive values from Kubernetes Secrets or ConfigMaps, and reuse values like your bucket name across multiple features, such as Tiered Storage, Iceberg, and topic recovery.
 
 See xref:manage:kubernetes/k-configure-helm-chart.adoc#extra-cluster-config[Set Redpanda cluster properties from Kubernetes Secrets or ConfigMaps].
 ====


### PR DESCRIPTION
## Description

Based on https://github.com/redpanda-data/redpanda-operator/blob/371f59cfe2cb4605c274c28dff56a29446a67f62/charts/redpanda/values.yaml#L927 I believe the config should be `extraClusterConfiguration` rather than the documented `extraClusterConfig`.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
