### PR TITLE
Bootstrapping a user supports SASL_MECHANISM

### DIFF
--- a/modules/deploy/pages/redpanda/manual/production/production-deployment.adoc
+++ b/modules/deploy/pages/redpanda/manual/production/production-deployment.adoc
@@ -173,7 +173,8 @@ When using username/password authentication, it's helpful to be able to create o
 
 Do this by setting the `RP_BOOTSTRAP_USER` environment variable
 when starting Redpanda for the first time. The value has the format
-`<username>:<password>`. For example, you could set `RP_BOOTSTRAP_USER` to `alice:letmein`.
+`RP_BOOTSTRAP_USER=username:password[:mechanism]`. The only supported values for `mechanism` are `SCRAM-SHA-512` or `SCRAM-SHA-256`; if it is omitted, Redpanda defaults to `SCRAM-SHA-256`.
+For example: `RP_BOOTSTRAP_USER=alice:letmein:SCRAM-SHA-512`.
 
 NOTE: `RP_BOOTSTRAP_USER` only creates a user account. You must still
 set up authentication using cluster configuration.

--- a/modules/deploy/pages/redpanda/manual/production/production-deployment.adoc
+++ b/modules/deploy/pages/redpanda/manual/production/production-deployment.adoc
@@ -251,4 +251,3 @@ include::shared:partial$suggested-reading.adoc[]
 
 * xref:manage:cluster-maintenance/cluster-property-configuration.adoc[Configure Cluster Properties]
 * xref:console:config/configure-console.adoc[Redpanda Console Configuration]
-* xref:manage:schema-registry.adoc[Schema Registry]


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-158
Review deadline:

## Page previews
[Bootstrap a user account](https://deploy-preview-1319--redpanda-docs-preview.netlify.app/current/deploy/redpanda/manual/production/production-deployment/#bootstrap-a-user-account)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
