### PR TITLE
Fix CodeRabbit badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 image:https://img.shields.io/badge/slack-purple[Slack, link="https://redpanda.com/slack"]
 image:https://img.shields.io/twitter/follow/redpandadata.svg?style=social&label=Follow[Twitter, link="https://twitter.com/intent/follow?screen_name=redpandadata"]
 image:https://api.netlify.com/api/v1/badges/5b89dd6f-1847-419c-b3be-a1650ce8992f/deploy-status[Netlify Status, link="https://app.netlify.com/sites/redpanda-documentation/deploys"]
-image:https://img.shields.io/coderabbit/prs/github/redpanda-data/docs?utm_source=oss&utm_medium=github&utm_campaign=redpanda-data%2Fdocs&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews[]
+image:https://img.shields.io/coderabbit/prs/github/redpanda-data/docs?utm_source=oss&utm_medium=github&utm_campaign=redpanda-data%2Fdocs&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews[CodeRabbit Reviews]
 
 
 ++++

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 image:https://img.shields.io/badge/slack-purple[Slack, link="https://redpanda.com/slack"]
 image:https://img.shields.io/twitter/follow/redpandadata.svg?style=social&label=Follow[Twitter, link="https://twitter.com/intent/follow?screen_name=redpandadata"]
 image:https://api.netlify.com/api/v1/badges/5b89dd6f-1847-419c-b3be-a1650ce8992f/deploy-status[Netlify Status, link="https://app.netlify.com/sites/redpanda-documentation/deploys"]
-image:https://img.shields.io/coderabbit/prs/github/redpanda-data/docs?utm_source=oss&utm_medium=github&utm_campaign=redpanda-data%2Fdocs&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews
+image:https://img.shields.io/coderabbit/prs/github/redpanda-data/docs?utm_source=oss&utm_medium=github&utm_campaign=redpanda-data%2Fdocs&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews[]
 
 
 ++++

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,8 @@
 image:https://img.shields.io/badge/slack-purple[Slack, link="https://redpanda.com/slack"]
 image:https://img.shields.io/twitter/follow/redpandadata.svg?style=social&label=Follow[Twitter, link="https://twitter.com/intent/follow?screen_name=redpandadata"]
 image:https://api.netlify.com/api/v1/badges/5b89dd6f-1847-419c-b3be-a1650ce8992f/deploy-status[Netlify Status, link="https://app.netlify.com/sites/redpanda-documentation/deploys"]
+image:https://img.shields.io/coderabbit/prs/github/redpanda-data/docs?utm_source=oss&utm_medium=github&utm_campaign=redpanda-data%2Fdocs&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews
+
 
 ++++
 <p>
@@ -13,8 +15,6 @@ image:https://api.netlify.com/api/v1/badges/5b89dd6f-1847-419c-b3be-a1650ce8992f
 </object>
 </p></a>
 ++++
-
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/redpanda-data/docs?utm_source=oss&utm_medium=github&utm_campaign=redpanda-data%2Fdocs&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 This repository hosts the documentation content for Redpanda Self-Managed.
 


### PR DESCRIPTION
## Description

Fixes the CodeRabbit badge syntax, so it correctly displays. 

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
