### PR TITLE
Update Glue doc with Cloud-specific guidance

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1377-cloud-aws-glue'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1377-cloud-aws-glue'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -121,12 +121,13 @@ iceberg_catalog_type: rest
 iceberg_rest_catalog_endpoint: https://glue.<glue-region>.amazonaws.com/iceberg
 iceberg_rest_catalog_authentication_mode: aws_sigv4
 iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
-# Use the following properties if you want to use separate AWS credentials
-# for the catalog, or delete to reuse S3 (cloud_storage) credentials.
-# iceberg_rest_catalog_aws_region:
+# Use the iceberg_rest_catalog_aws_* properties if you want to 
+# use separate AWS credentials for the catalog, or delete to reuse S3 
+# (cloud_storage_*) credentials.
 # For access using access keys only, use iceberg_rest_catalog_aws_access_key
 # and iceberg_rest_catalog_aws_secret_key. For access with an IAM role, use 
 # iceberg_rest_catalog_aws_credentials_source only. 
+# iceberg_rest_catalog_aws_region:
 # iceberg_rest_catalog_aws_access_key:
 # iceberg_rest_catalog_aws_secret_key:
 # iceberg_rest_catalog_aws_credentials_source:
@@ -154,7 +155,7 @@ rpk cluster config set \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
   iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
-
+  iceberg_rest_catalog_aws_region=<glue-region>
   iceberg_rest_catalog_aws_access_key=<glue-access-key>
   iceberg_rest_catalog_aws_secret_key=${secrets.<glue-secret-key-name>}
 ----

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -112,11 +112,11 @@ Run `rpk cluster config edit` to update these properties:
 ----
 iceberg_enabled: true 
 iceberg_catalog_type: rest
-iceberg_rest_catalog_endpoint: https://glue.<aws-region>.amazonaws.com/iceberg
+iceberg_rest_catalog_endpoint: https://glue.<glue-region>.amazonaws.com/iceberg
 iceberg_rest_catalog_authentication_mode: aws_sigv4
 iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
-# Also configure the following if you want to use separate AWS credentials
-# for the catalog: 
+# Use the following properties if you want to use separate AWS credentials
+# for the catalog, or delete to reuse S3 (cloud_storage) credentials: 
 # iceberg_rest_catalog_aws_access_key:
 # iceberg_rest_catalog_aws_secret_key:
 # iceberg_rest_catalog_aws_region:
@@ -126,7 +126,7 @@ iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
 Use your own values for the following placeholders:
 +
 --
-- `<aws-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in either your config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`] or config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
+- `<glue-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in either your config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`] or config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
 - `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. As a security best practice, Redpanda Data recommends specifying a subfolder (using prefixes) rather than the root of the bucket.
 --
 endif::[]
@@ -142,23 +142,21 @@ rpk profile create --from-cloud <cluster-id>
 rpk cluster config set \
   iceberg_enabled=true \
   iceberg_catalog_type=rest \
-  iceberg_rest_catalog_endpoint=https://glue.<aws-region>.amazonaws.com/iceberg \
+  iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
   iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
 
   iceberg_rest_catalog_aws_access_key=<glue-access-key>
   iceberg_rest_catalog_aws_secret_key=${secrets.<glue-secret-key-name>}
-  iceberg_rest_catalog_aws_region=<glue-region>
 ----
 +
 Use your own values for the following placeholders:
 +
 --
-- `<aws-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in either your config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`] or config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
+- `<glue-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in your config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
 - `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. As a security best practice, Redpanda Data recommends specifying a subfolder (using prefixes) rather than the root of the bucket.
 - `<glue-access-key>`: The AWS access key ID for your Glue service account.
 - `<glue-secret-key-name>`: The name of the secret that stores the AWS secret access key for your Glue service account. To reference a secret in a cluster property, for example `iceberg_rest_catalog_aws_secret_key`, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value].
-- `<glue-region>`: The AWS region where your Glue service is located.
 --
 endif::[]
 +

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -46,15 +46,21 @@ If you want to use partitioning, you must specify a custom partition specificati
 
 == Authorize access to AWS Glue
 
+ifndef::env-cloud[]
 You must allow Redpanda access to AWS Glue services in your AWS account. You can use the same access credentials that you configured for S3 (IAM role, access keys, and KMS key), as long as you have also added read and write access to AWS Glue Data Catalog.
 
 For example, you could create a separate IAM policy that manages access to AWS Glue, and attach it to the IAM role that Redpanda also uses to access S3. It is recommended to add all AWS Glue API actions in the policy (`"glue:*"`) on the following resources:
+endif::[]
+
+ifdef::env-cloud[]
+You must allow Redpanda access to AWS Glue services in your AWS account. It is recommended to create a new IAM policy or role that manages access to AWS Glue, allowing all AWS Glue API actions (`"glue:*"`) on the following resources:
+endif::[]
 
 - Root catalog (`catalog`)
 - All databases (`database/*`)
 - All tables (`table/\*/*`)
 
-Your policy should include a statement similar to the following:
+Your IAM policy should include a statement similar to the following:
 
 [,json]
 ----
@@ -116,10 +122,13 @@ iceberg_rest_catalog_endpoint: https://glue.<glue-region>.amazonaws.com/iceberg
 iceberg_rest_catalog_authentication_mode: aws_sigv4
 iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
 # Use the following properties if you want to use separate AWS credentials
-# for the catalog, or delete to reuse S3 (cloud_storage) credentials: 
+# for the catalog, or delete to reuse S3 (cloud_storage) credentials.
+# iceberg_rest_catalog_aws_region:
+# For access using access keys only, use iceberg_rest_catalog_aws_access_key
+# and iceberg_rest_catalog_aws_secret_key. For access with an IAM role, use 
+# iceberg_rest_catalog_aws_credentials_source only. 
 # iceberg_rest_catalog_aws_access_key:
 # iceberg_rest_catalog_aws_secret_key:
-# iceberg_rest_catalog_aws_region:
 # iceberg_rest_catalog_aws_credentials_source:
 ----
 +

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -2,15 +2,6 @@
 :description: Add Redpanda topics as Iceberg tables that you can query from AWS Glue Data Catalog.
 :page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
 :page-beta: true
-ifdef::env-cloud[]
-:rp_version: 25.2
-:rpk_install_doc: manage:rpk/rpk-install.adoc
-endif::[]
-ifndef::env-cloud[]
-:rp_version: 25.1.7
-:rpk_install_doc: get-started:rpk-install.adoc
-endif::[]
-
 
 [NOTE]
 ====
@@ -18,6 +9,15 @@ include::shared:partial$enterprise-license.adoc[]
 ====
 
 // tag::single-source[]
+ifdef::env-cloud[]
+:rp_version: 25.2
+:rpk_install_doc: manage:rpk/rpk-install.adoc
+endif::[]
+
+ifndef::env-cloud[]
+:rp_version: 25.1.7
+:rpk_install_doc: get-started:rpk-install.adoc
+endif::[]
 
 This guide walks you through querying Redpanda topics as Iceberg tables stored in AWS S3, using a catalog integration with https://docs.aws.amazon.com/glue/latest/dg/components-overview.html#data-catalog-intro[AWS Glue^]. For general information about Iceberg catalog integrations in Redpanda, see xref:manage:iceberg/use-iceberg-catalogs.adoc[].
 
@@ -95,7 +95,7 @@ ifdef::env-cloud[]
 You must configure credentials for the AWS Glue Data Catalog integration using the following properties:
 
 * config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`]
-* config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`], added as a secret value
+* config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`], added as a secret value (see the <<update-cluster-configuration,next section>> for details)
 * config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`]
 endif::[]
 
@@ -117,16 +117,21 @@ iceberg_rest_catalog_authentication_mode: aws_sigv4
 iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
 # Also configure the following if you want to use separate AWS credentials
 # for the catalog: 
-# iceberg_rest_catalog_aws_access_key
-# iceberg_rest_catalog_aws_secret_key
-# iceberg_rest_catalog_aws_region
-# iceberg_rest_catalog_aws_credentials_source
+# iceberg_rest_catalog_aws_access_key:
+# iceberg_rest_catalog_aws_secret_key:
+# iceberg_rest_catalog_aws_region:
+# iceberg_rest_catalog_aws_credentials_source:
 ----
++
+Use your own values for the following placeholders:
++
+--
+- `<aws-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in either your config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`] or config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
+- `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. As a security best practice, Redpanda Data recommends specifying a subfolder (using prefixes) rather than the root of the bucket.
+--
 endif::[]
 ifdef::env-cloud[]
 Use `rpk` like in the following example, or use the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
-+
-To reference a secret in a cluster property, for example `iceberg_rest_catalog_aws_secret_key`, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value]. 
 +
 [,bash]
 ----
@@ -140,20 +145,22 @@ rpk cluster config set \
   iceberg_rest_catalog_endpoint=https://glue.<aws-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
   iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
-  # Also configure the following if you want to use separate AWS credentials
-  # for the catalog: 
-  # iceberg_rest_catalog_aws_access_key
-  # iceberg_rest_catalog_aws_secret_key
-  # iceberg_rest_catalog_aws_region
+
+  iceberg_rest_catalog_aws_access_key=<glue-access-key>
+  iceberg_rest_catalog_aws_secret_key=${secrets.<glue-secret-key-name>}
+  iceberg_rest_catalog_aws_region=<glue-region>
 ----
-endif::[]
 +
 Use your own values for the following placeholders:
 +
 --
 - `<aws-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in either your config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`] or config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
 - `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. As a security best practice, Redpanda Data recommends specifying a subfolder (using prefixes) rather than the root of the bucket.
+- `<glue-access-key>`: The AWS access key ID for your Glue service account.
+- `<glue-secret-key-name>`: The name of the secret that stores the AWS secret access key for your Glue service account. To reference a secret in a cluster property, for example `iceberg_rest_catalog_aws_secret_key`, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value].
+- `<glue-region>`: The AWS region where your Glue service is located.
 --
+endif::[]
 +
 [,bash,role=no-copy]
 ----

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -3,10 +3,12 @@
 :page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
 :page-beta: true
 ifdef::env-cloud[]
-:rpk-install-doc: manage:rpk/rpk-install.adoc
+:rp_version: 25.2
+:rpk_install_doc: manage:rpk/rpk-install.adoc
 endif::[]
 ifndef::env-cloud[]
-:rpk-install-doc: get-started:rpk-install.adoc
+:rp_version: 25.1.7
+:rpk_install_doc: get-started:rpk-install.adoc
 endif::[]
 
 
@@ -21,8 +23,8 @@ This guide walks you through querying Redpanda topics as Iceberg tables stored i
 
 == Prerequisites
 
-* Redpanda version 25.1.7 or later.
-* xref:{rpk-install-doc}[`rpk`] installed or updated to the latest version.
+* Redpanda version {rp_version} or later.
+* xref:{rpk_install_doc}[`rpk`] installed or updated to the latest version.
 ifdef::env-cloud[]
 ** You can also use the Redpanda Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[reference secrets in your cluster configuration].
 endif::[]

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -78,7 +78,8 @@ For more information on configuring IAM permissions, see the https://docs.aws.am
 
 == Configure authentication and credentials
 
-You can configure credentials for the AWS Glue Data Catalog integration in either of the following ways:
+ifndef::env-cloud[]
+You must configure credentials for the AWS Glue Data Catalog integration in either of the following ways:
 
 * Allow Redpanda to use the same `cloud_storage_*` credential properties configured for S3. If you do not configure the overrides listed below, Redpanda uses the same credentials for both S3 and AWS Glue. This is the recommended approach.
 * If you want to configure authentication to AWS Glue separately from authentication to S3, there are equivalent credential configuration properties named `iceberg_rest_catalog_aws_*` that override the object storage credentials. These properties only apply to REST catalog authentication, and never to S3 authentication:
@@ -86,6 +87,15 @@ You can configure credentials for the AWS Glue Data Catalog integration in eithe
 ** config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`] overrides config_ref:cloud_storage_secret_key,true,properties/cluster-properties[`cloud_storage_secret_key`]
 ** config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] overrides config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`]
 ** config_ref:iceberg_rest_catalog_aws_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_aws_credentials_source`] overrides config_ref:cloud_storage_credentials_source,true,properties/cluster-properties[`cloud_storage_credentials_source`]
+endif::[]
+
+ifdef::env-cloud[]
+You must configure credentials for the AWS Glue Data Catalog integration using the following properties:
+
+* config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`]
+* config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`], added as a secret value
+* config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`]
+endif::[]
 
 == Update cluster configuration
 
@@ -103,12 +113,18 @@ iceberg_catalog_type: rest
 iceberg_rest_catalog_endpoint: https://glue.<aws-region>.amazonaws.com/iceberg
 iceberg_rest_catalog_authentication_mode: aws_sigv4
 iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
+# Also configure the following if you want to use separate AWS credentials
+# for the catalog: 
+# iceberg_rest_catalog_aws_access_key
+# iceberg_rest_catalog_aws_secret_key
+# iceberg_rest_catalog_aws_region
+# iceberg_rest_catalog_aws_credentials_source
 ----
 endif::[]
 ifdef::env-cloud[]
 Use `rpk` like in the following example, or use the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
 +
-To reference a secret in a cluster property, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value]. 
+To reference a secret in a cluster property, for example `iceberg_rest_catalog_aws_secret_key`, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value]. 
 +
 [,bash]
 ----
@@ -122,7 +138,11 @@ rpk cluster config set \
   iceberg_rest_catalog_endpoint=https://glue.<aws-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
   iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
-
+  # Also configure the following if you want to use separate AWS credentials
+  # for the catalog: 
+  # iceberg_rest_catalog_aws_access_key
+  # iceberg_rest_catalog_aws_secret_key
+  # iceberg_rest_catalog_aws_region
 ----
 endif::[]
 +


### PR DESCRIPTION
## Description

Related PR to add Glue doc to Cloud: https://github.com/redpanda-data/cloud-docs/pull/363

This pull request introduces updates to the Antora playbook and documentation for integrating Redpanda topics with AWS Glue Data Catalog. The changes include branch updates in the playbook, dynamic versioning for prerequisites, and detailed instructions for configuring credentials and cluster properties for AWS Glue integration. Below is a summary of the most important changes:

### Playbook Updates
* Updated the branch reference for the `cloud-docs` repository in the `local-antora-playbook.yml` file to `DOC-1377-cloud-aws-glue` for more targeted documentation updates.

### Documentation Enhancements for AWS Glue Integration
* **Dynamic Versioning and Prerequisite Updates**:
  - Introduced dynamic variables (`rp_version` and `rpk_install_doc`) to specify Redpanda version and `rpk` installation instructions based on the environment (`env-cloud` or non-cloud). This ensures accurate and up-to-date prerequisites for users.

* **Credential Configuration**:
  - Added separate instructions for configuring AWS Glue credentials in cloud and non-cloud environments. Non-cloud users can override S3 credentials, while cloud users must use specific properties for AWS Glue.

* **Cluster Property Placeholders**:
  - Included detailed explanations for placeholders such as `<aws-region>`, `<bucket-name>`, `<warehouse-path>`, `<glue-access-key>`, and `<glue-secret-key-name>` to guide users in setting up their configurations securely and correctly. [[1]](diffhunk://#diff-3bd481de18a4f29147c493bbbb9109ffe08bb6c449f20eb1ca2e1093a655ab68R118-L112) [[2]](diffhunk://#diff-3bd481de18a4f29147c493bbbb9109ffe08bb6c449f20eb1ca2e1093a655ab68R149-R163)

These changes aim to improve clarity, flexibility, and precision in the documentation, making it easier for users to integrate Redpanda with AWS Glue.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 4 Aug

## Page previews

Cloud: [Query Iceberg Topics Using AWS Glue](https://deploy-preview-1275--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/iceberg-topics-aws-glue/)

Self-managed version: [Query Iceberg Topics Using AWS Glue](https://deploy-preview-1275--redpanda-docs-preview.netlify.app/current/manage/iceberg/iceberg-topics-aws-glue/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
