### PR TITLE
DOC-1521 Update memory requirements in sizing

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
@@ -15,7 +15,7 @@ Throughput and retention requirements can cause bottlenecks in the system. On an
 In general, choose the number of nodes based on the following criteria, and add nodes for fault tolerance. This ensures that the system can operate with full throughput in a degraded state.
 
 * **Network bandwidth**: Total bandwidth must account for maximum simultaneous writes and reads, multiplied by the replication factor.
-* **Memory per core**: Allocate a minimum of 2 GB memory for each CPU core. More memory improves performance.
+* **Memory per core**: Allocate a minimum of 2 GB memory for each CPU core. Additional memory could improve performance.
 * **Memory per partition**: Allocate a minimum of 2 MB of memory for each topic partition replica. 
 +
 For example: If you have 10,000 total partitions with a replication factor of 3, you need at least 60 GB of memory across all brokers:

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
@@ -25,9 +25,9 @@ For example: If you have 10,000 total partitions with a replication factor of 3,
 * **Performance testing**: Run hardware and Redpanda benchmark tests to establish a performance baseline. Choose instance types that prioritize storage and network performance:
 +
 --
-* **AWS**: Test with i3en (NVMe SSD), i4i (latest NVMe), or is4gen (Intel-based NVMe)
-* **Azure**: Test with Lsv2-series (high I/O performance)
-* **GCP**: Test with n2-standard instances with local SSD
+* **AWS**: Test with i3en (NVMe SSD), i4i (NVMe), or is4gen (Intel-based NVMe) instances, or other NVMe-backed types
+* **Azure**: Test with Lsv2-series instances (high I/O performance) or other high-performance storage types
+* **GCP**: Test with n2-standard instances with local SSD or other high-performance local storage types
 --
 
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
@@ -14,12 +14,22 @@ Throughput and retention requirements can cause bottlenecks in the system. On an
 
 In general, choose the number of nodes based on the following criteria, and add nodes for fault tolerance. This ensures that the system can operate with full throughput in a degraded state.
 
-* Total network bandwidth must account for maximum simultaneous writes and reads, multiplied by the replication factor.
-* Have a minimum of 2 GB memory for each core, but more memory is better.
-* Have a minimum of 4 MB of memory for each topic partition replica. You can enforce this requirement in the tunable xref:reference:tunable-properties.adoc#topic_memory_per_partition[`topic_memory_per_partition` property].
-* Use Tiered Storage to unify historical and real-time data.
-* For AWS, test with either i3en, i4i, or is4gen; for GCP, test with n2-standard (GCP); and for Azure, test with lsv2. In general, choose instance types that prioritize storage and network performance.
-* Run hardware and Redpanda benchmark tests for a performance baseline.
+* **Network bandwidth**: Total bandwidth must account for maximum simultaneous writes and reads, multiplied by the replication factor.
+* **Memory per core**: Allocate a minimum of 2 GB memory for each CPU core. More memory improves performance.
+* **Memory per partition**: Allocate a minimum of 2 MB of memory for each topic partition replica. 
++
+For example: If you have 10,000 total partitions with a replication factor of 3, you need at least 60 GB of memory across all brokers:
++
+10,000 partitions × 3 replicas × 2 MB = 60,000 MB (60 GB)
+* **Storage strategy**: Use Tiered Storage to unify historical and real-time data cost-effectively.
+* **Performance testing**: Run hardware and Redpanda benchmark tests to establish a performance baseline. Choose instance types that prioritize storage and network performance:
++
+--
+* **AWS**: Test with i3en (NVMe SSD), i4i (latest NVMe), or is4gen (Intel-based NVMe)
+* **Azure**: Test with Lsv2-series (high I/O performance)
+* **GCP**: Test with n2-standard instances with local SSD
+--
+
 
 == Sizing considerations
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/sizing.adoc
@@ -20,7 +20,9 @@ In general, choose the number of nodes based on the following criteria, and add 
 +
 For example: If you have 10,000 total partitions with a replication factor of 3, you need at least 60 GB of memory across all brokers:
 +
-10,000 partitions × 3 replicas × 2 MB = 60,000 MB (60 GB)
+10,000 partitions × 3 replicas × 2 MB = 60,000 MB (60 GB) 
++
+If these partitions are evenly distributed across three brokers, each broker needs at least 20 GB of memory.
 * **Storage strategy**: Use Tiered Storage to unify historical and real-time data cost-effectively.
 * **Performance testing**: Run hardware and Redpanda benchmark tests to establish a performance baseline. Choose instance types that prioritize storage and network performance:
 +


### PR DESCRIPTION
## Description
This pull request refines the recommendations for self-hosted deployment sizing in the `manual/sizing.adoc` file. The changes improve clarity and provide examples to help users better understand memory allocation and instance type selection.

### Improvements to deployment sizing recommendations:

* **Memory allocation**: Updated the minimum memory requirements per partition replica to 2 MB (down from 4 MB) and added a detailed example calculation for clarity.
* **Instance types**: Expanded recommendations for cloud providers with specific instance types and their attributes (e.g., NVMe SSDs for AWS, high I/O performance for Azure, and local SSDs for GCP).
* **Formatting enhancements**: Improved readability with bold labels for key criteria like network bandwidth, memory per core, and storage strategy.

Resolves https://redpandadata.atlassian.net/browse/DOC-1521
Review deadline:

## Page previews
[Sizing Guidelines](https://deploy-preview-1223--redpanda-docs-preview.netlify.app/current/deploy/deployment-option/self-hosted/manual/sizing/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
