### PR TITLE
docs: add aliases to properties

### DIFF
--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -94,7 +94,7 @@ You must configure credentials for the AWS Glue Data Catalog integration in eith
 ** config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`] overrides config_ref:cloud_storage_access_key,true,properties/cluster-properties[`cloud_storage_access_key`]
 ** config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`] overrides config_ref:cloud_storage_secret_key,true,properties/cluster-properties[`cloud_storage_secret_key`]
 ** config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] overrides config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`]
-** config_ref:iceberg_rest_catalog_aws_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_aws_credentials_source`] overrides config_ref:cloud_storage_credentials_source,true,properties/cluster-properties[`cloud_storage_credentials_source`]
+** config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`] overrides config_ref:cloud_storage_credentials_source,true,properties/cluster-properties[`cloud_storage_credentials_source`]
 endif::[]
 
 ifdef::env-cloud[]
@@ -126,11 +126,11 @@ iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
 # (cloud_storage_*) credentials.
 # For access using access keys only, use iceberg_rest_catalog_aws_access_key
 # and iceberg_rest_catalog_aws_secret_key. For access with an IAM role, use 
-# iceberg_rest_catalog_aws_credentials_source only. 
+# iceberg_rest_catalog_credentials_source only. 
 # iceberg_rest_catalog_aws_region:
 # iceberg_rest_catalog_aws_access_key:
 # iceberg_rest_catalog_aws_secret_key:
-# iceberg_rest_catalog_aws_credentials_source:
+# iceberg_rest_catalog_credentials_source:
 ----
 +
 Use your own values for the following placeholders:

--- a/modules/manage/partials/audit-logging.adoc
+++ b/modules/manage/partials/audit-logging.adoc
@@ -361,7 +361,7 @@ With audit logging, the pattern of message generation may be very different from
 
 A typical scenario with audit logging is to route the messages to an analytics platform like Splunk. If your retention period is too long, you may find that you are storing excessive amounts of replicated messages in both Redpanda and in your analytics suite. Identifying the right balance of retention and replication settings minimizes this duplication while retaining your data in a system that provides actionable intelligence.
 
-Assess the retention needs for your audit logs. You may not need to keep the logs for the default seven days. This is controlled by setting xref:reference:topic-properties.adoc#retentionms[`retention.ms`] for the `_redpanda.audit_log` topic or by setting xref:reference:cluster-properties.adoc#delete_retention_ms[`delete_retention_ms`] at the cluster level.
+Assess the retention needs for your audit logs. You may not need to keep the logs for the default seven days. This is controlled by setting xref:reference:topic-properties.adoc#retentionms[`retention.ms`] for the `_redpanda.audit_log` topic or by setting xref:reference:cluster-properties.adoc#log_retention_ms[`log_retention_ms`] at the cluster level.
 
 == Next steps
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -1012,7 +1012,7 @@ At topic creation with Tiered Storage enabled:
 * If `retention.ms` or `retention.bytes` is set, Redpanda initializes the `retention.local.target.*` properties.
 * If `retention.local.target.ms` or `retention.local.target.bytes` is set, Redpanda initializes the `min(retention.bytes, retention.local.target.bytes)` and `max(retention.ms, retention.local.target.ms)` properties.
 * If properties are not specified:
-** Starting in version 22.3, new topics use the default retention values of one day for local storage (`retention_local_target_ms_default`) and seven days for all storage, including object storage (`delete_retention_ms`).
+** Starting in version 22.3, new topics use the default retention values of one day for local storage (config_ref:retention_local_target_ms_default,true,cluster-properties[]) and seven days for all storage, including object storage (config_ref:log_retention_ms,true,cluster-properties[]).
 ** Upgraded topics retain their historical defaults of infinite retention.
 
 After topic configuration, if Tiered Storage was disabled and must be enabled, or was enabled and must be disabled, Redpanda uses the local retention properties set for the topic. It is strongly recommended that you do not re-enable Tiered Storage after previously enabling and disabling it. Re-enabling Tiered Storage can result in inconsistent data and data gaps in Tiered Storage for a topic.

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -838,6 +838,8 @@ The amount of memory to reserve per core for data transform (Wasm) virtual machi
 
 *Type:* integer
 
+*Aliases:* `wasm_per_core_memory_reservation`
+
 ifndef::env-cloud[]
 *Default:* `20971520`
 endif::[]
@@ -860,6 +862,8 @@ The amount of memory to give an instance of a data transform (Wasm) virtual mach
 *Visibility:* `user`
 
 *Type:* integer
+
+*Aliases:* `wasm_per_function_memory_limit`
 
 *Default:* `2097152`
 
@@ -2264,6 +2268,8 @@ Source of AWS credentials for Iceberg REST catalog SigV4 authentication. If not 
 
 *Visibility:* `user`
 
+*Aliases:* `iceberg_rest_catalog_aws_credentials_source`
+
 *Default:* `null`
 
 ---
@@ -2593,18 +2599,18 @@ Path to a file containing a certificate chain to trust for the REST Iceberg cata
 
 ---
 
-// tag::iceberg_rest_catalog_prefix[]
+// tag::iceberg_rest_catalog_warehouse[]
 === iceberg_rest_catalog_warehouse
 
 Warehouse to use for the Iceberg REST catalog. Redpanda queries the catalog to retrieve warehouse-specific configurations and automatically configures settings like the appropriate prefix. The prefix is appended to the catalog path (for example, `/v1/\{prefix}/namespaces`).
-
-*Alias:* `iceberg_rest_catalog_prefix`
 
 *Requires restart:* Yes
 
 *Visibility:* `user`
 
 *Type:* string
+
+*Aliases:* `iceberg_rest_catalog_prefix`
 
 ifndef::env-cloud[]
 *Default:* `null`
@@ -2616,7 +2622,7 @@ endif::[]
 
 ---
 
-// end::iceberg_rest_catalog_prefix[]
+// end::iceberg_rest_catalog_warehouse[]
 
 === iceberg_target_backlog_size
 
@@ -3849,6 +3855,8 @@ The amount of time to keep a log file before deleting it (in milliseconds). If s
 *Requires restart:* No
 
 *Visibility:* `user`
+
+*Aliases:* `delete_retention_ms`
 
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
@@ -5673,6 +5681,8 @@ Always normalize schemas. If set, this overrides the `normalize` parameter in re
 
 *Type:* boolean
 
+*Aliases:* `schema_registry_normalize_on_startup`
+
 *Default:* `false`
 
 ---
@@ -5689,20 +5699,6 @@ uses ACL-based authorization instead of the default `public/user/superuser` auth
 *Type:* boolean
 
 *Enterprise license required:* `true`
-
-*Default:* `false`
-
----
-
-=== schema_registry_normalize_on_startup
-
-Normalize schemas as they are read from the topic on startup.
-
-*Requires restart:* Yes
-
-*Visibility:* `user`
-
-*Type:* boolean
 
 *Default:* `false`
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -868,6 +868,8 @@ Time limit on waiting for uploads to complete before a leadership transfer.  If 
 
 *Type:* integer
 
+*Aliases:* `cloud_storage_graceful_transfer_timeout`
+
 *Accepted values:* [`-17592186044416`, `17592186044415`]
 
 *Default:* `5000`
@@ -1217,6 +1219,8 @@ Maximum concurrent I/O cursors of materialized remote segments per CPU core.  If
 *Visibility:* `tunable`
 
 *Type:* integer
+
+*Aliases:* `cloud_storage_max_readers_per_shard`
 
 *Accepted values:* [`0`, `4294967295`]
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-set.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config-set.adoc
@@ -59,13 +59,13 @@ rpk cluster config set <key> <value> [flags]
 Setting properties to non-number values (such as setting string values with `-`) can be problematic for some terminals due to how POSIX flags are parsed. For example, the following command may not work from some terminals:
 
 ```
-rpk cluster config set delete_retention_ms -1
+rpk cluster config set log_retention_ms -1
 ```
 
 Workaround: Use `--` to disable parsing for all subsequent characters. For example:
 
 ```
-rpk cluster config set -- delete_retention_ms -1
+rpk cluster config set -- log_retention_ms -1
 ```
 ====
 

--- a/modules/troubleshoot/partials/debug-bundle/inspect.adoc
+++ b/modules/troubleshoot/partials/debug-bundle/inspect.adoc
@@ -97,7 +97,7 @@ cat admin/cluster_config.json | jq
   "topic_partitions_per_shard": 1000,
   "topic_partitions_reserve_shard0": 2,
   "transaction_coordinator_cleanup_policy": "delete",
-  "transaction_coordinator_delete_retention_ms": 604800000,
+  "transaction_coordinator_log_retention_ms": 604800000,
   "transaction_coordinator_log_segment_size": 1073741824,
   "transactional_id_expiration_ms": 604800000,
   "tx_timeout_delay_ms": 1000,
@@ -383,7 +383,7 @@ cat kafka.json | jq '.[1:]'
             "Source": "DEFAULT_CONFIG",
             "Synonyms": [
               {
-                "Key": "delete_retention_ms",
+                "Key": "log_retention_ms",
                 "Value": "604800000",
                 "Source": "DEFAULT_CONFIG"
               }

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -43,7 +43,7 @@ a| Client throughput quota cluster configuration:
 | This property was a workaround in an older version of Redpanda. It is no longer required and the property is ignored.
 
 | 23.3.1
-| xref:reference:cluster-properties.adoc#delete_retention_ms[`delete_retention_ms`]
+| `delete_retention_ms`
 | Use xref:reference:cluster-properties.adoc#log_retention_ms[`log_retention_ms`] instead.
 
 | 23.2.12


### PR DESCRIPTION
## Description

Content change related to https://github.com/redpanda-data/docs-extensions-and-macros/pull/123



Resolves https://redpandadata.atlassian.net/browse/DOC-415
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
