### PR TITLE
docs: use attributes instead of page level props

### DIFF
--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -1,7 +1,6 @@
 = What's New in Redpanda
 :description: Summary of new features and updates in this Redpanda release.
 :page-aliases: get-started:whats-new-233.adoc, get-started:whats-new-241.adoc, get-started:whats-new.adoc
-:page-whats-new:
 
 This topic includes new content added in version {page-component-version}. For a complete list of all product updates, see the https://github.com/redpanda-data/redpanda/releases/[Redpanda release notes^]. See also:
 
@@ -23,7 +22,7 @@ The Redpanda Admin API now includes new health probes to help you ensure safe br
 
 [IMPORTANT]
 ====
-include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[]
+include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[tags=include-config-link]
 ====
 
 HTTP Proxy previously used automatically-generated ephemeral credentials to authenticate with the Kafka API when the HTTP Proxy listeners specified `authentication_method: none`. To improve security and simplify the authentication model, ephemeral credentials are no longer available.

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -22,7 +22,7 @@ The Redpanda Admin API now includes new health probes to help you ensure safe br
 
 [IMPORTANT]
 ====
-include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[tags=include-config-link]
+include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[tags=!*;include-config-link]
 ====
 
 HTTP Proxy previously used automatically-generated ephemeral credentials to authenticate with the Kafka API when the HTTP Proxy listeners specified `authentication_method: none`. To improve security and simplify the authentication model, ephemeral credentials are no longer available.

--- a/modules/manage/pages/security/authentication.adoc
+++ b/modules/manage/pages/security/authentication.adoc
@@ -4,7 +4,6 @@
 :page-aliases: security:authentication.adoc
 :page-toclevels: 3
 :page-categories: Management, Security
-:page-http-proxy-auth:
 
 include::manage:partial$authentication.adoc[]
 

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -659,7 +659,7 @@ Schema Registry and HTTP Proxy connect to Redpanda over the Kafka API.
 
 [IMPORTANT]
 ====
-include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[]
+include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[tags=include-release-notes-link]
 ====
 
 Schema Registry and HTTP Proxy support only the SASL/SCRAM mechanism.
@@ -1779,7 +1779,7 @@ To disable authentication for a listener, set `authentication_method` to `none`:
 
 [IMPORTANT]
 ====
-include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[]
+include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[tags=include-release-notes-link]
 ====
 
 ifdef::env-kubernetes[]

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -659,7 +659,7 @@ Schema Registry and HTTP Proxy connect to Redpanda over the Kafka API.
 
 [IMPORTANT]
 ====
-include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[tags=include-release-notes-link]
+include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[tags=!*;include-release-notes-link]
 ====
 
 Schema Registry and HTTP Proxy support only the SASL/SCRAM mechanism.
@@ -1779,7 +1779,7 @@ To disable authentication for a listener, set `authentication_method` to `none`:
 
 [IMPORTANT]
 ====
-include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[tags=include-release-notes-link]
+include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[tags=!*;include-release-notes-link]
 ====
 
 ifdef::env-kubernetes[]

--- a/modules/shared/partials/http-proxy-ephemeral-credentials-breaking-change.adoc
+++ b/modules/shared/partials/http-proxy-ephemeral-credentials-breaking-change.adoc
@@ -2,10 +2,10 @@
 
 Redpanda Data recommends enabling authentication on both HTTP Proxy and the Kafka API.
 
-ifndef::page-http-proxy-auth[]
+// tag::include-config-link[]
 For configuration instructions, see xref:manage:security/authentication.adoc#schema-and-http-to-redpanda[Configure HTTP Proxy to connect to Redpanda with SASL].
-endif::[]
+// end::include-config-link[]
 
-ifndef::page-whats-new[]
+// tag::include-release-notes-link[]
 For details about this breaking change, see xref:get-started:release-notes/redpanda.adoc#http-proxy-authentication-changes[What's new].
-endif::[]
+// end::include-release-notes-link[]

--- a/modules/upgrade/partials/incompat-changes.adoc
+++ b/modules/upgrade/partials/incompat-changes.adoc
@@ -1,6 +1,10 @@
 === Review incompatible changes
 
+* {empty}
++
+--
 include::shared:partial$http-proxy-ephemeral-credentials-breaking-change.adoc[]
+--
 
 * Redpanda Console v3.0.0 introduces breaking changes. If you are using Redpanda Console v2.x, xref:migrate:console-v3.adoc[review the migration guide] to address breaking changes before upgrading Redpanda Console.
 


### PR DESCRIPTION
## Description

Use attributes instead of page level props, making it easier to understand. 


## Page previews

* [What's new](https://deploy-preview-1220--redpanda-docs-preview.netlify.app/25.2/get-started/release-notes/redpanda/)
* [Authentication](https://deploy-preview-1220--redpanda-docs-preview.netlify.app/25.2/manage/security/authentication/#schema-and-http-to-redpanda)
* [Broker properties](https://deploy-preview-1220--redpanda-docs-preview.netlify.app/25.2/reference/properties/broker-properties/#sasl_mechanism)
* [Rolling Upgrade](https://deploy-preview-1220--redpanda-docs-preview.netlify.app/25.2/upgrade/rolling-upgrade/#review-incompatible-changes)


## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
