### PR TITLE
DOCS-71 Add note to use TLS when HTTP basic is enabled

### DIFF
--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1383,6 +1383,8 @@ Before enabling authentication for the HTTP APIs, you must <<sasl,enable SASL au
 
 ==== Basic authentication
 
+NOTE: Redpanda recommends that you use TLS when HTTP Basic Auth is enabled.
+
 Basic authentication provides a method for securing HTTP endpoints. With basic authentication enabled, HTTP user agents, such as web browsers, must provide a username and password when making a request.
 
 To add users to the Redpanda credential store that HTTP basic authentication uses, create users with xref:reference:rpk/rpk-acl/rpk-acl-user-create.adoc[`rpk security user create`].
@@ -1393,7 +1395,6 @@ The Admin API uses the same credential store as the Kafka API, but it requires s
 ifdef::env-kubernetes[]
 When you <<enable-authentication, enable authentication>> in the Redpanda Helm chart, the Schema Registry API and the HTTP Proxy API are configured with basic authentication by default.
 
-NOTE: Redpanda recommends that you use TLS when HTTP Basic Auth is enabled.
 
 To enable basic authentication for the Admin API:
 

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1684,7 +1684,9 @@ ifndef::env-kubernetes[]
 rpk cluster config set http_authentication '["BASIC","OIDC"]'
 ----
 
-Alternatively, you can enable OIDC for specific listeners by configuring the `authentication_method` property for individual API listeners. To enable both basic authentication and OIDC for specific listeners, set `authentication_method` to a list including both `http_basic` and `oidc`. For example, in `redpanda.yaml`, enter:
+NOTE: Valid values for the cluster configuration `http_authentication` are `BASIC` and `OIDC`. Note that the value `BASIC` is different from the `http_basic` value, which enables authentication for the listener using the broker configuration `authentication_method`.
+
+To enable OIDC for specific listeners, set `authentication_method` to `http_basic`. For example, in redpanda.yaml, enter:
 
 [,yaml,lines=5+10]
 ----
@@ -1692,12 +1694,12 @@ pandaproxy:
   pandaproxy_api:
   - address: "localhost"
     port: 8082
-    authentication_method: ["http_basic", "oidc"]
+    authentication_method: http_basic
 schema_registry:
   schema_registry_api:
     address: "localhost"
     port: 8081
-    authentication_method: ["http_basic", "oidc"]
+    authentication_method: http_basic
 ----
 
 To enable only OIDC authentication (without basic authentication) for specific listeners, set `authentication_method` to `oidc`:
@@ -1708,12 +1710,12 @@ pandaproxy:
   pandaproxy_api:
   - address: "localhost"
     port: 8082
-    authentication_method: oidc
+    authentication_method: http_basic
 schema_registry:
   schema_registry_api:
     address: "localhost"
     port: 8081
-    authentication_method: oidc
+    authentication_method: http_basic
 ----
 endif::[]
 

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1593,7 +1593,12 @@ See <<Enable OIDC>> to configure the required OIDC cluster configuration propert
 
 NOTE: If you enable OIDC authentication for the Admin API, you must also <<create-superusers,create a SCRAM superuser>> so that you can use `rpk` to create ACLs. `rpk` supports only basic authentication for the Admin API. See <<Authentication for the HTTP APIs>>.
 
-To enable OIDC for the HTTP API listeners as well as basic authentication, include OIDC in the `http_authentication` cluster property list:
+You can enable OIDC for HTTP APIs in two ways:
+
+* **Cluster-wide**: Use the `http_authentication` cluster property to enable OIDC for all HTTP API listeners
+* **Per-listener**: Use the `authentication_method` property to enable OIDC for specific API listeners
+
+To enable OIDC cluster-wide for all HTTP API listeners, include both `BASIC` and `OIDC` in the `http_authentication` cluster property list:
 
 ifdef::env-kubernetes[]
 [tabs]
@@ -1679,7 +1684,7 @@ ifndef::env-kubernetes[]
 rpk cluster config set http_authentication '["BASIC","OIDC"]'
 ----
 
-To enable OIDC for specific listeners, set `authentication_method` to `http_basic`. For example, in `redpanda.yaml`, enter:
+Alternatively, you can enable OIDC for specific listeners by configuring the `authentication_method` property for individual API listeners. To enable both basic authentication and OIDC for specific listeners, set `authentication_method` to a list including both `http_basic` and `oidc`. For example, in `redpanda.yaml`, enter:
 
 [,yaml,lines=5+10]
 ----
@@ -1687,12 +1692,28 @@ pandaproxy:
   pandaproxy_api:
   - address: "localhost"
     port: 8082
-    authentication_method: http_basic
+    authentication_method: ["http_basic", "oidc"]
 schema_registry:
   schema_registry_api:
     address: "localhost"
     port: 8081
-    authentication_method: http_basic
+    authentication_method: ["http_basic", "oidc"]
+----
+
+To enable only OIDC authentication (without basic authentication) for specific listeners, set `authentication_method` to `oidc`:
+
+[,yaml,lines=5+10]
+----
+pandaproxy:
+  pandaproxy_api:
+  - address: "localhost"
+    port: 8082
+    authentication_method: oidc
+schema_registry:
+  schema_registry_api:
+    address: "localhost"
+    port: 8081
+    authentication_method: oidc
 ----
 endif::[]
 

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1701,22 +1701,6 @@ schema_registry:
     port: 8081
     authentication_method: http_basic
 ----
-
-To enable only OIDC authentication (without basic authentication) for specific listeners, set `authentication_method` to `oidc`:
-
-[,yaml,lines=5+10]
-----
-pandaproxy:
-  pandaproxy_api:
-  - address: "localhost"
-    port: 8082
-    authentication_method: http_basic
-schema_registry:
-  schema_registry_api:
-    address: "localhost"
-    port: 8081
-    authentication_method: http_basic
-----
 endif::[]
 
 ===== Connect to the HTTP API

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1383,7 +1383,7 @@ Before enabling authentication for the HTTP APIs, you must <<sasl,enable SASL au
 
 ==== Basic authentication
 
-NOTE: Redpanda recommends that you use TLS when enabling HTTP Basic Auth.
+NOTE: Redpanda Data recommends that you use TLS when enabling HTTP Basic Auth.
 
 Basic authentication provides a method for securing HTTP endpoints. With basic authentication enabled, HTTP user agents, such as web browsers, must provide a username and password when making a request.
 
@@ -1486,6 +1486,8 @@ rpk cluster config set admin_api_require_auth true
 ----
 rpk cluster config set http_authentication '["BASIC"]'
 ----
+
+NOTE: Valid values for the cluster configuration property xref:reference/properties/cluster-properties.adoc#http_authentication[`http_authentication`] are `BASIC` and `OIDC`. Note that the value `BASIC` is different from the `http_basic` value, which enables authentication for the listener using the broker configuration property `authentication_method`.
 
 To enable basic authentication for specific listeners, set `authentication_method` to `http_basic`. For example, in `redpanda.yaml`, enter:
 

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1393,6 +1393,8 @@ The Admin API uses the same credential store as the Kafka API, but it requires s
 ifdef::env-kubernetes[]
 When you <<enable-authentication, enable authentication>> in the Redpanda Helm chart, the Schema Registry API and the HTTP Proxy API are configured with basic authentication by default.
 
+NOTE: Redpanda recommends that you use TLS when HTTP Basic Auth is enabled.
+
 To enable basic authentication for the Admin API:
 
 [tabs]

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1597,7 +1597,7 @@ NOTE: If you enable OIDC authentication for the Admin API, you must also <<creat
 
 You can enable OIDC for HTTP APIs in two ways:
 
-* **Cluster-wide**: Use the `http_authentication` cluster property to enable OIDC for all HTTP API listeners
+* **Cluster-wide**: Use the xref:reference/properties/cluster-properties.adoc#http_authentication[`http_authentication`] cluster property to enable OIDC for all HTTP API listeners
 * **Per-listener**: Use the `authentication_method` property to enable OIDC for specific API listeners
 
 To enable OIDC cluster-wide for all HTTP API listeners, include both `BASIC` and `OIDC` in the `http_authentication` cluster property list:

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1383,7 +1383,7 @@ Before enabling authentication for the HTTP APIs, you must <<sasl,enable SASL au
 
 ==== Basic authentication
 
-NOTE: Redpanda recommends that you use TLS when HTTP Basic Auth is enabled.
+NOTE: Redpanda recommends that you use TLS when enabling HTTP Basic Auth.
 
 Basic authentication provides a method for securing HTTP endpoints. With basic authentication enabled, HTTP user agents, such as web browsers, must provide a username and password when making a request.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-71 and https://redpandadata.atlassian.net/browse/DOC-401
Review deadline: **Monday, August 4th**

## Page previews

[Basic authentication](https://deploy-preview-1272--redpanda-docs-preview.netlify.app/current/manage/security/authentication/#basic-authentication)

[OIDC](https://deploy-preview-1272--redpanda-docs-preview.netlify.app/current/manage/security/authentication/#oidc-http)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x ] Small fix (typos, links, copyedits, etc)
