### PR TITLE
DOC-1494 Mark KC as community supported

### DIFF
--- a/modules/console/pages/config/configure-console.adoc
+++ b/modules/console/pages/config/configure-console.adoc
@@ -46,6 +46,8 @@ KAFKA_BROKERS=redpanda-0:9092,redpanda-1:9092,redpanda-2:9092
 NOTE: You cannot use environment variables to configure object arrays, such as the configuration
 for Kafka Connect clusters. In this case, use a YAML file, and provide secrets using environment variables or command line arguments.
 
+include::shared:partial$community-supported-kc.adoc[]
+
 == Docker Compose example
 
 If you are using Docker Compose, you can mount the configuration file and set the environment variable in your `docker-compose.yml` file:

--- a/modules/console/pages/config/kafka-connect.adoc
+++ b/modules/console/pages/config/kafka-connect.adoc
@@ -2,6 +2,8 @@
 :description: Connect one or more Kafka Connect clusters with Redpanda Console.
 :page-aliases: console:features/kafka-connect.adoc, manage:console/kafka-connect.adoc
 
+include::shared:partial$community-supported-kc.adoc[]
+
 Redpanda Console provides a user interface that lets you manage multiple Kafka Connect clusters.
 You can inspect or patch connectors; restart, pause, and resume connector tasks; and delete connectors.
 Redpanda Console queries all configured Kafka Connect

--- a/modules/console/pages/config/security/authorization.adoc
+++ b/modules/console/pages/config/security/authorization.adoc
@@ -158,6 +158,8 @@ Redpanda Console provides the following predefined roles:
 | No limitations
 |===
 
+include::shared:partial$community-supported-kc.adoc[]
+
 == Grant permissions through role bindings
 
 When impersonation is disabled, Redpanda Console connects to Redpanda APIs using the service account defined in:

--- a/modules/console/pages/index.adoc
+++ b/modules/console/pages/index.adoc
@@ -45,6 +45,8 @@ image::schema-reg.png[]
 
 View and manage Kafka Connect clusters and connectors, simplifying the integration of external systems with your streaming data.
 
+include::shared:partial$community-supported-kc.adoc[]
+
 == Who should use Redpanda Console?
 
 Redpanda Console is designed for:

--- a/modules/shared/partials/community-supported-kc.adoc
+++ b/modules/shared/partials/community-supported-kc.adoc
@@ -1,0 +1,5 @@
+:note-caption: Community
+NOTE: *Kafka Connect is community-supported on https://redpanda.com/slack[Redpanda Community Slack^]*. Redpanda Data does not provide enterprise support for Kafka Connect with Redpanda Console. For a supported and scalable Kafka Connect alternative, try xref:redpanda-connect:get-started:index.adoc[Redpanda Connect].
+
+:note-caption: Note
+


### PR DESCRIPTION
## Description
This pull request introduces a shared partial note about Kafka Connect's community support and integrates it across multiple documentation files in the Redpanda Console module. The changes aim to clarify the scope of support for Kafka Connect and provide users with alternative solutions.

### Addition of community support note:

* [`modules/shared/partials/community-supported-kc.adoc`](diffhunk://#diff-31f6091d2224f4cf762f923a0f011b8f3120e89752f855038fce6db1a2edbb06R1-R5): Added a note indicating that Kafka Connect is community-supported via Redpanda Community Slack and suggesting Redpanda Connect as an enterprise-supported alternative.

### Integration of the community support note across documentation:

* [`modules/console/pages/config/configure-console.adoc`](diffhunk://#diff-c4861a9d003080535d1aa8075d373d85457b7827acf3f9e1692ff03a32d57381R49-R50): Included the community support note to inform users configuring Redpanda Console about Kafka Connect's support limitations.
* [`modules/console/pages/config/kafka-connect.adoc`](diffhunk://#diff-ab3ba0db7faebafbdd8061068e4f965c5cfb13c0569a6ba7e2b8e3e9db503800R5-R6): Added the community support note to the Kafka Connect configuration guide.
* [`modules/console/pages/config/security/authorization.adoc`](diffhunk://#diff-65034e6679891f34d1b838901ef6e5cf3098eca3fd92bddfac7e86265942bf74R161-R162): Integrated the community support note into the authorization documentation.
* [`modules/console/pages/index.adoc`](diffhunk://#diff-87c9f4aa928a7ecdac16eed831010aac98b3775cdcdaf433d31dee161c78e16fR48-R49): Included the community support note in the Redpanda Console overview page.

Resolves https://redpandadata.atlassian.net/browse/DOC-1494 
Review deadline: July 18

## Page previews

- [Console - Kafka Connect](https://deploy-preview-1211--redpanda-docs-preview.netlify.app/current/console/config/kafka-connect/)
- [Console - Configure Console](https://deploy-preview-1211--redpanda-docs-preview.netlify.app/current/console/config/configure-console/#environment-variables)
- [Console - Authorization roles](https://deploy-preview-1211--redpanda-docs-preview.netlify.app/current/console/config/configure-console/#environment-variables)
- [Intro to Console](https://deploy-preview-1211--redpanda-docs-preview.netlify.app/current/console/#connectivity-and-integrations)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
