### PR TITLE
Iceberg updates for REST catalog and wire format compatible modes

### DIFF
--- a/modules/manage/pages/iceberg/choose-iceberg-mode.adoc
+++ b/modules/manage/pages/iceberg/choose-iceberg-mode.adoc
@@ -45,6 +45,16 @@ The latest schema is cached periodically. The cache period is defined by the clu
 
 Default for `redpanda.iceberg.mode`. Disables writing to an Iceberg table for the topic.
 
+[NOTE]
+====
+The following modes are compatible with producing to an Iceberg topic using Redpanda Console:
+
+- `key_value`
+- Starting in version 25.2, `value_schema_latest` with a JSON schema
+
+Otherwise, records may fail to write to the Iceberg table and instead write to the xref:manage:iceberg/about-iceberg-topics.adoc#manage-dead-letter-queue[dead-letter queue].
+====
+
 == Configure Iceberg mode for a topic
 
 You can set the Iceberg mode for a topic when you create the topic, or you can update the mode for an existing topic.

--- a/modules/manage/partials/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/partials/iceberg/about-iceberg-topics.adoc
@@ -135,7 +135,7 @@ TOPIC              STATUS
 <new-topic-name>   OK
 ----
 
-. Configure `redpanda.iceberg.mode` for the topic. You can choose one of the following modes:
+. Configure `redpanda.iceberg.mode` for the topic. You can choose one of the following xref:manage:iceberg/choose-iceberg-mode.adoc[Iceberg modes]:
 +
 --
 * `key_value`: Creates an Iceberg table using a simple schema, consisting of two columns, one for the record metadata including the key, and another binary column for the record's value.
@@ -154,8 +154,6 @@ rpk topic alter-config <new-topic-name> --set redpanda.iceberg.mode=<topic-icebe
 TOPIC              STATUS
 <new-topic-name>   OK
 ----
-+
-See also: xref:manage:iceberg/choose-iceberg-mode.adoc[].
 
 . Register a schema for the topic. This step is required for the `value_schema_id_prefix` and `value_schema_latest` modes.
 +

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -28,11 +28,11 @@ The Iceberg integration for Redpanda Cloud supports multiple Iceberg catalogs ac
 The following matrix shows the current status of Iceberg integrations across different cloud providers and catalogs. Check this matrix regularly as Redpanda Cloud continues to expand GA coverage for Iceberg topics.
 
 |===
-| | AWS Glue Data Catalog |Databricks Unity Catalog |Google BigQuery |Snowflake Open Catalog |Dremio Nessie
+| | AWS Glue Data Catalog |Databricks Unity Catalog |Google BigQuery |Snowflake Open Catalog 
 
-|AWS   |Beta |Supported |N/A |Beta |Beta
-|Azure |N/A  |Beta      |N/A |Beta |Beta
-|GCP   |N/A  |Beta      |Beta|Beta |Beta
+|AWS   |Beta |Supported |N/A |Beta 
+|Azure |N/A  |Beta      |N/A |Beta 
+|GCP   |N/A  |Supported |Beta|Beta 
 |===
 endif::[]
 
@@ -46,16 +46,15 @@ The following shows the current status of Iceberg catalog integrations. Check th
 |===
 |Catalog service | Status
 
-|AWS Glue Data Catalog |Tested
-|Databricks Unity Catalog |Tested
-|Snowflake Open Catalog |Tested
-|Dremio Nessie |Tested
-|Google BigQuery |Tested
+|AWS Glue Data Catalog | Beta
+|Databricks Unity Catalog |Supported
+|Google BigQuery |Beta
+|Snowflake Open Catalog |Supported
 
 |===
 endif::[]
 
-Other REST catalogs such as Apache Polaris and the Apache reference implementation have been tested but are not regularly verified. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+Other REST catalogs such as Dremio Nessie, Apache Polaris, and the Apache reference implementation have been tested but are not regularly verified. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 
 === Set cluster properties
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -28,11 +28,11 @@ The Iceberg integration for Redpanda Cloud supports multiple Iceberg catalogs ac
 The following matrix shows the current status of Iceberg integrations across different cloud providers and catalogs. Check this matrix regularly as Redpanda Cloud continues to expand GA coverage for Iceberg topics.
 
 |===
-| | AWS Glue Data Catalog |Databricks Unity Catalog |Snowflake Open Catalog |Dremio Nessie
+| | AWS Glue Data Catalog |Databricks Unity Catalog |Google BigQuery |Snowflake Open Catalog |Dremio Nessie
 
-|AWS |Beta |Beta |Beta |Beta
-|Azure |N/A |Beta |Beta |Beta
-|GCP |N/A |Beta |Beta |Beta
+|AWS |Beta |Supported |Beta |Beta |Beta
+|Azure |N/A |Beta |Beta |Beta |Beta
+|GCP |N/A |Beta |Beta |Beta |Beta
 |===
 endif::[]
 
@@ -46,7 +46,7 @@ The following shows the current status of Iceberg catalog integrations. Check th
 |===
 |Catalog service | Status
 
-|AWS Glue Data Catalog |
+|AWS Glue Data Catalog |Tested
 |Databricks Unity Catalog |Tested
 |Snowflake Open Catalog |Tested
 |Dremio Nessie |Tested
@@ -54,6 +54,8 @@ The following shows the current status of Iceberg catalog integrations. Check th
 
 |===
 endif::[]
+
+Other REST catalogs such as Apache Polaris and the Apache reference implementation have been tested but are not regularly verified. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 
 === Set cluster properties
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -28,11 +28,11 @@ The Iceberg integration for Redpanda Cloud supports multiple Iceberg catalogs ac
 The following matrix shows the current status of Iceberg integrations across different cloud providers and catalogs. Check this matrix regularly as Redpanda Cloud continues to expand GA coverage for Iceberg topics.
 
 |===
-| | AWS Glue Data Catalog |Databricks Unity Catalog |Google BigQuery |Snowflake Open Catalog 
+| | Databricks Unity Catalog | Snowflake Open Catalog | AWS Glue Data Catalog | Google BigQuery
 
-|AWS   |Beta |Supported |N/A |Beta 
-|Azure |N/A  |Beta      |N/A |Beta 
-|GCP   |N/A  |Supported |Beta|Beta 
+|AWS   |Supported |Beta |Beta |N/A
+|GCP   |Supported |Beta |N/A  |Beta
+|Azure |Beta      |Beta |N/A  |N/A
 |===
 endif::[]
 
@@ -46,10 +46,10 @@ The following shows the current status of Iceberg catalog integrations. Check th
 |===
 |Catalog service | Status
 
-|AWS Glue Data Catalog | Beta
 |Databricks Unity Catalog |Supported
-|Google BigQuery |Beta
 |Snowflake Open Catalog |Supported
+|AWS Glue Data Catalog | Beta
+|Google BigQuery |Beta
 
 |===
 endif::[]

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -30,9 +30,9 @@ The following matrix shows the current status of Iceberg integrations across dif
 |===
 | | AWS Glue Data Catalog |Databricks Unity Catalog |Google BigQuery |Snowflake Open Catalog |Dremio Nessie
 
-|AWS |Beta |Supported |Beta |Beta |Beta
-|Azure |N/A |Beta |Beta |Beta |Beta
-|GCP |N/A |Beta |Beta |Beta |Beta
+|AWS   |Beta |Supported |N/A |Beta |Beta
+|Azure |N/A  |Beta      |N/A |Beta |Beta
+|GCP   |N/A  |Beta      |Beta|Beta |Beta
 |===
 endif::[]
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -28,11 +28,11 @@ The Iceberg integration for Redpanda Cloud supports multiple Iceberg catalogs ac
 The following matrix shows the current status of Iceberg integrations across different cloud providers and catalogs. Check this matrix regularly as Redpanda Cloud continues to expand GA coverage for Iceberg topics.
 
 |===
-| |Databricks Unity Catalog |Snowflake Open Catalog |Dremio Nessie
+| | AWS Glue Data Catalog |Databricks Unity Catalog |Snowflake Open Catalog |Dremio Nessie
 
-|AWS |Beta |Beta |Beta
-|Azure |Beta |Beta |Beta
-|GCP |Beta |Beta |Beta
+|AWS |Beta |Beta |Beta |Beta
+|Azure |N/A |Beta |Beta |Beta
+|GCP |N/A |Beta |Beta |Beta
 |===
 endif::[]
 
@@ -46,9 +46,11 @@ The following shows the current status of Iceberg catalog integrations. Check th
 |===
 |Catalog service | Status
 
+|AWS Glue Data Catalog |
 |Databricks Unity Catalog |Tested
 |Snowflake Open Catalog |Tested
 |Dremio Nessie |Tested
+|Google BigQuery |Tested
 
 |===
 endif::[]

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2090,6 +2090,26 @@ endif::[]
 
 // end::iceberg_rest_catalog_authentication_mode[]
 
+// tag::iceberg_rest_catalog_base_location[]
+
+=== iceberg_rest_catalog_base_location
+
+NOTE: This property is available in Redpanda version 25.1.7 and later.
+
+Base URI for the Iceberg REST catalog. If unset, the REST catalog server determines the location. Some REST catalogs, like AWS Glue, require the client to set this. After Iceberg is enabled, do not change this value.
+
+*Requires restart:* Yes
+
+*Visibility:* `user`
+
+*Type:* string
+
+*Default:* `null`
+
+---
+
+// end::iceberg_rest_catalog_base_location[]
+
 // tag::iceberg_rest_catalog_client_id[]
 === iceberg_rest_catalog_client_id
 


### PR DESCRIPTION
## Description

This pull request introduces updates to the Redpanda Iceberg integration documentation, focusing on new features, compatibility updates, and catalog support. Key changes include the addition of supported Iceberg modes, updates to the catalog compatibility matrix, and a new configuration property for Iceberg REST catalogs.

### Updates to Iceberg mode and configuration:
* Added a note in `modules/manage/pages/iceberg/choose-iceberg-mode.adoc` specifying that the `value_schema_latest` mode with JSON schema is supported starting in version 25.2, along with a warning about potential record failures.
* Updated `modules/manage/partials/iceberg/about-iceberg-topics.adoc` to include a cross-reference to the Iceberg modes documentation and removed an unnecessary "See also" link. [[1]](diffhunk://#diff-ea5033692607173dad8ffa11b9e530bac4ee1d40279f0f826c446e7e75582c12L138-R138) [[2]](diffhunk://#diff-ea5033692607173dad8ffa11b9e530bac4ee1d40279f0f826c446e7e75582c12L157-L158)

### Updates to Iceberg catalog support:
* Expanded the catalog compatibility matrix in `modules/manage/partials/iceberg/use-iceberg-catalogs.adoc` to include AWS Glue Data Catalog and updated the status for Azure and GCP.
* Added Google BigQuery as a tested catalog in the catalog service status table.

### New Iceberg REST catalog property:
* Introduced a new property, `iceberg_rest_catalog_base_location`, in `modules/reference/pages/properties/cluster-properties.adoc`, which allows users to set the base URI for the Iceberg REST catalog. This property is available starting in Redpanda version 25.1.7.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 29 July

## Page previews

Cloud: [Use Iceberg Catalogs](https://deploy-preview-1238--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/use-iceberg-catalogs/#limitations) 
Self-managed: [Use Iceberg Catalogs](https://deploy-preview-1238--redpanda-docs-preview.netlify.app/current/manage/iceberg/use-iceberg-catalogs/#limitations)
Cluster config reference: [`iceberg_rest_catalog_base_location`](https://deploy-preview-1238--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/#iceberg_rest_catalog_base_location)
[Supported Iceberg modes](https://deploy-preview-1238--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/choose-iceberg-mode/#supported-iceberg-modes)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
