### PR TITLE
Do not run workflows from forked repos

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -52,7 +52,8 @@ jobs:
           echo "user=${{ github.actor }}" >> $GITHUB_OUTPUT
   backport:
     needs: get-labels
-    if: needs.get-labels.outputs.branches != '' && needs.get-labels.outputs.valid == 'true'
+    # Skip the entire job for fork PRs
+    if: needs.get-labels.outputs.branches != '' && needs.get-labels.outputs.valid == 'true' && github.event.pull_request.head.repo.fork != true
     strategy:
       matrix:
         branch: ${{fromJson(needs.get-labels.outputs.branches)}}

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -29,6 +29,8 @@ jobs:
 
   run-tests:
     needs: setup
+    # Skip the entire job for fork PRs
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1556
Review deadline: 3 August

This pull request updates GitHub Actions workflows to ensure certain jobs are skipped for pull requests originating from forks. The changes focus on improving workflow efficiency and security by preventing unnecessary or unintended job executions.

### Workflow Updates:

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491L55-R56): Updated the `backport` job to include a condition that skips the job if the pull request originates from a fork (`github.event.pull_request.head.repo.fork != true`).

* [`.github/workflows/test-docs.yml`](diffhunk://#diff-eb28fbd2c2a71f3e5f1fb977bb8dab63cbe6fa76afe4417001671f648beb76abR32-R33): Added a condition to the `run-tests` job to skip execution for pull requests from forks (`github.event.pull_request.head.repo.fork != true`).

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
