### PR TITLE
fix(docs): ansible inventory cloud provider variable

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/manual/production/production-deployment-automation.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/production/production-deployment-automation.adoc
@@ -157,7 +157,7 @@ export CLOUD_PROVIDER=<your-cloud-provider>
 export DEPLOYMENT_PREFIX=<your-prefix>
 export ANSIBLE_COLLECTIONS_PATHS=${PWD}/artifacts/collections
 export ANSIBLE_ROLES_PATH=${PWD}/artifacts/roles
-export ANSIBLE_INVENTORY=${PWD}/artifacts/hosts_gcp_$DEPLOYMENT_PREFIX.ini
+export ANSIBLE_INVENTORY=${PWD}/artifacts/hosts_${CLOUD_PROVIDER}_${DEPLOYMENT_PREFIX}.ini
 ----
 
 . Install the roles required by Ansible:


### PR DESCRIPTION
## Description

Documentation has `gcp` hardcoded into the path. Updated to use the `CLOUD_PROVIDER` variable set previously

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)
