### PR TITLE
docs: clarify OIDC principal formats in auth docs

### DIFF
--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -63,9 +63,9 @@ You assign ACLs and superuser roles to principals, not users. Even if a user exi
 
 For example, with OIDC:
 
-- If your token's `sub` claim is `example@company.com`, then your principal is `user:OIDC:example@company.com`.
-- This value must appear in the `superusers` list or ACL rules to have access.
-
+- If your token's `sub` claim is `example@company.com`, then:
+  * In the `superusers` list, specify the principal as `example@company.com`
+  * In ACL rules, specify the principal as `user:OIDC:example@company.com`
 ifdef::env-kubernetes[]
 == Prerequisites
 


### PR DESCRIPTION
## Description

Improve documentation around OIDC authentication by clarifying the different formats required for principals in superusers list versus ACL rules:
- Superusers list: example@company.com
- ACL rules: user:OIDC:example@company.com
## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
