### PR TITLE
Reset note caption back to default

### DIFF
--- a/modules/deploy/partials/kubernetes/deploy-operator.adoc
+++ b/modules/deploy/partials/kubernetes/deploy-operator.adoc
@@ -21,7 +21,7 @@ The `--set crds.enabled=true` flag is only supported in Redpanda Operator **v25.
 
 If you deploy an earlier version (such as v2.4.x), you must install the CRDs separately. See the xref:25.1@ROOT:deploy:deployment-option/self-hosted/kubernetes/k-production-deployment.adoc[v2.4.x deployment documentation] for more information.
 ========
-:note-caption: Note
+:!note-caption:
 endif::[]
 ifndef::latest-operator-version[]
 [,bash,subs="attributes+"]

--- a/modules/deploy/partials/kubernetes/deploy-operator.adoc
+++ b/modules/deploy/partials/kubernetes/deploy-operator.adoc
@@ -21,6 +21,7 @@ The `--set crds.enabled=true` flag is only supported in Redpanda Operator **v25.
 
 If you deploy an earlier version (such as v2.4.x), you must install the CRDs separately. See the xref:25.1@ROOT:deploy:deployment-option/self-hosted/kubernetes/k-production-deployment.adoc[v2.4.x deployment documentation] for more information.
 ========
+:note-caption: Note
 endif::[]
 ifndef::latest-operator-version[]
 [,bash,subs="attributes+"]

--- a/modules/deploy/partials/kubernetes/deploy-operator.adoc
+++ b/modules/deploy/partials/kubernetes/deploy-operator.adoc
@@ -21,7 +21,7 @@ The `--set crds.enabled=true` flag is only supported in Redpanda Operator **v25.
 
 If you deploy an earlier version (such as v2.4.x), you must install the CRDs separately. See the xref:25.1@ROOT:deploy:deployment-option/self-hosted/kubernetes/k-production-deployment.adoc[v2.4.x deployment documentation] for more information.
 ========
-:!note-caption:
+:note-caption: Note
 endif::[]
 ifndef::latest-operator-version[]
 [,bash,subs="attributes+"]


### PR DESCRIPTION
Including this partial in a page resulted in all note admonitions getting the custom note caption about older versions of the Redpanda Operator.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
