### PR TITLE
Document how to disable Pod antiaffinity rules

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -623,6 +623,19 @@ statefulset:
           topologyKey: "kubernetes.io/zone"
 ----
 
+To completely disable `podAntiAffinity` rules (for example, in development environments where you want to run multiple brokers on the same node), you can override the default configuration:
+
+[source,yaml]
+----
+statefulset:
+  podTemplate:
+    spec:
+      affinity:
+        podAntiAffinity: null
+----
+
+WARNING: Disabling `podAntiAffinity` rules is not recommended for production environments as it allows multiple brokers to be scheduled on the same node, increasing the risk of data loss if a node fails.
+
 See also: xref:./k-high-availability.adoc[]
 
 === Graceful shutdown

--- a/modules/troubleshoot/partials/errors-and-solutions.adoc
+++ b/modules/troubleshoot/partials/errors-and-solutions.adoc
@@ -269,7 +269,7 @@ Error: UPGRADE FAILED: cannot patch "redpanda" with kind StatefulSet: StatefulSe
 ----
 
 To fix this error, include all the value overrides from the previous installation using either the `--set` or the `--values` flags.
-+
+
 WARNING: Do not use the `--reuse-values` flag to upgrade from one version of the Helm chart to another. This flag stops Helm from using any new values in the upgraded chart.
 
 === Cannot patch "redpanda-console" with kind Deployment


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1388

This pull request adds documentation explaining how to disable `podAntiAffinity` rules in Kubernetes deployments, specifically for cases like development environments where running multiple brokers on the same node may be desirable. It also includes a warning about the risks of disabling these rules in production.

Key documentation update:

* Added instructions and a YAML example for disabling `podAntiAffinity` in the `statefulset` configuration, along with a warning about the risks of doing so in production environments.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
