### PR TITLE
[25.2] API: Support for returning serialized protobuf schema

### DIFF
--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -481,6 +481,54 @@
             "schema": {
               "$ref": "#/definitions/error_body"
             }
+          },
+          "501": {
+            "description": "Not implemented - The specified format parameter value is not supported",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a schema by ID.",
+        "operationId": "delete_schemas_ids_id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Schema not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
           }
         }
       }
@@ -700,6 +748,12 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "501": {
+            "description": "Not implemented - The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -927,6 +981,12 @@
             "schema": {
               "$ref": "#/definitions/error_body"
             }
+          },
+          "501": {
+            "description": "Not implemented - The specified format parameter value is not supported",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
           }
         }
       },
@@ -1043,6 +1103,12 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "501": {
+            "description": "Not implemented - The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -1048,8 +1048,9 @@
     },
     "/subjects/{subject}/versions/{version}/schema": {
       "get": {
-        "summary": "Retrieve a schema for the subject and version.",
+        "summary": "Retrieve the unescaped schema for the subject.",
         "operationId": "get_subject_versions_version_schema",
+        "description": "Returns the specified version of the schema in its original format, without escaping.",
         "parameters": [
           {
             "name": "subject",

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -447,7 +447,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. An empty string returns the schema in the current (default) format. If set to `serialized`, returns the schema in its wire binary format in Base64.\n\nFor Avro, `resolved` is a valid value, but is not supported and returns a 501 Not Implemented error. For Protobuf, `serialized` and `ignore_extensions` are valid, but only `serialized` is supported and passing `ignore_extensions` returns a 501 Not Implemented error. Cross-schema conditions such as `resolved` with Protobuf or `serialized` with Avro are ignored and the schema is returned in the default format."
+            "description": "For Avro and Protobuf schemas only (Redpanda 25.2 or later). Supported values: an empty string `''` returns the schema in the current format (default), and `serialized` (Protobuf only) returns the schema in its wire binary format in Base64. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -706,7 +706,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. An empty string returns the schema in the current (default) format. If set to `serialized`, returns the schema in its wire binary format in Base64.\n\nFor Avro, `resolved` is a valid value, but is not supported and returns a 501 Not Implemented error. For Protobuf, `serialized` and `ignore_extensions` are valid, but only `serialized` is supported and passing `ignore_extensions` returns a 501 Not Implemented error. Cross-schema conditions such as `resolved` with Protobuf or `serialized` with Avro are ignored and the schema is returned in the default format."
+            "description": "For Avro and Protobuf schemas only (Redpanda 25.2 or later). Supported values: an empty string `''` returns the schema in the current format (default), and `serialized` (Protobuf only) returns the schema in its wire binary format in Base64. Unsupported values return a 501 error."
           },
           {
             "name": "schema_def",
@@ -949,7 +949,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. An empty string returns the schema in the current (default) format. If set to `serialized`, returns the schema in its wire binary format in Base64.\n\nFor Avro, `resolved` is a valid value, but is not supported and returns a 501 Not Implemented error. For Protobuf, `serialized` and `ignore_extensions` are valid, but only `serialized` is supported and passing `ignore_extensions` returns a 501 Not Implemented error. Cross-schema conditions such as `resolved` with Protobuf or `serialized` with Avro are ignored and the schema is returned in the default format."
+            "description": "For Avro and Protobuf schemas only (Redpanda 25.2 or later). Supported values: an empty string `''` returns the schema in the current format (default), and `serialized` (Protobuf only) returns the schema in its wire binary format in Base64. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -1074,7 +1074,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. An empty string returns the schema in the current (default) format. If set to `serialized`, returns the schema in its wire binary format in Base64.\n\nFor Avro, `resolved` is a valid value, but is not supported and returns a 501 Not Implemented error. For Protobuf, `serialized` and `ignore_extensions` are valid, but only `serialized` is supported and passing `ignore_extensions` returns a 501 Not Implemented error. Cross-schema conditions such as `resolved` with Protobuf or `serialized` with Avro are ignored and the schema is returned in the default format."
+            "description": "For Avro and Protobuf schemas only (Redpanda 25.2 or later). Supported values: an empty string `''` returns the schema in the current format (default), and `serialized` (Protobuf only) returns the schema in its wire binary format in Base64. Unsupported values return a 501 error."
           }
         ],
         "produces": [

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -447,7 +447,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "If set to an empty string, returns the schema in the default (current) format. For Protobuf only: if set to 'serialized', returns the schema in its wire binary format in Base64."
+            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. For Avro, valid values are: `''` (empty string) or `resolved`. For Protobuf, valid values are: `''`, `ignore_extensions`, or `serialized`.\n\nIf set to an empty string, returns the schema in the default (current) format. If set to `serialized`, returns the schema in its wire binary format in Base64."
           }
         ],
         "produces": [
@@ -658,7 +658,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "If set to an empty string, returns the schema in the default (current) format. For Protobuf only: if set to 'serialized', returns the schema in its wire binary format in Base64."
+            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. For Avro, valid values are: `''` (empty string) or `resolved`. For Protobuf, valid values are: `''`, `ignore_extensions`, or `serialized`.\n\nIf set to an empty string, returns the schema in the default (current) format. If set to `serialized`, returns the schema in its wire binary format in Base64."
           },
           {
             "name": "schema_def",
@@ -895,7 +895,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "If set to an empty string, returns the schema in the default (current) format. For Protobuf only: if set to 'serialized', returns the schema in its wire binary format in Base64."
+            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. For Avro, valid values are: `''` (empty string) or `resolved`. For Protobuf, valid values are: `''`, `ignore_extensions`, or `serialized`.\n\nIf set to an empty string, returns the schema in the default (current) format. If set to `serialized`, returns the schema in its wire binary format in Base64."
           }
         ],
         "produces": [
@@ -1014,7 +1014,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "If set to an empty string, returns the schema in the default (current) format. For Protobuf only: if set to 'serialized', returns the schema in its wire binary format in Base64."
+            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. For Avro, valid values are: `''` (empty string) or `resolved`. For Protobuf, valid values are: `''`, `ignore_extensions`, or `serialized`.\n\nIf set to an empty string, returns the schema in the default (current) format. If set to `serialized`, returns the schema in its wire binary format in Base64."
           }
         ],
         "produces": [

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -1050,7 +1050,7 @@
       "get": {
         "summary": "Retrieve the raw schema for the subject.",
         "operationId": "get_subject_versions_version_schema",
-        "description": "Returns the specified version of the schema in its original format, unescaped with backslashes.",
+        "description": "Returns the specified version of the schema in its original format, without backslashes.",
         "parameters": [
           {
             "name": "subject",

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -447,7 +447,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. For Avro, valid values are: `''` (empty string) or `resolved`. For Protobuf, valid values are: `''`, `ignore_extensions`, or `serialized`.\n\nIf set to an empty string, returns the schema in the default (current) format. If set to `serialized`, returns the schema in its wire binary format in Base64."
+            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. An empty string returns the schema in the current (default) format. If set to `serialized`, returns the schema in its wire binary format in Base64.\n\nFor Avro, `resolved` is a valid value, but is not supported and returns a 501 Not Implemented error. For Protobuf, `serialized` and `ignore_extensions` are valid, but only `serialized` is supported and passing `ignore_extensions` returns a 501 Not Implemented error. Cross-schema conditions such as `resolved` with Protobuf or `serialized` with Avro are ignored and the schema is returned in the default format."
           }
         ],
         "produces": [
@@ -706,7 +706,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. For Avro, valid values are: `''` (empty string) or `resolved`. For Protobuf, valid values are: `''`, `ignore_extensions`, or `serialized`.\n\nIf set to an empty string, returns the schema in the default (current) format. If set to `serialized`, returns the schema in its wire binary format in Base64."
+            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. An empty string returns the schema in the current (default) format. If set to `serialized`, returns the schema in its wire binary format in Base64.\n\nFor Avro, `resolved` is a valid value, but is not supported and returns a 501 Not Implemented error. For Protobuf, `serialized` and `ignore_extensions` are valid, but only `serialized` is supported and passing `ignore_extensions` returns a 501 Not Implemented error. Cross-schema conditions such as `resolved` with Protobuf or `serialized` with Avro are ignored and the schema is returned in the default format."
           },
           {
             "name": "schema_def",
@@ -949,7 +949,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. For Avro, valid values are: `''` (empty string) or `resolved`. For Protobuf, valid values are: `''`, `ignore_extensions`, or `serialized`.\n\nIf set to an empty string, returns the schema in the default (current) format. If set to `serialized`, returns the schema in its wire binary format in Base64."
+            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. An empty string returns the schema in the current (default) format. If set to `serialized`, returns the schema in its wire binary format in Base64.\n\nFor Avro, `resolved` is a valid value, but is not supported and returns a 501 Not Implemented error. For Protobuf, `serialized` and `ignore_extensions` are valid, but only `serialized` is supported and passing `ignore_extensions` returns a 501 Not Implemented error. Cross-schema conditions such as `resolved` with Protobuf or `serialized` with Avro are ignored and the schema is returned in the default format."
           }
         ],
         "produces": [
@@ -1074,7 +1074,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. For Avro, valid values are: `''` (empty string) or `resolved`. For Protobuf, valid values are: `''`, `ignore_extensions`, or `serialized`.\n\nIf set to an empty string, returns the schema in the default (current) format. If set to `serialized`, returns the schema in its wire binary format in Base64."
+            "description": "For Avro and Protobuf schemas only, with Redpanda version 25.2 or later. An empty string returns the schema in the current (default) format. If set to `serialized`, returns the schema in its wire binary format in Base64.\n\nFor Avro, `resolved` is a valid value, but is not supported and returns a 501 Not Implemented error. For Protobuf, `serialized` and `ignore_extensions` are valid, but only `serialized` is supported and passing `ignore_extensions` returns a 501 Not Implemented error. Cross-schema conditions such as `resolved` with Protobuf or `serialized` with Avro are ignored and the schema is returned in the default format."
           }
         ],
         "produces": [

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -592,7 +592,7 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           },
           {
             "name": "subjectPrefix",
@@ -888,7 +888,7 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           },
           {
             "name": "format",
@@ -1007,7 +1007,7 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           },
           {
             "name": "format",

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -41,7 +41,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -84,7 +84,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -115,13 +115,13 @@
             }
           },
           "404": {
-            "description": "Subject not found",
+            "description": "Not Found: Subject not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -147,7 +147,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -184,7 +184,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -210,7 +210,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -253,7 +253,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -300,7 +300,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -356,7 +356,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -394,7 +394,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -423,7 +423,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -471,19 +471,19 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "501": {
-            "description": "Not Implemented: the specified format parameter value is not supported",
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -519,13 +519,13 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -569,13 +569,13 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -617,13 +617,13 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -729,7 +729,7 @@
             }
           },
           "404": {
-            "description": "Not found",
+            "description": "Not Found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -753,7 +753,7 @@
             }
           },
           "501": {
-            "description": "Not Implemented: the specified format parameter value is not supported",
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -793,7 +793,7 @@
             }
           },
           "404": {
-            "description": "Subject not found",
+            "description": "Not Found: Subject not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -841,7 +841,7 @@
             }
           },
           "404": {
-            "description": "Subject not found",
+            "description": "Not Found: Subject not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -965,7 +965,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -983,7 +983,7 @@
             }
           },
           "501": {
-            "description": "Not Implemented: the specified format parameter value is not supported",
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1026,7 +1026,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1091,7 +1091,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1109,7 +1109,7 @@
             }
           },
           "501": {
-            "description": "Not Implemented: the specified format parameter value is not supported",
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1151,7 +1151,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1206,7 +1206,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -441,6 +441,13 @@
             "in": "path",
             "required": true,
             "type": "integer"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "If set to an empty string, returns the schema in the default (current) format. For Protobuf only: if set to 'serialized', returns the schema in its wire binary format in Base64."
           }
         ],
         "produces": [
@@ -647,6 +654,13 @@
             "type": "boolean"
           },
           {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "If set to an empty string, returns the schema in the default (current) format. For Protobuf only: if set to 'serialized', returns the schema in its wire binary format in Base64."
+          },
+          {
             "name": "schema_def",
             "in": "body",
             "schema": {
@@ -663,7 +677,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/subject_schema"
+              "$ref": "#/definitions/stored_schema"
             }
           },
           "404": {
@@ -754,7 +768,7 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           }
         ],
         "produces": [
@@ -875,6 +889,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "If set to an empty string, returns the schema in the default (current) format. For Protobuf only: if set to 'serialized', returns the schema in its wire binary format in Base64."
           }
         ],
         "produces": [
@@ -886,7 +907,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/subject_schema"
+              "$ref": "#/definitions/stored_schema"
             }
           },
           "404": {
@@ -987,6 +1008,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "If set to an empty string, returns the schema in the default (current) format. For Protobuf only: if set to 'serialized', returns the schema in its wire binary format in Base64."
           }
         ],
         "produces": [
@@ -1255,7 +1283,7 @@
         }
       }
     },
-    "subject_schema": {
+    "stored_schema": {
       "type": "object",
       "properties": {
         "subject": {

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -447,7 +447,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only (Redpanda 25.2 or later). Supported values: an empty string `''` returns the schema in the current format (default), and `serialized` (Protobuf only) returns the schema in its wire binary format in Base64. Unsupported values return a 501 error."
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -483,7 +483,7 @@
             }
           },
           "501": {
-            "description": "Not implemented - The specified format parameter value is not supported",
+            "description": "Not Implemented: the specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -706,7 +706,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only (Redpanda 25.2 or later). Supported values: an empty string `''` returns the schema in the current format (default), and `serialized` (Protobuf only) returns the schema in its wire binary format in Base64. Unsupported values return a 501 error."
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           },
           {
             "name": "schema_def",
@@ -753,7 +753,7 @@
             }
           },
           "501": {
-            "description": "Not implemented - The specified format parameter value is not supported",
+            "description": "Not Implemented: the specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -949,7 +949,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only (Redpanda 25.2 or later). Supported values: an empty string `''` returns the schema in the current format (default), and `serialized` (Protobuf only) returns the schema in its wire binary format in Base64. Unsupported values return a 501 error."
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -983,7 +983,7 @@
             }
           },
           "501": {
-            "description": "Not implemented - The specified format parameter value is not supported",
+            "description": "Not Implemented: the specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1048,9 +1048,9 @@
     },
     "/subjects/{subject}/versions/{version}/schema": {
       "get": {
-        "summary": "Retrieve the unescaped schema for the subject.",
+        "summary": "Retrieve the raw schema for the subject.",
         "operationId": "get_subject_versions_version_schema",
-        "description": "Returns the specified version of the schema in its original format, without escaping.",
+        "description": "Returns the specified version of the schema in its original format, unescaped with backslashes.",
         "parameters": [
           {
             "name": "subject",
@@ -1075,7 +1075,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "For Avro and Protobuf schemas only (Redpanda 25.2 or later). Supported values: an empty string `''` returns the schema in the current format (default), and `serialized` (Protobuf only) returns the schema in its wire binary format in Base64. Unsupported values return a 501 error."
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -1109,7 +1109,7 @@
             }
           },
           "501": {
-            "description": "Not implemented - The specified format parameter value is not supported",
+            "description": "Not Implemented: the specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }


### PR DESCRIPTION
## Description

Separate PR opened (https://github.com/redpanda-data/docs/pull/1205) to further explain usage of the `format` parameter, and add an entry to What's New

This pull request updates the `schema-registry-api.json` file to enhance the API schema with additional functionality and improve clarity. Key changes include the addition of a new `format` query parameter, updates to schema references, and a type correction for an existing parameter.

### Additions to query parameters:
* Introduced a `format` query parameter in multiple endpoints. This parameter allows users to specify the schema format, with special handling for Protobuf schemas (e.g., returning the schema in its wire binary format in Base64 when set to `'serialized'`). (`[[1]](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421R444-R450)`, `[[2]](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421R656-R662)`, `[[3]](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421R892-R898)`, `[[4]](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421R1011-R1017)`)

### Schema reference updates:
* Updated schema references from `subject_schema` to `stored_schema` to reflect a more accurate representation of the returned data structure. (`[[1]](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421L666-R680)`, `[[2]](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421L889-R910)`)

### Parameter type correction:
* Changed the type of the `deleted` query parameter from `string` to `boolean` to align with expected usage. (`[modules/ROOT/attachments/schema-registry-api.jsonL757-R771](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421L757-R771)`)

### Schema definition renaming:
* Renamed the `subject_schema` definition to `stored_schema` for consistency and clarity in schema definitions. (`[modules/ROOT/attachments/schema-registry-api.jsonL1258-R1286](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421L1258-R1286)`)

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 16 July 2025

## Page previews

https://deploy-preview-1204--redpanda-docs-preview.netlify.app/api/schema-registry-api/#get-/schemas/ids/-id-

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
