### PR TITLE
DOC-1560 conditionalize out rpk cluster config list for Cloud

### DIFF
--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-list.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-list.adoc
@@ -1,7 +1,13 @@
 = rpk cluster config list
 // tag::single-source[]
 
-This command lists all available cluster configuration properties. Use the xref:reference:rpk/rpk-cluster/rpk-cluster-config-get.adoc[`rpk cluster config get`] command to retrieve specific property values, or xref:reference:rpk/rpk-cluster/rpk-cluster-config-edit.adoc[`rpk cluster config edit`] for interactive editing.
+This command lists all available cluster configuration properties. 
+
+Use the xref:reference:rpk/rpk-cluster/rpk-cluster-config-get.adoc[`rpk cluster config get`] command to retrieve specific property values.
+
+ifndef::env-cloud[]
+Use xref:reference:rpk/rpk-cluster/rpk-cluster-config-edit.adoc[`rpk cluster config edit`] for interactive editing.
+endif::env-cloud[]
 
 Use the `--filter` flag with a regular expression to filter configuration keys. This is useful for exploring related configuration properties or finding specific settings.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-list.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-list.adoc
@@ -3,7 +3,7 @@
 
 This command lists all available cluster configuration properties. 
 
-Use the xref:reference:rpk/rpk-cluster/rpk-cluster-config-get.adoc[`rpk cluster config get`] command to retrieve specific property values.
+Use xref:reference:rpk/rpk-cluster/rpk-cluster-config-get.adoc[`rpk cluster config get`] to retrieve specific property values.
 
 ifndef::env-cloud[]
 Use xref:reference:rpk/rpk-cluster/rpk-cluster-config-edit.adoc[`rpk cluster config edit`] for interactive editing.


### PR DESCRIPTION
## Description
This pull request updates the documentation for the `rpk cluster config list` command to clarify usage instructions:

* Split the usage instructions into separate lines for clarity and readability.
* Added a conditional (`ifndef::env-cloud[] ... endif::env-cloud[]`) so that the reference to `rpk cluster config edit` for interactive editing only appears when not in a cloud environment.

Resolves https://redpandadata.atlassian.net/browse/DOC-1560
Review deadline:

## Page previews
[rpk cluster config list in SM](https://deploy-preview-1278--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-cluster/rpk-cluster-config-list/)
[rpk cluster config list in Cloud](https://deploy-preview-1278--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-cluster/rpk-cluster-config-list/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)
