### PR TITLE
Fix GitHub Action

### DIFF
--- a/.github/workflows/get-cloud-api-spec.yml
+++ b/.github/workflows/get-cloud-api-spec.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Run the script and save the output
         working-directory: redpanda-docs
         run: |
-          npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.controlplane.prod.yaml -d ../../modules/ROOT/attachments cloud-controlplane-api.yaml
-          npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.dataplane.prod.yaml -d ../../modules/ROOT/attachments cloud-dataplane-api.yaml
+          npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.controlplane.prod.yaml -d ../modules/ROOT/attachments cloud-controlplane-api.yaml
+          npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.dataplane.prod.yaml -d ../modules/ROOT/attachments cloud-dataplane-api.yaml
         env:
           VBOT_GITHUB_API_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
       - name: Create pull request

--- a/.github/workflows/get-cloud-api-spec.yml
+++ b/.github/workflows/get-cloud-api-spec.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Get commit SHA and build URL
         id: commit-info
+        working-directory: redpanda-docs
         run: |
           COMMIT_SHA="${{ github.event.client_payload.commit_sha }}"
           COMMIT_URL="https://github.com/redpanda-data/cloudv2/commit/${COMMIT_SHA}"
@@ -43,10 +44,12 @@ jobs:
           echo "COMMIT_URL=${COMMIT_URL}" >> $GITHUB_ENV
 
       - name: Install dependencies
+        working-directory: redpanda-docs
         run: |
           npm install
 
       - name: Run the script and save the output
+        working-directory: redpanda-docs
         run: |
           npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.controlplane.prod.yaml -d ../../modules/ROOT/attachments cloud-controlplane-api.yaml
           npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.dataplane.prod.yaml -d ../../modules/ROOT/attachments cloud-dataplane-api.yaml


### PR DESCRIPTION
## Description

This pull request updates the `.github/workflows/get-cloud-api-spec.yml` file to ensure that all relevant steps execute within the correct working directory. 

### Workflow updates:
* Added `working-directory: redpanda-docs` to the following steps in the GitHub Actions workflow: "Get commit SHA and build URL," "Install dependencies," and "Run the script and save the output." This ensures that all commands run in the `redpanda-docs` directory.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
