### PR TITLE
DOC-1620: tag prop for SR AUthZ in Cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: main
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1618'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1618'
+    branches: main
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -5675,6 +5675,7 @@ Always normalize schemas. If set, this overrides the `normalize` parameter in re
 
 ---
 
+// tag::schema_registry_enable_authorization[]
 === schema_registry_enable_authorization
 
 Enables ACL-based authorization for Schema Registry requests. When `true`, Schema Registry
@@ -5691,6 +5692,8 @@ uses ACL-based authorization instead of the default `public/user/superuser` auth
 *Default:* `false`
 
 ---
+
+// end::schema_registry_enable_authorization[]
 
 === segment_appender_flush_timeout_ms
 


### PR DESCRIPTION
## Description

Resolves [DOC-1620: tag prop for SR AuthZ in Cloud](https://redpandadata.atlassian.net/browse/DOC-1620)
Review deadline:

## Page previews
https://deploy-preview-1310--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/properties/cluster-properties/#schema_registry_enable_authorization

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
