### PR TITLE
Update rpk-debug-remote-bundle-download.adoc

### DIFF
--- a/modules/reference/pages/rpk/rpk-debug/rpk-debug-remote-bundle-download.adoc
+++ b/modules/reference/pages/rpk/rpk-debug/rpk-debug-remote-bundle-download.adoc
@@ -29,7 +29,7 @@ rpk debug remote-bundle download [flags]
 
 |-o, --output |string |The file path where the debug file will be written (default `./<timestamp>-remote-bundle.zip`).
 
-|--upload-url |string |Upload URL provided by Redpanda Support. When specified, uploads the bundle to Redpanda in addition to creating a local copy. For details, see xref:troubleshoot:debug-bundle/generate/kubernetes.adoc#debug-bundle[generating debug bundles].
+|--upload-url |string |Upload URL provided by Redpanda Support. When specified, uploads the bundle to Redpanda in addition to creating a local copy. For details, see xref:troubleshoot:debug-bundle/generate/kubernetes.adoc#debug-bundle[Generate debug bundles].
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 

--- a/modules/reference/pages/rpk/rpk-debug/rpk-debug-remote-bundle-download.adoc
+++ b/modules/reference/pages/rpk/rpk-debug/rpk-debug-remote-bundle-download.adoc
@@ -29,7 +29,7 @@ rpk debug remote-bundle download [flags]
 
 |-o, --output |string |The file path where the debug file will be written (default `./<timestamp>-remote-bundle.zip`).
 
-|--upload-url |string |Upload URL provided by Redpanda Support. When specified, uploads the bundle to Redpanda in addition to creating a local copy. For details, see xref:troubleshoot:debug-bundle/generate/kubernetes.adoc#debug-bundle[].
+|--upload-url |string |Upload URL provided by Redpanda Support. When specified, uploads the bundle to Redpanda in addition to creating a local copy. For details, see xref:troubleshoot:debug-bundle/generate/kubernetes.adoc#debug-bundle[generating debug bundles].
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 

--- a/modules/reference/pages/rpk/rpk-debug/rpk-debug-remote-bundle-download.adoc
+++ b/modules/reference/pages/rpk/rpk-debug/rpk-debug-remote-bundle-download.adoc
@@ -8,6 +8,8 @@ Use the flag `--job-id` to only download the debug bundle with the given job ID.
 
 Use the flag `--no-confirm` to avoid the confirmation prompt.
 
+For details, see xref:troubleshoot:debug-bundle/generate/index.adoc[Generate debug bundles].
+
 == Usage
 
 [,bash]
@@ -29,7 +31,7 @@ rpk debug remote-bundle download [flags]
 
 |-o, --output |string |The file path where the debug file will be written (default `./<timestamp>-remote-bundle.zip`).
 
-|--upload-url |string |Upload URL provided by Redpanda Support. When specified, uploads the bundle to Redpanda in addition to creating a local copy. For details, see xref:troubleshoot:debug-bundle/generate/kubernetes.adoc#debug-bundle[Generate debug bundles].
+|--upload-url |string |Upload URL provided by Redpanda Support. When specified, uploads the bundle to Redpanda in addition to creating a local copy.
 
 |--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
