### PR TITLE
docs: Add warning about unsupported Helm v3.18.0

### DIFF
--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -28,6 +28,17 @@ Make sure to do the following:
 Minimum required Helm version: {supported-helm-version}
 
 https://helm.sh/docs/intro/install/[Install Helm^].
+
+[NOTE]
+====
+Helm v3.18.0 is not supported due to a bug that causes errors such as:
+
+[.no-copy]
+----
+Error: INSTALLATION FAILED: execution error at (redpanda/templates/entry-point.yaml:17:4): invalid Quantity expected string or float64 got: json.Number (1)
+----
+
+To avoid this and similar errors, upgrade to Helm v3.18.4 or later. For more details, see the https://github.com/helm/helm/issues/30880[Helm GitHub issue^].
 endif::[]
 
 [[number-of-workers]]

--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -38,7 +38,7 @@ Helm v3.18.0 is not supported due to a bug that causes errors such as:
 Error: INSTALLATION FAILED: execution error at (redpanda/templates/entry-point.yaml:17:4): invalid Quantity expected string or float64 got: json.Number (1)
 ----
 
-To avoid this and similar errors, upgrade to Helm v3.18.4 or later. For more details, see the https://github.com/helm/helm/issues/30880[Helm GitHub issue^].
+To avoid similar errors, upgrade to a later version. For more details, see the https://github.com/helm/helm/issues/30880[Helm GitHub issue^].
 endif::[]
 
 [[number-of-workers]]

--- a/modules/troubleshoot/partials/errors-and-solutions.adoc
+++ b/modules/troubleshoot/partials/errors-and-solutions.adoc
@@ -4,9 +4,22 @@ ifdef::env-kubernetes+include-categories[]
 This section addresses common issues that may occur when deploying Redpanda in a Kubernetes environment.
 endif::[]
 
+
 //tag::deployment[]
 
 ifdef::env-kubernetes[]
+//tag::deployment-helm-3-18[]
+=== Helm v3.18.0 is not supported (json.Number error)
+
+If you are using Helm v3.18.0, you may encounter errors such as:
+
+[.no-copy]
+----
+Error: INSTALLATION FAILED: execution error at (redpanda/templates/entry-point.yaml:17:4): invalid Quantity expected string or float64 got: json.Number (1)
+----
+
+This is due to a bug in Helm v3.18.0. To avoid similar errors, upgrade to a later version. For more details, see the https://github.com/helm/helm/issues/30880[Helm GitHub issue^].
+//end::deployment-helm-3-18[]
 //tag::deployment-pod-pending[]
 === StatefulSet never rolls out
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1581

This pull request improves documentation around Helm compatibility by warning users about a known issue with Helm v3.18.0 and providing troubleshooting guidance. The most important changes are grouped below.

Helm compatibility warnings and troubleshooting:

* Added a note to `modules/deploy/partials/requirements.adoc` explicitly stating that Helm v3.18.0 is not supported due to a bug, including an example error message and a link to the relevant Helm GitHub issue.
* Added a new troubleshooting section in `modules/troubleshoot/partials/errors-and-solutions.adoc` describing the Helm v3.18.0 bug, its symptoms, and the recommended solution to upgrade Helm, with a link to the GitHub issue for more details.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
