### PR TITLE
Prepare Kubernetes docs for 25.2 release using 25.1 helm chart/operator

### DIFF
--- a/modules/console/partials/operator-console-version-note.adoc
+++ b/modules/console/partials/operator-console-version-note.adoc
@@ -1,4 +1,4 @@
-.The Redpanda Operator deploys Redpanda Console v2.x, not v3.x
+.The Redpanda Operator deploys Redpanda Console v2.x, not v3.x.
 [%collapsible]
 ====
 Redpanda Console v3 is **not yet available when deploying with the Redpanda Operator**. The Redpanda Operator continues to deploy Redpanda Console v2. To try Redpanda Console v3 in Kubernetes, you can xref:deploy:deployment-option/self-hosted/kubernetes/k-production-deployment.adoc[deploy Redpanda using the Redpanda Helm chart] instead of the Redpanda Operator.

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -85,7 +85,7 @@ spec:
         #name: <secret-name>
         #key: <secret-key>
     image:
-      tag: {latest-redpanda-version}
+      tag: {latest-redpanda-tag}
     statefulset:
       extraVolumes: |-
         - name: redpanda-io-config

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -173,7 +173,7 @@ The Redpanda Helm chart enables TLS by default and uses cert-manager to manage T
 [,yaml]
 ----
 image:
-  tag: {latest-redpanda-version}
+  tag: {latest-redpanda-tag}
 statefulset:
   extraVolumes: |-
     - name: redpanda-io-config

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -84,6 +84,8 @@ spec:
       #licenseSecretRef:
         #name: <secret-name>
         #key: <secret-key>
+    image:
+      tag: {latest-redpanda-version}
     statefulset:
       extraVolumes: |-
         - name: redpanda-io-config
@@ -99,6 +101,7 @@ spec:
 - `metadata.name`: Name to assign the Redpanda cluster.
 - xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-api-redpanda-v1alpha2-redpandaclusterspec[`spec.clusterSpec`]: This is where you can override default values in the Redpanda Helm chart. Here, you mount the <<prerequisites, I/O configuration file>> to the Pods that run Redpanda. For other configuration details, see <<Production considerations>>.
 - `spec.clusterSpec.enterprise`: If you want to use enterprise features in Redpanda, uncomment this section and add the details of a Secret that stores your Enterprise Edition license key. For details, see xref:get-started:licenses.adoc[].
+- `spec.clusterSpec.image.tag`: Deploys the latest version of Redpanda.
 - `spec.clusterSpec.statefulset`: Here, you mount the <<prerequisites, I/O configuration file>> to the Pods that run Redpanda. For other configuration details, see <<Production considerations>>.
 
 . Apply the Redpanda resource:
@@ -169,6 +172,8 @@ The Redpanda Helm chart enables TLS by default and uses cert-manager to manage T
 .`redpanda-values.yaml`
 [,yaml]
 ----
+image:
+  tag: {latest-redpanda-version}
 statefulset:
   extraVolumes: |-
     - name: redpanda-io-config

--- a/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
+++ b/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
@@ -58,7 +58,7 @@ metadata:
 spec:
   clusterSpec:
     image:
-      tag: {latest-redpanda-version}
+      tag: {latest-redpanda-tag}
     external:
       domain: customredpandadomain.local
     auth:

--- a/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
+++ b/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
@@ -57,6 +57,8 @@ metadata:
   name: redpanda
 spec:
   clusterSpec:
+    image:
+      tag: {latest-redpanda-version}
     external:
       domain: customredpandadomain.local
     auth:
@@ -75,6 +77,7 @@ spec:
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
 ```
 +
+- `image.tag`: Deploys the latest version of Redpanda.
 - `external.domain`: The custom domain that each broker will advertise to clients externally. This domain is added to the internal and external TLS certificates so that you can connect to the cluster using this domain.
 - `auth.sasl.name`: Creates a superuser called `superuser` that can grant permissions to new users in your cluster using access control lists (ACLs).
 - `storage.persistentVolume.storageClass`: Points each PVC associated with the Redpanda brokers to the `csi-driver-lvm-striped-xfs` StorageClass. This StorageClass allows the LVM CSI driver to provision the appropriate local PersistentVolumes backed by NVMe disks for each Redpanda broker.
@@ -127,6 +130,7 @@ helm repo update
 helm install redpanda redpanda/redpanda \
   --version {latest-redpanda-helm-chart-version} \
   --namespace <namespace> --create-namespace \
+  --set image.tag={latest-redpanda-version} \
   --set auth.sasl.enabled=true \
   --set "auth.sasl.users[0].name=superuser" \
   --set "auth.sasl.users[0].password=secretpassword" \
@@ -136,6 +140,7 @@ helm install redpanda redpanda/redpanda \
   --timeout 1h
 ----
 +
+- `image.tag`: Deploys the latest version of Redpanda.
 - `external.domain`: The custom domain that each broker advertises to clients externally. This domain is added to the internal and external TLS certificates so that you can connect to the cluster using this domain.
 - `auth.sasl.name`: Creates a superuser called `superuser` that can grant permissions to new users in your cluster using access control lists (ACLs).
 - `storage.persistentVolume.storageClass`: Points each PVC associated with the Redpanda brokers to the `csi-driver-lvm-striped-xfs` StorageClass. This StorageClass allows the LVM CSI driver to provision the appropriate local PersistentVolumes backed by NVMe disks for each Redpanda broker.

--- a/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
+++ b/modules/deploy/partials/kubernetes/guides/deploy-redpanda.adoc
@@ -130,7 +130,7 @@ helm repo update
 helm install redpanda redpanda/redpanda \
   --version {latest-redpanda-helm-chart-version} \
   --namespace <namespace> --create-namespace \
-  --set image.tag={latest-redpanda-version} \
+  --set image.tag={latest-redpanda-tag} \
   --set auth.sasl.enabled=true \
   --set "auth.sasl.users[0].name=superuser" \
   --set "auth.sasl.users[0].password=secretpassword" \

--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -11,23 +11,19 @@ include::partial$versioning.adoc[]
 
 The Redpanda Helm chart and Redpanda Operator are versioned and tested alongside specific Redpanda core releases, Kubernetes, and Helm.
 
-Starting from version v25.1.1-beta1, the Redpanda Operator and Redpanda Helm chart follow a new versioning scheme aligned with Redpanda core releases:
+Starting from version v25.1.1, the Redpanda Operator and Redpanda Helm chart follow a new versioning scheme aligned with Redpanda core releases:
 
 - `v25.1` refers to the Redpanda core feature release deployed by default.
 
 - The patch version denotes the patch version for either the operator or Helm chart. It is not the patch version of Redpanda core.
 
-- The beta version is used for pre-release versions of the Redpanda Operator and Helm chart. These versions are not intended for production use.
+NOTE: If a version includes `-beta`, it is a pre-release version of the Redpanda Operator and Helm chart. These versions are not supported and should not be used in production environments. Beta versions are available only for testing and feedback. To give feedback on beta releases, reach out to the Redpanda team in https://redpanda.com/slack[Redpanda Community Slack^].
 
 Each Redpanda Operator and Helm chart version supports the corresponding Redpanda core version plus one minor version above and one below. This approach ensures flexibility during upgrades. For example, Redpanda Operator version 25.1.1 supports Redpanda core versions 25.2.x, 25.1.x, and 24.3.x.
 
 Redpanda Operator and Helm chart versions are supported only while their associated Redpanda core version remains supported. If the core version reaches end of life (EoL), the corresponding versions of the Redpanda Operator and Helm chart also reach EoL.
 
-NOTE: Beta versions are available only for testing and feedback. They are not supported by Redpanda and should not be used in production environments. To give feedback on beta releases, reach out to the Redpanda team in https://redpanda.com/slack[Redpanda Community Slack^].
-
 == Kubernetes version policy
-
-The minimum supported Kubernetes version is {supported-kubernetes-version}.
 
 The Kubernetes versions listed in the compatibility matrix are suggested ranges, based on testing and reported usage. Not every patch or minor version within these ranges is explicitly tested.
 
@@ -41,32 +37,69 @@ Redpanda Core has no direct dependency on Kubernetes. Compatibility is influence
 |===
 |Redpanda Core / `rpk` |Helm Chart |Operator Helm Chart |Operator |Helm CLI |Kubernetes
 
-// |25.2.x
-// |25.3-k8sx, 25.2-k8sx, 25.1-k8sx
-// |25.3-k8sx, 25.2-k8sx, 25.1-k8sx
-// |25.3-k8sx, 25.2-k8sx, 25.1-k8sx
-// |3.13+
-// |1.30.x - 1.33.x
+.1+|25.2.x
 
 |25.1.x
-|25.1.1-betaX, 5.10.x, 5.9.x
-|25.1.1-betaX, 2.4.x, 0.4.36
-|25.1.1-betaX, 2.4.x, 2.3.x
+|25.1.x
+|25.1.x
+|3.12+
+d|1.28.x - 1.32.x{fn-k8s-compatibility}
+
+.3+|25.1.x
+|25.1.x
+|25.1.x
+|25.1.x
 |3.12+
 // d (default) here is required to get footnotes to appear at the bottom of the page
 // instead of inside the table cell.
 // See https://github.com/asciidoctor/asciidoctor/issues/2350#issuecomment-546841684
 d|1.28.x - 1.32.x{fn-k8s-compatibility}
 
-|24.3.x
-|25.1.1-betaX, 5.9.x
-|25.1.1-betaX, 0.4.41, 0.4.36, 0.4.29
-|25.1.1-betaX, 2.4.x, 2.3.x, 2.2.x
+|5.10.x
+|2.4.x
+|2.4.x
+|3.12+
+d|1.28.x - 1.32.x{fn-k8s-compatibility}
+
+|5.9.x
+|0.4.36
+|2.3.x
+|3.12+
+d|1.28.x - 1.32.x{fn-k8s-compatibility}
+
+.4+|24.3.x
+|25.1.x
+|25.1.x
+|25.1.x
+|3.11+
+d|1.28.x - 1.32.x{fn-k8s-compatibility}
+
+|5.9.x
+|0.4.41
+|2.4.x
 |3.11+
 d|1.28.x - 1.31.x{fn-k8s-compatibility}
 
-|24.2.x
-|5.9.x, 5.8.x
+|5.9.x
+|0.4.36
+|2.3.x
+|3.11+
+d|1.28.x - 1.31.x{fn-k8s-compatibility}
+
+|5.9.x
+|0.4.29
+|2.2.x
+|3.11+
+d|1.28.x - 1.31.x{fn-k8s-compatibility}
+
+.2+|24.2.x
+|5.9.x
+|0.4.29
+|2.2.x
+|3.10+
+d|1.27.x - 1.30.x{fn-k8s-compatibility}
+
+|5.8.x
 |0.4.29
 |2.2.x
 |3.10+
@@ -90,12 +123,12 @@ Upgrading the Helm chart may also upgrade Redpanda Console. Because of this buil
 |Redpanda Console |Helm Chart |Operator
 
 |v3.x.x
-|v25.1.1-beta1
-|v25.1.1-beta1
+|25.1.x
+|Not yet supported
 
 |v2.x.x
-| 5.10.1, 5.9.x, 5.8.x
-|2.4.x, 2.3.x, 2.2.x
+|5.10.1, 5.9.x, 5.8.x
+|25.2.x, 25.1.x, 2.4.x, 2.3.x, 2.2.x
 
 |===
 

--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -11,7 +11,7 @@ include::partial$versioning.adoc[]
 
 The Redpanda Helm chart and Redpanda Operator are versioned and tested alongside specific Redpanda core releases, Kubernetes, and Helm.
 
-Starting from version v25.1.1, the Redpanda Operator and Redpanda Helm chart follow a new versioning scheme aligned with Redpanda core releases:
+Starting from version 25.1.1, the Redpanda Operator and Redpanda Helm chart follow a new versioning scheme aligned with Redpanda core releases:
 
 - `v25.1` refers to the Redpanda core feature release deployed by default.
 

--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -128,7 +128,7 @@ Upgrading the Helm chart may also upgrade Redpanda Console. Because of this buil
 
 |v2.x.x
 |5.10.1, 5.9.x, 5.8.x
-|25.2.x, 25.1.x, 2.4.x, 2.3.x, 2.2.x
+|25.1.x, 2.4.x, 2.3.x, 2.2.x
 
 |===
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1499
Review deadline: July 29

Since we won't have a 25.2 version of the helm chart/operator, we need to tell users to use 25.1 and specify the image tag in order to use 25.2 of Redpanda.

This pull request includes updates to improve documentation for deploying and upgrading Redpanda in Kubernetes environments. Key changes focus on clarifying version compatibility, adding support for specifying the latest Redpanda image version, and refining the presentation of beta version information.

### Deployment Documentation Updates:
* Added support for specifying the latest Redpanda version using the `image.tag` field in deployment configurations and Helm chart commands across multiple files. This ensures users can deploy the most recent version of Redpanda. (`[[1]](diffhunk://#diff-ba465241faaf03d6f02dd9063fecb88dd302ee60067e8d35a3dad3d541ffebe5R87-R88)`, `[[2]](diffhunk://#diff-ba465241faaf03d6f02dd9063fecb88dd302ee60067e8d35a3dad3d541ffebe5R104)`, `[[3]](diffhunk://#diff-ba465241faaf03d6f02dd9063fecb88dd302ee60067e8d35a3dad3d541ffebe5R175-R176)`, `[[4]](diffhunk://#diff-33293782bb3cb9c37c96e4388d7d463da7bec1ca8bd086fed9a9de0c80ea23d4R60-R61)`, `[[5]](diffhunk://#diff-33293782bb3cb9c37c96e4388d7d463da7bec1ca8bd086fed9a9de0c80ea23d4R80)`, `[[6]](diffhunk://#diff-33293782bb3cb9c37c96e4388d7d463da7bec1ca8bd086fed9a9de0c80ea23d4R133)`, `[[7]](diffhunk://#diff-33293782bb3cb9c37c96e4388d7d463da7bec1ca8bd086fed9a9de0c80ea23d4R143)`)

### Versioning and Compatibility Clarifications:
* Updated versioning documentation to remove references to beta versions as default and clarified that beta versions are not supported for production use. Added guidance for providing feedback on beta releases. (`[modules/upgrade/pages/k-compatibility.adocL14-L31](diffhunk://#diff-93aafe1b444825c515ad00c3bc0535a80cd07b12c929d172ac39af8f84f91a0bL14-L31)`)
* Refined compatibility matrix and versioning details to align with new versioning schemes and to improve clarity on supported versions for Redpanda core, Helm chart, and Operator. (`[[1]](diffhunk://#diff-93aafe1b444825c515ad00c3bc0535a80cd07b12c929d172ac39af8f84f91a0bL44-R102)`, `[[2]](diffhunk://#diff-93aafe1b444825c515ad00c3bc0535a80cd07b12c929d172ac39af8f84f91a0bL93-R131)`)

### Minor Fixes:
* Fixed a minor punctuation issue in the Redpanda Operator note for deploying Redpanda Console. (`[modules/console/partials/operator-console-version-note.adocL1-R1](diffhunk://#diff-4589022cb982f5fc25e673b4bbdc96e39f9b57d4e30178aef9f012dd49d45a20L1-R1)`)

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
