### PR TITLE
properties: add deprecation context to raft_replica_max_flush_delay_ms

### DIFF
--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -36,7 +36,7 @@ a| Client throughput quota cluster configuration:
 
 | 24.1.1
 | `raft_flush_timer_interval_ms`
-| Use xref:reference:cluster-properties.adoc#raft_replica_max_flush_delay_ms[`raft_replica_max_flush_delay_ms`] instead. The new configuration implements a maximum delay timer since the last flush, while the deprecated property set how often partitions checked for pending flush bytes.
+| Use xref:reference:cluster-properties.adoc#raft_replica_max_flush_delay_ms[`raft_replica_max_flush_delay_ms`] instead. This configuration enforces a maximum delay since the last flush (timer-based flush), whereas the deprecated property controlled how often a partition checked for pending flush bytes. Because the semantics differ, review and adjust your values as needed.
 
 | 23.3.2
 | `space_management_enable_override`

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -36,7 +36,7 @@ a| Client throughput quota cluster configuration:
 
 | 24.1.1
 | `raft_flush_timer_interval_ms`
-| Use xref:reference:cluster-properties.adoc#raft_replica_max_flush_delay_ms[`raft_replica_max_flush_delay_ms`] instead.
+| Use xref:reference:cluster-properties.adoc#raft_replica_max_flush_delay_ms[`raft_replica_max_flush_delay_ms`] instead. The new configuration implements a maximum delay timer since the last flush, while the deprecated property set how often partitions checked for pending flush bytes.
 
 | 23.3.2
 | `space_management_enable_override`


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-212
Review deadline: Aug 15th

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
