### PR TITLE
fix single sourced link

### DIFF
--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -91,9 +91,9 @@ endif::[]
 . Default quota configured through the Kafka API on `client_id`
 ifndef::env-cloud[]
 . Default quota configured through cluster configuration properties (`target_quota_byte_rate`, `target_fetch_quota_byte_rate`, `kafka_admin_topic_api_rate`-deprecated in v24.2) on `client_id`
-endif::[]
 
 Redpanda recommends <<migrate,migrating>> over from cluster configuration-managed quotas to Kafka-compatible quotas. You can re-create the configuration-based quotas with `rpk`, and then remove the cluster configurations.
+endif::[]
 
 === Individual client throughput limit
 
@@ -194,7 +194,7 @@ rpk cluster config get kafka_client_group_byte_rate_quota
   }, 
 ]
 ----
-
+ifndef::env-cloud[]
 . Each client quota cluster property (xref:upgrade:deprecated/index.adoc[deprecated in v24.2]) corresponds to a quota type in Kafka. Check the corresponding `rpk` arguments to use when setting the new quota values:
 +
 |===
@@ -218,6 +218,7 @@ rpk cluster config get kafka_client_group_byte_rate_quota
 |===
 +
 The client throughput quotas set through the Kafka API apply per broker, so you must convert the cluster configuration values that were applied on a per-shard (logical CPU core) basis. For example, if you set `target_fetch_quota_byte_rate` to 100 MBps/shard, and you run Redpanda on 16-core brokers, you can set the new consumer_byte_rate quota to 100 * 16 = 1600 MBps.
+endif::env-cloud[]
 
 . Use `rpk cluster quotas alter` to set the corresponding client throughput quotas based on the Kafka API:
 +

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -191,7 +191,7 @@ rpk cluster config get kafka_client_group_byte_rate_quota
   { "group_name": "group_2", 
     "clients_prefix": "producer_group_multiple", 
     "quota": 20480 
-  }, 
+  } 
 ]
 ----
 ifndef::env-cloud[]
@@ -218,7 +218,7 @@ ifndef::env-cloud[]
 |===
 +
 The client throughput quotas set through the Kafka API apply per broker, so you must convert the cluster configuration values that were applied on a per-shard (logical CPU core) basis. For example, if you set `target_fetch_quota_byte_rate` to 100 MBps/shard, and you run Redpanda on 16-core brokers, you can set the new consumer_byte_rate quota to 100 * 16 = 1600 MBps.
-endif::env-cloud[]
+endif::[]
 
 . Use `rpk cluster quotas alter` to set the corresponding client throughput quotas based on the Kafka API:
 +


### PR DESCRIPTION
## Description
Conditionalizes info about cluster config properties that doesn't apply to Cloud docs.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews
[Manage Throughput in Cloud docs](https://deploy-preview-1327--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/cluster-maintenance/manage-throughput/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
