### PR TITLE
Add details about information collected by Redpanda Console

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -198,6 +198,7 @@
 *** xref:console:config/deserialization.adoc[Deserialization]
 *** xref:console:config/kafka-connect.adoc[Kafka Connect]
 *** xref:console:config/topic-documentation.adoc[Topic Documentation]
+*** xref:console:config/analytics.adoc[Telemetry]
 ** xref:manage:recovery-mode.adoc[Recovery Mode]
 ** xref:manage:rack-awareness.adoc[Rack Awareness]
 ** xref:manage:monitoring.adoc[]

--- a/modules/console/pages/config/analytics.adoc
+++ b/modules/console/pages/config/analytics.adoc
@@ -17,38 +17,31 @@ The following information is collected from the running instance of Redpanda Con
 - License hash, license type, and license organization
 - Kafka configuration hash (anonymized)
 - Whether Kafka is connected as `localhost`
+- Behavioral user analytics
 
 === Redpanda cluster metadata
 
 The following information is collected from the connected Kafka cluster:
 
 - Cluster configuration details (excluding sensitive values)
-- Broker log directories
+- Broker log dir statistics such as the size
 - Topic configurations (settings only, no message contents)
-- Consumer group metadata (names and counts only)
+- Consumer group metadata (total count, and counts by protocol and state)
 - General cluster metadata:
 ** Number of brokers
 ** Number of topics
 ** Number of partitions
-
-=== User tracking
-
-Redpanda Console also tracks individual users for behavior analytics using the following tools:
-
-- link:https://www.heap.io/[Heap]
-- link:https://www.hubspot.com/[Hubspot]
-
-Tracking is enabled per unique Redpanda Console user and is used for improving the product experience. No personally identifiable information (PII) is sent.
+** Number of racks
+** Kafka cluster ID
 
 == How telemetry data is handled
 
-Telemetry data is processed with the following guarantees:
+Telemetry data is processed with the following features:
 
 - All telemetry payloads are signed and encoded as JWTs
 - Data is sent using HTTPS POST requests to Redpanda's telemetry endpoint
-- Data is sent periodically (default interval: every 24 hours)
 - Configuration data is anonymized using secure hashes
-- No message contents, credentials, or PII are collected or transmitted
+- No message contents or credentials are collected or transmitted
 
 == Disable telemetry
 

--- a/modules/console/pages/config/analytics.adoc
+++ b/modules/console/pages/config/analytics.adoc
@@ -1,0 +1,64 @@
+= Redpanda Console Telemetry
+:description: Understand what telemetry Redpanda Console collects by default, how it is handled, and how to disable it.
+
+Redpanda Console collects telemetry (analytics) data to improve the product and user experience. This document explains what data is collected, how it is processed, and how you can disable telemetry if desired.
+
+== What is tracked by default
+
+When telemetry is enabled, which is the default behavior, Redpanda Console collects metadata to help improve product functionality and reliability. This data is sent securely to Redpanda.
+
+=== Redpanda Console metadata
+
+The following information is collected from the running instance of Redpanda Console:
+
+- Startup timestamp (when the Redpanda Console process starts)
+- Runtime UUID (a unique ID generated per instance)
+- Redpanda Console version and build timestamp
+- License hash, license type, and license organization
+- Kafka configuration hash (anonymized)
+- Whether Kafka is connected as `localhost`
+
+=== Redpanda cluster metadata
+
+The following information is collected from the connected Kafka cluster:
+
+- Cluster configuration details (excluding sensitive values)
+- Broker log directories
+- Topic configurations (settings only, no message contents)
+- Consumer group metadata (names and counts only)
+- General cluster metadata:
+** Number of brokers
+** Number of topics
+** Number of partitions
+
+=== User tracking
+
+Redpanda Console also tracks individual users for behavior analytics using the following tools:
+
+- link:https://www.heap.io/[Heap]
+- link:https://www.hubspot.com/[Hubspot]
+
+Tracking is enabled per unique Redpanda Console user and is used for improving the product experience. No personally identifiable information (PII) is sent.
+
+== How telemetry data is handled
+
+Telemetry data is processed with the following guarantees:
+
+- All telemetry payloads are signed and encoded as JWTs
+- Data is sent using HTTPS POST requests to Redpanda's telemetry endpoint
+- Data is sent periodically (default interval: every 24 hours)
+- Configuration data is anonymized using secure hashes
+- No message contents, credentials, or PII are collected or transmitted
+
+== Disable telemetry
+
+To turn off telemetry and user tracking, set the following in your Console configuration file:
+
+[source,yaml]
+----
+analytics:
+  enabled: false
+----
+
+Restart the Redpanda Console service to apply the change and stop all telemetry and user tracking.
+

--- a/modules/console/pages/config/analytics.adoc
+++ b/modules/console/pages/config/analytics.adoc
@@ -1,11 +1,11 @@
 = Redpanda Console Telemetry
 :description: Understand what telemetry Redpanda Console collects by default, how it is handled, and how to disable it.
 
-Redpanda Console collects telemetry (analytics) data to improve the product and user experience. This document explains what data is collected, how it is processed, and how you can disable telemetry if desired.
+Redpanda Console collects telemetry (analytics) data for purposes including product improvements and user experience optimization. This document explains what data is collected, how it is processed, and how you can disable telemetry if desired.
 
 == What is tracked by default
 
-When telemetry is enabled, which is the default behavior, Redpanda Console collects metadata to help improve product functionality and reliability. This data is sent securely to Redpanda.
+When telemetry is enabled, which is the default behavior, Redpanda Console collects metadata and sends it securely to Redpanda.
 
 === Redpanda Console metadata
 

--- a/modules/console/pages/config/analytics.adoc
+++ b/modules/console/pages/config/analytics.adoc
@@ -19,7 +19,7 @@ The following information is collected from the running instance of Redpanda Con
 - Whether Kafka is connected as `localhost`
 - Behavioral user analytics
 
-=== Redpanda cluster metadata
+=== Cluster metadata
 
 The following information is collected from the connected Kafka cluster:
 
@@ -32,7 +32,7 @@ The following information is collected from the connected Kafka cluster:
 ** Number of topics
 ** Number of partitions
 ** Number of racks
-** Kafka cluster ID
+** Cluster ID
 
 == How telemetry data is handled
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1382
Review deadline: August 3

This pull request introduces a new telemetry documentation page for Redpanda Console and updates the navigation structure to include it. The changes focus on providing detailed information about telemetry data collection, handling, and how to disable it.

### Documentation updates:

* **New telemetry documentation page**: Added a new file, `modules/console/pages/config/analytics.adoc`, which explains the telemetry data collected by Redpanda Console, how it is processed, and instructions to disable it. The document includes sections on metadata tracking, user behavior analytics, data handling guarantees, and configuration options.

### Navigation updates:

* **Added telemetry link to navigation**: Updated `modules/ROOT/nav.adoc` to include a link to the new telemetry documentation under the "Configuration" section.

## Page previews

https://deploy-preview-1270--redpanda-docs-preview.netlify.app/current/console/config/analytics/

## Checks

- [x] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
