### PR TITLE
rpk: add reference for env variables

### DIFF
--- a/modules/get-started/pages/config-rpk-profile.adoc
+++ b/modules/get-started/pages/config-rpk-profile.adoc
@@ -31,10 +31,12 @@ rpk profile create <profile-name> \
   --set brokers=<hostname:port> \
   --set user=<username> \
   --set pass=<password> \
-  --set sasl.mechanism=<SCRAM-SHA-256|SCRAM-SHA-512|PLAIN> \
+  --set sasl.mechanism=<mechanism> \
   --set tls.enabled=true \
   --description "<profile-description>"
 ----
+
+Replace `<mechanism>` with your desired SASL mechanism (`SCRAM-SHA-256`, `SCRAM-SHA-512`, or `PLAIN`).
 
 Use your profile for all commands:
 

--- a/modules/get-started/pages/config-rpk-profile.adoc
+++ b/modules/get-started/pages/config-rpk-profile.adoc
@@ -11,6 +11,8 @@ Use rpk profiles to simplify your development experience using `rpk` with multip
 **rpk profiles are the recommended way to configure rpk**. They provide persistent, reusable configurations that work across sessions and are easier to manage than environment variables or command-line flags.
 ====
 
+include::shared:partials$rpk-profile-sec-notice.adoc[]
+
 == About rpk profiles
 
 An rpk profile contains a reusable configuration for a Redpanda cluster. When running `rpk`, you can create a profile, configure it for a cluster you're working with, and use it repeatably when running an `rpk` command for the cluster.

--- a/modules/get-started/pages/config-rpk-profile.adoc
+++ b/modules/get-started/pages/config-rpk-profile.adoc
@@ -29,6 +29,7 @@ Create a profile with authentication and TLS to quickly set up cluster access in
 ----
 rpk profile create <profile-name> \
   --set brokers=<hostname:port> \
+  --set admin.hosts=<hostname:port> \
   --set user=<username> \
   --set pass=<password> \
   --set sasl.mechanism=<mechanism> \
@@ -59,6 +60,13 @@ Now all commands use this profile automatically:
 ----
 rpk topic list
 rpk topic create <topic-name>
+----
+
+You can check what profile you're using with:
+
+[,bash]
+----
+rpk profile current
 ----
 
 For environment variables and other configuration methods, see xref:reference:rpk/rpk-x-options.adoc[rpk -X options].

--- a/modules/get-started/pages/config-rpk-profile.adoc
+++ b/modules/get-started/pages/config-rpk-profile.adoc
@@ -23,7 +23,7 @@ A profile saves rpk-specific command properties. For details, see xref:get-start
 
 All `rpk` commands can read configuration values from a profile. You pass a profile to an `rpk` command by setting the `--profile` flag. For example, the command `rpk topic produce dev-topic --profile dev` gets its configuration from the profile named `dev`.
 
-== Quick start
+== Quickstart
 
 Create a profile with authentication and TLS to quickly set up cluster access instead of using environment variables or connection flags:
 
@@ -41,16 +41,16 @@ rpk profile create <profile-name> \
 
 Replace `<mechanism>` with your desired SASL mechanism (`SCRAM-SHA-256`, `SCRAM-SHA-512`, or `PLAIN`).
 
-When you create a profile, rpk automatically switches to use that profile so you don't have to keep passing `--profile` flags every time.
+When you create a profile, rpk automatically switches to use that profile so you don't need to pass `--profile` flags every time.
 
-Check what profile you're using with:
+Check the active profile:
 
 [,bash]
 ----
 rpk profile current
 ----
 
-Now all commands use this profile automatically:
+Now all `rpk` commands use this profile automatically:
 
 [,bash]
 ----

--- a/modules/get-started/pages/config-rpk-profile.adoc
+++ b/modules/get-started/pages/config-rpk-profile.adoc
@@ -6,6 +6,11 @@ ifdef::env-cloud[:page-aliases: get-started:config-rpk-profile.adoc]
 
 Use rpk profiles to simplify your development experience using `rpk` with multiple Redpanda clusters by saving and reusing configurations for different clusters.
 
+[TIP]
+====
+**rpk profiles are the recommended way to configure rpk**. They provide persistent, reusable configurations that work across sessions and are easier to manage than environment variables or command-line flags.
+====
+
 == About rpk profiles
 
 An rpk profile contains a reusable configuration for a Redpanda cluster. When running `rpk`, you can create a profile, configure it for a cluster you're working with, and use it repeatably when running an `rpk` command for the cluster.
@@ -15,6 +20,46 @@ You can create different profiles for different Redpanda clusters. For example, 
 A profile saves rpk-specific command properties. For details, see xref:get-started:intro-to-rpk.adoc#specify-command-properties[Specify command properties].
 
 All `rpk` commands can read configuration values from a profile. You pass a profile to an `rpk` command by setting the `--profile` flag. For example, the command `rpk topic produce dev-topic --profile dev` gets its configuration from the profile named `dev`.
+
+== Quick start
+
+Create a profile with authentication and TLS to quickly set up cluster access instead of using environment variables or connection flags:
+
+[,bash]
+----
+rpk profile create <profile-name> \
+  --set brokers=<hostname:port> \
+  --set user=<username> \
+  --set pass=<password> \
+  --set sasl.mechanism=<SCRAM-SHA-256|SCRAM-SHA-512|PLAIN> \
+  --set tls.enabled=true \
+  --description "<profile-description>"
+----
+
+Use your profile for all commands:
+
+[,bash]
+----
+rpk topic list --profile <profile-name>
+rpk topic create <topic-name> --profile <profile-name>
+----
+
+You can set it as your current profile to avoid passing `--profile` flags every time:
+
+[,bash]
+----
+rpk profile use <profile-name>
+----
+
+Now all commands use this profile automatically:
+
+[,bash]
+----
+rpk topic list
+rpk topic create <topic-name>
+----
+
+For environment variables and other configuration methods, see xref:reference:rpk/rpk-x-options.adoc[rpk -X options].
 
 == Work with rpk profiles
 

--- a/modules/get-started/pages/config-rpk-profile.adoc
+++ b/modules/get-started/pages/config-rpk-profile.adoc
@@ -11,7 +11,7 @@ Use rpk profiles to simplify your development experience using `rpk` with multip
 **rpk profiles are the recommended way to configure rpk**. They provide persistent, reusable configurations that work across sessions and are easier to manage than environment variables or command-line flags.
 ====
 
-include::shared:partials$rpk-profile-sec-notice.adoc[]
+include::shared:partial$rpk-profile-sec-notice.adoc[]
 
 == About rpk profiles
 

--- a/modules/get-started/pages/config-rpk-profile.adoc
+++ b/modules/get-started/pages/config-rpk-profile.adoc
@@ -41,19 +41,13 @@ rpk profile create <profile-name> \
 
 Replace `<mechanism>` with your desired SASL mechanism (`SCRAM-SHA-256`, `SCRAM-SHA-512`, or `PLAIN`).
 
-Use your profile for all commands:
+When you create a profile, rpk automatically switches to use that profile so you don't have to keep passing `--profile` flags every time.
+
+Check what profile you're using with:
 
 [,bash]
 ----
-rpk topic list --profile <profile-name>
-rpk topic create <topic-name> --profile <profile-name>
-----
-
-You can set it as your current profile to avoid passing `--profile` flags every time:
-
-[,bash]
-----
-rpk profile use <profile-name>
+rpk profile current
 ----
 
 Now all commands use this profile automatically:
@@ -64,11 +58,11 @@ rpk topic list
 rpk topic create <topic-name>
 ----
 
-You can check what profile you're using with:
+You can change profiles by running:
 
 [,bash]
 ----
-rpk profile current
+rpk profile use <profile-name>
 ----
 
 For environment variables and other configuration methods, see xref:reference:rpk/rpk-x-options.adoc[rpk -X options].

--- a/modules/get-started/pages/intro-to-rpk.adoc
+++ b/modules/get-started/pages/intro-to-rpk.adoc
@@ -63,7 +63,7 @@ Some of the common configuration properties apply across all `rpk` commands as d
 
 === Environment variables
 
-In addition to the `RPK_*` environment variables that correspond to `-X` options, `rpk` also supports legacy `REDPANDA_*` environment variables for backward compatibility and convenience. For a comprehensive list and configuration examples, see:
+`rpk` supports environment variables through `RPK_*` that correspond to `-X` options. For a comprehensive list and configuration examples, see:
 
 * xref:get-started:config-rpk-profile.adoc[rpk profiles] - Create and manage persistent configurations (recommended)
 * xref:reference:rpk/rpk-x-options.adoc[rpk -X options] - Complete configuration reference including environment variables

--- a/modules/get-started/pages/intro-to-rpk.adoc
+++ b/modules/get-started/pages/intro-to-rpk.adoc
@@ -26,7 +26,7 @@ You can specify `rpk` command properties in the following ways:
 
 * Create an xref:get-started:config-rpk-profile.adoc[`rpk profile`].
 * Specify the appropriate flag on the command line.
-* Define the corresponding environment variables.
+* Define the corresponding <<environment-variables,environment variables>>.
 +
 Environment variable settings only last for the duration of a shell session.
 

--- a/modules/get-started/pages/intro-to-rpk.adoc
+++ b/modules/get-started/pages/intro-to-rpk.adoc
@@ -61,6 +61,13 @@ Every `-X` option can be translated into an environment variable by prefixing it
 
 Some of the common configuration properties apply across all `rpk` commands as defaults. These default properties have keys with names starting with `globals`, and they're viewable in `rpk -X list` and `rpk -X help`. For more details, see xref:reference:rpk/rpk-x-options.adoc[`rpk -X options`].
 
+=== Environment variables
+
+In addition to the `RPK_*` environment variables that correspond to `-X` options, `rpk` also supports legacy `REDPANDA_*` environment variables for backward compatibility and convenience. For a comprehensive list and configuration examples, see:
+
+* xref:get-started:config-rpk-profile.adoc[rpk profiles] - Create and manage persistent configurations (recommended)
+* xref:reference:rpk/rpk-x-options.adoc[rpk -X options] - Complete configuration reference including environment variables
+
 == Next steps
 
 * xref:get-started:rpk-install.adoc[]

--- a/modules/manage/pages/schema-reg/schema-id-validation.adoc
+++ b/modules/manage/pages/schema-reg/schema-id-validation.adoc
@@ -46,7 +46,7 @@ For example, use `rpk` to set the value of `enable_schema_id_validation` to `red
 
 [,bash]
 ----
-rpk cluster config set enable_schema_id_validation redpanda --api-urls=<admin-api-IP>:9644
+rpk cluster config set enable_schema_id_validation redpanda -X admin.hosts=<admin-api-IP>:9644
 ----
 endif::[]
 

--- a/modules/reference/pages/rpk/rpk-container/rpk-container-status.adoc
+++ b/modules/reference/pages/rpk/rpk-container/rpk-container-status.adoc
@@ -33,7 +33,7 @@ You can use rpk to interact with this cluster. E.g:
 You may also set an environment variable with the comma-separated list of
 broker addresses:
 
-    export REDPANDA_BROKERS="127.0.0.1:34189,127.0.0.1:45523,127.0.0.1:37223"
+    export RPK_BROKERS="127.0.0.1:34189,127.0.0.1:45523,127.0.0.1:37223"
     rpk cluster info
 ----
 

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-set.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-set.adoc
@@ -20,7 +20,7 @@ the path.
 
 You can also use the format `set key value` if you intend to only set one key.
 
-include::shared:partials$rpk-profile-sec-notice.adoc[]
+include::shared:partial$rpk-profile-sec-notice.adoc[]
 
 == Usage
 

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-set.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-set.adoc
@@ -20,6 +20,8 @@ the path.
 
 You can also use the format `set key value` if you intend to only set one key.
 
+include::shared:partials$rpk-profile-sec-notice.adoc[]
+
 == Usage
 
 [,bash]

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -16,7 +16,7 @@ Every `-X` option can be translated into an environment variable by prefixing wi
 
 [TIP]
 ====
-* For persistent configuration across commands and sessions, we recommend using xref:get-started:config-rpk-profile.adoc[rpk profiles] instead of environment variables or `-X` flags.
+* For persistent configuration across commands and sessions, Redpanda Data recommends using xref:get-started:config-rpk-profile.adoc[rpk profiles] instead of environment variables or `-X` flags.
 * `rpk` supports command-line (tab) completion for `-X` flag keys.
 * Each `rpk` command's `-help` text prints information specific to the command. To view a description of `-X` options, run `rpk -X list` to list supported options, or run `rpk -X help` to get details about supported options.
 ====
@@ -26,7 +26,7 @@ Every `-X` option can be translated into an environment variable by prefixing wi
 `rpk` resolves configuration values in the following priority order (highest to lowest):
 
 1. **Command-line flags** (including `-X` options): Highest priority, applies to current command only
-2. **Environment variables**: Medium priority, `RPK_*` env variables lasts for shell session
+2. **Environment variables**: Medium priority, `RPK_*` environment variables lasts for shell session
 3. **rpk profile** (`rpk.yaml`): Lower priority, persistent across sessions (recommended)
 4. **Redpanda configuration** (`redpanda.yaml` rpk section): Lowest priority, system-wide defaults
 
@@ -74,12 +74,12 @@ Every `-X` option has a corresponding `RPK_*` environment variable. Convert by p
 |<<globals-kafka-protocol-request-client-id,globals.kafka_protocol_request_client_id>> |RPK_GLOBALS_KAFKA_PROTOCOL_REQUEST_CLIENT_ID
 |===
 
-== Quick configuration examples
+== Configuration examples
 
 For regular use, create an xref:get-started:config-rpk-profile.adoc[rpk profile]:
 
-Create a persistent profile:
-
+Create a profile:
++
 ```
 rpk profile create <profile-name> \
   --set brokers=<broker1:port>,<broker2:port> \
@@ -89,15 +89,15 @@ rpk profile create <profile-name> \
   --set tls.enabled=true \
   --description "<profile-description>"
 ```
-
++
 Use the profile for commands:
-
++
 ```
 rpk topic list --profile <profile-name>
 ```
 
-For temporary use or automation scripts, set environment variables:
-
+* For temporary use or automation scripts, set environment variables:
++
 ```
 export RPK_BROKERS="<broker1:port>,<broker2:port>"
 export RPK_USER="<username>"
@@ -105,9 +105,9 @@ export RPK_PASS="<password>"
 export RPK_SASL_MECHANISM="<mechanism>"
 export RPK_TLS_ENABLED="true"
 ```
-
++
 Run commands that use environment variables automatically:
-
++
 ```
 rpk topic list
 ```
@@ -133,7 +133,7 @@ The following options are available:
 
 === brokers
 
-A comma-delimited list of broker `host:port`'s to connect to the Kafka API.
+A comma-delimited list of broker `host:port` pairs to connect to the Kafka API.
 
 *Type*: string
 

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -44,13 +44,37 @@ Every `-X` option has a corresponding `RPK_*` environment variable. Convert by p
 |===
 |`-X` Option |Environment Variable
 
-|brokers |RPK_BROKERS
-|tls.enabled |RPK_TLS_ENABLED
-|tls.ca |RPK_TLS_CA
-|user |RPK_USER
-|pass |RPK_PASS
-|sasl.mechanism |RPK_SASL_MECHANISM
-|admin.hosts |RPK_ADMIN_HOSTS
+|<<brokers,brokers>> |RPK_BROKERS
+|<<tls-enabled,tls.enabled>> |RPK_TLS_ENABLED
+|<<tls-insecure-skip-verify,tls.insecure_skip_verify>> |RPK_TLS_INSECURE_SKIP_VERIFY
+|<<tls-ca,tls.ca>> |RPK_TLS_CA
+|<<tls-cert,tls.cert>> |RPK_TLS_CERT
+|<<tls-key,tls.key>> |RPK_TLS_KEY
+|<<sasl-mechanism,sasl.mechanism>> |RPK_SASL_MECHANISM
+|<<user,user>> |RPK_USER
+|<<pass,pass>> |RPK_PASS
+|<<admin-hosts,admin.hosts>> |RPK_ADMIN_HOSTS
+|<<admin-tls-enabled,admin.tls.enabled>> |RPK_ADMIN_TLS_ENABLED
+|<<admin-tls-insecure-skip-verify,admin.tls.insecure_skip_verify>> |RPK_ADMIN_TLS_INSECURE_SKIP_VERIFY
+|<<admin-tls-ca,admin.tls.ca>> |RPK_ADMIN_TLS_CA
+|<<admin-tls-cert,admin.tls.cert>> |RPK_ADMIN_TLS_CERT
+|<<admin-tls-key,admin.tls.key>> |RPK_ADMIN_TLS_KEY
+|<<registry-hosts,registry.hosts>> |RPK_REGISTRY_HOSTS
+|<<registry-tls-enabled,registry.tls.enabled>> |RPK_REGISTRY_TLS_ENABLED
+|<<registry-tls-insecure-skip-verify,registry.tls.insecure_skip_verify>> |RPK_REGISTRY_TLS_INSECURE_SKIP_VERIFY
+|<<registry-tls-ca,registry.tls.ca>> |RPK_REGISTRY_TLS_CA
+|<<registry-tls-cert,registry.tls.cert>> |RPK_REGISTRY_TLS_CERT
+|<<registry-tls-key,registry.tls.key>> |RPK_REGISTRY_TLS_KEY
+|<<cloud-client-id,cloud.client_id>> |RPK_CLOUD_CLIENT_ID
+|<<cloud-client-secret,cloud.client_secret>> |RPK_CLOUD_CLIENT_SECRET
+|<<globals-prompt,globals.prompt>> |RPK_GLOBALS_PROMPT
+|<<globals-no-default-cluster,globals.no_default_cluster>> |RPK_GLOBALS_NO_DEFAULT_CLUSTER
+|<<globals-command-timeout,globals.command_timeout>> |RPK_GLOBALS_COMMAND_TIMEOUT
+|<<globals-dial-timeout,globals.dial_timeout>> |RPK_GLOBALS_DIAL_TIMEOUT
+|<<globals-request-timeout-overhead,globals.request_timeout_overhead>> |RPK_GLOBALS_REQUEST_TIMEOUT_OVERHEAD
+|<<globals-retry-timeout,globals.retry_timeout>> |RPK_GLOBALS_RETRY_TIMEOUT
+|<<globals-fetch-max-wait,globals.fetch_max_wait>> |RPK_GLOBALS_FETCH_MAX_WAIT
+|<<globals-kafka-protocol-request-client-id,globals.kafka_protocol_request_client_id>> |RPK_GLOBALS_KAFKA_PROTOCOL_REQUEST_CLIENT_ID
 |===
 
 === Legacy REDPANDA_* environment variables

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -74,6 +74,21 @@ Every `-X` option has a corresponding `RPK_*` environment variable. Convert by p
 |<<globals-kafka-protocol-request-client-id,globals.kafka_protocol_request_client_id>> |RPK_GLOBALS_KAFKA_PROTOCOL_REQUEST_CLIENT_ID
 |===
 
+== Duration format
+
+Duration values use Go's standard duration format. A duration string is a sequence of decimal numbers with unit suffixes:
+
+- `ns` = nanoseconds
+- `us` or `µs` = microseconds  
+- `ms` = milliseconds
+- `s` = seconds
+- `m` = minutes
+- `h` = hours
+
+*Examples*: `30s`, `1m30s`, `2h`, `500ms`, `1h15m30s`
+
+You can combine multiple units: `2h45m30s` means 2 hours, 45 minutes, and 30 seconds.
+
 == Configuration examples
 
 * To persist configuration across sessions, use a xref:get-started:config-rpk-profile.adoc[rpk profile]:
@@ -655,20 +670,5 @@ This string value is the client ID that `rpk` uses when issuing Kafka protocol r
 ```
 rpk topic list -X globals.kafka_protocol_request_client_id=<client-id>
 ```
-
-==== Duration format
-
-Duration values use Go's standard duration format. A duration string is a sequence of decimal numbers with unit suffixes:
-
-- `ns` = nanoseconds
-- `us` or `µs` = microseconds  
-- `ms` = milliseconds
-- `s` = seconds
-- `m` = minutes
-- `h` = hours
-
-*Examples*: `30s`, `1m30s`, `2h`, `500ms`, `1h15m30s`
-
-You can combine multiple units: `2h45m30s` means 2 hours, 45 minutes, and 30 seconds.
 
 // end::single-source[]

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -23,12 +23,12 @@ Every `-X` option can be translated into an environment variable by prefixing wi
 
 == Configuration priority
 
-`rpk` resolves configuration values in the following priority order (highest to lowest):
+`rpk` resolves configuration values in the following priority order where higher priority options override lower priority ones:
 
-1. **Command-line flags** (including `-X` options): Highest priority, applies to current command only
-2. **Environment variables**: Medium priority, `RPK_*` environment variables lasts for shell session
-3. **rpk profile** (`rpk.yaml`): Lower priority, persistent across sessions (recommended)
-4. **Redpanda configuration** (`redpanda.yaml` rpk section): Lowest priority, system-wide defaults
+1. **Command-line flags** (including `-X` options): Applies to current command only
+2. **Environment variables**: `RPK_*` environment variables lasts for shell session
+3. **rpk profile** (`rpk.yaml`): Persistent across sessions (recommended)
+4. **Redpanda configuration** (`redpanda.yaml` rpk section): System-wide defaults
 
 == Environment variables
 
@@ -76,7 +76,7 @@ Every `-X` option has a corresponding `RPK_*` environment variable. Convert by p
 
 == Configuration examples
 
-For regular use, create an xref:get-started:config-rpk-profile.adoc[rpk profile]:
+* To persist configuration across sessions, use a xref:get-started:config-rpk-profile.adoc[rpk profile]:
 
 Create a profile:
 +
@@ -113,21 +113,6 @@ rpk topic list
 ```
 
 == Options
-
-=== Duration format
-
-Duration values use Go's standard duration format. A duration string is a sequence of decimal numbers with unit suffixes:
-
-- `ns` = nanoseconds
-- `us` or `µs` = microseconds  
-- `ms` = milliseconds
-- `s` = seconds
-- `m` = minutes
-- `h` = hours
-
-*Examples*: `30s`, `1m30s`, `2h`, `500ms`, `1h15m30s`
-
-You can combine multiple units: `2h45m30s` means 2 hours, 45 minutes, and 30 seconds.
 
 The following options are available:
 
@@ -670,5 +655,20 @@ This string value is the client ID that `rpk` uses when issuing Kafka protocol r
 ```
 rpk topic list -X globals.kafka_protocol_request_client_id=<client-id>
 ```
+
+==== Duration format
+
+Duration values use Go's standard duration format. A duration string is a sequence of decimal numbers with unit suffixes:
+
+- `ns` = nanoseconds
+- `us` or `µs` = microseconds  
+- `ms` = milliseconds
+- `s` = seconds
+- `m` = minutes
+- `h` = hours
+
+*Examples*: `30s`, `1m30s`, `2h`, `500ms`, `1h15m30s`
+
+You can combine multiple units: `2h45m30s` means 2 hours, 45 minutes, and 30 seconds.
 
 // end::single-source[]

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -16,9 +16,103 @@ Every `-X` option can be translated into an environment variable by prefixing wi
 
 [TIP]
 ====
+* For persistent configuration across commands and sessions, we recommend using xref:get-started:config-rpk-profile.adoc[rpk profiles] instead of environment variables or `-X` flags.
 * `rpk` supports command-line (tab) completion for `-X` flag keys.
 * Each `rpk` command's `-help` text prints information specific to the command. To view a description of `-X` options, run `rpk -X list` to list supported options, or run `rpk -X help` to get details about supported options.
 ====
+
+== Configuration priority
+
+`rpk` resolves configuration values in this priority order (highest to lowest):
+
+1. **Command-line flags** (including `-X` options): Applies to current command only
+2. **Environment variables** (`REDPANDA_*` and `RPK_*`): Lasts for shell session
+3. **rpk profile** (`rpk.yaml`): Persistent across sessions (recommended)
+4. **Redpanda configuration** (`redpanda.yaml` rpk section): System-wide defaults
+
+== Environment variables
+
+=== RPK_* environment variables
+
+Every `-X` option has a corresponding `RPK_*` environment variable. Convert by prefixing with `RPK_` and replacing dots with underscores:
+
+[cols="1m,1m"]
+|===
+|`-X` Option |Environment Variable
+
+|brokers |RPK_BROKERS
+|tls.enabled |RPK_TLS_ENABLED
+|tls.ca |RPK_TLS_CA
+|user |RPK_USER
+|pass |RPK_PASS
+|sasl.mechanism |RPK_SASL_MECHANISM
+|admin.hosts |RPK_ADMIN_HOSTS
+|===
+
+=== Legacy REDPANDA_* environment variables
+
+For backward compatibility, `rpk` supports these legacy environment variables:
+
+[cols="1m,1m"]
+|===
+|Environment Variable |Equivalent `-X` Option
+
+|REDPANDA_BROKERS |brokers
+|REDPANDA_SASL_USERNAME |user
+|REDPANDA_SASL_PASSWORD |pass
+|REDPANDA_SASL_MECHANISM |sasl.mechanism
+|REDPANDA_TLS_TRUSTSTORE |tls.ca
+|REDPANDA_TLS_CA |tls.ca
+|REDPANDA_TLS_CERT |tls.cert
+|REDPANDA_TLS_KEY |tls.key
+|REDPANDA_API_ADMIN_ADDRS |admin.hosts
+|REDPANDA_ADMIN_TLS_TRUSTSTORE |admin.tls.ca
+|REDPANDA_ADMIN_TLS_CA |admin.tls.ca
+|REDPANDA_ADMIN_TLS_CERT |admin.tls.cert
+|REDPANDA_ADMIN_TLS_KEY |admin.tls.key
+|===
+
+== Quick configuration examples
+
+For regular use, create an xref:get-started:config-rpk-profile.adoc[rpk profile]:
+
+Create a persistent profile:
+
+[,bash]
+----
+rpk profile create <profile-name> \
+  --set brokers=<broker1:port>,<broker2:port> \
+  --set user=<username> \
+  --set pass=<password> \
+  --set sasl.mechanism=<SCRAM-SHA-256|SCRAM-SHA-512|PLAIN> \
+  --set tls.enabled=true \
+  --description "<profile description>"
+----
+
+Use the profile for commands:
+
+[,bash]
+----
+rpk topic list --profile <profile-name>
+----
+
+For temporary use or automation scripts, set environment variables:
+
+[,bash]
+----
+export REDPANDA_BROKERS="<broker1:port>,<broker2:port>"
+export REDPANDA_SASL_USERNAME="<username>"
+export REDPANDA_SASL_PASSWORD="<password>"
+export REDPANDA_SASL_MECHANISM="<SCRAM-SHA-256|SCRAM-SHA-512|PLAIN>"
+export RPK_TLS_ENABLED="true"
+----
+
+Run commands that use environment variables automatically:
+
+[,bash]
+----
+rpk topic list
+----
 
 == Options
 

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -23,12 +23,16 @@ Every `-X` option can be translated into an environment variable by prefixing wi
 
 == Configuration priority
 
-`rpk` resolves configuration values in this priority order (highest to lowest):
+`rpk` resolves configuration values in the following priority order (highest to lowest):
 
-1. **Command-line flags** (including `-X` options): Applies to current command only
-2. **Environment variables** (`REDPANDA_*` and `RPK_*`): Lasts for shell session
-3. **rpk profile** (`rpk.yaml`): Persistent across sessions (recommended)
-4. **Redpanda configuration** (`redpanda.yaml` rpk section): System-wide defaults
+1. **Command-line flags** (including `-X` options): Highest priority, applies to current command only
+2. **Environment variables**: Medium priority, lasts for shell session
+   - **RPK_*** variables (modern): Higher precedence
+   - **REDPANDA_*** variables (legacy): Lower precedence
+3. **rpk profile** (`rpk.yaml`): Lower priority, persistent across sessions (recommended)
+4. **Redpanda configuration** (`redpanda.yaml` rpk section): Lowest priority, system-wide defaults
+
+NOTE: If both `RPK_*` and `REDPANDA_*` environment variables are set for the same option, the `RPK_*` variable takes precedence.
 
 == Environment variables
 
@@ -51,7 +55,7 @@ Every `-X` option has a corresponding `RPK_*` environment variable. Convert by p
 
 === Legacy REDPANDA_* environment variables
 
-For backward compatibility, `rpk` supports these legacy environment variables:
+For backward compatibility, `rpk` supports these specific legacy environment variables. Note that not all `-X` options have `REDPANDA_*` equivalents - only certain commonly used connection and authentication options:
 
 [cols="1m,1m"]
 |===
@@ -71,6 +75,8 @@ For backward compatibility, `rpk` supports these legacy environment variables:
 |REDPANDA_ADMIN_TLS_CERT |admin.tls.cert
 |REDPANDA_ADMIN_TLS_KEY |admin.tls.key
 |===
+
+TIP: For options not listed above (such as `tls.enabled`, `globals.*`, etc.), use the `RPK_*` format.
 
 == Quick configuration examples
 
@@ -97,10 +103,10 @@ rpk topic list --profile <profile-name>
 For temporary use or automation scripts, set environment variables:
 
 ```
-export REDPANDA_BROKERS="<broker1:port>,<broker2:port>"
-export REDPANDA_SASL_USERNAME="<username>"
-export REDPANDA_SASL_PASSWORD="<password>"
-export REDPANDA_SASL_MECHANISM="<mechanism>"
+export RPK_BROKERS="<broker1:port>,<broker2:port>"
+export RPK_USER="<username>"
+export RPK_PASS="<password>"
+export RPK_SASL_MECHANISM="<mechanism>"
 export RPK_TLS_ENABLED="true"
 ```
 

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -118,11 +118,30 @@ rpk topic list
 
 == Options
 
+=== Duration format
+
+Duration values use Go's standard duration format. A duration string is a sequence of decimal numbers with unit suffixes:
+
+- `ns` = nanoseconds
+- `us` or `µs` = microseconds  
+- `ms` = milliseconds
+- `s` = seconds
+- `m` = minutes
+- `h` = hours
+
+*Examples*: `30s`, `1m30s`, `2h`, `500ms`, `1h15m30s`
+
+You can combine multiple units: `2h45m30s` means 2 hours, 45 minutes, and 30 seconds.
+
 The following options are available:
 
 === brokers
 
-A comma separated list of `host:ports` that `rpk` communicates with for the Kafka API. By default, this option is set to `127.0.0.1:9092`.
+A comma-delimited list of broker `host:port`'s to connect to the Kafka API.
+
+*Type*: string
+
+*Default*: `localhost:9092`
 
 *Example*: `brokers=127.0.0.1:9092,localhost:9094`
 
@@ -139,7 +158,9 @@ A boolean that enables `rpk` to speak TLS to your broker's Kafka API listeners.
 
 You can use this if you have well known certificates set up on your Kafka API. If you use mTLS, specifying mTLS certificate filepaths automatically opts into `tls.enabled`.
 
-*Acceptable values*: `true`, `false`
+*Type*: boolean
+
+*Default*: `false`
 
 *Example*: `tls.enabled=true`
 
@@ -154,7 +175,9 @@ rpk topic list -X tls.enabled=<value>
 
 A boolean that disables `rpk` from verifying the broker's certificate chain.
 
-*Acceptable values*: `true`, `false`
+*Type*: boolean
+
+*Default*: `false`
 
 *Example*: `tls.insecure_skip_verify=true`
 
@@ -171,6 +194,10 @@ A filepath to a PEM-encoded CA certificate file to talk to your broker's Kafka A
 
 You may need this option if your listeners are using a certificate by a well known authority that is not bundled with your operating system.
 
+*Type*: string
+
+*Default*: ""
+
 *Example*: `tls.ca=/path/to/ca.pem`
 
 *Usage*: 
@@ -183,6 +210,10 @@ rpk topic list -X tls.ca=<filepath>
 === tls.cert
 
 A filepath to a PEM-encoded client certificate file to talk to your broker's Kafka API listeners with mTLS.
+
+*Type*: string
+
+*Default*: ""
 
 *Example*: `tls.cert=/path/to/cert.pem`
 
@@ -197,6 +228,10 @@ rpk topic list -X tls.cert=<filepath>
 
 A filepath to a PEM-encoded client key file to talk to your broker's Kafka API listeners with mTLS.
 
+*Type*: string
+
+*Default*: ""
+
 *Example*: `tls.key=/path/to/key.pem`
 
 *Usage*: 
@@ -208,11 +243,15 @@ rpk topic list -X tls.key=<filepath>
 
 === sasl.mechanism
 
-The SASL mechanism to use for authentication, either `SCRAM-SHA-256` or `SCRAM-SHA-512`.
+The SASL mechanism to use for authentication.
 
-NOTE: With Redpanda, the Admin API can be configured to require basic authentication with your Kafka API SASL credentials. This defaults to `SCRAM-SHA-256` if no mechanism is specified.
+*Type*: string
+
+*Default*: ""
 
 *Acceptable values*: `SCRAM-SHA-256`, `SCRAM-SHA-512`, `PLAIN`
+
+NOTE: With Redpanda, the Admin API can be configured to require basic authentication with your Kafka API SASL credentials. This defaults to `SCRAM-SHA-256` if no mechanism is specified.
 
 *Example*: `sasl.mechanism=SCRAM-SHA-256`
 
@@ -227,6 +266,10 @@ rpk topic list -X sasl.mechanism=<mechanism>
 
 The SASL username to use for authentication. It's also used for the Admin API if you have configured it to require basic authentication.
 
+*Type*: string
+
+*Default*: ""
+
 *Example*: `user=myusername`
 
 *Usage*: 
@@ -240,6 +283,10 @@ rpk topic list -X user=<username>
 
 The SASL password to use for authentication. It's also used for the Admin API if you have configured it to require basic authentication.
 
+*Type*: string
+
+*Default*: ""
+
 *Example*: `pass=mypassword`
 
 *Usage*: 
@@ -251,14 +298,13 @@ rpk topic list -X pass=<password>
 
 === admin.hosts
 
-A comma separated list of `host:ports` that `rpk` communicates with for the Admin API. By default, this is set to `127.0.0.1:9644`.
+A comma-delimited list of admin hosts to connect to.
 
-*Example*: `admin.hosts=localhost:9644,rp.example.com:9644`
+*Type*: string
 
-*Usage*: 
-```
-rpk cluster info -X admin.hosts=<host:port>,<host:port>
-```
+*Default*: `localhost:9644`
+
+*Example*: `admin.hosts=192.168.1.1:9644,192.168.1.2:9644`
 
 '''
 
@@ -268,7 +314,9 @@ A boolean that enables `rpk` to speak TLS to your broker's Admin API listeners.
 
 You can use this if you have well known certificates set up on your Admin API. If you use mTLS, specifying mTLS certificate filepaths automatically opts into `admin.tls.enabled`.
 
-*Acceptable values*: `true`, `false`
+*Type*: boolean
+
+*Default*: `false`
 
 *Example*: `admin.tls.enabled=true`
 
@@ -283,7 +331,9 @@ rpk cluster info -X admin.tls.enabled=<value>
 
 A boolean that disables `rpk` from verifying the broker's certificate chain.
 
-*Acceptable values*: `true`, `false`
+*Type*: boolean
+
+*Default*: `false`
 
 *Example*: `admin.tls.insecure_skip_verify=true`
 
@@ -298,6 +348,10 @@ rpk cluster info -X admin.tls.insecure_skip_verify=<value>
 
 A filepath to a PEM-encoded CA certificate file to talk to your broker's Admin API listeners with mTLS. You may also need this if your listeners are using a certificate by a well known authority that is not yet bundled with your operating system.
 
+*Type*: string
+
+*Default*: ""
+
 *Example*: `admin.tls.ca=/path/to/ca.pem`
 
 *Usage*: 
@@ -310,6 +364,10 @@ rpk cluster info -X admin.tls.ca=<filepath>
 === admin.tls.cert
 
 A filepath to a PEM-encoded client certificate file to talk to your broker's Admin API listeners with mTLS.
+
+*Type*: string
+
+*Default*: ""
 
 *Example*: `admin.tls.cert=/path/to/cert.pem`
 
@@ -324,6 +382,10 @@ rpk cluster info -X admin.tls.cert=<filepath>
 
 A filepath to a PEM-encoded client key file to talk to your broker's Admin API listeners with mTLS.
 
+*Type*: string
+
+*Default*: ""
+
 *Example*: `admin.tls.key=/path/to/key.pem`
 
 *Usage*: 
@@ -335,9 +397,13 @@ rpk cluster info -X admin.tls.key=<filepath>
 
 === registry.hosts
 
-A comma-separated list of `host:ports` that `rpk` communicates with for the Schema Registry API. By default, this option is set to `127.0.0.1:8081`.
+A comma-delimited list of Schema Registry hosts to connect to.
 
-*Example*: `registry.hosts=localhost:8081,rp.example.com:8081`
+*Type*: string
+
+*Default*: `localhost:8081`
+
+*Example*: `registry.hosts=192.168.1.1:8081,192.168.1.2:8081`
 
 *Usage*: 
 ```
@@ -352,7 +418,9 @@ A boolean that enables `rpk` to use TLS with your broker's Schema Registry API l
 
 You can use this if you have well known certificates set up on your Schema Registry API. If you use mTLS, specifying mTLS certificate filepaths automatically opts into `registry.tls.enabled`.
 
-*Acceptable values*: `true`, `false`
+*Type*: boolean
+
+*Default*: `false`
 
 *Example*: `registry.tls.enabled=true`
 
@@ -367,7 +435,9 @@ rpk registry schema list -X registry.tls.enabled=<value>
 
 A boolean that disables `rpk` from verifying the broker's certificate chain.
 
-*Acceptable values*: `true`, `false`
+*Type*: boolean
+
+*Default*: `false`
 
 *Example*: `registry.tls.insecure_skip_verify=true`
 
@@ -382,6 +452,10 @@ rpk registry schema list -X registry.tls.insecure_skip_verify=<value>
 
 A filepath to a PEM-encoded CA certificate file to talk to your broker's Schema Registry API listeners with mTLS.
 
+*Type*: string
+
+*Default*: ""
+
 *Example*: `registry.tls.ca=/path/to/ca.pem`
 
 *Usage*: 
@@ -394,6 +468,10 @@ rpk registry schema list -X registry.tls.ca=<filepath>
 === registry.tls.cert
 
 A filepath to a PEM-encoded client certificate file to talk to your broker's Schema Registry API listeners with mTLS.
+
+*Type*: string
+
+*Default*: ""
 
 *Example*: `registry.tls.cert=/path/to/cert.pem`
 
@@ -408,6 +486,10 @@ rpk registry schema list -X registry.tls.cert=<filepath>
 
 A filepath to a PEM-encoded client key file to talk to your broker's Schema Registry API listeners with mTLS.
 
+*Type*: string
+
+*Default*: ""
+
 *Example*: `registry.tls.key=/path/to/key.pem`
 
 *Usage*: 
@@ -420,6 +502,10 @@ rpk registry schema list -X registry.tls.key=<filepath>
 === cloud.client_id
 
 An OAuth client ID to use for authenticating with the Redpanda Cloud API.
+
+*Type*: string
+
+*Default*: ""
 
 *Example*: `cloud.client_id=abcdef123456`
 
@@ -434,6 +520,10 @@ rpk cloud cluster list -X cloud.client_id=<client-id>
 
 An OAuth client secret to use for authenticating with the Redpanda Cloud API.
 
+*Type*: string
+
+*Default*: ""
+
 *Example*: `cloud.client_secret=secretvalue789`
 
 *Usage*: 
@@ -446,6 +536,10 @@ rpk cloud cluster list -X cloud.client_secret=<client-secret>
 === globals.prompt
 
 A format string to use for the default prompt. See xref:./rpk-profile/rpk-profile-prompt.adoc[`rpk profile prompt`] for more information.
+
+*Type*: string
+
+*Default*: `bg-red "%n"`
 
 *Example*: `globals.prompt="%n"`
 
@@ -460,7 +554,9 @@ rpk profile edit -X globals.prompt=<format-string>
 
 A boolean that disables `rpk` from communicating to `localhost:9092` if no other cluster is specified.
 
-*Acceptable values*: `true`, `false`
+*Type*: boolean
+
+*Default*: `false`
 
 *Example*: `globals.no_default_cluster=true`
 
@@ -473,20 +569,23 @@ rpk topic list -X globals.no_default_cluster=<value>
 
 === globals.command_timeout
 
-A duration that `rpk` will wait for a command to complete before timing out, for certain commands.
+Sets a timeout for all commands issued through rpk.
+
+*Type*: <<duration-format,duration>>
+
+*Default*: `30s`
 
 *Example*: `globals.command_timeout=30s`
-
-*Usage*: 
-```
-rpk topic list -X globals.command_timeout=<duration>
-```
 
 '''
 
 === globals.dial_timeout
 
 A duration that `rpk` will wait for a connection to be established before timing out.
+
+*Type*: <<duration-format,duration>>
+
+*Default*: `3s`
 
 *Example*: `globals.dial_timeout=3s`
 
@@ -500,6 +599,10 @@ rpk topic list -X globals.dial_timeout=<duration>
 === globals.request_timeout_overhead
 
 A duration that limits how long `rpk` waits for responses.
+
+*Type*: <<duration-format,duration>>
+
+*Default*: `10s`
 
 [NOTE]
 ====
@@ -521,6 +624,10 @@ rpk topic list -X globals.request_timeout_overhead=<duration>
 
 This timeout specifies how long `rpk` will retry Kafka API requests.
 
+*Type*: <<duration-format,duration>>
+
+*Default*: `30s`
+
 This timeout is evaluated before any backoff:
 
 * If a request fails, `rpk` first checks if the retry timeout has elapsed.
@@ -540,6 +647,10 @@ rpk topic list -X globals.retry_timeout=<duration>
 
 This timeout specifies the maximum duration that brokers will wait before replying to a fetch request with available data.
 
+*Type*: <<duration-format,duration>>
+
+*Default*: `5s`
+
 *Example*: `globals.fetch_max_wait=5s`
 
 *Usage*: 
@@ -552,6 +663,10 @@ rpk topic consume my-topic -X globals.fetch_max_wait=<duration>
 === globals.kafka_protocol_request_client_id
 
 This string value is the client ID that `rpk` uses when issuing Kafka protocol requests to Redpanda. This client ID shows up in Redpanda logs and metrics. Changing it can be useful if you want to have your own `rpk` client stand out from others that are also interacting with the cluster.
+
+*Type*: string
+
+*Default*: `rpk`
 
 *Example*: `globals.kafka_protocol_request_client_id=my-rpk-client`
 

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -91,7 +91,7 @@ You can combine multiple units: `2h45m30s` means 2 hours, 45 minutes, and 30 sec
 
 == Configuration examples
 
-* To persist configuration across sessions, use a xref:get-started:config-rpk-profile.adoc[rpk profile]:
+To persist configuration across sessions, use a xref:get-started:config-rpk-profile.adoc[rpk profile]:
 
 Create a profile:
 +
@@ -104,15 +104,15 @@ rpk profile create <profile-name> \
   --set tls.enabled=true \
   --description "<profile-description>"
 ```
-+
+
 Use the profile for commands:
-+
+
 ```
 rpk topic list --profile <profile-name>
 ```
 
-* For temporary use or automation scripts, set environment variables:
-+
+For temporary use or automation scripts, set environment variables:
+
 ```
 export RPK_BROKERS="<broker1:port>,<broker2:port>"
 export RPK_USER="<username>"
@@ -120,9 +120,9 @@ export RPK_PASS="<password>"
 export RPK_SASL_MECHANISM="<mechanism>"
 export RPK_TLS_ENABLED="true"
 ```
-+
-Run commands that use environment variables automatically:
-+
+
+Run a command:
+
 ```
 rpk topic list
 ```

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -94,8 +94,7 @@ You can combine multiple units: `2h45m30s` means 2 hours, 45 minutes, and 30 sec
 To persist configuration across sessions, use a xref:get-started:config-rpk-profile.adoc[rpk profile]:
 
 Create a profile:
-+
-```
+```bash
 rpk profile create <profile-name> \
   --set brokers=<broker1:port>,<broker2:port> \
   --set user=<username> \
@@ -107,24 +106,18 @@ rpk profile create <profile-name> \
 
 Use the profile for commands:
 
-```
+```bash
 rpk topic list --profile <profile-name>
 ```
 
 For temporary use or automation scripts, set environment variables:
 
-```
+```bash
 export RPK_BROKERS="<broker1:port>,<broker2:port>"
 export RPK_USER="<username>"
 export RPK_PASS="<password>"
 export RPK_SASL_MECHANISM="<mechanism>"
 export RPK_TLS_ENABLED="true"
-```
-
-Run a command:
-
-```
-rpk topic list
 ```
 
 == Options

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -26,16 +26,13 @@ Every `-X` option can be translated into an environment variable by prefixing wi
 `rpk` resolves configuration values in the following priority order (highest to lowest):
 
 1. **Command-line flags** (including `-X` options): Highest priority, applies to current command only
-2. **Environment variables**: Medium priority, lasts for shell session
-   - **RPK_*** variables (modern): Higher precedence
-   - **REDPANDA_*** variables (legacy): Lower precedence
+2. **Environment variables**: Medium priority, `RPK_*` env variables lasts for shell session
 3. **rpk profile** (`rpk.yaml`): Lower priority, persistent across sessions (recommended)
 4. **Redpanda configuration** (`redpanda.yaml` rpk section): Lowest priority, system-wide defaults
 
-NOTE: If both `RPK_*` and `REDPANDA_*` environment variables are set for the same option, the `RPK_*` variable takes precedence.
-
 == Environment variables
 
+[[rpk-environment-variables]]
 === RPK_* environment variables
 
 Every `-X` option has a corresponding `RPK_*` environment variable. Convert by prefixing with `RPK_` and replacing dots with underscores:
@@ -76,31 +73,6 @@ Every `-X` option has a corresponding `RPK_*` environment variable. Convert by p
 |<<globals-fetch-max-wait,globals.fetch_max_wait>> |RPK_GLOBALS_FETCH_MAX_WAIT
 |<<globals-kafka-protocol-request-client-id,globals.kafka_protocol_request_client_id>> |RPK_GLOBALS_KAFKA_PROTOCOL_REQUEST_CLIENT_ID
 |===
-
-=== Legacy REDPANDA_* environment variables
-
-For backward compatibility, `rpk` supports these specific legacy environment variables. Note that not all `-X` options have `REDPANDA_*` equivalents - only certain commonly used connection and authentication options:
-
-[cols="1m,1m"]
-|===
-|Environment Variable |Equivalent `-X` Option
-
-|REDPANDA_BROKERS |brokers
-|REDPANDA_SASL_USERNAME |user
-|REDPANDA_SASL_PASSWORD |pass
-|REDPANDA_SASL_MECHANISM |sasl.mechanism
-|REDPANDA_TLS_TRUSTSTORE |tls.ca
-|REDPANDA_TLS_CA |tls.ca
-|REDPANDA_TLS_CERT |tls.cert
-|REDPANDA_TLS_KEY |tls.key
-|REDPANDA_API_ADMIN_ADDRS |admin.hosts
-|REDPANDA_ADMIN_TLS_TRUSTSTORE |admin.tls.ca
-|REDPANDA_ADMIN_TLS_CA |admin.tls.ca
-|REDPANDA_ADMIN_TLS_CERT |admin.tls.cert
-|REDPANDA_ADMIN_TLS_KEY |admin.tls.key
-|===
-
-TIP: For options not listed above (such as `tls.enabled`, `globals.*`, etc.), use the `RPK_*` format.
 
 == Quick configuration examples
 

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -78,51 +78,52 @@ For regular use, create an xref:get-started:config-rpk-profile.adoc[rpk profile]
 
 Create a persistent profile:
 
-[,bash]
-----
+```
 rpk profile create <profile-name> \
   --set brokers=<broker1:port>,<broker2:port> \
   --set user=<username> \
   --set pass=<password> \
-  --set sasl.mechanism=<SCRAM-SHA-256|SCRAM-SHA-512|PLAIN> \
+  --set sasl.mechanism=<mechanism> \
   --set tls.enabled=true \
-  --description "<profile description>"
-----
+  --description "<profile-description>"
+```
 
 Use the profile for commands:
 
-[,bash]
-----
+```
 rpk topic list --profile <profile-name>
-----
+```
 
 For temporary use or automation scripts, set environment variables:
 
-[,bash]
-----
+```
 export REDPANDA_BROKERS="<broker1:port>,<broker2:port>"
 export REDPANDA_SASL_USERNAME="<username>"
 export REDPANDA_SASL_PASSWORD="<password>"
-export REDPANDA_SASL_MECHANISM="<SCRAM-SHA-256|SCRAM-SHA-512|PLAIN>"
+export REDPANDA_SASL_MECHANISM="<mechanism>"
 export RPK_TLS_ENABLED="true"
-----
+```
 
 Run commands that use environment variables automatically:
 
-[,bash]
-----
+```
 rpk topic list
-----
+```
 
 == Options
 
-The following options are available, with an example `option=value` for each.
+The following options are available:
 
 === brokers
 
 A comma separated list of `host:ports` that `rpk` communicates with for the Kafka API. By default, this option is set to `127.0.0.1:9092`.
 
 *Example*: `brokers=127.0.0.1:9092,localhost:9094`
+
+*Usage*: 
+```
+rpk topic list -X brokers=<host:port>,<host:port>
+```
 
 '''
 
@@ -132,7 +133,14 @@ A boolean that enables `rpk` to speak TLS to your broker's Kafka API listeners.
 
 You can use this if you have well known certificates set up on your Kafka API. If you use mTLS, specifying mTLS certificate filepaths automatically opts into `tls.enabled`.
 
+*Acceptable values*: `true`, `false`
+
 *Example*: `tls.enabled=true`
+
+*Usage*: 
+```
+rpk topic list -X tls.enabled=<value>
+```
 
 '''
 
@@ -140,7 +148,14 @@ You can use this if you have well known certificates set up on your Kafka API. I
 
 A boolean that disables `rpk` from verifying the broker's certificate chain.
 
+*Acceptable values*: `true`, `false`
+
 *Example*: `tls.insecure_skip_verify=true`
+
+*Usage*: 
+```
+rpk topic list -X tls.insecure_skip_verify=<value>
+```
 
 '''
 
@@ -152,6 +167,11 @@ You may need this option if your listeners are using a certificate by a well kno
 
 *Example*: `tls.ca=/path/to/ca.pem`
 
+*Usage*: 
+```
+rpk topic list -X tls.ca=<filepath>
+```
+
 '''
 
 === tls.cert
@@ -159,6 +179,11 @@ You may need this option if your listeners are using a certificate by a well kno
 A filepath to a PEM-encoded client certificate file to talk to your broker's Kafka API listeners with mTLS.
 
 *Example*: `tls.cert=/path/to/cert.pem`
+
+*Usage*: 
+```
+rpk topic list -X tls.cert=<filepath>
+```
 
 '''
 
@@ -168,6 +193,11 @@ A filepath to a PEM-encoded client key file to talk to your broker's Kafka API l
 
 *Example*: `tls.key=/path/to/key.pem`
 
+*Usage*: 
+```
+rpk topic list -X tls.key=<filepath>
+```
+
 '''
 
 === sasl.mechanism
@@ -176,7 +206,14 @@ The SASL mechanism to use for authentication, either `SCRAM-SHA-256` or `SCRAM-S
 
 NOTE: With Redpanda, the Admin API can be configured to require basic authentication with your Kafka API SASL credentials. This defaults to `SCRAM-SHA-256` if no mechanism is specified.
 
+*Acceptable values*: `SCRAM-SHA-256`, `SCRAM-SHA-512`, `PLAIN`
+
 *Example*: `sasl.mechanism=SCRAM-SHA-256`
+
+*Usage*: 
+```
+rpk topic list -X sasl.mechanism=<mechanism>
+```
 
 '''
 
@@ -184,7 +221,12 @@ NOTE: With Redpanda, the Admin API can be configured to require basic authentica
 
 The SASL username to use for authentication. It's also used for the Admin API if you have configured it to require basic authentication.
 
-*Example*: `user=username`
+*Example*: `user=myusername`
+
+*Usage*: 
+```
+rpk topic list -X user=<username>
+```
 
 '''
 
@@ -192,7 +234,12 @@ The SASL username to use for authentication. It's also used for the Admin API if
 
 The SASL password to use for authentication. It's also used for the Admin API if you have configured it to require basic authentication.
 
-*Example*: `pass=password`
+*Example*: `pass=mypassword`
+
+*Usage*: 
+```
+rpk topic list -X pass=<password>
+```
 
 '''
 
@@ -202,6 +249,11 @@ A comma separated list of `host:ports` that `rpk` communicates with for the Admi
 
 *Example*: `admin.hosts=localhost:9644,rp.example.com:9644`
 
+*Usage*: 
+```
+rpk cluster info -X admin.hosts=<host:port>,<host:port>
+```
+
 '''
 
 === admin.tls.enabled
@@ -210,7 +262,14 @@ A boolean that enables `rpk` to speak TLS to your broker's Admin API listeners.
 
 You can use this if you have well known certificates set up on your Admin API. If you use mTLS, specifying mTLS certificate filepaths automatically opts into `admin.tls.enabled`.
 
-*Example*: `admin.tls.enabled=false`
+*Acceptable values*: `true`, `false`
+
+*Example*: `admin.tls.enabled=true`
+
+*Usage*: 
+```
+rpk cluster info -X admin.tls.enabled=<value>
+```
 
 '''
 
@@ -218,7 +277,14 @@ You can use this if you have well known certificates set up on your Admin API. I
 
 A boolean that disables `rpk` from verifying the broker's certificate chain.
 
+*Acceptable values*: `true`, `false`
+
 *Example*: `admin.tls.insecure_skip_verify=true`
+
+*Usage*: 
+```
+rpk cluster info -X admin.tls.insecure_skip_verify=<value>
+```
 
 '''
 
@@ -228,6 +294,11 @@ A filepath to a PEM-encoded CA certificate file to talk to your broker's Admin A
 
 *Example*: `admin.tls.ca=/path/to/ca.pem`
 
+*Usage*: 
+```
+rpk cluster info -X admin.tls.ca=<filepath>
+```
+
 '''
 
 === admin.tls.cert
@@ -235,6 +306,11 @@ A filepath to a PEM-encoded CA certificate file to talk to your broker's Admin A
 A filepath to a PEM-encoded client certificate file to talk to your broker's Admin API listeners with mTLS.
 
 *Example*: `admin.tls.cert=/path/to/cert.pem`
+
+*Usage*: 
+```
+rpk cluster info -X admin.tls.cert=<filepath>
+```
 
 '''
 
@@ -244,6 +320,11 @@ A filepath to a PEM-encoded client key file to talk to your broker's Admin API l
 
 *Example*: `admin.tls.key=/path/to/key.pem`
 
+*Usage*: 
+```
+rpk cluster info -X admin.tls.key=<filepath>
+```
+
 '''
 
 === registry.hosts
@@ -251,6 +332,11 @@ A filepath to a PEM-encoded client key file to talk to your broker's Admin API l
 A comma-separated list of `host:ports` that `rpk` communicates with for the Schema Registry API. By default, this option is set to `127.0.0.1:8081`.
 
 *Example*: `registry.hosts=localhost:8081,rp.example.com:8081`
+
+*Usage*: 
+```
+rpk registry schema list -X registry.hosts=<host:port>,<host:port>
+```
 
 '''
 
@@ -260,7 +346,14 @@ A boolean that enables `rpk` to use TLS with your broker's Schema Registry API l
 
 You can use this if you have well known certificates set up on your Schema Registry API. If you use mTLS, specifying mTLS certificate filepaths automatically opts into `registry.tls.enabled`.
 
-*Example*: `registry.tls.enabled=false`
+*Acceptable values*: `true`, `false`
+
+*Example*: `registry.tls.enabled=true`
+
+*Usage*: 
+```
+rpk registry schema list -X registry.tls.enabled=<value>
+```
 
 '''
 
@@ -268,7 +361,14 @@ You can use this if you have well known certificates set up on your Schema Regis
 
 A boolean that disables `rpk` from verifying the broker's certificate chain.
 
-*Example*: `registry.tls.insecure_skip_verify=false`
+*Acceptable values*: `true`, `false`
+
+*Example*: `registry.tls.insecure_skip_verify=true`
+
+*Usage*: 
+```
+rpk registry schema list -X registry.tls.insecure_skip_verify=<value>
+```
 
 '''
 
@@ -278,6 +378,11 @@ A filepath to a PEM-encoded CA certificate file to talk to your broker's Schema 
 
 *Example*: `registry.tls.ca=/path/to/ca.pem`
 
+*Usage*: 
+```
+rpk registry schema list -X registry.tls.ca=<filepath>
+```
+
 '''
 
 === registry.tls.cert
@@ -285,6 +390,11 @@ A filepath to a PEM-encoded CA certificate file to talk to your broker's Schema 
 A filepath to a PEM-encoded client certificate file to talk to your broker's Schema Registry API listeners with mTLS.
 
 *Example*: `registry.tls.cert=/path/to/cert.pem`
+
+*Usage*: 
+```
+rpk registry schema list -X registry.tls.cert=<filepath>
+```
 
 '''
 
@@ -294,13 +404,23 @@ A filepath to a PEM-encoded client key file to talk to your broker's Schema Regi
 
 *Example*: `registry.tls.key=/path/to/key.pem`
 
+*Usage*: 
+```
+rpk registry schema list -X registry.tls.key=<filepath>
+```
+
 '''
 
 === cloud.client_id
 
 An OAuth client ID to use for authenticating with the Redpanda Cloud API.
 
-*Example*: `cloud.client_id=somestring`
+*Example*: `cloud.client_id=abcdef123456`
+
+*Usage*: 
+```
+rpk cloud cluster list -X cloud.client_id=<client-id>
+```
 
 '''
 
@@ -308,7 +428,12 @@ An OAuth client ID to use for authenticating with the Redpanda Cloud API.
 
 An OAuth client secret to use for authenticating with the Redpanda Cloud API.
 
-*Example*: `cloud.client_secret=somelongerstring`
+*Example*: `cloud.client_secret=secretvalue789`
+
+*Usage*: 
+```
+rpk cloud cluster list -X cloud.client_secret=<client-secret>
+```
 
 '''
 
@@ -318,13 +443,25 @@ A format string to use for the default prompt. See xref:./rpk-profile/rpk-profil
 
 *Example*: `globals.prompt="%n"`
 
+*Usage*: 
+```
+rpk profile edit -X globals.prompt=<format-string>
+```
+
 '''
 
 === globals.no_default_cluster
 
 A boolean that disables `rpk` from communicating to `localhost:9092` if no other cluster is specified.
 
-*Example*: `globals.no_default_cluster=false`
+*Acceptable values*: `true`, `false`
+
+*Example*: `globals.no_default_cluster=true`
+
+*Usage*: 
+```
+rpk topic list -X globals.no_default_cluster=<value>
+```
 
 '''
 
@@ -334,6 +471,11 @@ A duration that `rpk` will wait for a command to complete before timing out, for
 
 *Example*: `globals.command_timeout=30s`
 
+*Usage*: 
+```
+rpk topic list -X globals.command_timeout=<duration>
+```
+
 '''
 
 === globals.dial_timeout
@@ -341,6 +483,11 @@ A duration that `rpk` will wait for a command to complete before timing out, for
 A duration that `rpk` will wait for a connection to be established before timing out.
 
 *Example*: `globals.dial_timeout=3s`
+
+*Usage*: 
+```
+rpk topic list -X globals.dial_timeout=<duration>
+```
 
 '''
 
@@ -357,6 +504,11 @@ For example, `ListOffsets` has no `Timeout` field, so `rpk` will wait `request_t
 
 *Example*: `globals.request_timeout_overhead=5s`
 
+*Usage*: 
+```
+rpk topic list -X globals.request_timeout_overhead=<duration>
+```
+
 '''
 
 === globals.retry_timeout
@@ -371,6 +523,11 @@ This timeout is evaluated before any backoff:
 
 *Example*: `globals.retry_timeout=11s`
 
+*Usage*: 
+```
+rpk topic list -X globals.retry_timeout=<duration>
+```
+
 '''
 
 === globals.fetch_max_wait
@@ -379,12 +536,22 @@ This timeout specifies the maximum duration that brokers will wait before replyi
 
 *Example*: `globals.fetch_max_wait=5s`
 
+*Usage*: 
+```
+rpk topic consume my-topic -X globals.fetch_max_wait=<duration>
+```
+
 '''
 
 === globals.kafka_protocol_request_client_id
 
 This string value is the client ID that `rpk` uses when issuing Kafka protocol requests to Redpanda. This client ID shows up in Redpanda logs and metrics. Changing it can be useful if you want to have your own `rpk` client stand out from others that are also interacting with the cluster.
 
-*Example*: `globals.kafka_protocol_request_client_id=rpk`
+*Example*: `globals.kafka_protocol_request_client_id=my-rpk-client`
+
+*Usage*: 
+```
+rpk topic list -X globals.kafka_protocol_request_client_id=<client-id>
+```
 
 // end::single-source[]

--- a/modules/shared/partials/rpk-profile-sec-notice.adoc
+++ b/modules/shared/partials/rpk-profile-sec-notice.adoc
@@ -1,0 +1,4 @@
+[CAUTION]
+====
+Profile files may contain sensitive information such as passwords or SASL credentials. Do not commit `rpk.yaml` files to version control systems like Git.
+====

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -264,6 +264,11 @@ Prior to `rpk` supporting the `-X` flag, each common configuration option was it
 
 ====
 
+[[environment-variables]]
+=== Environment variables
+
+`REDPANDA_*` environment variables for rpk commands are deprecated. All `REDPANDA_*` variables have been replaced by `RPK_*` variables with the same suffix. For example, `REDPANDA_BROKERS` is now `RPK_BROKERS`.
+
 ifndef::env-cloud[]
 == Redpanda Console configuration
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-16
Review deadline: Aug 15th

Improved examples in config-rpk-profile.
Add recomendation to use rpk profile
Add clarification about RPK_ vs REDPANDA_ env variables, with order of execution
Add table for env variables
Improve example/usage of rpk -x flag.


## Page previews

[rpk -x options](https://deploy-preview-1306--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-x-options/)
[Get Started - config rpk profile](https://deploy-preview-1306--redpanda-docs-preview.netlify.app/current/get-started/config-rpk-profile/)
[Get Started - intro to rpk](https://deploy-preview-1306--redpanda-docs-preview.netlify.app/current/get-started/intro-to-rpk/)



## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
