### PR TITLE
Fix GitHub Action

### DIFF
--- a/.github/workflows/get-cloud-api-spec.yml
+++ b/.github/workflows/get-cloud-api-spec.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Run the script and save the output
         working-directory: redpanda-docs
         run: |
-          npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.controlplane.prod.yaml -d modules/ROOT/attachments cloud-controlplane-api.yaml
-          npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.dataplane.prod.yaml -d  modules/ROOT/attachments cloud-dataplane-api.yaml
+          npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.controlplane.prod.yaml -d modules/ROOT/attachments -f cloud-controlplane-api.yaml
+          npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.dataplane.prod.yaml -d  modules/ROOT/attachments -f cloud-dataplane-api.yaml
         env:
           VBOT_GITHUB_API_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
       - name: Create pull request


### PR DESCRIPTION
## Description

This pull request updates the script in the `get-cloud-api-spec.yml` workflow to include a missing flag for the `doc-tools fetch` command. This change ensures that the output files are correctly specified during the fetch process.

### Workflow script update:
* [`.github/workflows/get-cloud-api-spec.yml`](diffhunk://#diff-eaa09d73ce1cc4bc04210420414fc0fe7227e20fa9e90d94af8ebab62770e33cL54-R55): Added the `-f` flag to the `doc-tools fetch` command for both the control plane and data plane API specifications to explicitly specify the output file names (`cloud-controlplane-api.yaml` and `cloud-dataplane-api.yaml`).

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
