### PR TITLE
DOCS-71:Update authentication.adoc

### DIFF
--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1482,7 +1482,7 @@ rpk cluster config set admin_api_require_auth true
 rpk cluster config set http_authentication '["BASIC"]'
 ----
 
-NOTE: Valid values for the cluster configuration property xref:reference/properties/cluster-properties.adoc#http_authentication[`http_authentication`] are `BASIC` and `OIDC`. Note that the value `BASIC` is different from the `http_basic` value, which enables authentication for the listener using the broker configuration property `authentication_method`.
+NOTE: Valid values for the cluster configuration property xref:reference/properties/cluster-properties.adoc#http_authentication[`http_authentication`] (cluster-wide) are `BASIC` and `OIDC`. The value `BASIC` here is different from the per-listener setting `http_basic`, which enables authentication on a listener using the broker property `authentication_method` (see xref:reference/properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] for the Schema Registry listener and xref:reference/properties/broker-properties.adoc#http_proxy_auth_method[`authentication_method`] for the HTTP Proxy listener).
 
 To enable basic authentication for specific listeners, set xref:reference:properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] broker property to `http_basic`. For example, in `redpanda.yaml`, enter:
 

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1379,6 +1379,8 @@ Before enabling authentication for the HTTP APIs, you must <<sasl,enable SASL au
 
 ==== Basic authentication
 
+NOTE: Redpanda Data recommends that you use TLS when enabling HTTP Basic Auth.
+
 Basic authentication provides a method for securing HTTP endpoints. With basic authentication enabled, HTTP user agents, such as web browsers, must provide a username and password when making a request.
 
 To add users to the Redpanda credential store that HTTP basic authentication uses, create users with xref:reference:rpk/rpk-acl/rpk-acl-user-create.adoc[`rpk security user create`].
@@ -1479,6 +1481,8 @@ rpk cluster config set admin_api_require_auth true
 ----
 rpk cluster config set http_authentication '["BASIC"]'
 ----
+
+NOTE: Valid values for the cluster configuration property xref:reference/properties/cluster-properties.adoc#http_authentication[`http_authentication`] are `BASIC` and `OIDC`. Note that the value `BASIC` is different from the `http_basic` value, which enables authentication for the listener using the broker configuration property `authentication_method`.
 
 To enable basic authentication for specific listeners, set xref:reference:properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] broker property to `http_basic`. For example, in `redpanda.yaml`, enter:
 
@@ -1587,6 +1591,8 @@ See <<Enable OIDC>> to configure the required OIDC cluster configuration propert
 NOTE: If you enable OIDC authentication for the Admin API, you must also <<create-superusers,create a SCRAM superuser>> so that you can use `rpk` to create ACLs. `rpk` supports only basic authentication for the Admin API. See <<Authentication for the HTTP APIs>>.
 
 To enable OIDC for the HTTP API listeners as well as basic authentication, include OIDC in the `http_authentication` cluster property list:
+
+NOTE: Valid values for the cluster configuration property xref:reference/properties/cluster-properties.adoc#http_authentication[`http_authentication`] are `BASIC` and `OIDC`. Note that the value `BASIC` is different from the `http_basic` value, which enables authentication for the listener using the broker configuration property `authentication_method`.
 
 ifdef::env-kubernetes[]
 [tabs]

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1592,7 +1592,7 @@ NOTE: If you enable OIDC authentication for the Admin API, you must also <<creat
 
 To enable OIDC for the HTTP API listeners as well as basic authentication, include OIDC in the `http_authentication` cluster property list:
 
-NOTE: Valid values for the cluster configuration property xref:reference/properties/cluster-properties.adoc#http_authentication[`http_authentication`] are `BASIC` and `OIDC`. Note that the value `BASIC` is different from the `http_basic` value, which enables authentication for the listener using the broker configuration property `authentication_method`.
+NOTE: Valid values for the cluster configuration property xref:reference/properties/cluster-properties.adoc#http_authentication[`http_authentication`] (cluster-wide) are `BASIC` and `OIDC`. The value `BASIC` here is different from the per-listener setting `http_basic`, which enables authentication on a listener using the broker property `authentication_method` (see xref:reference/properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] for the Schema Registry listener and xref:reference/properties/broker-properties.adoc#http_proxy_auth_method[`authentication_method`] for the HTTP Proxy listener).
 
 ifdef::env-kubernetes[]
 [tabs]

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -1482,7 +1482,7 @@ rpk cluster config set admin_api_require_auth true
 rpk cluster config set http_authentication '["BASIC"]'
 ----
 
-NOTE: Valid values for the cluster configuration property xref:reference/properties/cluster-properties.adoc#http_authentication[`http_authentication`] (cluster-wide) are `BASIC` and `OIDC`. The value `BASIC` here is different from the per-listener setting `http_basic`, which enables authentication on a listener using the broker property `authentication_method` (see xref:reference/properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] for the Schema Registry listener and xref:reference/properties/broker-properties.adoc#http_proxy_auth_method[`authentication_method`] for the HTTP Proxy listener).
+NOTE: Valid values for the cluster configuration property xref:reference:properties/cluster-properties.adoc#http_authentication[`http_authentication`] (cluster-wide) are `BASIC` and `OIDC`. The value `BASIC` here is different from the per-listener setting `http_basic`, which enables authentication on a listener using the broker property `authentication_method` (see xref:reference:properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] for the Schema Registry listener and xref:reference:properties/broker-properties.adoc#http_proxy_auth_method[`authentication_method`] for the HTTP Proxy listener).
 
 To enable basic authentication for specific listeners, set xref:reference:properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] broker property to `http_basic`. For example, in `redpanda.yaml`, enter:
 
@@ -1592,7 +1592,7 @@ NOTE: If you enable OIDC authentication for the Admin API, you must also <<creat
 
 To enable OIDC for the HTTP API listeners as well as basic authentication, include OIDC in the `http_authentication` cluster property list:
 
-NOTE: Valid values for the cluster configuration property xref:reference/properties/cluster-properties.adoc#http_authentication[`http_authentication`] (cluster-wide) are `BASIC` and `OIDC`. The value `BASIC` here is different from the per-listener setting `http_basic`, which enables authentication on a listener using the broker property `authentication_method` (see xref:reference/properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] for the Schema Registry listener and xref:reference/properties/broker-properties.adoc#http_proxy_auth_method[`authentication_method`] for the HTTP Proxy listener).
+NOTE: Valid values for the cluster configuration property xref:reference:properties/cluster-properties.adoc#http_authentication[`http_authentication`] (cluster-wide) are `BASIC` and `OIDC`. The value `BASIC` here is different from the per-listener setting `http_basic`, which enables authentication on a listener using the broker property `authentication_method` (see xref:reference:properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] for the Schema Registry listener and xref:reference:properties/broker-properties.adoc#http_proxy_auth_method[`authentication_method`] for the HTTP Proxy listener).
 
 ifdef::env-kubernetes[]
 [tabs]


### PR DESCRIPTION
Most updates from https://github.com/redpanda-data/docs/pull/1272/files (now Closed) were implemented in https://github.com/redpanda-data/docs/pull/1298. This PR captures the point about TLS, and the Note, which are still of value.

## Description

Resolves DOC-71 and DOC-401
Review deadline:

## Page previews

[Basic authentication](https://deploy-preview-1317--redpanda-docs-preview.netlify.app/current/manage/security/authentication/#basic-authentication)



## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
