### PR TITLE
metrics: Recommend better metrics for global produce/consume TP

### DIFF
--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -89,7 +89,7 @@ While maximizing the rate of messages moving from producers to brokers then to c
 
 The total throughput of a cluster can be measured by the producer and consumer rates across all topics.
 
-To observe the total producer and consumer rates of a cluster, monitor xref:reference:public-metrics-reference.adoc#redpanda_kafka_request_bytes_total[`redpanda_kafka_request_bytes_total`] with the `produce` and `consume` labels, respectively.
+To observe the total producer and consumer rates of a cluster, monitor xref:reference:public-metrics-reference.adoc#redpanda_rpc_received_bytes[`redpanda_rpc_received_bytes`] for producer traffic and xref:reference:public-metrics-reference.adoc#redpanda_rpc_sent_bytes[`redpanda_rpc_sent_bytes`] for consumer traffic. Filter both metrics using the `redpanda_server` label with the value `kafka`.
 
 ==== Producer throughput
 
@@ -97,7 +97,7 @@ For the produce rate, create a query to get the produce rate across all topics:
 
 [,promql]
 ----
-sum(rate(redpanda_kafka_request_bytes_total{redpanda_request="produce"} [5m] )) by (redpanda_request)
+rate(redpanda_rpc_received_bytes{redpanda_server="kafka"}[$__rate_interval])
 ----
 
 ==== Consumer throughput
@@ -106,7 +106,7 @@ For the consume rate, create a query to get the total consume rate across all to
 
 [,promql]
 ----
-sum(rate(redpanda_kafka_request_bytes_total{redpanda_request="consume"} [5m] )) by (redpanda_request)
+rate(redpanda_rpc_sent_bytes{redpanda_server="kafka"}[$__rate_interval])
 ----
 
 === Latency

--- a/modules/upgrade/partials/rolling-upgrades/check-metrics.adoc
+++ b/modules/upgrade/partials/rolling-upgrades/check-metrics.adoc
@@ -16,7 +16,7 @@ ifdef::rolling-restart[Pause restart if non-zero.]
 | Represents the number of partitions that are currently unavailable. Value of zero indicates all partitions are available. Non-zero indicates the respective count of unavailable partitions.
 | Ensure metric shows zero unavailable partitions before restart.
 
-| xref:reference:public-metrics-reference.adoc#redpanda_kafka_request_bytes_total[redpanda_kafka_request_bytes_total]
+| xref:reference:public-metrics-reference.adoc#redpanda_rpc_received_bytes[redpanda_rpc_received_bytes] and xref:reference:public-metrics-reference.adoc#redpanda_rpc_sent_bytes[redpanda_rpc_sent_bytes]
 | Total bytes processed for Kafka requests.
 | ifdef::rolling-upgrade[Ensure produce and consume rate for each broker recovers to its pre-upgrade value before restart.]
 ifdef::rolling-restart[Ensure produce and consume rate for each broker recovers to its pre-restart value.]


### PR DESCRIPTION
We added these metrics a long while ago for better monitoring of global produce/consume throughput.

They don't suffer from various issues (prometheus bugs, including non-returned bytes) like the per partition metrics.

See https://github.com/redpanda-data/redpanda/pull/14836 for more background.

Hence, recommend them for total produce/consume TP monitoring.

## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
