### PR TITLE
[25.2] API - Schema Registry Authz updates

### DIFF
--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -2,9 +2,9 @@
   "swagger": "2.0",
   "info": {
     "title": "Redpanda Schema Registry API",
-    "version": "1.0.6"
+    "version": "1.1.0"
   },
-  "host": "localhost:18081",
+  "host": "localhost:8081",
   "basePath": "/",
   "schemes": [
     "http"
@@ -441,6 +441,12 @@
             "in": "path",
             "required": true,
             "type": "integer"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -647,6 +653,12 @@
             "type": "boolean"
           },
           {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
             "name": "schema_def",
             "in": "body",
             "schema": {
@@ -663,7 +675,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/subject_schema"
+              "$ref": "#/definitions/stored_schema"
             }
           },
           "404": {
@@ -875,6 +887,12 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -886,7 +904,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/subject_schema"
+              "$ref": "#/definitions/stored_schema"
             }
           },
           "404": {
@@ -984,6 +1002,12 @@
           },
           {
             "name": "deleted",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "format",
             "in": "query",
             "required": false,
             "type": "string"
@@ -1260,7 +1284,7 @@
             "name": "operation",
             "in": "query",
             "type": "string",
-            "enum": ["ALL", "READ", "WRITE", "REMOVE", "DESCRIBE", "DESCRIBE_CONFIGS", "ALTER", "ALTER_CONFIGS"],
+            "enum": ["ALL", "READ", "WRITE", "DELETE", "DESCRIBE", "DESCRIBE_CONFIGS", "ALTER_CONFIGS"],
             "description": "The operation to allow or deny."
           },
           {
@@ -1465,7 +1489,7 @@
         }
       }
     },
-    "subject_schema": {
+    "stored_schema": {
       "type": "object",
       "properties": {
         "subject": {
@@ -1593,7 +1617,6 @@
             "DELETE",
             "DESCRIBE",
             "DESCRIBE_CONFIGS",
-            "ALTER",
             "ALTER_CONFIGS"
           ],
           "description": "The operation to allow or deny."

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -1371,6 +1371,9 @@
         "summary": "Delete ACLs",
         "description": "Delete ACL rules that match the specified definitions exactly.",
         "operationId": "delete_security_acls",
+        "consumes": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "acls",
@@ -1421,7 +1424,8 @@
         }
       }
     }
-  },"definitions": {
+  },
+  "definitions": {
     "error_body": {
       "type": "object",
       "properties": {
@@ -1554,7 +1558,7 @@
       "properties": {
         "principal": {
           "type": "string",
-          "description": "The name of the principal, for example, User:alice or RedpandaRole:admin). Use \"*\" to represent a wildcard."
+          "description": "The name of the principal, for example, User:alice or RedpandaRole:admin. Use \"*\" to represent a wildcard."
         },
         "resource": {
           "type": "string",
@@ -1604,4 +1608,5 @@
         }
       }
     }
-}}
+  }
+}

--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -1214,6 +1214,212 @@
           }
         }
       }
+    },
+    "/security/acls": {
+      "get": {
+        "summary": "List ACLs",
+        "description": "Returns a list of ACL rules that match the specified filters.",
+        "operationId": "get_security_acls",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "principal",
+            "in": "query",
+            "type": "string",
+            "description": "The name of the principal, for example, User:alice or RedpandaRole:admin. Use \"*\" to represent a wildcard."
+          },
+          {
+            "name": "resource",
+            "in": "query",
+            "type": "string",
+            "description": "The name of the resource. Use \"*\" to represent a wildcard."
+          },
+          {
+            "name": "resource_type",
+            "in": "query",
+            "type": "string",
+            "enum": ["REGISTRY", "SUBJECT"],
+            "description": "The type of resource being secured. The REGISTRY type maps to top-level operations such as `GET /mode` and `GET /config`. The SUBJECT type maps to operations on the subject level, such as `GET /subjects` and `GET /config/{subject}`."
+          },
+          {
+            "name": "pattern_type",
+            "in": "query",
+            "type": "string",
+            "enum": ["LITERAL", "PREFIXED"],
+            "description": "Pattern match type for the resource. Only applies when `resource_type` is SUBJECT."
+          },
+          {
+            "name": "host",
+            "in": "query",
+            "type": "string",
+            "description": "Originating host for which this rule applies. Use \"*\" to represent a wildcard."
+          },
+          {
+            "name": "operation",
+            "in": "query",
+            "type": "string",
+            "enum": ["ALL", "READ", "WRITE", "REMOVE", "DESCRIBE", "DESCRIBE_CONFIGS", "ALTER", "ALTER_CONFIGS"],
+            "description": "The operation to allow or deny."
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "type": "string",
+            "enum": ["ALLOW", "DENY"],
+            "description": "Specifies whether the operation is allowed or denied."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List ACLs",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "principal": "User:alice",
+                  "resource": "model-",
+                  "resource_type": "SUBJECT",
+                  "pattern_type": "PREFIXED",
+                  "operation": "READ",
+                  "permission": "ALLOW",
+                  "host": "*"
+                }
+              ]
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create ACLs",
+        "description": "Create new ACL rules.",
+        "operationId": "post_security_acls",
+        "parameters": [
+          {
+            "name": "acls",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            }
+          }
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "ACLs created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete ACLs",
+        "description": "Delete ACL rules that match the specified definitions exactly.",
+        "operationId": "delete_security_acls",
+        "parameters": [
+          {
+            "name": "acls",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ACLs deleted",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
     }
   },"definitions": {
     "error_body": {
@@ -1331,6 +1537,70 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "security_acl": {
+      "type": "object",
+      "required": [
+        "principal",
+        "resource",
+        "resource_type",
+        "pattern_type",
+        "host",
+        "operation",
+        "permission"
+      ],
+      "properties": {
+        "principal": {
+          "type": "string",
+          "description": "The name of the principal, for example, User:alice or RedpandaRole:admin). Use \"*\" to represent a wildcard."
+        },
+        "resource": {
+          "type": "string",
+          "description": "The name of the resource. Use \"*\" to represent a wildcard."
+        },
+        "resource_type": {
+          "type": "string",
+          "enum": [
+            "REGISTRY",
+            "SUBJECT"
+          ],
+          "description": "The type of resource being secured."
+        },
+        "pattern_type": {
+          "type": "string",
+          "enum": [
+            "LITERAL",
+            "PREFIXED"
+          ],
+          "description": "Pattern match type for the resource. Only applies when `resource_type` is SUBJECT."
+        },
+        "host": {
+          "type": "string",
+          "description": "Originating host for which this rule applies. Use \"*\" to represent a wildcard."
+        },
+        "operation": {
+          "type": "string",
+          "enum": [
+            "ALL",
+            "READ",
+            "WRITE",
+            "DELETE",
+            "DESCRIBE",
+            "DESCRIBE_CONFIGS",
+            "ALTER",
+            "ALTER_CONFIGS"
+          ],
+          "description": "The operation to allow or deny."
+        },
+        "permission": {
+          "type": "string",
+          "enum": [
+            "ALLOW",
+            "DENY"
+          ],
+          "description": "Specifies whether the operation is allowed or denied."
         }
       }
     }


### PR DESCRIPTION
## Description

This pull request introduces new API endpoints and schema definitions to support managing Access Control Lists (ACLs) in the Schema Registry API. The changes include adding operations for listing, creating, and deleting ACLs, along with defining the structure of an ACL object.

### API Enhancements:
* Added a new `/security/acls` endpoint with `GET`, `POST`, and `DELETE` operations:
  - [`GET /security/acls`](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421R1217-R1428): Lists ACL rules based on specified filters. Supports query parameters such as `principal`, `resource`, `resource_type`, `pattern_type`, `host`, `operation`, and `permission`.
  - [`POST /security/acls`](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421R1217-R1428): Creates new ACL rules. Accepts an array of `security_acl` objects in the request body.
  - [`DELETE /security/acls`](diffhunk://#diff-7d01c9338c7a9bcf5bb1b0ca2b754ed1260d4b0119b09e408156c9564545a421R1217-R1428): Deletes ACL rules that match the provided definitions exactly. Accepts an array of `security_acl` objects in the request body.

### Schema Definitions:
* Introduced a new `security_acl` schema to define the structure of an ACL object:
  - Includes required fields such as `principal`, `resource`, `resource_type`, `pattern_type`, `host`, `operation`, and `permission`.
  - Provides enumerations for fields like `resource_type`, `pattern_type`, `operation`, and `permission` to ensure valid values.

These changes enhance the Schema Registry API by enabling fine-grained access control management.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 16 July

## Page previews

https://deploy-preview-1206--redpanda-docs-preview.netlify.app/api/schema-registry-api/#get-/security/acls

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
