### PR TITLE
fix(docs): ansible collections path var name

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/manual/production/production-deployment-automation.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/manual/production/production-deployment-automation.adoc
@@ -155,7 +155,7 @@ For a full, up-to-date list of configuration options, see the (https://registry.
 ----
 export CLOUD_PROVIDER=<your-cloud-provider>
 export DEPLOYMENT_PREFIX=<your-prefix>
-export ANSIBLE_COLLECTIONS_PATHS=${PWD}/artifacts/collections
+export ANSIBLE_COLLECTIONS_PATH=${PWD}/artifacts/collections
 export ANSIBLE_ROLES_PATH=${PWD}/artifacts/roles
 export ANSIBLE_INVENTORY=${PWD}/artifacts/hosts_${CLOUD_PROVIDER}_${DEPLOYMENT_PREFIX}.ini
 ----

--- a/modules/deploy/partials/high-availability.adoc
+++ b/modules/deploy/partials/high-availability.adoc
@@ -453,7 +453,7 @@ head -4 $HOSTS
 
 # Ensure the environment is ready
 export CLOUD_PROVIDER=aws    # or azure or gcp accordingly
-export ANSIBLE_COLLECTIONS_PATHS=${PWD}/artifacts/collections
+export ANSIBLE_COLLECTIONS_PATH=${PWD}/artifacts/collections
 export ANSIBLE_ROLES_PATH=${PWD}/artifacts/roles
 export ANSIBLE_INVENTORY=${PWD}/${CLOUD_PROVIDER}/hosts.ini
 


### PR DESCRIPTION
## Description

`ANSIBLE_COLLECTIONS_PATHS` does not fit Ansible's naming standard for variables, it pops up a warning. Changed to `ANSIBLE_COLLECTIONS_PATH` to align with their standard.

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)
