### PR TITLE
Console tab

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -6,6 +6,9 @@ prerelease: true
 start_page: home:index.adoc
 nav:
 - modules/ROOT/nav.adoc
+runtime:
+  log:
+    level: debug
 asciidoc:
   attributes:
     # Date of release in the format YYYY-MM-DD
@@ -19,7 +22,6 @@ asciidoc:
     # Fallback versions
     # We try to fetch the latest versions from GitHub at build time
     # --
-
     full-version: 25.1.1
     latest-redpanda-tag: 'v25.1.1'
     latest-console-tag: 'v2.8.5'

--- a/antora.yml
+++ b/antora.yml
@@ -6,9 +6,6 @@ prerelease: true
 start_page: home:index.adoc
 nav:
 - modules/ROOT/nav.adoc
-runtime:
-  log:
-    level: debug
 asciidoc:
   attributes:
     # Date of release in the format YYYY-MM-DD

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -25,7 +25,7 @@ content:
     branches: main
 ui:
   bundle:
-    url: ../docs-ui/build/ui-bundle.zip
+    url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:
@@ -43,7 +43,7 @@ antora:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-global-attributes'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/version-fetcher/set-latest-version'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/validate-attributes'
-  - require: '../docs-extensions-and-macros/extensions/process-context-switcher.js'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/process-context-switcher'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-index-data'
     data:
       sets:

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -25,7 +25,7 @@ content:
     branches: main
 ui:
   bundle:
-    url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip
+    url: ../docs-ui/build/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:
@@ -43,6 +43,7 @@ antora:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-global-attributes'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/version-fetcher/set-latest-version'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/validate-attributes'
+  - require: '../docs-extensions-and-macros/extensions/process-context-switcher.js'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-index-data'
     data:
       sets:

--- a/modules/console/pages/config/configure-console.adoc
+++ b/modules/console/pages/config/configure-console.adoc
@@ -1,6 +1,7 @@
 = Configure Redpanda Console
 :description: Redpanda Console configuration file with property descriptions.
 :page-aliases: console:reference/config.adoc, reference:console/config.adoc
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/configure-console.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
 Redpanda Console loads configuration properties from three sources, in the following order of precedence:
 

--- a/modules/console/pages/config/configure-console.adoc
+++ b/modules/console/pages/config/configure-console.adoc
@@ -3,6 +3,8 @@
 :page-aliases: console:reference/config.adoc, reference:console/config.adoc
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/configure-console.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
+include::console:partial$operator-console-version-note.adoc[]
+
 Redpanda Console loads configuration properties from three sources, in the following order of precedence:
 
 . Environment variables

--- a/modules/console/pages/config/connect-to-redpanda.adoc
+++ b/modules/console/pages/config/connect-to-redpanda.adoc
@@ -1,6 +1,8 @@
 = Configure Redpanda Console to Connect to a Redpanda Cluster
 :description: This topic provides instructions on configuring Redpanda Console to connect to a Redpanda cluster. The configuration ensures that Redpanda Console can communicate with your Redpanda brokers.
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/connect-to-redpanda.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 Redpanda Console connects to your Redpanda cluster using dedicated configuration blocks for the Kafka API, Schema Registry API, and Admin API. Each connection serves a different purpose:
 
 * **Kafka API:** Enables core messaging operations and authenticates requests to your Kafka cluster.

--- a/modules/console/pages/config/connect-to-redpanda.adoc
+++ b/modules/console/pages/config/connect-to-redpanda.adoc
@@ -1,7 +1,8 @@
 = Configure Redpanda Console to Connect to a Redpanda Cluster
 :description: This topic provides instructions on configuring Redpanda Console to connect to a Redpanda cluster. The configuration ensures that Redpanda Console can communicate with your Redpanda brokers.
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/connect-to-redpanda.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
 
 Redpanda Console connects to your Redpanda cluster using dedicated configuration blocks for the Kafka API, Schema Registry API, and Admin API. Each connection serves a different purpose:
 

--- a/modules/console/pages/config/deserialization.adoc
+++ b/modules/console/pages/config/deserialization.adoc
@@ -1,6 +1,8 @@
 = Configure Message Deserialization in Redpanda Console
 :description: Configure Redpanda Console to use Schema Registry, Protobuf files, and other deserialization methods to ensure your data is correctly interpreted and displayed.
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/deserialization.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 Redpanda Console provides tools for deserializing and inspecting messages in Kafka topics. This topic explains how to configure Redpanda Console to use Schema Registry, Protobuf files, and other deserialization methods to ensure your data is correctly interpreted and displayed.
 
 [[sr]]

--- a/modules/console/pages/config/deserialization.adoc
+++ b/modules/console/pages/config/deserialization.adoc
@@ -1,7 +1,8 @@
 = Configure Message Deserialization in Redpanda Console
 :description: Configure Redpanda Console to use Schema Registry, Protobuf files, and other deserialization methods to ensure your data is correctly interpreted and displayed.
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/deserialization.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
 
 Redpanda Console provides tools for deserializing and inspecting messages in Kafka topics. This topic explains how to configure Redpanda Console to use Schema Registry, Protobuf files, and other deserialization methods to ensure your data is correctly interpreted and displayed.
 

--- a/modules/console/pages/config/enterprise-license.adoc
+++ b/modules/console/pages/config/enterprise-license.adoc
@@ -1,6 +1,8 @@
 = Add a License Key to Redpanda Console
 :description: Learn how to apply or update a license key to Redpanda Console.
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/enterprise-license.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 To enable xref:get-started:licensing/overview.adoc#console[enterprise features for Redpanda Console], you must have an Enterprise Edition license to load at startup. This guide explains how to configure Redpanda Console to load the license key from its local configuration.
 
 TIP: This option is best for deployments that are not connected to a Redpanda cluster. If you plan to connect Redpanda Console to a Redpanda cluster, consider uploading the license to the Redpanda cluster. See xref:get-started:licensing/add-license-console.adoc[].

--- a/modules/console/pages/config/enterprise-license.adoc
+++ b/modules/console/pages/config/enterprise-license.adoc
@@ -1,7 +1,8 @@
 = Add a License Key to Redpanda Console
 :description: Learn how to apply or update a license key to Redpanda Console.
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/enterprise-license.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
 
 To enable xref:get-started:licensing/overview.adoc#console[enterprise features for Redpanda Console], you must have an Enterprise Edition license to load at startup. This guide explains how to configure Redpanda Console to load the license key from its local configuration.
 

--- a/modules/console/pages/config/http-path-rewrites.adoc
+++ b/modules/console/pages/config/http-path-rewrites.adoc
@@ -1,6 +1,7 @@
 = HTTP Path Rewrites in Redpanda Console
 :description: Learn how to configure Redpanda Console to work seamlessly with your URL path rewrites, particularly when hosted under a subpath.
 :page-aliases: console:features/http-path-rewrites.adoc, manage:console/http-path-rewrites.adoc
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/http-path-rewrites.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
 If you want to host Redpanda Console under a subpath rather than the root path, you need to configure HTTP path rewrites. This allows you to serve Redpanda Console under a subpath of your domain, such as `+https://my-company.com/redpanda/console+`, instead of directly from `+https://my-company.com+`. This type of configuration is often necessary when:
 

--- a/modules/console/pages/config/http-path-rewrites.adoc
+++ b/modules/console/pages/config/http-path-rewrites.adoc
@@ -3,6 +3,8 @@
 :page-aliases: console:features/http-path-rewrites.adoc, manage:console/http-path-rewrites.adoc
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/http-path-rewrites.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
+include::console:partial$operator-console-version-note.adoc[]
+
 If you want to host Redpanda Console under a subpath rather than the root path, you need to configure HTTP path rewrites. This allows you to serve Redpanda Console under a subpath of your domain, such as `+https://my-company.com/redpanda/console+`, instead of directly from `+https://my-company.com+`. This type of configuration is often necessary when:
 
 * You have multiple services and applications running under the same domain.

--- a/modules/console/pages/config/kafka-connect.adoc
+++ b/modules/console/pages/config/kafka-connect.adoc
@@ -1,10 +1,11 @@
 = Connect Redpanda Console to Kafka Connect Clusters
 :description: Connect one or more Kafka Connect clusters with Redpanda Console.
 :page-aliases: console:features/kafka-connect.adoc, manage:console/kafka-connect.adoc
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/kafka-connect.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
 include::shared:partial$community-supported-kc.adoc[]
+
+include::console:partial$operator-console-version-note.adoc[]
 
 Redpanda Console provides a user interface that lets you manage multiple Kafka Connect clusters.
 You can inspect or patch connectors; restart, pause, and resume connector tasks; and delete connectors.

--- a/modules/console/pages/config/kafka-connect.adoc
+++ b/modules/console/pages/config/kafka-connect.adoc
@@ -2,6 +2,8 @@
 :description: Connect one or more Kafka Connect clusters with Redpanda Console.
 :page-aliases: console:features/kafka-connect.adoc, manage:console/kafka-connect.adoc
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/kafka-connect.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 include::shared:partial$community-supported-kc.adoc[]
 
 Redpanda Console provides a user interface that lets you manage multiple Kafka Connect clusters.

--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -4,6 +4,9 @@
 :page-categories: Security, Management, Redpanda Console
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/security/authentication.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
+include::console:partial$operator-console-version-note.adoc[]
+
+
 // ========================AUTOMATED TESTS===================================
 // The comments in this file are used to run automated tests of the documented steps. Tests are run using GitHub Actions on each pull request that changes this file in the upstream repository. For more details about the testing tool we use, see https://doc-detective.com/.
 

--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -2,6 +2,7 @@
 :description: Authentication in Redpanda Console enables users to log in and optionally forward their credentials to the connected Redpanda cluster, ensuring all API requests are executed under the user's identity.
 :page-aliases: console:single-sign-on/authentication.adoc, manage:security/console/authentication.adoc, console:config/security/plain.adoc, console:config/security/okta.adoc, console:config/security/generic-oidc.adoc, console:config/security/keycloak.adoc, console:config/security/github.adoc, console:config/security/google.adoc, console:config/security/azure-ad.adoc
 :page-categories: Security, Management, Redpanda Console
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/security/authentication.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
 // ========================AUTOMATED TESTS===================================
 // The comments in this file are used to run automated tests of the documented steps. Tests are run using GitHub Actions on each pull request that changes this file in the upstream repository. For more details about the testing tool we use, see https://doc-detective.com/.

--- a/modules/console/pages/config/security/authorization.adoc
+++ b/modules/console/pages/config/security/authorization.adoc
@@ -2,6 +2,7 @@
 :description: Redpanda Console supports role-based access control (RBAC) to restrict system access to authorized users. This page is intended for cluster administrators who manage Redpanda Console access and need to configure UI-based authorization.
 :page-aliases: console:single-sign-on/authorization.adoc, manage:security/console/authorization.adoc, console:features/role-bindings.adoc, console:reference/role-bindings.adoc, reference:console/role-bindings.adoc
 :page-categories: Security, Management, Redpanda Console
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/security/authorization.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
 [NOTE]
 ====

--- a/modules/console/pages/config/security/authorization.adoc
+++ b/modules/console/pages/config/security/authorization.adoc
@@ -4,6 +4,8 @@
 :page-categories: Security, Management, Redpanda Console
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/security/authorization.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
+include::console:partial$operator-console-version-note.adoc[]
+
 [NOTE]
 ====
 include::shared:partial$enterprise-and-console.adoc[]

--- a/modules/console/pages/config/security/index.adoc
+++ b/modules/console/pages/config/security/index.adoc
@@ -2,3 +2,5 @@
 :page-aliases: manage:security/console/index.adoc
 :description: Security topics for Redpanda Console.
 :page-layout: index
+
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/security/index.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]

--- a/modules/console/pages/config/security/index.adoc
+++ b/modules/console/pages/config/security/index.adoc
@@ -2,5 +2,6 @@
 :page-aliases: manage:security/console/index.adoc
 :description: Security topics for Redpanda Console.
 :page-layout: index
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/security/index.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]

--- a/modules/console/pages/config/security/tls-termination.adoc
+++ b/modules/console/pages/config/security/tls-termination.adoc
@@ -4,6 +4,8 @@
 :page-categories: Management, Security, Redpanda Console
 :page-exclude-related-labs: true
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/security/tls-termination.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 To secure Redpanda Console using TLS (Transport Layer Security), you can either let Redpanda Console handle TLS termination or you can offload it to an upstream component, such as a reverse proxy or a cloud HTTPS load balancer. TLS termination refers to the process of decrypting incoming TLS-encrypted traffic. Choosing the right approach depends on various factors, such as your application's traffic load, the complexity of your infrastructure, security requirements, and resource availability:
 
 * Redpanda Console handles TLS termination

--- a/modules/console/pages/config/security/tls-termination.adoc
+++ b/modules/console/pages/config/security/tls-termination.adoc
@@ -3,8 +3,9 @@
 :description: To secure Redpanda Console using TLS, you can let Redpanda Console handle TLS termination or you can offload it to an upstream component, such as a reverse proxy or a Cloud HTTPS LoadBalancer.
 :page-categories: Management, Security, Redpanda Console
 :page-exclude-related-labs: true
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/security/tls-termination.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
 
 To secure Redpanda Console using TLS (Transport Layer Security), you can either let Redpanda Console handle TLS termination or you can offload it to an upstream component, such as a reverse proxy or a cloud HTTPS load balancer. TLS termination refers to the process of decrypting incoming TLS-encrypted traffic. Choosing the right approach depends on various factors, such as your application's traffic load, the complexity of your infrastructure, security requirements, and resource availability:
 

--- a/modules/console/pages/config/topic-documentation.adoc
+++ b/modules/console/pages/config/topic-documentation.adoc
@@ -2,6 +2,8 @@
 :description: Embed your Kafka topic documentation into the Redpanda Console UI by linking a Git repository that contains the topic documentation files.
 :page-aliases: console:features/topic-documentation.adoc, manage:console/topic-documentation.adoc
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/topic-documentation.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 You can embed your topic's documentation into the Redpanda Console user interface by providing access to a public or private Git repository that hosts your documentation files in Markdown format.
 
 image::topic-documentation.png[]

--- a/modules/console/pages/config/topic-documentation.adoc
+++ b/modules/console/pages/config/topic-documentation.adoc
@@ -1,8 +1,9 @@
 = Enable Topic Documentation in Redpanda Console
 :description: Embed your Kafka topic documentation into the Redpanda Console UI by linking a Git repository that contains the topic documentation files.
 :page-aliases: console:features/topic-documentation.adoc, manage:console/topic-documentation.adoc
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:config/topic-documentation.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
 
 You can embed your topic's documentation into the Redpanda Console user interface by providing access to a public or private Git repository that hosts your documentation files in Markdown format.
 

--- a/modules/console/pages/index.adoc
+++ b/modules/console/pages/index.adoc
@@ -1,8 +1,9 @@
 = Introduction to Redpanda Console
 :description: Learn about Redpanda Console: a web interface for managing and interacting with Redpanda clusters.
 :page-aliases: console:index/index.adoc, console:features/index.adoc, reference:console/index.adoc
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:index.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
-:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:pages/index.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+include::console:partial$operator-console-version-note.adoc[]
 
 Redpanda Console is a web interface for managing and interacting with Redpanda clusters. Built to provide a seamless experience for developers working with streaming data, Redpanda Console simplifies tasks associated with managing data streams, offering a UI that helps you monitor, troubleshoot, and optimize your streaming workloads.
 

--- a/modules/console/pages/index.adoc
+++ b/modules/console/pages/index.adoc
@@ -2,6 +2,8 @@
 :description: Learn about Redpanda Console: a web interface for managing and interacting with Redpanda clusters.
 :page-aliases: console:index/index.adoc, console:features/index.adoc, reference:console/index.adoc
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:pages/index.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 Redpanda Console is a web interface for managing and interacting with Redpanda clusters. Built to provide a seamless experience for developers working with streaming data, Redpanda Console simplifies tasks associated with managing data streams, offering a UI that helps you monitor, troubleshoot, and optimize your streaming workloads.
 
 image::overview.png[]

--- a/modules/console/pages/ui/add-license.adoc
+++ b/modules/console/pages/ui/add-license.adoc
@@ -1,7 +1,8 @@
 = Manage Enterprise Edition Licenses through Redpanda Console
 :description: Learn how to manage Enterprise Edition licenses in Redpanda Console.
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/add-license.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
 
 You can add or update an xref:get-started:licensing/overview.adoc#console[Enterprise Edition license] for both Redpanda and Redpanda Console directly through the Redpanda Console UI.
 

--- a/modules/console/pages/ui/add-license.adoc
+++ b/modules/console/pages/ui/add-license.adoc
@@ -1,6 +1,8 @@
 = Manage Enterprise Edition Licenses through Redpanda Console
 :description: Learn how to manage Enterprise Edition licenses in Redpanda Console.
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/add-license.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 You can add or update an xref:get-started:licensing/overview.adoc#console[Enterprise Edition license] for both Redpanda and Redpanda Console directly through the Redpanda Console UI.
 
 == Prerequisites

--- a/modules/console/pages/ui/check-license.adoc
+++ b/modules/console/pages/ui/check-license.adoc
@@ -1,6 +1,8 @@
 = Check License Status in Redpanda Console
 :description: Learn how to check the status of your Redpanda Enterprise Edition license using the Redpanda Console. This topic includes steps to check license details and understand license warnings.
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/check-license.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 You can check the expiration date of a license on the **Cluster Overview** page in Redpanda Console, under the **Licensing** section.
 
 Redpanda Console tries to load a valid license at startup in the following order:

--- a/modules/console/pages/ui/check-license.adoc
+++ b/modules/console/pages/ui/check-license.adoc
@@ -1,7 +1,8 @@
 = Check License Status in Redpanda Console
 :description: Learn how to check the status of your Redpanda Enterprise Edition license using the Redpanda Console. This topic includes steps to check license details and understand license warnings.
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/check-license.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
 
 You can check the expiration date of a license on the **Cluster Overview** page in Redpanda Console, under the **Licensing** section.
 

--- a/modules/console/pages/ui/data-transforms.adoc
+++ b/modules/console/pages/ui/data-transforms.adoc
@@ -2,6 +2,8 @@
 :description: Use {ui} to monitor the status and performance metrics of your transform functions. You can also view detailed logs and delete transform functions when they are no longer needed.
 // tag::single-source[]
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/data-transforms.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 {description}
 
 == Prerequisites

--- a/modules/console/pages/ui/data-transforms.adoc
+++ b/modules/console/pages/ui/data-transforms.adoc
@@ -1,8 +1,10 @@
 = Manage Data Transforms in {ui}
 :description: Use {ui} to monitor the status and performance metrics of your transform functions. You can also view detailed logs and delete transform functions when they are no longer needed.
-// tag::single-source[]
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/data-transforms.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
+
+// tag::single-source[]
 
 {description}
 

--- a/modules/console/pages/ui/edit-topic-configuration.adoc
+++ b/modules/console/pages/ui/edit-topic-configuration.adoc
@@ -3,6 +3,8 @@
 :description: Use {ui} to edit the configuration of existing topics in a cluster.
 // tag::single-source[]
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/edit-topic-configuration.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 {description}
 
 . In the menu, go to *Topics*.

--- a/modules/console/pages/ui/edit-topic-configuration.adoc
+++ b/modules/console/pages/ui/edit-topic-configuration.adoc
@@ -1,9 +1,11 @@
 = Edit Topic Configuration in {ui}
 :page-aliases: manage:console/edit-topic-configuration.adoc
 :description: Use {ui} to edit the configuration of existing topics in a cluster.
-// tag::single-source[]
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/edit-topic-configuration.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
+
+// tag::single-source[]
 
 {description}
 

--- a/modules/console/pages/ui/generate-bundle.adoc
+++ b/modules/console/pages/ui/generate-bundle.adoc
@@ -1,6 +1,8 @@
 = Manage Debug Bundles in Redpanda Console
 :description: Learn how to generate, download, and delete debug bundles in Redpanda Console for comprehensive cluster diagnostics.
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/generate-bundle.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 [NOTE]
 ====
 include::shared:partial$enterprise-and-console.adoc[]

--- a/modules/console/pages/ui/generate-bundle.adoc
+++ b/modules/console/pages/ui/generate-bundle.adoc
@@ -1,7 +1,8 @@
 = Manage Debug Bundles in Redpanda Console
 :description: Learn how to generate, download, and delete debug bundles in Redpanda Console for comprehensive cluster diagnostics.
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/generate-bundle.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
 
 [NOTE]
 ====

--- a/modules/console/pages/ui/programmable-push-filters.adoc
+++ b/modules/console/pages/ui/programmable-push-filters.adoc
@@ -2,8 +2,10 @@
 :page-aliases: console:features/programmable-push-filters.adoc, reference:console/programmable-push-filters.adoc
 // Do not put page aliases in the single-sourced content
 :description: Learn how to filter Kafka records using custom JavaScript code within {ui}.
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/programmable-push-filters.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
+
 // tag::single-source[]
 
 You can use push-down filters in {ui} to search through large Kafka topics that may contain millions of records. Filters are JavaScript functions executed on the backend, evaluating each record individually. Your function must return a boolean:

--- a/modules/console/pages/ui/programmable-push-filters.adoc
+++ b/modules/console/pages/ui/programmable-push-filters.adoc
@@ -2,6 +2,8 @@
 :page-aliases: console:features/programmable-push-filters.adoc, reference:console/programmable-push-filters.adoc
 // Do not put page aliases in the single-sourced content
 :description: Learn how to filter Kafka records using custom JavaScript code within {ui}.
+
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/programmable-push-filters.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 // tag::single-source[]
 
 You can use push-down filters in {ui} to search through large Kafka topics that may contain millions of records. Filters are JavaScript functions executed on the backend, evaluating each record individually. Your function must return a boolean:

--- a/modules/console/pages/ui/record-deserialization.adoc
+++ b/modules/console/pages/ui/record-deserialization.adoc
@@ -3,6 +3,8 @@
 :description: Learn how {ui} deserializes messages.
 // tag::single-source[]
 
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/record-deserialization.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
 In Redpanda, the messages exchanged between producers and consumers contain raw bytes. Schemas work as an agreed-upon format, like a contract, for producers and consumers to serialize and deserialize those messages. If a producer breaks this contract, consumers can fail.
 
 {ui} automatically tries to deserialize incoming messages and displays them in human-readable format. It tests different deserialization strategies until it finds one with no errors. If no deserialization attempts are successful, {ui} renders the byte array in a hex viewer. Sometimes, the payload is displayed in hex bytes because it's encrypted or because it uses a serializer that {ui} cannot deserialize. When this happens, {ui} displays troubleshooting information. You can also download the raw bytes of the message to feed it directly to your client deserializer or share it with a support team.

--- a/modules/console/pages/ui/record-deserialization.adoc
+++ b/modules/console/pages/ui/record-deserialization.adoc
@@ -1,9 +1,12 @@
 = View Deserialized Messages in {ui}
 :page-aliases: console:features/record-deserialization.adoc, manage:console/protobuf.adoc, reference:console/record-deserialization.adoc
 :description: Learn how {ui} deserializes messages.
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/record-deserialization.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
+
 // tag::single-source[]
 
-:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/record-deserialization.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 
 In Redpanda, the messages exchanged between producers and consumers contain raw bytes. Schemas work as an agreed-upon format, like a contract, for producers and consumers to serialize and deserialize those messages. If a producer breaks this contract, consumers can fail.
 

--- a/modules/console/pages/ui/schema-reg.adoc
+++ b/modules/console/pages/ui/schema-reg.adoc
@@ -2,6 +2,8 @@
 :page-aliases: manage:schema-reg/schema-reg-ui.adoc
 :page-categories: Management, Schema Registry
 :description: Perform common Schema Registry management operations in the {ui}.
+
+:page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/schema-reg.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
 // tag::single-source[]
 
 In {ui}, the *Schema Registry* menu lists registered and verified schemas, including their serialization format and versions. Select an individual schema to see which topics it applies to.

--- a/modules/console/pages/ui/schema-reg.adoc
+++ b/modules/console/pages/ui/schema-reg.adoc
@@ -2,8 +2,10 @@
 :page-aliases: manage:schema-reg/schema-reg-ui.adoc
 :page-categories: Management, Schema Registry
 :description: Perform common Schema Registry management operations in the {ui}.
-
 :page-context-switcher: [{"name": "Redpanda Console v2.x", "to": "24.3@ROOT:console:ui/schema-reg.adoc" },{"name": "Redpanda Console v3.x", "to": "current" } ]
+
+include::console:partial$operator-console-version-note.adoc[]
+
 // tag::single-source[]
 
 In {ui}, the *Schema Registry* menu lists registered and verified schemas, including their serialization format and versions. Select an individual schema to see which topics it applies to.

--- a/modules/console/partials/operator-console-version-note.adoc
+++ b/modules/console/partials/operator-console-version-note.adoc
@@ -1,0 +1,21 @@
+.The Redpanda Operator deploys Redpanda Console v2.x, not v3.x
+[%collapsible]
+====
+Redpanda Console v3 is **not yet available when deploying with the Redpanda Operator**. The Redpanda Operator continues to deploy Redpanda Console v2. To try Redpanda Console v3 in Kubernetes, you can xref:deploy:deployment-option/self-hosted/kubernetes/k-production-deployment.adoc[deploy Redpanda using the Redpanda Helm chart] instead of the Redpanda Operator.
+
+Redpanda Console configuration syntax varies by major version. Before configuring, determine which version you're using:
+
+[source,shell]
+----
+# Check console version from deployment
+kubectl get deployment -n <namespace> redpanda-console -o jsonpath='{.spec.template.spec.containers[0].image}'
+
+# Or check from running pod
+kubectl get pod -n <namespace> -l app.kubernetes.io/name=console -o jsonpath='{.items[0].spec.containers[0].image}'
+
+# Or check from console logs
+kubectl logs -n <namespace> -l app.kubernetes.io/name=console | grep "started Redpanda Console"
+----
+
+If you see output like `redpandadata/console:v2.8.0`, you're using Redpanda Console v2.x. If you see `redpandadata/console:v3.0.0`, you're using Redpanda Console v3.x.
+====

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-high-availability.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-high-availability.adoc
@@ -1,6 +1,5 @@
 = High Availability in Kubernetes
 :description: Explore high availability configurations of Redpanda in Kubernetes.
-:page-context-links: [{"name": "Linux", "to": "deploy:deployment-option/self-hosted/manual/high-availability.adoc" },{"name": "Kubernetes", "to": "deploy:deployment-option/self-hosted/kubernetes/k-high-availability.adoc" } ]
 :env-kubernetes: true
 :page-categories: Deployment, High Availability
 

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -3,7 +3,6 @@
 :tags: ["Kubernetes"]
 :page-aliases: deploy:deployment-option/self-hosted/kubernetes/kubernetes-best-practices.adoc, deploy:deployment-option/self-hosted/kubernetes/redpanda-cluster-recommendations.adoc, deploy:deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc
 :page-toclevels: 1
-:page-context-links: [{"name": "Linux", "to": "deploy:deployment-option/self-hosted/manual/production/production-deployment.adoc" },{"name": "Kubernetes", "to": "deploy:deployment-option/self-hosted/kubernetes/k-production-deployment.adoc" } ]
 :env-kubernetes: true
 :page-categories: Deployment, GitOps
 

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-requirements.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-requirements.adoc
@@ -2,7 +2,6 @@
 :description: A list of requirements and recommendations for provisioning Kubernetes clusters and worker nodes for running Redpanda in production.
 :tags: ["Kubernetes"]
 :page-aliases: deploy:deployment-option/self-hosted/kubernetes/cloud-instance-local-storage.adoc, deploy:deployment-option/self-hosted/kubernetes/kubernetes-requirements-index.adoc, deploy:deployment-option/self-hosted/kubernetes/kubernetes-cluster-requirements.adoc
-:page-context-links: [{"name": "Linux", "to": "deploy:deployment-option/self-hosted/manual/production/requirements.adoc" },{"name": "Kubernetes", "to": "deploy:deployment-option/self-hosted/kubernetes/k-requirements.adoc" } ]
 :env-kubernetes: true
 :page-categories: Deployment
 

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/high-availability.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/high-availability.adoc
@@ -1,6 +1,5 @@
 = High Availability
 :description: Learn about the trade-offs with different high availability configurations.
-:page-context-links: [{"name": "Linux", "to": "deploy:deployment-option/self-hosted/manual/high-availability.adoc" },{"name": "Kubernetes", "to": "deploy:deployment-option/self-hosted/kubernetes/k-high-availability.adoc" } ]
 :page-aliases: deployment:high-availability.adoc
 :env-linux: true
 :page-categories: Deployment

--- a/modules/deploy/pages/deployment-option/self-hosted/manual/production/requirements.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/production/requirements.adoc
@@ -1,6 +1,5 @@
 = Requirements and Recommendations
 :description: A list of requirements and recommendations for provisioning servers to run Redpanda in production.
-:page-context-links: [{"name": "Linux", "to": "deploy:deployment-option/self-hosted/manual/production/requirements.adoc" },{"name": "Kubernetes", "to": "deploy:deployment-option/self-hosted/kubernetes/k-requirements.adoc" } ]
 :env-linux: true
 :page-categories: Deployment
 

--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -1,5 +1,4 @@
 = Manage Topics
-:page-context-links: [{"name": "Linux", "to": "develop:config-topics.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-manage-topics.adoc" } ]
 :page-categories: Clients, Development
 :description: Learn how to create topics, update topic configurations, and delete topics or records.
 // tag::single-source[]

--- a/modules/develop/pages/data-transforms/k-run-transforms.adoc
+++ b/modules/develop/pages/data-transforms/k-run-transforms.adoc
@@ -1,7 +1,6 @@
 = Data Transforms in Kubernetes Quickstart
 :description: Learn how to build and deploy your first transform function in Kubernetes deployments.
 :env-kubernetes:
-:page-context-links: [{"name": "Linux", "to": "develop:data-transforms/run-transforms.adoc" },{"name": "Kubernetes", "to": "develop:data-transforms/k-run-transforms.adoc" } ]
 :page-categories: Development, Stream Processing, Data Transforms
 
 include::develop:partial$run-transforms.adoc[]

--- a/modules/develop/pages/data-transforms/run-transforms.adoc
+++ b/modules/develop/pages/data-transforms/run-transforms.adoc
@@ -1,6 +1,5 @@
 = Data Transforms in Linux Quickstart
 :description: Learn how to build and deploy your first transform function in Linux deployments.
-:page-context-links: [{"name": "Linux", "to": "develop:data-transforms/run-transforms.adoc" },{"name": "Kubernetes", "to": "develop:data-transforms/k-run-transforms.adoc" } ]
 :page-categories: Development, Stream Processing, Data Transforms
 
 include::develop:partial$run-transforms.adoc[]

--- a/modules/get-started/pages/release-notes/operator.adoc
+++ b/modules/get-started/pages/release-notes/operator.adoc
@@ -15,7 +15,7 @@ link:https://github.com/redpanda-data/redpanda-operator/blob/release/v25.1.x/ope
 
 === Redpanda Console v3
 
-Redpanda Console v3 is **not yet available when deploying with the Redpanda Operator**, due to pending CRD updates. The Redpanda Operator continues to deploy Redpanda Console v2.
+Redpanda Console v3 is **not yet available when deploying with the Redpanda Operator**, due to pending CRD updates. The Redpanda Operator continues to deploy Redpanda Console v2. xref:24.3@ROOT:console:index.adoc[View the Redpanda Console v2 documentation].
 
 To try Redpanda Console v3 in Kubernetes, you can xref:deploy:deployment-option/self-hosted/kubernetes/k-production-deployment.adoc[deploy Redpanda using the Redpanda Helm chart] instead of the Redpanda Operator. Redpanda Console v3 introduces support for unified authentication and authorization with Redpanda, including user impersonation.
 

--- a/modules/manage/pages/audit-logging.adoc
+++ b/modules/manage/pages/audit-logging.adoc
@@ -1,6 +1,5 @@
 = Audit Logging
 :description: Learn how to use Redpanda's audit logging capabilities.
-:page-context-links: [{"name": "Linux", "to": "manage:audit-logging.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/security/k-audit-logging.adoc" } ]
 :page-categories: Management, Security
 :env-linux: true
 // tag::single-source[]

--- a/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-property-configuration.adoc
@@ -1,6 +1,5 @@
 = Configure Cluster Properties
 :description: Learn how to configure cluster properties.
-:page-context-links: [{"name": "Linux", "to": "manage:cluster-maintenance/cluster-property-configuration.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-cluster-property-configuration.adoc" } ]
 :page-aliases: manage:cluster-maintenance/configuration.adoc, deploy-self-hosted:configuration.adoc, cluster-administration:configuration.adoc, cluster-management:configuration.adoc, cluster-administration:cluster-property-configuration.adoc
 :page-categories: Management
 

--- a/modules/manage/pages/cluster-maintenance/decommission-brokers.adoc
+++ b/modules/manage/pages/cluster-maintenance/decommission-brokers.adoc
@@ -1,6 +1,5 @@
 = Decommission Brokers
 :description: Remove a broker so that it is no longer considered part of the cluster.
-:page-context-links: [{"name": "Linux", "to": "manage:cluster-maintenance/decommission-brokers.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-decommission-brokers.adoc" } ]
 :page-categories: Management
 
 When you decommission a broker, its partition replicas are reallocated across the remaining brokers and it is removed from the cluster. You may want to decommission a broker in the following circumstances:

--- a/modules/manage/pages/cluster-maintenance/rolling-restart.adoc
+++ b/modules/manage/pages/cluster-maintenance/rolling-restart.adoc
@@ -1,7 +1,6 @@
 = Perform a Rolling Restart
 :description: Learn how to perform a rolling restart of your Redpanda cluster.
 :rolling-restart:
-:page-context-links: [{"name": "Linux", "to": "manage:cluster-maintenance/rolling-restart.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-rolling-restart.adoc" } ]
 :page-categories: Management
 
 A rolling restart involves restarting one broker at a time while the remaining brokers in your cluster continue running. This is to minimize downtime during a full cluster restart.

--- a/modules/manage/pages/fast-commission-decommission.adoc
+++ b/modules/manage/pages/fast-commission-decommission.adoc
@@ -1,6 +1,5 @@
 = Fast Commission and Decommission Brokers
 :description: Configure fast partition movement during cluster resize for high availability.
-:page-context-links: [{"name": "Linux", "to": "manage:fast-commission-decommission.adoc" } ]
 :page-categories: Management, High Availability
 :env-linux: true
 

--- a/modules/manage/pages/kubernetes/k-cluster-property-configuration.adoc
+++ b/modules/manage/pages/kubernetes/k-cluster-property-configuration.adoc
@@ -1,6 +1,5 @@
 = Configure Cluster Properties in Kubernetes
 :description: Learn how to configure cluster properties in Kubernetes.
-:page-context-links: [{"name": "Linux", "to": "manage:cluster-maintenance/cluster-property-configuration.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-cluster-property-configuration.adoc" } ]
 :page-aliases: manage:kubernetes/cluster-property-configuration.adoc, reference:redpanda-operator/kubernetes-additional-config.adoc, reference:redpanda-operator/arbitrary-configuration.adoc
 :page-categories: Management
 :env-kubernetes: true

--- a/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
+++ b/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
@@ -1,6 +1,5 @@
 = Decommission Brokers in Kubernetes
 :description: Remove a Redpanda broker from the cluster without risking data loss or causing instability.
-:page-context-links: [{"name": "Linux", "to": "manage:cluster-maintenance/decommission-brokers.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-decommission-brokers.adoc" } ]
 :tags: ["Kubernetes"]
 :page-aliases: manage:kubernetes/decommission-brokers.adoc
 :page-categories: Management

--- a/modules/manage/pages/kubernetes/k-manage-topics.adoc
+++ b/modules/manage/pages/kubernetes/k-manage-topics.adoc
@@ -1,6 +1,5 @@
 = Manage Topics with the Redpanda Operator
 :description: Use the Topic resource to declaratively create Kafka topics as part of a Redpanda deployment. Each Topic resource is mapped to a topic in your Redpanda cluster. The topic controller keeps the corresponding Kafka topic in sync with the Topic resource.
-:page-context-links: [{"name": "Linux", "to": "develop:config-topics.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-manage-topics.adoc" } ]
 :page-categories: Management, Development
 :env-kubernetes: true
 :page-aliases: manage:kubernetes/manage-topics.adoc

--- a/modules/manage/pages/kubernetes/k-rack-awareness.adoc
+++ b/modules/manage/pages/kubernetes/k-rack-awareness.adoc
@@ -1,6 +1,5 @@
 = Enable Rack Awareness in Kubernetes
 :description: Enable rack awareness to place partition replicas across different failure zones.
-:page-context-links: [{"name": "Linux", "to": "manage:rack-awareness.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-rack-awareness.adoc" } ]
 :page-tags: ["Kubernetes", "Helm configuration"]
 :page-aliases: manage:kubernetes/kubernetes-rack-awareness.adoc
 :page-categories: Management, High Availability

--- a/modules/manage/pages/kubernetes/k-remote-read-replicas.adoc
+++ b/modules/manage/pages/kubernetes/k-remote-read-replicas.adoc
@@ -1,6 +1,5 @@
 = Remote Read Replicas in Kubernetes
 :description: Create read-only topics (Remote Read Replica topics) that mirror topics on a different cluster.
-:page-context-links: [{"name": "Linux", "to": "manage:remote-read-replicas.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-remote-read-replicas.adoc" } ]
 :page-categories: Management, High Availability
 :env-kubernetes: true
 :tags: ["Kubernetes", "Helm configuration"]

--- a/modules/manage/pages/kubernetes/k-rolling-restart.adoc
+++ b/modules/manage/pages/kubernetes/k-rolling-restart.adoc
@@ -1,7 +1,6 @@
 = Perform a Rolling Restart of Redpanda in Kubernetes
 :description: Learn how to perform a rolling restart of your Redpanda cluster when it's running in Kubernetes.
 :rolling-restart:
-:page-context-links: [{"name": "Linux", "to": "manage:cluster-maintenance/rolling-restart.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-rolling-restart.adoc" } ]
 :page-categories: Management, High Availability
 :env-kubernetes: true
 

--- a/modules/manage/pages/kubernetes/monitoring/k-monitor-redpanda.adoc
+++ b/modules/manage/pages/kubernetes/monitoring/k-monitor-redpanda.adoc
@@ -1,6 +1,5 @@
 = Monitor Redpanda in Kubernetes
 :description: Monitor the health of your system to predict issues and optimize performance.
-:page-context-links: [{"name": "Linux", "to": "manage:monitoring.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/monitoring/k-monitor-redpanda.adoc" },{"name": "Cloud", "to": "deploy:deployment-option/cloud/monitor-cloud.adoc" } ]
 :env-kubernetes:
 :page-aliases: manage:kubernetes/monitoring/monitor-redpanda.adoc
 :page-categories: Management, Monitoring

--- a/modules/manage/pages/kubernetes/networking/k-configure-listeners.adoc
+++ b/modules/manage/pages/kubernetes/networking/k-configure-listeners.adoc
@@ -1,6 +1,5 @@
 = Configure Listeners in Kubernetes
 :description: Configure your Redpanda deployment in Kubernetes to meet specific network requirements by customizing advertised ports and TLS certificates for each listener. Learn to enable or disable access to these listeners as needed.
-:page-context-links: [{"name": "Linux", "to": "manage:security/listener-configuration.adoc"}, {"name": "Kubernetes", "to": "manage:kubernetes/networking/k-configure-listeners.adoc"}]
 :tags: [Kubernetes, Helm Configuration]
 :page-aliases: manage:kubernetes/networking/configure-listeners.adoc
 :page-categories: Management, Networking

--- a/modules/manage/pages/kubernetes/security/authentication/k-authentication.adoc
+++ b/modules/manage/pages/kubernetes/security/authentication/k-authentication.adoc
@@ -1,6 +1,5 @@
 = Configure Authentication for Redpanda in Kubernetes
 :description: Use Helm values or the Redpanda resource manifest to enable authentication for Redpanda. This method provides a way to configure authentication during the initial deployment or updates to the cluster configuration.
-:page-context-links: [{"name": "Linux", "to": "manage:security/authentication.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/security/authentication/k-authentication.adoc" } ]
 :tags: ["Kubernetes", "Helm configuration"]
 :page-categories: Management, Security
 :env-kubernetes: true

--- a/modules/manage/pages/kubernetes/security/k-audit-logging.adoc
+++ b/modules/manage/pages/kubernetes/security/k-audit-logging.adoc
@@ -1,6 +1,5 @@
 = Audit Logging in Kubernetes
 :description: Learn how to use Redpanda's audit logging capabilities.
-:page-context-links: [{"name": "Linux", "to": "manage:audit-logging.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/security/k-audit-logging.adoc" } ]
 :page-categories: Management, Security
 :env-kubernetes: true
 

--- a/modules/manage/pages/kubernetes/security/tls/index.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/index.adoc
@@ -1,6 +1,5 @@
 = TLS for Redpanda in Kubernetes
 :description: Use TLS to authenticate Redpanda brokers and encrypt communication between clients and brokers.
-:page-context-links: [{"name": "Linux", "to": "manage:security/encryption.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/security/kubernetes-tls.adoc" } ]
 :tags: ["Kubernetes", "Security"]
 :page-aliases: manage:kubernetes/security/kubernetes-tls.adoc, security:kubernetes-tls.adoc, security:kubernetes-mtls.adoc, features:tls-kubernetes.adoc, security:tls-kubernetes.adoc, reference:redpanda-operator/tls-kubernetes.adoc, manage:kubernetes/security/tls.adoc
 :page-layout: index

--- a/modules/manage/pages/kubernetes/tiered-storage/k-fast-commission-decommission.adoc
+++ b/modules/manage/pages/kubernetes/tiered-storage/k-fast-commission-decommission.adoc
@@ -1,6 +1,5 @@
 = Fast Commission and Decommission Brokers in Kubernetes
 :description: Configure fast partition movement during cluster resize for high availability.
-:page-context-links: [{"name": "Linux", "to": "manage:fast-commission-decommission.adoc" } ]
 :page-categories: Management, High Availability
 :env-kubernetes: true
 :page-aliases: manage:kubernetes/storage/tiered-storage/k-fast-commission-decommission.adoc

--- a/modules/manage/pages/kubernetes/tiered-storage/k-recovery-mode.adoc
+++ b/modules/manage/pages/kubernetes/tiered-storage/k-recovery-mode.adoc
@@ -1,6 +1,5 @@
 = Recovery Mode in Kubernetes
 :description: Recovery mode starts Redpanda with limited functionality and disables partitions so you can repair a failed cluster.
-:page-context-links: [{"name": "Linux", "to": "manage:recovery-mode.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-recovery-mode.adoc" } ]
 :page-categories: Management, High Availability, Disaster Recovery
 :env-kubernetes: true
 :page-aliases: manage:kubernetes/k-recovery-mode.adoc, manage:kubernetes/storage/tiered-storage/k-recovery-mode.adoc

--- a/modules/manage/pages/kubernetes/tiered-storage/k-remote-read-replicas.adoc
+++ b/modules/manage/pages/kubernetes/tiered-storage/k-remote-read-replicas.adoc
@@ -1,6 +1,5 @@
 = Remote Read Replicas in Kubernetes
 :description: Learn how to create a Remote Read Replica topic, which is a read-only topic that mirrors a topic on a different cluster.
-:page-context-links: [{"name": "Linux", "to": "manage:remote-read-replicas.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-remote-read-replicas.adoc" } ]
 :page-categories: Management, High Availability, Data Replication
 :env-kubernetes: true
 :page-aliases: manage:kubernetes/storage/tiered-storage/k-remote-read-replicas.adoc

--- a/modules/manage/pages/kubernetes/tiered-storage/k-topic-recovery.adoc
+++ b/modules/manage/pages/kubernetes/tiered-storage/k-topic-recovery.adoc
@@ -1,6 +1,5 @@
 = Topic Recovery in Kubernetes
 :description: Restore a single topic from object storage.
-:page-context-links: [{"name": "Linux", "to": "manage:topic-recovery.adoc" } ]
 :page-categories: Management, High Availability
 :env-kubernetes: true
 :page-aliases: manage:kubernetes/storage/tiered-storage/k-topic-recovery.adoc

--- a/modules/manage/pages/kubernetes/tiered-storage/k-whole-cluster-restore.adoc
+++ b/modules/manage/pages/kubernetes/tiered-storage/k-whole-cluster-restore.adoc
@@ -1,6 +1,5 @@
 = Whole Cluster Restore for Disaster Recovery in Kubernetes
 :description: Restore a failed cluster, including its metadata.
-:page-context-links: [{"name": "Linux", "to": "manage:whole-cluster-restore.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-whole-cluster-restore.adoc" } ]
 :page-categories: Management, High Availability, Disaster Recovery
 :env-kubernetes: true
 :page-aliases: manage:kubernetes/k-whole-cluster-restore.adoc, manage:kubernetes/storage/tiered-storage/k-whole-cluster-restore.adoc

--- a/modules/manage/pages/monitoring.adoc
+++ b/modules/manage/pages/monitoring.adoc
@@ -1,6 +1,5 @@
 = Monitor Redpanda
 :description: Metrics to monitor the health of your system to predict issues and optimize performance.
-:page-context-links: [{"name": "Linux", "to": "manage:monitoring.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/monitoring/k-monitor-redpanda.adoc" },{"name": "Cloud", "to": "deploy:deployment-option/cloud/monitor-cloud.adoc" } ]
 :page-aliases: deploy-self-hosted:monitoring.adoc, cluster-administration:monitoring.adoc, cluster-management:monitoring.adoc
 :page-categories: Management, Monitoring
 :env-linux: true

--- a/modules/manage/pages/mountable-topics.adoc
+++ b/modules/manage/pages/mountable-topics.adoc
@@ -1,6 +1,5 @@
 = Mountable Topics
 :description: Safely attach and detach Tiered Storage topics to and from a Redpanda cluster.
-:page-context-links: [{"name": "Linux", "to": "manage:mountable-topics.adoc" } ]
 :page-categories: Management
 :env-linux: true
 

--- a/modules/manage/pages/rack-awareness.adoc
+++ b/modules/manage/pages/rack-awareness.adoc
@@ -1,6 +1,5 @@
 = Enable Rack Awareness
 :description: Enable rack awareness to place partition replicas across different failure zones.
-:page-context-links: [{"name": "Linux", "to": "manage:rack-awareness.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-rack-awareness.adoc" } ]
 :page-aliases: data-management:rack-awareness.adoc
 :page-categories: Management, High Availability
 :env-linux: true

--- a/modules/manage/pages/recovery-mode.adoc
+++ b/modules/manage/pages/recovery-mode.adoc
@@ -1,6 +1,5 @@
 = Recovery Mode
 :description: Recovery mode starts Redpanda with limited functionality and disables partitions so you can repair a failed cluster.
-:page-context-links: [{"name": "Linux", "to": "manage:recovery-mode.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-recovery-mode.adoc" } ]
 :page-categories: Management, High Availability, Disaster Recovery
 :env-linux: true
 

--- a/modules/manage/pages/remote-read-replicas.adoc
+++ b/modules/manage/pages/remote-read-replicas.adoc
@@ -1,6 +1,5 @@
 = Remote Read Replicas
 :description: Learn how to create a Remote Read Replica topic, which is a read-only topic that mirrors a topic on a different cluster.
-:page-context-links: [{"name": "Linux", "to": "manage:remote-read-replicas.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-remote-read-replicas.adoc" } ]
 :page-aliases: data-management:remote-read-replicas.adoc
 :page-categories: Management, High Availability, Data Replication
 :env-linux: true

--- a/modules/manage/pages/security/authentication.adoc
+++ b/modules/manage/pages/security/authentication.adoc
@@ -1,6 +1,5 @@
 = Configure Authentication
 :description: Redpanda supports multiple forms of authentication including SASL/SCRAM, mTLS with principal mapping, and basic authentication.
-:page-context-links: [{"name": "Linux", "to": "manage:security/authentication.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/security/authentication/k-authentication.adoc" } ]
 :page-aliases: security:authentication.adoc
 :page-toclevels: 3
 :page-categories: Management, Security

--- a/modules/manage/pages/security/encryption.adoc
+++ b/modules/manage/pages/security/encryption.adoc
@@ -1,6 +1,5 @@
 = Configure Kafka TLS Encryption
 :description: Enable encryption with TLS or mTLS.
-:page-context-links: [{"name": "Linux", "to": "manage:security/encryption.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/security/kubernetes-tls.adoc" } ]
 :page-aliases: security:encryption.adoc
 :page-categories: Management, Security
 

--- a/modules/manage/pages/security/listener-configuration.adoc
+++ b/modules/manage/pages/security/listener-configuration.adoc
@@ -1,6 +1,5 @@
 = Configure Listeners
 :description: Use listeners to advertise the location of the broker, so other brokers in the cluster can be found.
-:page-context-links: [{"name": "Linux", "to": "manage:security/listener-configuration.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/networking/k-configure-listeners.adoc" } ]
 :page-aliases: cluster-administration:listener-configuration.adoc
 :page-categories: Management, Security
 

--- a/modules/manage/pages/tiered-storage.adoc
+++ b/modules/manage/pages/tiered-storage.adoc
@@ -1,6 +1,5 @@
 = Use Tiered Storage
 :description: Configure your Redpanda cluster to offload log segments to cloud storage and save storage costs.
-:page-context-links: [{"name": "Linux", "to": "manage:tiered-storage.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/storage/tiered-storage/k-tiered-storage.adoc" } ]
 :page-aliases: data-management:shadow-indexing.adoc, data-management:tiered-storage.adoc, data-management:data-archiving.adoc, manage:data-archiving.adoc
 :page-categories: Management, High Availability, Data Replication
 :env-linux: true

--- a/modules/manage/pages/topic-recovery.adoc
+++ b/modules/manage/pages/topic-recovery.adoc
@@ -1,6 +1,5 @@
 = Topic Recovery
 :description: Restore a single topic from object storage.
-:page-context-links: [{"name": "Linux", "to": "manage:topic-recovery.adoc" } ]
 :page-categories: Management, High Availability
 :env-linux: true
 

--- a/modules/manage/pages/whole-cluster-restore.adoc
+++ b/modules/manage/pages/whole-cluster-restore.adoc
@@ -1,6 +1,5 @@
 = Whole Cluster Restore for Disaster Recovery
 :description: Restore a failed cluster, including its metadata.
-:page-context-links: [{"name": "Linux", "to": "manage:whole-cluster-restore.adoc" },{"name": "Kubernetes", "to": "manage:kubernetes/k-whole-cluster-restore.adoc" } ]
 :page-categories: Management, High Availability, Disaster Recovery
 :env-linux: true
 

--- a/modules/upgrade/pages/k-rolling-upgrade.adoc
+++ b/modules/upgrade/pages/k-rolling-upgrade.adoc
@@ -1,6 +1,5 @@
 = Upgrade Redpanda in Kubernetes
 :description: To benefit from Redpanda's new features and enhancements, upgrade to the latest version.
-:page-context-links: [{"name": "Linux", "to": "upgrade:rolling-upgrade.adoc" },{"name": "Kubernetes", "to": "upgrade:k-rolling-upgrade.adoc" } ]
 :page-aliases: manage:kubernetes/rolling-upgrade.adoc
 :page-categories: Upgrades
 :env-kubernetes: true

--- a/modules/upgrade/pages/rolling-upgrade.adoc
+++ b/modules/upgrade/pages/rolling-upgrade.adoc
@@ -1,6 +1,5 @@
 = Upgrade Redpanda
 :description: To benefit from Redpanda's new features and enhancements, upgrade to the latest version.
-:page-context-links: [{"name": "Linux", "to": "upgrade:rolling-upgrade.adoc" },{"name": "Kubernetes", "to": "upgrade:k-rolling-upgrade.adoc" } ]
 :page-aliases: manage:cluster-maintenance/rolling-upgrade.adoc,install-upgrade:rolling-upgrade.adoc,install-upgrade:version-upgrade.adoc,cluster-management:version-upgrade.adoc,cluster-administration:version-upgrade.adoc,reference:version-upgrade.adoc
 :rolling-upgrade:
 :page-categories: Upgrades

--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-4.6.5.tgz",
-      "integrity": "sha512-DQH5WCjZ1+oTu5yWlgmeSNyN3Klb5MWw90SXTQUuoIGuN+PBCDt5mTsDXWMUuXVWGw9V/JvC0S/hUSxPKLz0WA==",
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-4.6.11.tgz",
+      "integrity": "sha512-JPvZiv6cxp0lZMGph+Q0XONBzFO2h3ZwvHKzCojKgZ+PvLoVTtWDpg1lhLhlPpkdCeEsMXecV+blI+4kxx6HDg==",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",


### PR DESCRIPTION
## Description

Review deadline: July 28

Because the Redpanda Operator (25.1 and 25.2) will not support Console v3 yet, we need to notify users who land on the Console docs and who may be using the Operator. We also need to provide them an easy escape hatch to the Console v2 docs.

This pull request introduces several updates to the Redpanda Console documentation and configuration files. The changes primarily focus on adding version-specific navigation aids, improving configuration options, and enhancing the documentation structure. Below is a summary of the most important changes, grouped by theme.

### Documentation Enhancements
* Added `:page-context-switcher` metadata to multiple documentation files, enabling navigation between Redpanda Console v2.x and v3.x versions. This includes files for configuration topics such as `configure-console.adoc`, `connect-to-redpanda.adoc`, `deserialization.adoc`, and others. [[1]](diffhunk://#diff-c4861a9d003080535d1aa8075d373d85457b7827acf3f9e1692ff03a32d57381R4-R6) [[2]](diffhunk://#diff-50a7a1c27464f0f16e2778da18ab6cdefb94fab27dc01ef99ee689ec3d1fbdc1R3-R5) [[3]](diffhunk://#diff-1f2f64ea0252501ba2a12ff4235b20ccaa243870a7c2ba767b5b2cfdda3f848eR3-R5) [[4]](diffhunk://#diff-c7d457b986370554907a4930d7a7b48dd69d02af9a118007134f9e3dba95fb98R3-R5) [[5]](diffhunk://#diff-c463dd3d3d32b66a50c2c8d3ed50de976f1948db0d469339514744aba2f16e34R4-R6) [[6]](diffhunk://#diff-ab3ba0db7faebafbdd8061068e4f965c5cfb13c0569a6ba7e2b8e3e9db503800R4-R9) [[7]](diffhunk://#diff-dcbd0b62522d079543df3fcf768c3a70f48179666d1073a06ee77482a60e85e3R5-R8) [[8]](diffhunk://#diff-65034e6679891f34d1b838901ef6e5cf3098eca3fd92bddfac7e86265942bf74R5-R7) [[9]](diffhunk://#diff-8894b5139739d4b794e981d659ea8fad0eab808f2f15098bc7c846a9c189b6c5R5-R7) [[10]](diffhunk://#diff-65694d5cda46665daa2912d6f926b6c1fcf93a07ea0e3d169408b248bbfcbc6aR6-R8) [[11]](diffhunk://#diff-78436e209228b164c60baf088effc4983866695987a7e5e797ef566515245eadR4-R6) [[12]](diffhunk://#diff-87c9f4aa928a7ecdac16eed831010aac98b3775cdcdaf433d31dee161c78e16fR4-R6) [[13]](diffhunk://#diff-32ed7684834eda4bd27c18053be58e4c6c1a6a5fc9d0f321a6377eb76e3ef1f3R3-R5) [[14]](diffhunk://#diff-e48abbe69c752a53162d5498a3be8e3c20ca9b6b878cbf3d4345860aea6e418aR3-R5) [[15]](diffhunk://#diff-625443c3df94fe4db536c6827f61a51a5b1d2fb2e2a755f4eb95944e93de0bf2R3-R6) [[16]](diffhunk://#diff-bbe53f21dc8e5f863a798a901b5c9fa8b99934bdddd4f2c393fab559f74599bcR4-R7) [[17]](diffhunk://#diff-4b54ac213467dc842bb0e779d8af7fe4cc6e7e3e268e9b3f482754ef1d54e757R3-R5) [[18]](diffhunk://#diff-b80b781107b197b1339fe59f8b3ac319324c3522e3984aed1825e408285006e1R5-R8)
* Included a shared partial file (`operator-console-version-note.adoc`) in relevant documentation pages to provide additional context for version-specific features. (References as above)

### Configuration Updates
* Added a new extension (`process-context-switcher`) to the `local-antora-playbook.yml` file to handle context switching for documentation.

These changes collectively improve the usability, maintainability, and clarity of the Redpanda Console documentation and its configuration files.

## Page previews

https://deploy-preview-1239--redpanda-docs-preview.netlify.app/25.2/console/config/configure-console/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
