### PR TITLE
Additional guidance for Iceberg cluster configs for Glue catalog

### DIFF
--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -46,7 +46,7 @@ If you want to use partitioning, you must implement custom partitioning using yo
 
 [NOTE]
 ====
-In Redpanda versions 25.2.1, and 25.1.9 and earlier, an empty partition spec () can cause a known issue that prevents certain engines like Amazon Redshift from successfully querying the table. To resolve this issue, specify custom partitioning, or upgrade Redpanda to versions 25.2.2 or 25.1.10 and later.
+In Redpanda versions 25.2.1 and earlier, an empty partition spec `()` can cause a known issue that prevents certain engines like Amazon Redshift from successfully querying the table. To resolve this issue, specify custom partitioning, or upgrade Redpanda to versions 25.2.2 or later.
 ====
 
 === Manual deletion of Iceberg tables
@@ -65,7 +65,6 @@ When `iceberg_delete` or the topic override `redpanda.iceberg.delete` is set to 
 
 == Authorize access to AWS Glue
 
-ifndef::env-cloud[]
 You must allow Redpanda access to AWS Glue services in your AWS account. You can use the same access credentials that you configured for S3 (IAM role, access keys, and KMS key), as long as you have also added read and write access to AWS Glue Data Catalog.
 
 For example, you could create a separate IAM policy that manages access to AWS Glue, and attach it to the IAM role that Redpanda also uses to access S3. It is recommended to add all AWS Glue API actions in the policy (`"glue:*"`) on the following resources:
@@ -95,64 +94,6 @@ Your IAM policy should include a statement similar to the following:
   ]
 }
 ----
-endif::[]
-
-ifdef::env-cloud[]
-You must allow Redpanda access to AWS Glue services in your AWS account. It is recommended to create a new IAM policy or role that manages access to AWS Glue, allowing all AWS Glue API actions (`"glue:*"`) on the following resources:
-
-- Root catalog (`catalog`)
-- All databases (`database/*`)
-- All tables (`table/\*/*`)
-
-Your IAM policy should include a statement similar to the following:
-
-[,json]
-----
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "glue:*"
-      ],
-      "Resource": [
-        "arn:aws:glue:<aws-region>:<aws-account-id>:catalog",
-        "arn:aws:glue:<aws-region>:<aws-account-id>:database/*",
-        "arn:aws:glue:<aws-region>:<aws-account-id>:table/*/*"
-        ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:PutObject",
-        "s3:PutObjectAcl",
-        "s3:DeleteObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::redpanda-cloud-storage-<redpanda-cluster-id>/redpanda-iceberg-catalog/*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "arn:aws:s3:::redpanda-cloud-storage-<redpanda-cluster-id>"
-      ],
-      "Condition": {
-        "StringLike": {
-          "s3:prefix": [
-            "redpanda-iceberg-catalog/*"
-          ]
-        }
-      }
-    }
-  ]
-}
-----
-endif::[]
 
 For more information on configuring IAM permissions, see the https://docs.aws.amazon.com/glue/latest/dg/configure-iam-for-glue.html[AWS Glue documentation^].
 

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -46,9 +46,9 @@ If you want to use partitioning, you must specify a custom partition specificati
 
 === Manual deletion of Iceberg tables
 
-The AWS Glue catalog integration requires Redpanda Iceberg tables to be manually deleted. To manually delete Iceberg tables, you must first set the cluster property config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] to `false` when you first configure the catalog integration. 
+The AWS Glue catalog integration requires Redpanda Iceberg tables to be manually deleted. To manually delete Iceberg tables, you must first set the cluster property config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] to `false` when you configure the catalog integration. 
 
-When `iceberg_delete` is set to `false`, you can delete the Redpanda topic, and then delete the Iceberg table data in AWS S3. You are required to delete the Iceberg table data if you delete an Iceberg topic and then create a new topic with the same name.
+When `iceberg_delete` is set to `false`, you can delete the Redpanda topic, and then delete the table in AWS Glue and the table data (Parquet) files in the S3 bucket. You are required to delete the table data entirely if you delete an Iceberg topic and then create a new Iceberg topic with the same name.
 
 == Authorize access to AWS Glue
 

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -42,7 +42,7 @@ endif::[]
 AWS Glue does not support partitioning on nested fields. If Redpanda detects that
 the default partitioning `(hour(redpanda.timestamp))` based on the record metadata is in use, it will instead apply an empty partition spec `()`, which means the table will not be partitioned.
 
-If you want to use partitioning, you must implement custom partitioning using your own partition columns (columns that are not nested).
+To use partitioning, you must implement custom partitioning using your own partition columns (that is, columns that are not nested).
 
 [NOTE]
 ====
@@ -55,19 +55,19 @@ The AWS Glue catalog integration does not support automatic deletion of Iceberg 
 
 * Set the cluster property config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] to `false` when you configure the catalog integration.
 ifndef::env-cloud[]
-* Override the cluster-wide `iceberg_delete` configuration and set the topic property xref:reference:properties/topic-properties.adoc#redpanda-iceberg-delete[`redpanda.iceberg.delete`] to `false` for the topic you want to delete.
+* Override the cluster property `iceberg_delete` by setting the topic property xref:reference:properties/topic-properties.adoc#redpanda-iceberg-delete[`redpanda.iceberg.delete`] to `false` for the topic you want to delete.
 endif::[]
 ifdef::env-cloud[]
-* Override the cluster-wide `iceberg_delete` configuration and set the topic property `redpanda.iceberg.delete` to `false` for the topic you want to delete.
+* Override the cluster property `iceberg_delete` by setting the topic property `redpanda.iceberg.delete` to `false` for the topic you want to delete.
 endif::[]
 
-When `iceberg_delete` or the topic override `redpanda.iceberg.delete` is set to `false`, you can delete the Redpanda topic, and then delete the table in AWS Glue and the Iceberg data and metadata files in the S3 bucket. If your intent is to recreate the topic after deleting it, you are required to delete the table data entirely before recreating the topic.
+When `iceberg_delete` or the topic override `redpanda.iceberg.delete` is set to `false`, you can delete the Redpanda topic, and then delete the table in AWS Glue and the Iceberg data and metadata files in the S3 bucket. If you plan to re-create the topic after deleting it, you must delete the table data entirely before re-creating the topic.
 
 == Authorize access to AWS Glue
 
 You must allow Redpanda access to AWS Glue services in your AWS account. You can use the same access credentials that you configured for S3 (IAM role, access keys, and KMS key), as long as you have also added read and write access to AWS Glue Data Catalog.
 
-For example, you could create a separate IAM policy that manages access to AWS Glue, and attach it to the IAM role that Redpanda also uses to access S3. It is recommended to add all AWS Glue API actions in the policy (`"glue:*"`) on the following resources:
+For example, you could create a separate IAM policy that manages access to AWS Glue and attach it to the IAM role that Redpanda also uses to access S3. Add all AWS Glue API actions in the policy (`"glue:*"`) on the following resources:
 
 - Root catalog (`catalog`)
 - All databases (`database/*`)

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -48,7 +48,7 @@ If you want to use partitioning, you must specify a custom partition specificati
 
 The AWS Glue catalog integration requires Redpanda Iceberg tables to be manually deleted. To manually delete Iceberg tables, you must first set the cluster property config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] to `false` when you configure the catalog integration. 
 
-When `iceberg_delete` is set to `false`, you can delete the Redpanda topic, and then delete the table in AWS Glue and the table data (Parquet) files in the S3 bucket. You are required to delete the table data entirely if you delete an Iceberg topic and then create a new Iceberg topic with the same name.
+When `iceberg_delete` is set to `false`, you can delete the Redpanda topic, and then delete the table in AWS Glue and the Iceberg data and metadata files in the S3 bucket. If your intent is to recreate the topic after deleting it, you are required to delete the table data entirely before recreating the topic.
 
 == Authorize access to AWS Glue
 

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -44,6 +44,12 @@ the default partitioning `(hour(redpanda.timestamp))` is in use, it will instead
 
 If you want to use partitioning, you must specify a custom partition specification using your own partition columns (columns that are not nested).
 
+=== Manual deletion of Iceberg tables
+
+The AWS Glue catalog integration requires Redpanda Iceberg tables to be manually deleted. To manually delete Iceberg tables, you must first set the cluster property config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] to `false` when you first configure the catalog integration. 
+
+When `iceberg_delete` is set to `false`, you can delete the Redpanda topic, and then delete the Iceberg table data in AWS S3. You are required to delete the Iceberg table data if you delete an Iceberg topic and then create a new topic with the same name.
+
 == Authorize access to AWS Glue
 
 ifndef::env-cloud[]
@@ -117,7 +123,9 @@ Run `rpk cluster config edit` to update these properties:
 +
 [,bash]
 ----
-iceberg_enabled: true 
+iceberg_enabled: true
+# Glue requires Redpanda Iceberg tables to be manually deleted
+iceberg_delete: false 
 iceberg_catalog_type: rest
 iceberg_rest_catalog_endpoint: https://glue.<glue-region>.amazonaws.com/iceberg
 iceberg_rest_catalog_authentication_mode: aws_sigv4

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -46,7 +46,7 @@ If you want to use partitioning, you must specify a custom partition specificati
 
 === Manual deletion of Iceberg tables
 
-The AWS Glue catalog integration requires Redpanda Iceberg tables to be manually deleted. To manually delete Iceberg tables, you must first set the cluster property config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] to `false` when you configure the catalog integration. 
+The AWS Glue catalog integration does not support automatic deletion of Iceberg tables from Redpanda. To manually delete Iceberg tables in AWS Glue, you must first set the cluster property config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] to `false` when you configure the catalog integration. 
 
 When `iceberg_delete` is set to `false`, you can delete the Redpanda topic, and then delete the table in AWS Glue and the Iceberg data and metadata files in the S3 bucket. If your intent is to recreate the topic after deleting it, you are required to delete the table data entirely before recreating the topic.
 
@@ -56,11 +56,6 @@ ifndef::env-cloud[]
 You must allow Redpanda access to AWS Glue services in your AWS account. You can use the same access credentials that you configured for S3 (IAM role, access keys, and KMS key), as long as you have also added read and write access to AWS Glue Data Catalog.
 
 For example, you could create a separate IAM policy that manages access to AWS Glue, and attach it to the IAM role that Redpanda also uses to access S3. It is recommended to add all AWS Glue API actions in the policy (`"glue:*"`) on the following resources:
-endif::[]
-
-ifdef::env-cloud[]
-You must allow Redpanda access to AWS Glue services in your AWS account. It is recommended to create a new IAM policy or role that manages access to AWS Glue, allowing all AWS Glue API actions (`"glue:*"`) on the following resources:
-endif::[]
 
 - Root catalog (`catalog`)
 - All databases (`database/*`)
@@ -87,6 +82,64 @@ Your IAM policy should include a statement similar to the following:
   ]
 }
 ----
+endif::[]
+
+ifdef::env-cloud[]
+You must allow Redpanda access to AWS Glue services in your AWS account. It is recommended to create a new IAM policy or role that manages access to AWS Glue, allowing all AWS Glue API actions (`"glue:*"`) on the following resources:
+
+- Root catalog (`catalog`)
+- All databases (`database/*`)
+- All tables (`table/\*/*`)
+
+Your IAM policy should include a statement similar to the following:
+
+[,json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "glue:*"
+      ],
+      "Resource": [
+        "arn:aws:glue:<aws-region>:<aws-account-id>:catalog",
+        "arn:aws:glue:<aws-region>:<aws-account-id>:database/*",
+        "arn:aws:glue:<aws-region>:<aws-account-id>:table/*/*"
+        ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::redpanda-cloud-storage-<redpanda-cluster-id>/redpanda-iceberg-catalog/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::redpanda-cloud-storage-<redpanda-cluster-id>"
+      ],
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "redpanda-iceberg-catalog/*"
+          ]
+        }
+      }
+    }
+  ]
+}
+----
+endif::[]
 
 For more information on configuring IAM permissions, see the https://docs.aws.amazon.com/glue/latest/dg/configure-iam-for-glue.html[AWS Glue documentation^].
 
@@ -125,13 +178,13 @@ Run `rpk cluster config edit` to update these properties:
 ----
 iceberg_enabled: true
 # Glue requires Redpanda Iceberg tables to be manually deleted
-iceberg_delete: false 
+iceberg_delete: false
 iceberg_catalog_type: rest
 iceberg_rest_catalog_endpoint: https://glue.<glue-region>.amazonaws.com/iceberg
 iceberg_rest_catalog_authentication_mode: aws_sigv4
 iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
 # Use the iceberg_rest_catalog_aws_* properties if you want to 
-# use separate AWS credentials for the catalog, or delete to reuse S3 
+# use separate AWS credentials for the catalog, or omit these lines to reuse S3 
 # (cloud_storage_*) credentials.
 # For access using access keys only, use iceberg_rest_catalog_aws_access_key
 # and iceberg_rest_catalog_aws_secret_key. For access with an IAM role, use 

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -51,9 +51,17 @@ In Redpanda versions 25.2.1, and 25.1.9 and earlier, an empty partition spec () 
 
 === Manual deletion of Iceberg tables
 
-The AWS Glue catalog integration does not support automatic deletion of Iceberg tables from Redpanda. To manually delete Iceberg tables in AWS Glue, you must first set the cluster property config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] to `false` when you configure the catalog integration. 
+The AWS Glue catalog integration does not support automatic deletion of Iceberg tables from Redpanda. To manually delete Iceberg tables in AWS Glue, you must either:
 
-When `iceberg_delete` is set to `false`, you can delete the Redpanda topic, and then delete the table in AWS Glue and the Iceberg data and metadata files in the S3 bucket. If your intent is to recreate the topic after deleting it, you are required to delete the table data entirely before recreating the topic.
+* Set the cluster property config_ref:iceberg_delete,true,properties/cluster-properties[`iceberg_delete`] to `false` when you configure the catalog integration.
+ifndef::env-cloud[]
+* Override the cluster-wide `iceberg_delete` configuration and set the topic property xref:reference:properties/topic-properties.adoc#redpanda-iceberg-delete[`redpanda.iceberg.delete`] to `false` for the topic you want to delete.
+endif::[]
+ifdef::env-cloud[]
+* Override the cluster-wide `iceberg_delete` configuration and set the topic property `redpanda.iceberg.delete` to `false` for the topic you want to delete.
+endif::[]
+
+When `iceberg_delete` or the topic override `redpanda.iceberg.delete` is set to `false`, you can delete the Redpanda topic, and then delete the table in AWS Glue and the Iceberg data and metadata files in the S3 bucket. If your intent is to recreate the topic after deleting it, you are required to delete the table data entirely before recreating the topic.
 
 == Authorize access to AWS Glue
 

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -100,6 +100,7 @@ endif::[]
 ifdef::env-cloud[]
 You must configure credentials for the AWS Glue Data Catalog integration using the following properties:
 
+* config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`] set to `config_file`
 * config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`]
 * config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`], added as a secret value (see the <<update-cluster-configuration,next section>> for details)
 * config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`]
@@ -155,6 +156,9 @@ rpk cluster config set \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
   iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path> \
+  # Set credentials source to config_file if using 
+  # iceberg_rest_catalog_aws_access_key and iceberg_rest_catalog_aws_secret_key
+  iceberg_rest_catalog_credentials_source=config_file
   iceberg_rest_catalog_aws_region=<glue-region> \
   iceberg_rest_catalog_aws_access_key=<glue-access-key> \
   iceberg_rest_catalog_aws_secret_key='${secrets.<glue-secret-key-name>}'

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -42,9 +42,12 @@ endif::[]
 AWS Glue does not support partitioning on nested fields. If Redpanda detects that
 the default partitioning `(hour(redpanda.timestamp))` based on the record metadata is in use, it will instead apply an empty partition spec `()`, which means the table will not be partitioned.
 
-If you want to use partitioning, you must specify a custom partition specification using your own partition columns (columns that are not nested).
+If you want to use partitioning, you must implement custom partitioning using your own partition columns (columns that are not nested).
 
-NOTE: An empty partition spec `()` can cause a known issue in Amazon Redshift that prevents queries from running successfully on the table.
+[NOTE]
+====
+In Redpanda versions 25.2.1, and 25.1.9 and earlier, an empty partition spec () can cause a known issue that prevents certain engines like Amazon Redshift from successfully querying the table. To resolve this issue, specify custom partitioning, or upgrade Redpanda to versions 25.2.2 or 25.1.10 and later.
+====
 
 === Manual deletion of Iceberg tables
 

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -40,9 +40,11 @@ endif::[]
 === Nested partition spec support
 
 AWS Glue does not support partitioning on nested fields. If Redpanda detects that
-the default partitioning `(hour(redpanda.timestamp))` is in use, it will instead apply an empty partition spec `()`, which means the table will not be partitioned.
+the default partitioning `(hour(redpanda.timestamp))` based on the record metadata is in use, it will instead apply an empty partition spec `()`, which means the table will not be partitioned.
 
 If you want to use partitioning, you must specify a custom partition specification using your own partition columns (columns that are not nested).
+
+NOTE: An empty partition spec `()` can cause a known issue in Amazon Redshift that prevents queries from running successfully on the table.
 
 === Manual deletion of Iceberg tables
 

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -230,7 +230,7 @@ To query the table in Amazon Athena:
 +
 [,sql]
 ----
-SELECT * FROM "AwsDataCatalog"."redpanda"."<table-name>" limit 1;
+SELECT * FROM "AwsDataCatalog"."redpanda"."<table-name>" limit 10;
 ----
 +
 Your query results should look like the following:

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -66,7 +66,7 @@ The following shows the current status of Iceberg catalog integrations. Check th
 |===
 endif::[]
 
-Other REST catalogs such as Dremio Nessie, Apache Polaris, and the Apache reference implementation have been tested but are not regularly verified. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+Other REST catalogs such as Apache Polaris, Dremio Nessie (to be link:https://www.dremio.com/newsroom/polaris-catalog-to-be-merged-with-nessie-now-available-on-github/[merged with Polaris]), and the Apache reference implementation have been tested but are not regularly verified. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 
 === Set cluster properties
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -66,7 +66,7 @@ The following shows the current status of Iceberg catalog integrations. Check th
 |===
 endif::[]
 
-Other REST catalogs such as Apache Polaris, Dremio Nessie (to be link:https://www.dremio.com/newsroom/polaris-catalog-to-be-merged-with-nessie-now-available-on-github/[merged with Polaris]), and the Apache reference implementation have been tested but are not regularly verified. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+Other REST catalogs, such as Apache Polaris, Dremio Nessie (to be link:https://www.dremio.com/newsroom/polaris-catalog-to-be-merged-with-nessie-now-available-on-github/[merged with Polaris]), and the Apache reference implementation, have been tested but are not regularly verified. For more information, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 
 === Set cluster properties
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2265,7 +2265,7 @@ Source of AWS credentials for Iceberg REST catalog SigV4 authentication. If not 
 endif::[]
 
 ifdef::env-cloud[]
-Source of AWS credentials for Iceberg REST catalog SigV4 authentication. If using `iceberg_rest_catalog_aws_access_key` and `iceberg_rest_catalog_aws_secret_key` for Glue catalog authentication, you must set this property to `config_file`.
+Source of AWS credentials for Iceberg REST catalog SigV4 authentication. If providing explicit credentials using `iceberg_rest_catalog_aws_access_key` and `iceberg_rest_catalog_aws_secret_key` for Glue catalog authentication, you must set this property to `config_file`.
 endif::[]
 
 *Accepted values*: `aws_instance_metadata`, `azure_aks_oidc_federation`, `azure_vm_instance_metadata`, `config_file`, `gcp_instance_metadata`, `sts`.

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -5685,7 +5685,14 @@ Always normalize schemas. If set, this overrides the `normalize` parameter in re
 === schema_registry_enable_authorization
 
 Enables ACL-based authorization for Schema Registry requests. When `true`, Schema Registry
-uses ACL-based authorization instead of the default `public/user/superuser` authorization model. Requires authentication to be enabled using the xref:reference:properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] property in the `schema_registry_api` broker configuration.
+uses ACL-based authorization instead of the default `public/user/superuser` authorization model. 
+
+ifndef::env-cloud[]
+Requires authentication to be enabled using the xref:reference:properties/broker-properties.adoc#schema_registry_auth_method[`authentication_method`] property in the `schema_registry_api` broker configuration.
+endif::[]
+ifdef::env-cloud[]
+Requires authentication to be enabled using the `authentication_method` property in the `schema_registry_api` broker configuration.
+endif::[]
 
 *Requires restart:* No
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2260,7 +2260,13 @@ AWS access key for Iceberg REST catalog SigV4 authentication. If not set, falls 
 
 === iceberg_rest_catalog_credentials_source
 
+ifndef::env-cloud[]
 Source of AWS credentials for Iceberg REST catalog SigV4 authentication. If not set, falls back to xref:reference:properties/object-storage-properties.adoc#cloud_storage_credentials_source[`cloud_storage_credentials_source`] when using aws_sigv4 authentication mode.
+endif::[]
+
+ifdef::env-cloud[]
+Source of AWS credentials for Iceberg REST catalog SigV4 authentication. If using `iceberg_rest_catalog_aws_access_key` and `iceberg_rest_catalog_aws_secret_key` for Glue catalog authentication, you must set this property to `config_file`.
+endif::[]
 
 *Accepted values*: `aws_instance_metadata`, `azure_aks_oidc_federation`, `azure_vm_instance_metadata`, `config_file`, `gcp_instance_metadata`, `sts`.
 


### PR DESCRIPTION
## Description

This pull request updates the AWS Glue integration documentation for Redpanda Iceberg tables. The changes clarify partitioning limitations, add instructions for manual table deletion, enhance IAM policy requirements, and provide more explicit configuration guidance for credentials and deletion behavior.

**Documentation improvements for AWS Glue and Iceberg:**

* Added a section explaining that AWS Glue does not support partitioning on nested fields and that an empty partition spec can cause issues with Amazon Redshift queries.
* Added instructions for manual deletion of Iceberg tables in AWS Glue, including the requirement to set `iceberg_delete` to `false` before deleting tables and topics.
* Updated sample IAM policy to include required S3 permissions (`s3:PutObject`, `s3:PutObjectAcl`, `s3:DeleteObject`, `s3:ListBucket`) for Iceberg catalog operations.

**Configuration guidance updates:**

* Added and clarified the `iceberg_rest_catalog_credentials_source` property, specifying when to set it to `config_file`, and updated example configuration blocks accordingly. [[1]](diffhunk://#diff-3bd481de18a4f29147c493bbbb9109ffe08bb6c449f20eb1ca2e1093a655ab68R164) [[2]](diffhunk://#diff-3bd481de18a4f29147c493bbbb9109ffe08bb6c449f20eb1ca2e1093a655ab68R182-R189) [[3]](diffhunk://#diff-3bd481de18a4f29147c493bbbb9109ffe08bb6c449f20eb1ca2e1093a655ab68R222-R224) [[4]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2263-R2269)
* Updated Athena example query to use `limit 10` instead of `limit 1` for better demonstration.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

[Query Iceberg Topics using AWS Glue](https://deploy-preview-1336--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/iceberg-topics-aws-glue/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
