### PR TITLE
schema-registryapi Remove delete_schemas_ids_id

### DIFF
--- a/modules/ROOT/attachments/schema-registry-api.json
+++ b/modules/ROOT/attachments/schema-registry-api.json
@@ -489,48 +489,6 @@
             }
           }
         }
-      },
-      "delete": {
-        "summary": "Delete a schema by ID.",
-        "operationId": "delete_schemas_ids_id",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "integer"
-          }
-        ],
-        "produces": [
-          "application/vnd.schemaregistry.v1+json",
-          "application/vnd.schemaregistry+json",
-          "application/json"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found: Schema not found",
-            "schema": {
-              "$ref": "#/definitions/error_body"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/error_body"
-            }
-          }
-        }
       }
     },
     "/schemas/ids/{id}/versions": {


### PR DESCRIPTION
This endpoint never existed.

It was introduced here: https://github.com/redpanda-data/docs/commit/e1713845c8aac9655b047545a1212a2c51ac3b09

## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
