### PR TITLE
docs: add redpanda_trust_file_crc32c and redpanda_truststore_expires_at_timestamp_seconds metrics

### DIFF
--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -1867,8 +1867,8 @@ CRC32C checksum calculated from the contents of the trust file. This value is ca
 
 *Labels*:
 
-- `aggregates`
-- `label`
+- `area`
+- `detail`
 - `shard`
 
 ---
@@ -1881,9 +1881,9 @@ Expiry time of the shortest-lived CA in the truststore, measured in seconds sinc
 
 *Labels*:
 
-- `aggregates`
-- `label`
-- `label_instance`
+- `area`
+- `detail`
+- `shard`
 
 ---
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -1859,33 +1859,6 @@ Indicator of whether a resource has at least one valid TLS certificate installed
 
 ---
 
-[[data_transform_metrics]]
-== Data transforms metrics
-
-=== redpanda_transform_execution_latency_sec
-
-Histogram tracking the execution latency (in seconds) for processing a single record via data transforms.
-
-*Type*: histogram
-
-*Labels*:
-
-* `function_name`
-
----
-
-=== redpanda_transform_execution_errors
-
-Counter for the number of errors encountered during the invocation of data transforms.
-
-*Type*: counter
-
-*Labels*:
-
-* `function_name`
-
----
-
 === redpanda_trust_file_crc32c
 
 CRC32C checksum calculated from the contents of the trust file. This value is calculated when a valid certificate is loaded and a trust store is present. Otherwise, the value is zero.
@@ -1911,6 +1884,33 @@ Expiry time of the shortest-lived CA in the truststore, measured in seconds sinc
 - `aggregates`
 - `label`
 - `label_instance`
+
+---
+
+[[data_transform_metrics]]
+== Data transforms metrics
+
+=== redpanda_transform_execution_latency_sec
+
+Histogram tracking the execution latency (in seconds) for processing a single record via data transforms.
+
+*Type*: histogram
+
+*Labels*:
+
+* `function_name`
+
+---
+
+=== redpanda_transform_execution_errors
+
+Counter for the number of errors encountered during the invocation of data transforms.
+
+*Type*: counter
+
+*Labels*:
+
+* `function_name`
 
 ---
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -1886,6 +1886,34 @@ Counter for the number of errors encountered during the invocation of data trans
 
 ---
 
+=== redpanda_trust_file_crc32c
+
+CRC32C checksum calculated from the contents of the trust file. This value is calculated when a valid certificate is loaded and a trust store is present. Otherwise, the value is zero.
+
+*Type*: gauge
+
+*Labels*:
+
+- `aggregates`
+- `label`
+- `shard`
+
+---
+
+=== redpanda_truststore_expires_at_timestamp_seconds
+
+Expiry time of the shortest-lived CA in the truststore, measured in seconds since epoch.
+
+*Type*: gauge
+
+*Labels*:
+
+- `aggregates`
+- `label`
+- `label_instance`
+
+---
+
 === redpanda_wasm_engine_cpu_seconds_total
 
 Total CPU time (in seconds) consumed by WebAssembly functions.


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-177
Review deadline: 28th July

## Page previews

- [redpanda_trust_file_crc32c](https://deploy-preview-1236--redpanda-docs-preview.netlify.app/current/reference/public-metrics-reference/#redpanda_trust_file_crc32c)
 
- [redpanda_truststore_expires_at_timestamp_seconds](https://deploy-preview-1236--redpanda-docs-preview.netlify.app/current/reference/public-metrics-reference/#redpanda_truststore_expires_at_timestamp_seconds)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
