### PR TITLE
Topic props

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -150,6 +150,7 @@
 ** xref:manage:cluster-maintenance/index.adoc[Cluster Maintenance]
 *** xref:manage:cluster-maintenance/cluster-property-configuration.adoc[]
 *** xref:manage:cluster-maintenance/node-property-configuration.adoc[]
+*** xref:manage:cluster-maintenance/topic-property-configuration.adoc[]
 *** xref:manage:cluster-maintenance/cluster-balancing.adoc[]
 *** xref:manage:cluster-maintenance/continuous-data-balancing.adoc[Continuous Data Balancing]
 *** xref:manage:cluster-maintenance/decommission-brokers.adoc[Decommission Brokers]

--- a/modules/develop/partials/topic-properties-warning.adoc
+++ b/modules/develop/partials/topic-properties-warning.adoc
@@ -1,1 +1,1 @@
-WARNING: Modifying the properties of topics that are created and managed by Redpanda applications can cause unexpected errors. This may lead to connector and cluster failures.
+WARNING: All topic properties take effect immediately after being set. Do not modify properties on internal Redpanda topics (such as `__consumer_offsets`, `_schemas`, or other system topics) as this can cause cluster instability.

--- a/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
@@ -54,8 +54,7 @@ Kubernetes::
 --
 
 ```bash
-kubectl exec <pod-name> -- rpk topic create -c cleanup.policy=compact<topic-name>
-```
+kubectl exec <pod-name> -- rpk topic create -c cleanup.policy=compact <topic-name>
 
 --
 ====

--- a/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
@@ -179,47 +179,40 @@ kubectl apply -f topic-config.yaml
 
 == Common topic property categories
 
-Topic properties are organized into several categories based on their functionality:
+The most commonly configured topic properties fall into these main categories:
 
 === Disk space management
 
-Redpanda manages disk space through two main mechanisms: **compaction** (removing duplicate keys) and **retention** (removing old data). Configure the core compaction properties to control how Redpanda cleans up data:
+Redpanda manages disk space through two main mechanisms: **compaction** (removing duplicate keys) and **retention** (removing old data). 
 
-- Choose cleanup strategy: deletion, compaction, or both (xref:reference:properties/topic-properties.adoc#cleanuppolicy[`cleanup.policy`]).
-- Control when compaction triggers based on dirty data ratio (xref:reference:properties/topic-properties.adoc#mincleanabledirtyratio[`min.cleanable.dirty.ratio`]).
-- Set maximum time before compaction is forced (xref:reference:properties/topic-properties.adoc#maxcompactionlagms[`max.compaction.lag.ms`]).
-- Set minimum time before compaction can occur (xref:reference:properties/topic-properties.adoc#mincompactionlagms[`min.compaction.lag.ms`]).
+Choose your cleanup strategy with xref:reference:properties/topic-properties.adoc#cleanuppolicy[`cleanup.policy`]:
+- `delete` - Remove old data based on time or size limits
+- `compact` - Keep only the latest value for each key
+- `compact,delete` - Combine both strategies
 
-=== Write performance and caching
+=== Compaction
 
-Control how Redpanda writes and syncs data to disk:
+When using `cleanup.policy=compact` or `cleanup.policy=compact,delete`, configure:
 
-- Cache batches until the segment appender chunk is full, instead of fsyncing for every `acks=all` write (xref:reference:properties/topic-properties.adoc#writecaching[`write.caching`]).
-- Configure the maximum delay between two subsequent fsyncs (xref:reference:properties/topic-properties.adoc#flushms[`flush.ms`]).
-- Set the maximum bytes not fsynced per partition (xref:reference:properties/topic-properties.adoc#flushbytes[`flush.bytes`]).
+- xref:reference:properties/topic-properties.adoc#mincleanabledirtyratio[`min.cleanable.dirty.ratio`] - Control when compaction triggers based on dirty data ratio
+- xref:reference:properties/topic-properties.adoc#maxcompactionlagms[`max.compaction.lag.ms`] - Set maximum time before compaction is forced
+- xref:reference:properties/topic-properties.adoc#mincompactionlagms[`min.compaction.lag.ms`] - Set minimum time before compaction can occur
 
-=== Message properties
+=== Retention
 
-Configure message-specific settings:
+When using `cleanup.policy=delete` or `cleanup.policy=compact,delete`, configure:
 
-- Set the source of a message's timestamp (xref:reference:properties/topic-properties.adoc#messagetimestamptype[`message.timestamp.type`]).
-- Set the maximum size of a message (xref:reference:properties/topic-properties.adoc#maxmessagebytes[`max.message.bytes`]).
-- Configure compression for stored data (xref:reference:properties/topic-properties.adoc#compressiontype[`compression.type`]).
+- xref:reference:properties/topic-properties.adoc#retentionbytes[`retention.bytes`] - Maximum size before cleanup (size-based retention)
+- xref:reference:properties/topic-properties.adoc#retentionms[`retention.ms`] - Maximum age before cleanup (time-based retention)
+- xref:reference:properties/topic-properties.adoc#segmentbytes[`segment.bytes`] - Control how frequently cleanup can occur by setting segment size
 
-=== Tiered Storage
+=== Performance
 
-For topics using Tiered Storage, configure:
+Essential performance tuning properties:
 
-- Upload and fetch data to and from object storage (xref:reference:properties/topic-properties.adoc#redpandaremotewrite[`redpanda.remote.write`] and xref:reference:properties/topic-properties.adoc#redpandaremoteread[`redpanda.remote.read`]).
-- Recover data from object storage (xref:reference:properties/topic-properties.adoc#redpandaremoterecovery[`redpanda.remote.recovery`]).
-- Configure local storage retention limits (xref:reference:properties/topic-properties.adoc#retentionlocaltargetbytes[`retention.local.target.bytes`] and xref:reference:properties/topic-properties.adoc#retentionlocaltargetms[`retention.local.target.ms`]).
-
-=== Replication and leadership
-
-Configure replication and leadership settings:
-
-- Number of replicas for the topic (xref:reference:properties/topic-properties.adoc#replicationfactor[`replication.factor`]).
-- Preferred location for partition leaders (xref:reference:properties/topic-properties.adoc#redpandaleaderspreference[`redpanda.leaders.preference`]).
+- xref:reference:properties/topic-properties.adoc#writecaching[`write.caching`] - Cache writes for lower latency with `acks=all`
+- xref:reference:properties/topic-properties.adoc#maxmessagebytes[`max.message.bytes`] - Set maximum message size
+- xref:reference:properties/topic-properties.adoc#replicationfactor[`replication.factor`] - Number of replicas for durability vs. performance
 
 For complete details about all available topic properties, see xref:reference:properties/topic-properties.adoc[Topic Configuration Properties].
 

--- a/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
@@ -143,14 +143,12 @@ Topic properties are organized into several categories based on their functional
 
 === Disk space management
 
-Configure properties to manage disk space usage for a topic:
+Redpanda manages disk space through two main mechanisms: **compaction** (removing duplicate keys) and **retention** (removing old data). Configure the core compaction properties to control how Redpanda cleans up data:
 
-- Clean up log segments by deletion and/or compaction (xref:reference:properties/topic-properties.adoc#cleanuppolicy[`cleanup.policy`]).
-- Control compaction timing with maximum and minimum lag settings (xref:reference:properties/topic-properties.adoc#maxcompactionlagms[`max.compaction.lag.ms`] and xref:reference:properties/topic-properties.adoc#mincompactionlagms[`min.compaction.lag.ms`]).
-- Retain logs up to a maximum size per partition before cleanup (xref:reference:properties/topic-properties.adoc#retentionbytes[`retention.bytes`]).
-- Retain logs for a maximum duration before cleanup (xref:reference:properties/topic-properties.adoc#retentionms[`retention.ms`]).
-- Periodically close an active log segment (xref:reference:properties/topic-properties.adoc#segmentms[`segment.ms`]).
-- Limit the maximum size of an active log segment (xref:reference:properties/topic-properties.adoc#segmentbytes[`segment.bytes`]).
+- Choose cleanup strategy: deletion, compaction, or both (xref:reference:properties/topic-properties.adoc#cleanuppolicy[`cleanup.policy`]).
+- Control when compaction triggers based on dirty data ratio (xref:reference:properties/topic-properties.adoc#mincleanabledirtyratio[`min.cleanable.dirty.ratio`]).
+- Set maximum time before compaction is forced (xref:reference:properties/topic-properties.adoc#maxcompactionlagms[`max.compaction.lag.ms`]).
+- Set minimum time before compaction can occur (xref:reference:properties/topic-properties.adoc#mincompactionlagms[`min.compaction.lag.ms`]).
 
 === Write performance and caching
 
@@ -175,13 +173,6 @@ For topics using Tiered Storage, configure:
 - Upload and fetch data to and from object storage (xref:reference:properties/topic-properties.adoc#redpandaremotewrite[`redpanda.remote.write`] and xref:reference:properties/topic-properties.adoc#redpandaremoteread[`redpanda.remote.read`]).
 - Recover data from object storage (xref:reference:properties/topic-properties.adoc#redpandaremoterecovery[`redpanda.remote.recovery`]).
 - Configure local storage retention limits (xref:reference:properties/topic-properties.adoc#retentionlocaltargetbytes[`retention.local.target.bytes`] and xref:reference:properties/topic-properties.adoc#retentionlocaltargetms[`retention.local.target.ms`]).
-
-=== Compaction settings
-
-For topics with compacted cleanup policies, configure:
-
-- Minimum ratio of dirty segments required before compaction (xref:reference:properties/topic-properties.adoc#mincleanabledirtyratio[`min.cleanable.dirty.ratio`]).
-- Retention time for tombstone records (xref:reference:properties/topic-properties.adoc#deleteretentionms[`delete.retention.ms`]).
 
 === Replication and leadership
 

--- a/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
@@ -1,0 +1,202 @@
+= Configure Topic Properties
+:description: Learn how to configure topic properties to control Redpanda's behavior for individual topics, including retention, cleanup policies, and Tiered Storage settings.
+:page-categories: Management
+
+Topic properties control Redpanda's behavior for individual topics, including data retention, cleanup policies, compression settings, and Tiered Storage configurations. These properties let you customize how Redpanda stores, processes, and manages data for each topic, overriding cluster-wide defaults when needed.
+
+Redpanda stores topic properties as metadata associated with each topic and replicates them across the cluster to ensure consistency. Many topic properties correspond to xref:manage:cluster-maintenance/cluster-property-configuration.adoc[cluster properties] that establish default values for all topics. When you set a topic property, it overrides the corresponding cluster default for that specific topic.
+
+NOTE: All topic properties take effect immediately after being set.
+
+For a complete reference of available topic properties and their corresponding cluster properties, see xref:reference:properties/topic-properties.adoc[Topic Configuration Properties].
+
+== Configuration methods
+
+You can configure topic properties through multiple interfaces:
+
+* **rpk commands** - Use xref:reference:rpk/rpk-topic/rpk-topic-create.adoc[`rpk topic create`] with the `-c` flag to set properties during topic creation, or xref:reference:rpk/rpk-topic/rpk-topic-alter-config.adoc[`rpk topic alter-config`] to modify existing topics.
+* **Kafka Admin API** - Any Kafka-compatible client can use the standard Admin API to configure topic properties.
+* **Kubernetes Topic resources** - In Kubernetes deployments, configure topic properties using the `additionalConfig` field in Topic resources. See xref:manage:kubernetes/k-manage-topics.adoc[Manage Topics in Kubernetes].
+* **Redpanda Console** - Use the web interface to xref:console:ui/edit-topic-configuration.adoc[edit topic configuration] through a graphical interface.
+
+== Verify topic property configuration
+
+The `SOURCE` output of the xref:reference:rpk/rpk-topic/rpk-topic-describe.adoc[`rpk topic describe <topic>`] command shows how properties are configured for the topic:
+
+* `DEFAULT_CONFIG` is set by a Redpanda default.
+* `DYNAMIC_TOPIC_CONFIG` is set by the user specifically for the topic and overrides inherited default configurations, such as a default or a cluster-level property.
+
+Although xref:reference:rpk/rpk-topic/rpk-topic-describe.adoc[`rpk topic describe`] doesn't report `replication.factor` as a configuration, `replication.factor` can indeed be set by using the xref:reference:rpk/rpk-topic/rpk-topic-alter-config.adoc[`rpk topic alter-config`] command.
+
+== Examples
+
+The following examples show how to configure topic-level properties. Set a topic-level property for a topic to override the value of corresponding cluster property.
+
+=== Create topic with topic properties
+
+To set topic properties when creating a topic, use the xref:reference:rpk/rpk-topic/rpk-topic-create.adoc[rpk topic create] command with the `-c` option.
+
+For example, to create a topic with the `cleanup.policy` property set to `compact`:
+
+[tabs]
+====
+Local::
++
+--
+
+```bash
+rpk topic create -c cleanup.policy=compact <topic-name>
+```
+
+--
+Kubernetes::
++
+--
+
+```bash
+kubectl exec <pod-name> -- rpk topic create -c cleanup.policy=compact<topic-name>
+```
+
+--
+====
+
+To configure multiple properties for a topic, use the `-c` option for each property.
+
+For example, to create a topic with all necessary properties for Tiered Storage:
+
+[tabs]
+====
+Local::
++
+--
+
+```bash
+rpk topic create -c redpanda.remote.recovery=true -c redpanda.remote.write=true -c redpanda.remote.read=true <topic-name>
+```
+
+--
+Kubernetes::
++
+--
+
+```bash
+kubectl exec <pod-name> -- rpk topic create -c redpanda.remote.recovery=true -c redpanda.remote.write=true -c redpanda.remote.read=true <topic-name>
+```
+
+--
+====
+
+=== Modify topic properties
+
+To modify topic properties of an existing topic, use the xref:reference:rpk/rpk-topic/rpk-topic-alter-config.adoc[rpk topic alter-config] command.
+
+For example, to modify a topic's `retention.ms` property:
+
+[tabs]
+====
+Local::
++
+--
+
+```bash
+rpk topic alter-config <topic-name> --set retention.ms=<retention-time>
+```
+
+--
+Kubernetes::
++
+--
+
+```bash
+kubectl exec <pod-name> -- rpk topic alter-config <topic-name> --set retention.ms=<retention-time>
+```
+
+--
+====
+
+=== Configure topic properties with Kubernetes
+
+In Kubernetes deployments, configure topic properties using the `additionalConfig` field in Topic resources:
+
+```yaml
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Topic
+metadata:
+  name: example-topic
+spec:
+  partitions: 3
+  replicationFactor: 3
+  additionalConfig:
+    cleanup.policy: "compact"
+    retention.ms: "604800000"
+    segment.ms: "86400000"
+```
+
+Apply the configuration:
+
+```bash
+kubectl apply -f topic-config.yaml
+```
+
+== Common topic property categories
+
+Topic properties are organized into several categories based on their functionality:
+
+=== Disk space management
+
+Configure properties to manage disk space usage for a topic:
+
+- Clean up log segments by deletion and/or compaction (xref:reference:properties/topic-properties.adoc#cleanuppolicy[`cleanup.policy`]).
+- Control compaction timing with maximum and minimum lag settings (xref:reference:properties/topic-properties.adoc#maxcompactionlagms[`max.compaction.lag.ms`] and xref:reference:properties/topic-properties.adoc#mincompactionlagms[`min.compaction.lag.ms`]).
+- Retain logs up to a maximum size per partition before cleanup (xref:reference:properties/topic-properties.adoc#retentionbytes[`retention.bytes`]).
+- Retain logs for a maximum duration before cleanup (xref:reference:properties/topic-properties.adoc#retentionms[`retention.ms`]).
+- Periodically close an active log segment (xref:reference:properties/topic-properties.adoc#segmentms[`segment.ms`]).
+- Limit the maximum size of an active log segment (xref:reference:properties/topic-properties.adoc#segmentbytes[`segment.bytes`]).
+
+=== Write performance and caching
+
+Control how Redpanda writes and syncs data to disk:
+
+- Cache batches until the segment appender chunk is full, instead of fsyncing for every `acks=all` write (xref:reference:properties/topic-properties.adoc#writecaching[`write.caching`]).
+- Configure the maximum delay between two subsequent fsyncs (xref:reference:properties/topic-properties.adoc#flushms[`flush.ms`]).
+- Set the maximum bytes not fsynced per partition (xref:reference:properties/topic-properties.adoc#flushbytes[`flush.bytes`]).
+
+=== Message properties
+
+Configure message-specific settings:
+
+- Set the source of a message's timestamp (xref:reference:properties/topic-properties.adoc#messagetimestamptype[`message.timestamp.type`]).
+- Set the maximum size of a message (xref:reference:properties/topic-properties.adoc#maxmessagebytes[`max.message.bytes`]).
+- Configure compression for stored data (xref:reference:properties/topic-properties.adoc#compressiontype[`compression.type`]).
+
+=== Tiered Storage
+
+For topics using Tiered Storage, configure:
+
+- Upload and fetch data to and from object storage (xref:reference:properties/topic-properties.adoc#redpandaremotewrite[`redpanda.remote.write`] and xref:reference:properties/topic-properties.adoc#redpandaremoteread[`redpanda.remote.read`]).
+- Recover data from object storage (xref:reference:properties/topic-properties.adoc#redpandaremoterecovery[`redpanda.remote.recovery`]).
+- Configure local storage retention limits (xref:reference:properties/topic-properties.adoc#retentionlocaltargetbytes[`retention.local.target.bytes`] and xref:reference:properties/topic-properties.adoc#retentionlocaltargetms[`retention.local.target.ms`]).
+
+=== Compaction settings
+
+For topics with compacted cleanup policies, configure:
+
+- Minimum ratio of dirty segments required before compaction (xref:reference:properties/topic-properties.adoc#mincleanabledirtyratio[`min.cleanable.dirty.ratio`]).
+- Retention time for tombstone records (xref:reference:properties/topic-properties.adoc#deleteretentionms[`delete.retention.ms`]).
+
+=== Replication and leadership
+
+Configure replication and leadership settings:
+
+- Number of replicas for the topic (xref:reference:properties/topic-properties.adoc#replicationfactor[`replication.factor`]).
+- Preferred location for partition leaders (xref:reference:properties/topic-properties.adoc#redpandaleaderspreference[`redpanda.leaders.preference`]).
+
+For complete details about all available topic properties, see xref:reference:properties/topic-properties.adoc[Topic Configuration Properties].
+
+== Related topics
+
+* xref:reference:properties/topic-properties.adoc[Topic Configuration Properties] - Complete reference of all available topic properties
+* xref:manage:cluster-maintenance/cluster-property-configuration.adoc[Configure Cluster Properties] - Configure cluster-wide defaults
+* xref:develop:config-topics.adoc[Manage Topics] - Create and manage topics
+* xref:manage:kubernetes/k-manage-topics.adoc[Manage Topics in Kubernetes] - Topic management in Kubernetes deployments
+* xref:console:ui/edit-topic-configuration.adoc[Edit Topic Configuration in Redpanda Console] - Graphical topic configuration

--- a/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
@@ -21,12 +21,49 @@ You can configure topic properties through multiple interfaces:
 
 == Verify topic property configuration
 
-The `SOURCE` output of the xref:reference:rpk/rpk-topic/rpk-topic-describe.adoc[`rpk topic describe <topic>`] command shows how properties are configured for the topic:
+Use `rpk topic describe <topic>` to view topic properties and their configuration sources:
 
-* `DEFAULT_CONFIG` is set by a Redpanda default.
-* `DYNAMIC_TOPIC_CONFIG` is set by the user specifically for the topic and overrides inherited default configurations, such as a default or a cluster-level property.
+```
+rpk topic describe my-topic
+```
 
-Although xref:reference:rpk/rpk-topic/rpk-topic-describe.adoc[`rpk topic describe`] doesn't report `replication.factor` as a configuration, `replication.factor` can indeed be set by using the xref:reference:rpk/rpk-topic/rpk-topic-alter-config.adoc[`rpk topic alter-config`] command.
+The output shows two sections:
+
+```
+SUMMARY
+=======
+NAME        my-topic
+PARTITIONS  1
+REPLICAS    1
+
+CONFIGS
+=======
+KEY                     VALUE          SOURCE
+cleanup.policy          delete         DEFAULT_CONFIG
+compression.type        producer       DEFAULT_CONFIG
+retention.ms            604800000      DEFAULT_CONFIG
+write.caching           true           DYNAMIC_TOPIC_CONFIG
+```
+
+The `SOURCE` column indicates how each property is configured:
+
+* `DEFAULT_CONFIG` - Redpanda's default value
+* `DYNAMIC_TOPIC_CONFIG` - User-configured value
+
+The replication factor appears as REPLICAS in the SUMMARY section, not as replication.factor in the CONFIGS list. However, you need to use the `replication.factor` key when modifying the value with `rpk topic alter-config`.
+
+For partition-level details, add the `-p` flag:
+
+```
+rpk topic describe my-topic -p
+```
+
+This shows a different output focused on partition information:
+
+```
+PARTITION  LEADER  EPOCH  REPLICAS  LOG-START-OFFSET  HIGH-WATERMARK
+0          0       1      [0]       0                 0
+```
 
 == Examples
 

--- a/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
@@ -6,7 +6,7 @@ Topic properties control Redpanda's behavior for individual topics, including da
 
 Redpanda stores topic properties as metadata associated with each topic and replicates them across the cluster to ensure consistency. Many topic properties correspond to xref:manage:cluster-maintenance/cluster-property-configuration.adoc[cluster properties] that establish default values for all topics. When you set a topic property, it overrides the corresponding cluster default for that specific topic.
 
-NOTE: All topic properties take effect immediately after being set.
+include::develop:partial$topic-properties-warning.adoc[]
 
 For a complete reference of available topic properties and their corresponding cluster properties, see xref:reference:properties/topic-properties.adoc[Topic Configuration Properties].
 

--- a/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
@@ -33,8 +33,8 @@ The output shows two sections:
 SUMMARY
 =======
 NAME        my-topic
-PARTITIONS  1
-REPLICAS    1
+PARTITIONS  3
+REPLICAS    3
 
 CONFIGS
 =======
@@ -62,7 +62,9 @@ This shows a different output focused on partition information:
 
 ```
 PARTITION  LEADER  EPOCH  REPLICAS  LOG-START-OFFSET  HIGH-WATERMARK
-0          0       1      [0]       0                 0
+0          1       2     [1 2 3]   0                 6
+1          2       4     [1 2 3]   0                 10
+2          3       1     [1 2 3]   0                 8
 ```
 
 == Examples

--- a/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
+++ b/modules/manage/pages/cluster-maintenance/topic-property-configuration.adoc
@@ -55,6 +55,7 @@ Kubernetes::
 
 ```bash
 kubectl exec <pod-name> -- rpk topic create -c cleanup.policy=compact <topic-name>
+```
 
 --
 ====

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -350,11 +350,11 @@ When `segment.bytes` is set to a positive value, it overrides the cluster proper
 
 The maximum duration that a log segment of a topic is active (open for writes and not deletable). A periodic event, with `segment.ms` as its period, forcibly closes the active segment and transitions, or rolls, to a new active segment. The closed (inactive) segment is then eligible to be cleaned up according to cleanup and retention properties.
 
-If set to a positive duration, `segment.ms` overrides the cluster property xref:./cluster-properties.adoc#log_segment_ms[`log_segment_ms`] and its lower and upper bounds set by xref:./cluster-properties.adoc#log_segment_ms_min[`log_segment_ms_min`] and xref:./cluster-properties.adoc#log_segment_ms_max[`log_segment_ms_max`], respectively.
+If set to a positive duration, `segment.ms` overrides the cluster property xref:./cluster-properties.adoc#log_segment_ms[`log_segment_ms`]. Values are automatically clamped between the cluster bounds set by xref:./cluster-properties.adoc#log_segment_ms_min[`log_segment_ms_min`] (default: 10 minutes) and xref:./cluster-properties.adoc#log_segment_ms_max[`log_segment_ms_max`] (default: 1 year). If your configured value exceeds these bounds, Redpanda uses the bound value and logs a warning. Check current cluster bounds with `rpk cluster config get log_segment_ms_min log_segment_ms_max`.
 
 *Type:* integer
 
-*Accepted values:* `[600000, 31536000000]` milliseconds (clamped by cluster bounds)
+*Accepted values:* [`600000`, `31536000000`] milliseconds (clamped by cluster bounds)
 
 *Default:* null
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -54,7 +54,7 @@ NOTE: All topic properties take effect immediately after being set.
 | xref:./cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`]
 
 | <<replicationfactor,`replication.factor`>>
-| xref:./cluster-properties.adoc#replication_factor[`replication_factor`]
+| xref:./cluster-properties.adoc#default_topic_replications[`default_topic_replications`]
 
 | <<retentionbytes,`retention.bytes`>>
 | xref:./cluster-properties.adoc#retention_bytes[`retention_bytes`]

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -101,7 +101,7 @@ include::develop:partial$topic-properties-warning.adoc[]
 
 *Accepted values:* [`delete`, `compact`, `compact,delete`]
 
-**Default**: `delete`
+*Default:* `delete`
 
 **Values**:
 
@@ -182,7 +182,7 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 
 *Accepted values:* [`0`, `1.0`]
 
-**Default**: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#min_cleanable_dirty_ratio[`min_cleanable_dirty_ratio`]
 
@@ -222,7 +222,7 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 
 *Accepted values:* [1, 9223372036854775807] bytes
 
-**Default**: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#retention_bytes[`retention_bytes`]
 
@@ -244,7 +244,7 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 
 *Accepted values:* [1, 9223372036854775] milliseconds
 
-**Default**: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#log_retention_ms[`log_retention_ms`]
 
@@ -293,7 +293,7 @@ If `max.message.bytes` is set to a positive value, it overrides the cluster prop
 
 *Accepted values:* [1, 2147483647] bytes
 
-**Default**: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#kafka_batch_max_bytes[`kafka_batch_max_bytes`]
 
@@ -313,7 +313,7 @@ When `message.timestamp.type` is set, it overrides the cluster property xref:./c
 
 *Accepted values:* [`CreateTime`, `LogAppendTime`]
 
-**Default**: `CreateTime`
+*Default:* `CreateTime`
 
 **Values**:
 
@@ -334,7 +334,7 @@ When `segment.bytes` is set to a positive value, it overrides the cluster proper
 
 *Accepted values:* [1, 9223372036854775807] bytes
 
-**Default**: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#log_segment_size[`log_segment_size`]
 
@@ -356,7 +356,7 @@ If set to a positive duration, `segment.ms` overrides the cluster property xref:
 
 *Accepted values:* [600000, 31536000000] milliseconds (clamped by cluster bounds)
 
-**Default**: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#log_segment_ms[`log_segment_ms`]
 
@@ -378,7 +378,7 @@ The maximum bytes not fsynced per partition. If this configured threshold is rea
 
 *Accepted values:* [1, 9223372036854775807] bytes
 
-**Default**: `262144`
+*Default:* `262144`
 
 *Related cluster property:* xref:./cluster-properties.adoc#flush_bytes[`flush_bytes`]
 
@@ -396,7 +396,7 @@ The maximum delay (in ms) between two subsequent fsyncs. After this delay, the l
 
 *Accepted values:* [1, 9223372036854775] milliseconds
 
-**Default**: `100`
+*Default:* `100`
 
 *Related cluster property:* xref:./cluster-properties.adoc#flush_ms[`flush_ms`]
 
@@ -414,7 +414,7 @@ This property inherits the value from the config_ref:default_leaders_preference,
 
 If the cluster configuration property config_ref:enable_rack_awareness,true,properties/cluster-properties[] is set to `false`, Leader Pinning is disabled across the cluster.
 
-**Default**: `none`
+*Default:* `none`
 
 **Values**:
 
@@ -439,7 +439,7 @@ NOTE: Although `replication.factor` isn't returned or displayed by xref:referenc
 
 *Accepted values:* [`1`, `512`]
 
-**Default**: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#default_topic_replication[`default_topic_replication`]
 
@@ -458,7 +458,7 @@ When `write.caching` is set, it overrides the cluster property xref:cluster-prop
 
 *Type:* boolean
 
-**Default**: `false`
+*Default:* `false`
 
 **Values**:
 
@@ -485,7 +485,7 @@ A size-based initial retention limit for Tiered Storage that determines how much
 
 *Accepted values:* [1, 9223372036854775807] bytes
 
-**Default**: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#initial_retention_local_target_bytes[`initial_retention_local_target_bytes`]
 
@@ -503,7 +503,7 @@ A time-based initial retention limit for Tiered Storage that determines how much
 
 *Accepted values:* [1, 9223372036854775] milliseconds
 
-**Default**: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#initial_retention_local_target_ms[`initial_retention_local_target_ms`]
 
@@ -519,7 +519,7 @@ A flag that enables deletion of data from object storage for Tiered Storage when
 
 NOTE: `redpanda.remote.delete` doesn't apply to Remote Read Replica topics: a Remote Read Replica topic isn't deleted from object storage when this flag is `true`.
 
-**Default**:
+*Default:*
 
 - `false` for topics created using Redpanda 22.2 or earlier.
 - `true` for topics created in Redpanda 22.3 and later, including new topics on upgraded clusters.
@@ -534,7 +534,7 @@ NOTE: `redpanda.remote.delete` doesn't apply to Remote Read Replica topics: a Re
 
 A flag for enabling Redpanda to fetch data for a topic from object storage to local storage. When set to `true` together with <<redpandaremotewrite, `redpanda.remote.write`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
 
-**Default**: false
+*Default:* false
 
 **Related topics**:
 
@@ -548,7 +548,7 @@ A flag that enables the recovery or reproduction of a topic from object storage 
 
 TIP: You can only configure `redpanda.remote.recovery` when you create a topic. You cannot apply this setting to existing topics.
 
-**Default**: false
+*Default:* false
 
 **Related topics**:
 
@@ -560,7 +560,7 @@ TIP: You can only configure `redpanda.remote.recovery` when you create a topic. 
 
 A flag for enabling Redpanda to upload data for a topic from local storage to object storage. When set to `true` together with <<redpandaremoteread, `redpanda.remote.read`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
 
-**Default**: false
+*Default:* false
 
 **Related topics**:
 
@@ -576,7 +576,7 @@ A size-based retention limit for Tiered Storage that configures the maximum size
 
 *Accepted values:* [1, 9223372036854775807] bytes
 
-**Default**: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#retention_local_target_bytes[`retention_local_target_bytes`]
 
@@ -594,7 +594,7 @@ A time-based retention limit for Tiered Storage that sets the maximum duration t
 
 *Accepted values:* [1, 9223372036854775] milliseconds
 
-**Default**: 86400000
+*Default:* 86400000
 
 *Related cluster property:* xref:./cluster-properties.adoc#retention_local_target_ms[`retention_local_target_ms`]
 
@@ -614,7 +614,7 @@ The name of the object storage bucket for a Remote Read Replica topic.
 
 CAUTION: Setting `redpanda.remote.readreplica` together with either `redpanda.remote.read` or `redpanda.remote.write` results in an error.
 
-**Default**: null
+*Default:* null
 
 **Related topics**:
 
@@ -630,7 +630,7 @@ Integrate Redpanda topics as Iceberg tables.
 
 Whether the corresponding Iceberg table is deleted upon deleting the topic.
 
-**Default**: `true`
+*Default:* `true`
 
 **Related topics**:
 
@@ -642,7 +642,7 @@ Whether the corresponding Iceberg table is deleted upon deleting the topic.
 
 Whether to write invalid records to a dead-letter queue (DLQ).
 
-**Default**: `dlq_table`
+*Default:* `dlq_table`
 
 **Values**:
 
@@ -659,7 +659,7 @@ Whether to write invalid records to a dead-letter queue (DLQ).
 
 Enable the Iceberg integration for the topic. You can choose one of four modes.
 
-**Default**: `disabled`
+*Default:* `disabled`
 
 **Values**:
 
@@ -679,7 +679,7 @@ Enable the Iceberg integration for the topic. You can choose one of four modes.
 
 The link:https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] specification for the Iceberg table.
 
-**Default**: `(hour(redpanda.timestamp))`
+*Default:* `(hour(redpanda.timestamp))`
 
 **Related topics**:
 
@@ -691,7 +691,7 @@ The link:https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] sp
 
 Controls how often the data in the Iceberg table is refreshed with new data from the topic. Redpanda attempts to commit all data produced to the topic within the lag target, subject to resource availability.
 
-**Default**: `60000`
+*Default:* `60000`
 
 **Related topics**:
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -8,7 +8,7 @@ Many topic-level properties have corresponding xref:manage:cluster-maintenance/c
 
 For information on how to configure topic properties, see xref:manage:cluster-maintenance/topic-property-configuration.adoc[].
 
-NOTE: All topic properties take effect immediately after being set. 
+NOTE: All topic properties take effect immediately after being set.
 
 == Topic property mappings
 
@@ -18,50 +18,66 @@ NOTE: All topic properties take effect immediately after being set.
 | <<cleanuppolicy,`cleanup.policy`>>
 | xref:./cluster-properties.adoc#log_cleanup_policy[`log_cleanup_policy`]
 
-| <<flushbytes,`flush.bytes`>>
-| xref:./cluster-properties.adoc#raft_replica_max_pending_flush_bytes[`raft_replica_max_pending_flush_bytes`]
-
-| <<flushms,`flush.ms`>>
-| xref:./cluster-properties.adoc#raft_replica_max_flush_delay_ms[`raft_replica_max_flush_delay_ms`]
-
-| <<initialretentionlocaltargetms,`initial.retention.local.target.ms`>>
-| xref:./cluster-properties.adoc#initial_retention_local_target_ms_default[`initial_retention_local_target_ms_default`]
-
-| <<mincleanabledirtyratio,`min.cleanable.dirty.ratio`>>
-| xref:reference:cluster-properties.adoc#min_cleanable_dirty_ratio[`min_cleanable_dirty_ratio`]
-
-| <<retentionbytes,`retention.bytes`>>
-| xref:./cluster-properties.adoc#retention_bytes[`retention_bytes`]
-
-| <<retentionms,`retention.ms`>>
-| xref:./cluster-properties.adoc#log_retention_ms[`log_retention_ms`]
-
-| <<segmentms,`segment.ms`>>
-| xref:./cluster-properties.adoc#log_segment_ms[`log_segment_ms`]
-
-| <<segmentbytes,`segment.bytes`>>
-| xref:reference:properties/cluster-properties.adoc#log_segment_size[`log_segment_size`]
+| <<compactionstrategy,`compaction.strategy`>>
+| xref:./cluster-properties.adoc#compaction_strategy[`compaction_strategy`]
 
 | <<compressiontype,`compression.type`>>
 | xref:./cluster-properties.adoc#log_compression_type[`log_compression_type`]
 
+| <<deleteretentionms,`delete.retention.ms`>>
+| xref:./cluster-properties.adoc#delete_retention_ms[`delete_retention_ms`]
+
+| <<flushbytes,`flush.bytes`>>
+| xref:./cluster-properties.adoc#flush_bytes[`flush_bytes`]
+
+| <<flushms,`flush.ms`>>
+| xref:./cluster-properties.adoc#flush_ms[`flush_ms`]
+
+| <<initialretentionlocaltargetbytes,`initial.retention.local.target.bytes`>>
+| xref:./cluster-properties.adoc#initial_retention_local_target_bytes[`initial_retention_local_target_bytes`]
+
+| <<initialretentionlocaltargetms,`initial.retention.local.target.ms`>>
+| xref:./cluster-properties.adoc#initial_retention_local_target_ms[`initial_retention_local_target_ms`]
+
 | <<maxcompactionlagms,`max.compaction.lag.ms`>>
 | xref:./cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`]
 
-| <<mincompactionlagms,`min.compaction.lag.ms`>>
-| xref:./cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`]
+| <<maxmessagebytes,`max.message.bytes`>>
+| xref:./cluster-properties.adoc#kafka_batch_max_bytes[`kafka_batch_max_bytes`]
 
 | <<messagetimestamptype,`message.timestamp.type`>>
 | xref:./cluster-properties.adoc#log_message_timestamp_type[`log_message_timestamp_type`]
 
-| <<maxmessagebytes,`max.message.bytes`>>
-| xref:reference:properties/cluster-properties.adoc#kafka_batch_max_bytes[`kafka_batch_max_bytes`]
+| <<mincleanabledirtyratio,`min.cleanable.dirty.ratio`>>
+| xref:./cluster-properties.adoc#min_cleanable_dirty_ratio[`min_cleanable_dirty_ratio`]
+
+| <<mincompactionlagms,`min.compaction.lag.ms`>>
+| xref:./cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`]
 
 | <<replicationfactor,`replication.factor`>>
-| xref:./cluster-properties.adoc#default_topic_replication[`default_topic_replication`]
+| xref:./cluster-properties.adoc#replication_factor[`replication_factor`]
+
+| <<retentionbytes,`retention.bytes`>>
+| xref:./cluster-properties.adoc#retention_bytes[`retention_bytes`]
+
+| <<retentionlocaltargetbytes,`retention.local.target.bytes`>>
+| xref:./cluster-properties.adoc#retention_local_target_bytes[`retention_local_target_bytes`]
+
+| <<retentionlocaltargetms,`retention.local.target.ms`>>
+| xref:./cluster-properties.adoc#retention_local_target_ms[`retention_local_target_ms`]
+
+| <<retentionms,`retention.ms`>>
+| xref:./cluster-properties.adoc#retention_ms[`retention_ms`]
+
+| <<segmentbytes,`segment.bytes`>>
+| xref:./cluster-properties.adoc#log_segment_size[`log_segment_size`]
+
+| <<segmentms,`segment.ms`>>
+| xref:./cluster-properties.adoc#segment_ms[`segment_ms`]
 
 | <<writecaching,`write.caching`>>
-| xref:./cluster-properties.adoc#write_caching_default[`write_caching_default`]
+| xref:./cluster-properties.adoc#write_caching[`write_caching`]
+
 |===
 
 == Topic properties

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -144,9 +144,9 @@ If both `delete.retention.ms` and the cluster property config_ref:tombstone_rete
 
 *Type:* integer
 
-*Accepted values:* [1, 9223372036854775] milliseconds
+*Accepted values:* [`1`, `9223372036854775`] milliseconds
 
-*Default*: null
+*Default:* null
 
 *Related cluster property:* xref:./cluster-properties.adoc#tombstone_retention_ms[`tombstone_retention_ms`]
 
@@ -220,7 +220,7 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 
 *Type:* integer
 
-*Accepted values:* [1, 9223372036854775807] bytes
+*Accepted values:* [`1`, `9223372036854775807`] bytes
 
 *Default:* null
 
@@ -242,7 +242,7 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 
 *Type:* integer
 
-*Accepted values:* [-1, 9223372036854775807] milliseconds
+*Accepted values:* [`-9223372036854775808`, `9223372036854775807`] milliseconds
 
 *Default:* null
 
@@ -270,7 +270,7 @@ When set, this property overrides the cluster property xref:./cluster-properties
 
 *Type:* string
 
-*Accepted Values:* `producer`. The following values are accepted for Kafka compatibility but ignored: `gzip`, `snappy`, `lz4`, `zstd`, `none`.
+*Accepted values:* `producer`. The following values are accepted for Kafka compatibility but ignored: `gzip`, `snappy`, `lz4`, `zstd`, `none`.
 
 *Default:* `producer`
 
@@ -291,7 +291,7 @@ If `max.message.bytes` is set to a positive value, it overrides the cluster prop
 
 *Type:* integer
 
-*Accepted values:* [1, 2147483647] bytes
+*Accepted values:* [`1`, `2147483647`] bytes
 
 *Default:* null
 
@@ -332,7 +332,7 @@ When `segment.bytes` is set to a positive value, it overrides the cluster proper
 
 *Type:* integer
 
-*Accepted values:* [1, 9223372036854775807] bytes
+*Accepted values:* [`1`, `9223372036854775807`] bytes
 
 *Default:* null
 
@@ -354,7 +354,7 @@ If set to a positive duration, `segment.ms` overrides the cluster property xref:
 
 *Type:* integer
 
-*Accepted values:* [600000, 31536000000] milliseconds (clamped by cluster bounds)
+*Accepted values:* `[600000, 31536000000]` milliseconds (clamped by cluster bounds)
 
 *Default:* null
 
@@ -376,7 +376,7 @@ The maximum bytes not fsynced per partition. If this configured threshold is rea
 
 *Type:* integer
 
-*Accepted values:* [1, 9223372036854775807] bytes
+*Accepted values:* [`1`, `9223372036854775807`] bytes
 
 *Default:* `262144`
 
@@ -394,7 +394,7 @@ The maximum delay (in ms) between two subsequent fsyncs. After this delay, the l
 
 *Type:* integer
 
-*Accepted values:* [1, 9223372036854775] milliseconds
+*Accepted values:* [`1`, `9223372036854775`] milliseconds
 
 *Default:* `100`
 
@@ -413,6 +413,8 @@ The preferred location (rack) for partition leaders of a topic.
 This property inherits the value from the config_ref:default_leaders_preference,true,properties/cluster-properties[] cluster configuration property. You may override the cluster-wide setting by specifying the value for individual topics.
 
 If the cluster configuration property config_ref:enable_rack_awareness,true,properties/cluster-properties[] is set to `false`, Leader Pinning is disabled across the cluster.
+
+*Type:* string
 
 *Default:* `none`
 
@@ -483,7 +485,7 @@ A size-based initial retention limit for Tiered Storage that determines how much
 
 *Type:* integer
 
-*Accepted values:* [1, 9223372036854775807] bytes
+*Accepted values:* [`1`, `9223372036854775807`] bytes
 
 *Default:* null
 
@@ -501,7 +503,7 @@ A time-based initial retention limit for Tiered Storage that determines how much
 
 *Type:* integer
 
-*Accepted values:* [1, 9223372036854775] milliseconds
+*Accepted values:* [`1`, `9223372036854775`] milliseconds
 
 *Default:* null
 
@@ -519,6 +521,8 @@ A flag that enables deletion of data from object storage for Tiered Storage when
 
 NOTE: `redpanda.remote.delete` doesn't apply to Remote Read Replica topics: a Remote Read Replica topic isn't deleted from object storage when this flag is `true`.
 
+*Type:* boolean
+
 *Default:*
 
 - `false` for topics created using Redpanda 22.2 or earlier.
@@ -534,6 +538,8 @@ NOTE: `redpanda.remote.delete` doesn't apply to Remote Read Replica topics: a Re
 
 A flag for enabling Redpanda to fetch data for a topic from object storage to local storage. When set to `true` together with <<redpandaremotewrite, `redpanda.remote.write`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
 
+*Type:* boolean
+
 *Default:* false
 
 **Related topics**:
@@ -548,6 +554,8 @@ A flag that enables the recovery or reproduction of a topic from object storage 
 
 TIP: You can only configure `redpanda.remote.recovery` when you create a topic. You cannot apply this setting to existing topics.
 
+*Type:* boolean
+
 *Default:* false
 
 **Related topics**:
@@ -559,6 +567,8 @@ TIP: You can only configure `redpanda.remote.recovery` when you create a topic. 
 ==== redpanda.remote.write
 
 A flag for enabling Redpanda to upload data for a topic from local storage to object storage. When set to `true` together with <<redpandaremoteread, `redpanda.remote.read`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
+
+*Type:* boolean
 
 *Default:* false
 
@@ -574,7 +584,7 @@ A size-based retention limit for Tiered Storage that configures the maximum size
 
 *Type:* integer
 
-*Accepted values:* [1, 9223372036854775807] bytes
+*Accepted values:* [`1`, `9223372036854775807`] bytes
 
 *Default:* null
 
@@ -592,7 +602,7 @@ A time-based retention limit for Tiered Storage that sets the maximum duration t
 
 *Type:* integer
 
-*Accepted values:* [1, 9223372036854775] milliseconds
+*Accepted values:* [`1`, `9223372036854775`] milliseconds
 
 *Default:* 86400000
 
@@ -614,6 +624,8 @@ The name of the object storage bucket for a Remote Read Replica topic.
 
 CAUTION: Setting `redpanda.remote.readreplica` together with either `redpanda.remote.read` or `redpanda.remote.write` results in an error.
 
+*Type:* string
+
 *Default:* null
 
 **Related topics**:
@@ -630,6 +642,8 @@ Integrate Redpanda topics as Iceberg tables.
 
 Whether the corresponding Iceberg table is deleted upon deleting the topic.
 
+*Type:* boolean
+
 *Default:* `true`
 
 **Related topics**:
@@ -641,6 +655,8 @@ Whether the corresponding Iceberg table is deleted upon deleting the topic.
 ==== redpanda.iceberg.invalid.record.action
 
 Whether to write invalid records to a dead-letter queue (DLQ).
+
+*Type:* string
 
 *Default:* `dlq_table`
 
@@ -658,6 +674,8 @@ Whether to write invalid records to a dead-letter queue (DLQ).
 ==== redpanda.iceberg.mode
 
 Enable the Iceberg integration for the topic. You can choose one of four modes.
+
+*Type:* string
 
 *Default:* `disabled`
 
@@ -679,6 +697,8 @@ Enable the Iceberg integration for the topic. You can choose one of four modes.
 
 The link:https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] specification for the Iceberg table.
 
+*Type:* string
+
 *Default:* `(hour(redpanda.timestamp))`
 
 **Related topics**:
@@ -690,6 +710,8 @@ The link:https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] sp
 ==== redpanda.iceberg.target.lag.ms
 
 Controls how often the data in the Iceberg table is refreshed with new data from the topic. Redpanda attempts to commit all data produced to the topic within the lag target, subject to resource availability.
+
+*Type:* integer
 
 *Default:* `60000`
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -6,8 +6,11 @@ A topic-level property sets a Redpanda or Kafka configuration for a particular t
 
 Many topic-level properties have corresponding xref:manage:cluster-maintenance/cluster-property-configuration.adoc[cluster properties] that set a default value for all topics of a cluster. To customize the value for a topic, you can set a topic-level property that overrides the value of the corresponding cluster property.
 
+For information on how to configure topic properties, see xref:manage:cluster-maintenance/topic-property-configuration.adoc[].
 
 NOTE: All topic properties take effect immediately after being set. 
+
+== Topic property mappings
 
 |===
 | Topic property | Corresponding cluster property
@@ -61,115 +64,7 @@ NOTE: All topic properties take effect immediately after being set.
 | xref:./cluster-properties.adoc#write_caching_default[`write_caching_default`]
 |===
 
-[NOTE]
-====
-The `SOURCE` output of the xref:reference:rpk/rpk-topic/rpk-topic-describe.adoc[`rpk topic describe <topic>`] command describes how the property is set for the topic:
-
-* `DEFAULT_CONFIG` is set by a Redpanda default.
-* `DYNAMIC_TOPIC_CONFIG` is set by the user specifically for the topic and overrides inherited default configurations, such as a default or a cluster-level property.
-
-Although xref:reference:rpk/rpk-topic/rpk-topic-describe.adoc[`rpk topic describe`] doesn't report `replication.factor` as a configuration, `replication.factor` can indeed be set by using the xref:reference:rpk/rpk-topic/rpk-topic-alter-config.adoc[`rpk topic alter-config`] command.
-====
-
-== Examples
-
-The following examples show how to configure topic-level properties. Set a topic-level property for a topic to override the value of corresponding cluster property.
-
-=== Create topic with topic properties
-
-To set topic properties when creating a topic, use the xref:reference:rpk/rpk-topic/rpk-topic-create.adoc[rpk topic create] command with the `-c` option.
-
-For example, to create a topic with the `cleanup.policy` property set to `compact`:
-
-[tabs]
-====
-Local::
-+
---
-
-```bash
-rpk topic create -c cleanup.policy=compact <topic-name>
-```
-
---
-Kubernetes::
-+
---
-
-```bash
-kubectl exec <pod-name> -- rpk topic create -c cleanup.policy=compact<topic-name>
-```
-
---
-====
-
-To configure multiple properties for a topic, use the `-c` option for each property.
-
-For example, to create a topic with all necessary properties for Tiered Storage:
-
-[tabs]
-====
-Local::
-+
---
-
-```bash
-rpk topic create -c redpanda.remote.recovery=true -c redpanda.remote.write=true -c redpanda.remote.read=true <topic-name>
-```
-
---
-Kubernetes::
-+
---
-
-```bash
-kubectl exec <pod-name> -- rpk topic create -c redpanda.remote.recovery=true -c redpanda.remote.write=true -c redpanda.remote.read=true <topic-name>
-```
-
---
-====
-
-=== Modify topic properties
-
-To modify topic properties of an existing topic, use the xref:reference:rpk/rpk-topic/rpk-topic-alter-config.adoc[rpk topic alter-config] command.
-
-For example, to modify a topic's `retention.ms` property:
-
-[tabs]
-====
-Local::
-+
---
-
-```bash
-rpk topic alter-config <topic-name> --set retention.ms=<retention-time>
-```
-
---
-Kubernetes::
-+
---
-
-```bash
-kubectl exec <pod-name> -- rpk topic alter-config <topic-name> --set retention.ms=<retention-time>
-```
-
---
-====
-
-== Disk space properties
-
-Configure properties to manage the disk space used by a topic:
-
-- Clean up log segments by deletion and/or compaction (<<cleanuppolicy, `cleanup.policy`>>).
-- Control compaction timing with maximum and minimum lag settings (<<maxcompactionlagms, `max.compaction.lag.ms`>> and <<mincompactionlagms, `min.compaction.lag.ms`>>).
-- Retain logs up to a maximum size per partition before cleanup (<<retentionbytes, `retention.bytes`>>).
-- Retain logs for a maximum duration before cleanup (<<retentionms, `retention.ms`>>).
-- Periodically close an active log segment (<<segmentms, `segment.ms`>>).
-- Limit the maximum size of an active log segment (<<segmentbytes, `segment.bytes`>>).
-- Cache batches until the segment appender chunk is full, instead of fsyncing for every `acks=all` write (<<writecaching,`write.caching`>>). With `write.caching` enabled, fsyncs follow <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>, whichever is reached first.
-
----
+== Topic properties
 
 [[cleanuppolicy]]
 === cleanup.policy
@@ -187,7 +82,6 @@ include::develop:partial$topic-properties-warning.adoc[]
 - `[delete]` - Deletes data according to size-based or time-based retention limits, or both.
 - `[compact]` - Deletes data according to a key-based retention policy, discarding all but the latest value for each key.
 - `[compact,delete]` - The latest values are kept for each key, while the remaining data is deleted according to retention limits.
-
 
 
 **Related topics**:
@@ -356,7 +250,7 @@ When `write.caching` is set, it overrides the cluster property xref:cluster-prop
 
 ---
 
-== Message properties
+=== Message properties
 
 Configure properties for the messages of a topic:
 
@@ -419,7 +313,7 @@ If `max.message.bytes` is set to a positive value, it overrides the cluster prop
 
 ---
 
-== Tiered Storage properties
+=== Tiered Storage properties
 
 Configure properties to manage topics for xref:manage:tiered-storage.adoc[Tiered Storage]:
 
@@ -539,7 +433,7 @@ NOTE: `redpanda.remote.delete` doesn't apply to Remote Read Replica topics: a Re
 
 ---
 
-== Remote Read Replica properties
+=== Remote Read Replica properties
 
 Configure properties to manage topics for xref:manage:remote-read-replicas.adoc[Remote Read Replicas].
 
@@ -557,7 +451,7 @@ CAUTION: Setting `redpanda.remote.readreplica` together with either `redpanda.re
 
 ---
 
-== Apache Iceberg integration properties
+=== Apache Iceberg integration properties
 
 Integrate Redpanda topics as Iceberg tables.
 
@@ -634,7 +528,7 @@ Controls how often the data in the Iceberg table is refreshed with new data from
 
 ---
 
-== Redpanda topic properties
+=== Redpanda topic properties
 
 Configure Redpanda-specific topic properties.
 
@@ -700,7 +594,7 @@ NOTE: Although `replication.factor` isn't returned or displayed by xref:referenc
 
 
 
-== Related topics
+=== Related topics
 
 - xref:develop:produce-data/configure-producers.adoc[Configure Producers]
 - xref:develop:config-topics.adoc[Manage Topics]

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -260,25 +260,23 @@ These properties control the size and lifecycle of log segment files and setting
 [[compressiontype]]
 ==== compression.type
 
-IMPORTANT: This property is ignored regardless of the value specified. The behavior is always the same as the `producer` value. If producers send compressed data, Redpanda stores and serves it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and `rpk topic describe` outputs for compatibility.
+Redpanda ignores this property and always uses producer compression semantics. If producers send compressed data, Redpanda stores and serves it as-is. If producers send uncompressed data, Redpanda stores it uncompressed.
 
-Redpanda does not enforce or change compression for stored data; configure compression in your producers.
+This property exists for Apache Kafka compatibility. Configure compression in your producers instead of using this topic property.
 
-Enabling compression reduces message size, which improves throughput and decreases storage for messages with repetitive values and data structures. The trade-off is increased CPU utilization and network latency to perform the compression. You can also enable producer batching to increase compression efficiency, since the messages in a batch likely have repeated data that can be compressed.
+Compression reduces message size and improves throughput, but increases CPU utilization. Enable producer batching to increase compression efficiency.
 
-When `compression.type` is set, it overrides the cluster property xref:./cluster-properties.adoc#log_compression_type[`log_compression_type`] for the topic.
-
-NOTE: The valid values of `compression.type` are taken from `log_compression_type` and differ from Kafka's compression types.
+When set, this property overrides the cluster property xref:./cluster-properties.adoc#log_compression_type[`log_compression_type`] for the topic.
 
 *Type:* string
 
-*Accepted Values:* `producer`. The following values are accepted for Kafka compatibility but ignored by the broker: `gzip`, `snappy`, `lz4`, `zstd`, `none`.
+*Accepted Values:* `producer`. The following values are accepted for Kafka compatibility but ignored: `gzip`, `snappy`, `lz4`, `zstd`, `none`.
 
-**Default**: `none`
+*Default:* `producer`
 
 *Related cluster property:* xref:./cluster-properties.adoc#log_compression_type[`log_compression_type`]
 
-**Related topics**:
+*Related topics:*
 
 - xref:develop:produce-data/configure-producers.adoc#message-batching[Message batching]
 - xref:develop:produce-data/configure-producers.adoc#commonly-used-producer-configuration-options[Common producer configuration options]

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -242,7 +242,7 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 
 *Type:* integer
 
-*Accepted values:* [1, 9223372036854775] milliseconds
+*Accepted values:* [-1, 9223372036854775807] milliseconds
 
 *Default:* null
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -82,8 +82,15 @@ NOTE: All topic properties take effect immediately after being set.
 
 == Topic properties
 
+Properties are grouped by feature area. Within each group, properties are listed in alphabetical order.
+
+---
+=== Retention and Compaction Properties
+
+These properties control how data is stored, for how long, and when it is deleted or compacted.
+
 [[cleanuppolicy]]
-=== cleanup.policy
+==== cleanup.policy
 
 The cleanup policy to apply for log segments of a topic.
 
@@ -91,14 +98,19 @@ When `cleanup.policy` is set, it overrides the cluster property xref:cluster-pro
 
 include::develop:partial$topic-properties-warning.adoc[]
 
-**Default**: `[delete]`
+*Type:* string
+
+*Accepted values:* [`delete`, `compact`, `compact,delete`]
+
+**Default**: `delete`
 
 **Values**:
 
-- `[delete]` - Deletes data according to size-based or time-based retention limits, or both.
-- `[compact]` - Deletes data according to a key-based retention policy, discarding all but the latest value for each key.
-- `[compact,delete]` - The latest values are kept for each key, while the remaining data is deleted according to retention limits.
+- `delete` - Deletes data according to size-based or time-based retention limits, or both.
+- `compact` - Deletes data according to a key-based retention policy, discarding all but the latest value for each key.
+- `compact,delete` - The latest values are kept for each key, while the remaining data is deleted according to retention limits.
 
+*Related cluster property:* xref:./cluster-properties.adoc#log_cleanup_policy[`log_cleanup_policy`]
 
 **Related topics**:
 
@@ -106,82 +118,100 @@ include::develop:partial$topic-properties-warning.adoc[]
 - xref:manage:tiered-storage.adoc#compacted-topics-in-tiered-storage[Compacted topics in Tiered Storage]
 
 ---
+[[compactionstrategy]]
+==== compaction.strategy
 
-[[flushms]]
-=== flush.ms
+Specifies the strategy used to determine which records to remove during log compaction. The compaction strategy controls how Redpanda identifies and removes duplicate records while preserving the latest value for each key.
 
-The maximum delay (in ms) between two subsequent fsyncs. After this delay, the log is automatically fsynced.
+*Type:* string
 
-**Default**: `100`
+*Default:* `offset`
+
+*Accepted values:*
+
+* `offset` - Uses record offsets to determine which records to compact (default and currently the only supported strategy)
+
+*Related cluster property:* xref:./cluster-properties.adoc#compaction_strategy[`compaction_strategy`]
+
+---
+[[deleteretentionms]]
+==== delete.retention.ms
+
+The retention time for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
+
+If you have enabled Tiered Storage and set <<redpandaremoteread,`redpanda.remote.read`>> or <<redpandaremotewrite,`redpanda.remote.write`>> for the topic, you cannot enable tombstone removal.
+
+If both `delete.retention.ms` and the cluster property config_ref:tombstone_retention_ms,true,properties/cluster-properties[] are set, `delete.retention.ms` overrides the cluster level tombstone retention for an individual topic.
+
+*Type:* integer
+
+*Accepted values:* [1, 9223372036854775] milliseconds
+
+*Default*: null
+
+*Related cluster property:* xref:./cluster-properties.adoc#tombstone_retention_ms[`tombstone_retention_ms`]
 
 **Related topics**:
 
-- xref:develop:produce-data/configure-producers.adoc[]
+- xref:manage:cluster-maintenance/compaction-settings.adoc#tombstone-record-removal[Tombstone record removal]
 
 ---
-
-[[flushbytes]]
-=== flush.bytes
-
-The maximum bytes not fsynced per partition. If this configured threshold is reached, the log is automatically fsynced, even though it wasn't explicitly requested.
-
-**Default**: `262144`
-
-**Related topics**:
-
-- xref:develop:produce-data/configure-producers.adoc[]
-
----
-
-[[mincleanabledirtyratio]]
-=== min.cleanable.dirty.ratio
-
-The minimum ratio between the number of bytes in dirty segments and the total number of bytes in closed segments that must be reached before a partition's log is eligible for compaction in a compact topic.
-
-**Default**: null
-
-**Related topics**:
-
-- xref:manage:cluster-maintenance/compaction-settings.adoc[]
-
----
-
 [[maxcompactionlagms]]
-=== max.compaction.lag.ms
+==== max.compaction.lag.ms
 
 The maximum amount of time (in ms) that a log segment can remain unaltered before it is eligible for compaction in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`] for the topic.
 
 *Type:* integer
 
-*Accepted values:* [`1`, `9223372036854`]
+*Accepted values:* [`1`, `9223372036854775`]
 
-*Default:* `9223372036854`
+**Default:* `9223372036854775`
+
+*Related cluster property:* xref:./cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`]
 
 **Related topics**:
 
 - xref:manage:cluster-maintenance/compaction-settings.adoc#configuration-options[Configure maximum compaction lag]
 
 ---
+[[mincleanabledirtyratio]]
+==== min.cleanable.dirty.ratio
 
+The minimum ratio between the number of bytes in dirty segments and the total number of bytes in closed segments that must be reached before a partition's log is eligible for compaction in a compact topic.
+
+*Type:* number
+
+*Accepted values:* [`0`, `1.0`]
+
+**Default**: null
+
+*Related cluster property:* xref:./cluster-properties.adoc#min_cleanable_dirty_ratio[`min_cleanable_dirty_ratio`]
+
+**Related topics**:
+
+- xref:manage:cluster-maintenance/compaction-settings.adoc[]
+
+---
 [[mincompactionlagms]]
-=== min.compaction.lag.ms
+==== min.compaction.lag.ms
 
 The minimum amount of time (in ms) that a log segment must remain unaltered before it can be compacted in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`] for the topic.
 
 *Type:* integer
 
-*Accepted values:* [`0`, `9223372036854`]
+*Accepted values:* [`0`, `9223372036854775`]
 
-*Default:* `0`
+**Default:* `0`
+
+*Related cluster property:* xref:./cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`]
 
 **Related topics**:
 
 - xref:manage:cluster-maintenance/compaction-settings.adoc#configure-min-compaction-lag[Configure minimum compaction lag]
 
 ---
-
 [[retentionbytes]]
-=== retention.bytes
+==== retention.bytes
 
 A size-based retention limit that configures the maximum size that a topic partition can grow before becoming eligible for cleanup.
 
@@ -189,16 +219,21 @@ If `retention.bytes` is set to a positive value, it overrides the cluster proper
 
 When both size-based (`retention.bytes`) and time-based (`retention.ms`) retention limits are set, cleanup occurs when either limit is reached.
 
+*Type:* integer
+
+*Accepted values:* [1, 9223372036854775807] bytes
+
 **Default**: null
+
+*Related cluster property:* xref:./cluster-properties.adoc#retention_bytes[`retention_bytes`]
 
 **Related topics**:
 
 - xref:manage:cluster-maintenance/disk-utilization.adoc#configure-message-retention[Configure message retention]
 
 ---
-
 [[retentionms]]
-=== retention.ms
+==== retention.ms
 
 A time-based retention limit that configures the maximum duration that a log's segment file for a topic is retained before it becomes eligible to be cleaned up. To consume all data, a consumer of the topic must read from a segment before its `retention.ms` elapses, otherwise the segment may be compacted and/or deleted. If a non-positive value, no per-topic limit is applied.
 
@@ -206,78 +241,27 @@ If `retention.ms` is set to a positive value, it overrides the cluster property 
 
 When both size-based (`retention.bytes`) and time-based (`retention.ms`) retention limits are set, the earliest occurring limit applies.
 
+*Type:* integer
+
+*Accepted values:* [1, 9223372036854775] milliseconds
+
 **Default**: null
+
+*Related cluster property:* xref:./cluster-properties.adoc#log_retention_ms[`log_retention_ms`]
 
 **Related topics**:
 
 - xref:manage:cluster-maintenance/disk-utilization.adoc#configure-message-retention[Configure message retention]
 
 ---
+### Segment and Message Properties
 
-[[segmentms]]
-=== segment.ms
-
-The maximum duration that a log segment of a topic is active (open for writes and not deletable). A periodic event, with `segment.ms` as its period, forcibly closes the active segment and transitions, or rolls, to a new active segment. The closed (inactive) segment is then eligible to be cleaned up according to cleanup and retention properties.
-
-If set to a positive duration, `segment.ms` overrides the cluster property xref:./cluster-properties.adoc#log_segment_ms[`log_segment_ms`] and its lower and upper bounds set by xref:./cluster-properties.adoc#log_segment_ms_min[`log_segment_ms_min`] and xref:./cluster-properties.adoc#log_segment_ms_max[`log_segment_ms_max`], respectively.
-
-**Default**: null
-
-**Related topics**:
-
-- xref:manage:cluster-maintenance/disk-utilization.adoc#log-rolling[Log rolling]
-
----
-
-[[segmentbytes]]
-=== segment.bytes
-
-The maximum size of an active log segment for a topic. When the size of an active segment exceeds `segment.bytes`, the segment is closed and a new active segment is created. The closed, inactive segment is then eligible to be cleaned up according to retention properties.
-
-When `segment.bytes` is set to a positive value, it overrides the cluster property xref:reference:properties/cluster-properties.adoc#log_segment_size[`log_segment_size`] for the topic.
-
-**Default**: null
-
-**Related topics**:
-
-- xref:manage:cluster-maintenance/disk-utilization.adoc#configure-segment-size[Configure segment size]
-- xref:manage:cluster-maintenance/disk-utilization.adoc#configure-message-retention[Configure message retention]
-- xref:manage:remote-read-replicas.adoc[Remote Read Replicas]
-
----
-
-[[writecaching]]
-=== write.caching
-
-The write caching mode to apply to a topic. 
-
-When `write.caching` is set, it overrides the cluster property xref:cluster-properties.adoc#write_caching_default[`write_caching_default`]. Write caching acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to be written to disk. With `acks=all`, this provides lower latency while still ensuring that a majority of brokers acknowledge the write. Fsyncs follow <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>, whichever is reached first.
-
-**Default**: `false`
-
-**Values**:
-
-- `true` - Enables write caching for a topic, according to <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>.
-- `false` - Disables write caching for a topic, according to <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>.
-
-**Related topics**:
-
-- xref:develop:config-topics.adoc#configure-write-caching[Write caching]
-
----
-
-=== Message properties
-
-Configure properties for the messages of a topic:
-
-- Compress a message or batch to reduce storage space and increase throughput (<<compressiontype, `compression.type`>>).
-- Set the source of a message's timestamp (<<messagetimestamptype, `message.timestamp.type`>>).
-- Set the maximum size of a message (<<maxmessagebytes, `max.message.bytes`>>).
+These properties control the size and lifecycle of log segment files and settings for individual messages.
 
 [[compressiontype]]
-=== compression.type
+==== compression.type
 
-IMPORTANT:  This property is ignored regardless of the value specified. The behavior is always the same as the `producer` value. If producers send compressed data, Redpanda stores and serves it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and `rpk topic describe` outputs for compatibility.
+IMPORTANT: This property is ignored regardless of the value specified. The behavior is always the same as the `producer` value. If producers send compressed data, Redpanda stores and serves it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and `rpk topic describe` outputs for compatibility.
 
 Redpanda does not enforce or change compression for stored data; configure compression in your producers.
 
@@ -287,9 +271,13 @@ When `compression.type` is set, it overrides the cluster property xref:./cluster
 
 NOTE: The valid values of `compression.type` are taken from `log_compression_type` and differ from Kafka's compression types.
 
-**Default**: `none`
+*Type:* string
 
 *Accepted Values:* `producer`. The following values are accepted for Kafka compatibility but ignored by the broker: `gzip`, `snappy`, `lz4`, `zstd`, `none`.
+
+**Default**: `none`
+
+*Related cluster property:* xref:./cluster-properties.adoc#log_compression_type[`log_compression_type`]
 
 **Related topics**:
 
@@ -297,13 +285,36 @@ NOTE: The valid values of `compression.type` are taken from `log_compression_typ
 - xref:develop:produce-data/configure-producers.adoc#commonly-used-producer-configuration-options[Common producer configuration options]
 
 ---
+[[maxmessagebytes]]
+==== max.message.bytes
 
+The maximum size of a message or batch of a topic. If a compression type is enabled, `max.message.bytes` sets the maximum size of the compressed message or batch.
+
+If `max.message.bytes` is set to a positive value, it overrides the cluster property xref:reference:properties/cluster-properties.adoc#kafka_batch_max_bytes[`kafka_batch_max_bytes`] for the topic.
+
+*Type:* integer
+
+*Accepted values:* [1, 2147483647] bytes
+
+**Default**: null
+
+*Related cluster property:* xref:./cluster-properties.adoc#kafka_batch_max_bytes[`kafka_batch_max_bytes`]
+
+**Related topics**:
+
+- xref:develop:produce-data/configure-producers.adoc#message-batching[Message batching]
+
+---
 [[messagetimestamptype]]
-=== message.timestamp.type
+==== message.timestamp.type
 
 The source of a message's timestamp: either the message's creation time or its log append time.
 
 When `message.timestamp.type` is set, it overrides the cluster property xref:./cluster-properties.adoc#log_message_timestamp_type[`log_message_timestamp_type`] for the topic.
+
+*Type:* string
+
+*Accepted values:* [`CreateTime`, `LogAppendTime`]
 
 **Default**: `CreateTime`
 
@@ -312,265 +323,93 @@ When `message.timestamp.type` is set, it overrides the cluster property xref:./c
 - `CreateTime`
 - `LogAppendTime`
 
+*Related cluster property:* xref:./cluster-properties.adoc#log_message_timestamp_type[`log_message_timestamp_type`]
+
 ---
+[[segmentbytes]]
+==== segment.bytes
 
-[[maxmessagebytes]]
-=== max.message.bytes
+The maximum size of an active log segment for a topic. When the size of an active segment exceeds `segment.bytes`, the segment is closed and a new active segment is created. The closed, inactive segment is then eligible to be cleaned up according to retention properties.
 
-The maximum size of a message or batch of a topic. If a compression type is enabled, `max.message.bytes` sets the maximum size of the compressed message or batch.
+When `segment.bytes` is set to a positive value, it overrides the cluster property xref:reference:properties/cluster-properties.adoc#log_segment_size[`log_segment_size`] for the topic.
 
-If `max.message.bytes` is set to a positive value, it overrides the cluster property xref:reference:properties/cluster-properties.adoc#kafka_batch_max_bytes[`kafka_batch_max_bytes`] for the topic.
+*Type:* integer
+
+*Accepted values:* [1, 9223372036854775807] bytes
 
 **Default**: null
 
-**Related topics**:
-
-- xref:develop:produce-data/configure-producers.adoc#message-batching[Message batching]
-
----
-
-=== Tiered Storage properties
-
-Configure properties to manage topics for xref:manage:tiered-storage.adoc[Tiered Storage]:
-
-- Upload and fetch data to and from object storage for a topic (<<redpandaremotewrite, `redpanda.remote.write`>> and <<redpandaremoteread, `redpanda.remote.read`>>).
-- Configure size-based and time-based retention properties for local storage of a topic (<<retentionlocaltargetbytes, `retention.local.target.bytes`>> and <<retentionlocaltargetms, `retention.local.target.ms`>>).
-- Recover or reproduce data for a topic from object storage (<<redpandaremoterecovery, `redpanda.remote.recovery`>>).
-- Delete data from object storage for a topic when it's deleted from local storage (<<redpandaremotedelete, `redpanda.remote.delete`>>).
-
-[[redpandaremotewrite]]
-=== redpanda.remote.write
-
-A flag for enabling Redpanda to upload data for a topic from local storage to object storage. When set to `true` together with <<redpandaremoteread, `redpanda.remote.read`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
-
-**Default**: false
+*Related cluster property:* xref:./cluster-properties.adoc#log_segment_size[`log_segment_size`]
 
 **Related topics**:
 
-- xref:manage:tiered-storage.adoc[Tiered Storage]
-
----
-
-[[redpandaremoteread]]
-=== redpanda.remote.read
-
-A flag for enabling Redpanda to fetch data for a topic from object storage to local storage. When set to `true` together with <<redpandaremotewrite, `redpanda.remote.write`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
-
-**Default**: false
-
-**Related topics**:
-
-- xref:manage:tiered-storage.adoc[Tiered Storage]
-
----
-
-[[initialretentionlocaltargetbytes]]
-=== initial.retention.local.target.bytes
-
-A size-based initial retention limit for Tiered Storage that determines how much data in local storage is transferred to a partition replica when a cluster is resized. If `null` (default), all locally retained data is transferred.
-
-**Default**: null
-
-**Related topics**:
-
-- xref:manage:tiered-storage.adoc#fast-commission-and-decommission[Fast commission and decommission through Tiered Storage]
-
----
-
-[[initialretentionlocaltargetms]]
-=== initial.retention.local.target.ms
-
-A time-based initial retention limit for Tiered Storage that determines how much data in local storage is transferred to a partition replica when a cluster is resized. If `null` (default), all locally retained data is transferred.
-
-**Default**: null
-
-**Related topics**:
-
-- xref:manage:tiered-storage.adoc#fast-commission-and-decommission[Fast commission and decommission through Tiered Storage]
-
----
-
-[[retentionlocaltargetbytes]]
-=== retention.local.target.bytes
-
-A size-based retention limit for Tiered Storage that configures the maximum size that a topic partition in local storage can grow before becoming eligible for cleanup. It applies per partition and is equivalent to <<retentionbytes, `retention.bytes`>> without Tiered Storage.
-
-**Default**: null
-
-**Related topics**:
-
-- xref:manage:tiered-storage.adoc[Tiered Storage]
-
----
-
-[[retentionlocaltargetms]]
-=== retention.local.target.ms
-
-A time-based retention limit for Tiered Storage that sets the maximum duration that a log's segment file for a topic is retained in local storage before it's eligible for cleanup. This property is equivalent to <<retentionms, `retention.ms`>> without Tiered Storage.
-
-**Default**: 86400000
-
-**Related topics**:
-
-- xref:manage:tiered-storage.adoc[Tiered Storage]
-
----
-
-[[redpandaremoterecovery]]
-=== redpanda.remote.recovery
-
-A flag that enables the recovery or reproduction of a topic from object storage for Tiered Storage. The recovered data is saved in local storage, and the maximum amount of recovered data is determined by the local storage retention limits of the topic.
-
-TIP: You can only configure `redpanda.remote.recovery` when you create a topic. You cannot apply this setting to existing topics.
-
-**Default**: false
-
-**Related topics**:
-
-- xref:manage:tiered-storage.adoc[Tiered Storage]
-
----
-
-[[redpandaremotedelete]]
-=== redpanda.remote.delete
-
-A flag that enables deletion of data from object storage for Tiered Storage when it's deleted from local storage for a topic.
-
-NOTE: `redpanda.remote.delete` doesn't apply to Remote Read Replica topics: a Remote Read Replica topic isn't deleted from object storage when this flag is `true`.
-
-**Default**:
-
-- `false` for topics created using Redpanda 22.2 or earlier.
-- `true` for topics created in Redpanda 22.3 and later, including new topics on upgraded clusters.
-
-**Related topics**:
-
-- xref:manage:tiered-storage.adoc[Tiered Storage]
-
----
-
-=== Remote Read Replica properties
-
-Configure properties to manage topics for xref:manage:remote-read-replicas.adoc[Remote Read Replicas].
-
-=== redpanda.remote.readreplica
-
-The name of the object storage bucket for a Remote Read Replica topic.
-
-CAUTION: Setting `redpanda.remote.readreplica` together with either `redpanda.remote.read` or `redpanda.remote.write` results in an error.
-
-**Default**: null
-
-**Related topics**:
-
+- xref:manage:cluster-maintenance/disk-utilization.adoc#configure-segment-size[Configure segment size]
+- xref:manage:cluster-maintenance/disk-utilization.adoc#configure-message-retention[Configure message retention]
 - xref:manage:remote-read-replicas.adoc[Remote Read Replicas]
 
 ---
+[[segmentms]]
+==== segment.ms
 
-=== Apache Iceberg integration properties
+The maximum duration that a log segment of a topic is active (open for writes and not deletable). A periodic event, with `segment.ms` as its period, forcibly closes the active segment and transitions, or rolls, to a new active segment. The closed (inactive) segment is then eligible to be cleaned up according to cleanup and retention properties.
 
-Integrate Redpanda topics as Iceberg tables.
+If set to a positive duration, `segment.ms` overrides the cluster property xref:./cluster-properties.adoc#log_segment_ms[`log_segment_ms`] and its lower and upper bounds set by xref:./cluster-properties.adoc#log_segment_ms_min[`log_segment_ms_min`] and xref:./cluster-properties.adoc#log_segment_ms_max[`log_segment_ms_max`], respectively.
 
-=== redpanda.iceberg.mode
+*Type:* integer
 
-Enable the Iceberg integration for the topic. You can choose one of four modes.
-
-**Default**: `disabled`
-
-**Values**:
-
-- `key_value`: Creates an Iceberg table with a `Key` column and a `Value` column. Redpanda stores the raw topic content in the `Value` column.
-- `value_schema_id_prefix`: Creates an Iceberg table whose structure matches the Redpanda schema for the topic, with columns corresponding to each field. Redpanda uses the Schema Registry wire format, consisting of the "magic byte" and schema ID encoded in the payload header, to parse the topic values per field and store them in the corresponding table columns.
-- `value_schema_latest`: Creates an Iceberg table whose structure matches the latest schema version in Schema Registry that matches the subject name. This mode is compatible with Avro and Protobuf schemas and is used when you don't produce to the topic using the wire format. See xref:manage:iceberg/choose-iceberg-mode.adoc#override-value-schema-latest-default[Choose an Iceberg Mode] for details on using this mode.
-- `disabled`: Disables writing to an Iceberg table for the topic.
-
-**Related topics**:
-
-- xref:manage:iceberg/choose-iceberg-mode.adoc[]
-- xref:manage:iceberg/about-iceberg-topics.adoc[]
-
----
-
-=== redpanda.iceberg.delete
-
-Whether the corresponding Iceberg table is deleted upon deleting the topic.
-
-**Default**: `true`
-
-**Related topics**:
-
-- xref:manage:iceberg/about-iceberg-topics.adoc[]
-
----
-
-=== redpanda.iceberg.invalid.record.action
-
-Whether to write invalid records to a dead-letter queue (DLQ).
-
-**Default**: `dlq_table`
-
-**Values**:
-
-- `drop`: Disable the DLQ and drop invalid records.
-- `dlq_table`: Write invalid records to a separate DLQ Iceberg table.
-
-**Related topics**:
-
-- xref:manage:iceberg/about-iceberg-topics.adoc#troubleshoot-errors[Troubleshoot errors]
-
----
-
-=== redpanda.iceberg.partition.spec
-
-The https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] specification for the Iceberg table.
-
-**Default**: `(hour(redpanda.timestamp))`
-
-**Related topics**:
-
-- xref:manage:iceberg/about-iceberg-topics.adoc#use-custom-partitioning[Use custom partitioning]
-
----
-
-=== redpanda.iceberg.target.lag.ms
-
-Controls how often the data in the Iceberg table is refreshed with new data from the topic. Redpanda attempts to commit all data produced to the topic within the lag target, subject to resource availability.
-
-**Default**: `60000`
-
-**Related topics**:
-
-- xref:manage:iceberg/about-iceberg-topics.adoc[]
-
----
-
-=== Redpanda topic properties
-
-Configure Redpanda-specific topic properties.
-
----
-
-[[deleteretentionms]]
-=== delete.retention.ms
-
-The retention time for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
-
-If you have enabled Tiered Storage and set <<redpandaremoteread,`redpanda.remote.read`>> or <<redpandaremotewrite,`redpanda.remote.write`>> for the topic, you cannot enable tombstone removal. 
-
-If both `delete.retention.ms` and the cluster property config_ref:tombstone_retention_ms,true,properties/cluster-properties[] are set, `delete.retention.ms` overrides the cluster level tombstone retention for an individual topic.
-
-*Unit:* milliseconds
+*Accepted values:* [600000, 31536000000] milliseconds (clamped by cluster bounds)
 
 **Default**: null
 
+*Related cluster property:* xref:./cluster-properties.adoc#segment_ms[`segment_ms`]
+
 **Related topics**:
 
-- xref:manage:cluster-maintenance/compaction-settings.adoc#tombstone-record-removal[Tombstone record removal]
+- xref:manage:cluster-maintenance/disk-utilization.adoc#log-rolling[Log rolling]
 
 ---
+### Performance and Cluster Properties
 
+These properties control disk flushing, replication, and how topics interact with the cluster.
+
+[[flushbytes]]
+==== flush.bytes
+
+The maximum bytes not fsynced per partition. If this configured threshold is reached, the log is automatically fsynced, even though it wasn't explicitly requested.
+
+*Type:* integer
+
+*Accepted values:* [1, 9223372036854775807] bytes
+
+**Default**: `262144`
+
+*Related cluster property:* xref:./cluster-properties.adoc#flush_bytes[`flush_bytes`]
+
+**Related topics**:
+
+- xref:develop:produce-data/configure-producers.adoc[]
+
+---
+[[flushms]]
+==== flush.ms
+
+The maximum delay (in ms) between two subsequent fsyncs. After this delay, the log is automatically fsynced.
+
+*Type:* integer
+
+*Accepted values:* [1, 9223372036854775] milliseconds
+
+**Default**: `100`
+
+*Related cluster property:* xref:./cluster-properties.adoc#flush_ms[`flush_ms`]
+
+**Related topics**:
+
+- xref:develop:produce-data/configure-producers.adoc[]
+
+---
 [[redpandaleaderspreference]]
-=== redpanda.leaders.preference
+==== redpanda.leaders.preference
 
 The preferred location (rack) for partition leaders of a topic.
 
@@ -590,8 +429,8 @@ If the cluster configuration property config_ref:enable_rack_awareness,true,prop
 - xref:develop:produce-data/leader-pinning.adoc[Leader pinning]
 
 ---
-
-=== replication.factor
+[[replicationfactor]]
+==== replication.factor
 
 The number of replicas of a topic to save in different nodes (brokers) of a cluster.
 
@@ -599,7 +438,13 @@ If `replication.factor` is set to a positive value, it overrides the cluster pro
 
 NOTE: Although `replication.factor` isn't returned or displayed by xref:reference:rpk/rpk-topic/rpk-topic-describe.adoc[`rpk topic describe`] as a valid Kafka property, you can set it using xref:reference:rpk/rpk-topic/rpk-topic-alter-config.adoc[`rpk topic alter-config`]. When the `replication.factor` of a topic is altered, it isn't simply a property value that's updated, but rather the actual replica sets of topic partitions that are changed.
 
+*Type:* integer
+
+*Accepted values:* [`1`, `512`]
+
 **Default**: null
+
+*Related cluster property:* xref:./cluster-properties.adoc#default_topic_replication[`default_topic_replication`]
 
 **Related topics**:
 
@@ -607,11 +452,250 @@ NOTE: Although `replication.factor` isn't returned or displayed by xref:referenc
 - xref:develop:config-topics.adoc#change-the-replication-factor[Change the replication factor]
 
 ---
+[[writecaching]]
+==== write.caching
 
+The write caching mode to apply to a topic.
 
+When `write.caching` is set, it overrides the cluster property xref:cluster-properties.adoc#write_caching_default[`write_caching_default`]. Write caching acknowledges a message as soon as it is received and acknowledged on a majority of brokers, without waiting for it to be written to disk. With `acks=all`, this provides lower latency while still ensuring that a majority of brokers acknowledge the write. Fsyncs follow <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>, whichever is reached first.
 
-=== Related topics
+*Type:* boolean
 
-- xref:develop:produce-data/configure-producers.adoc[Configure Producers]
-- xref:develop:config-topics.adoc[Manage Topics]
+**Default**: `false`
 
+**Values**:
+
+- `true` - Enables write caching for a topic, according to <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>.
+- `false` - Disables write caching for a topic, according to <<flushms, `flush.ms`>> and <<flushbytes, `flush.bytes`>>.
+
+*Related cluster property:* xref:./cluster-properties.adoc#write_caching_default[`write_caching_default`]
+
+**Related topics**:
+
+- xref:develop:config-topics.adoc#configure-write-caching[Write caching]
+
+---
+### Tiered Storage properties
+
+Configure properties to manage topics for xref:manage:tiered-storage.adoc[Tiered Storage].
+
+[[initialretentionlocaltargetbytes]]
+==== initial.retention.local.target.bytes
+
+A size-based initial retention limit for Tiered Storage that determines how much data in local storage is transferred to a partition replica when a cluster is resized. If `null` (default), all locally retained data is transferred.
+
+*Type:* integer
+
+*Accepted values:* [1, 9223372036854775807] bytes
+
+**Default**: null
+
+*Related cluster property:* xref:./cluster-properties.adoc#initial_retention_local_target_bytes[`initial_retention_local_target_bytes`]
+
+**Related topics**:
+
+- xref:manage:tiered-storage.adoc#fast-commission-and-decommission[Fast commission and decommission through Tiered Storage]
+
+---
+[[initialretentionlocaltargetms]]
+==== initial.retention.local.target.ms
+
+A time-based initial retention limit for Tiered Storage that determines how much data in local storage is transferred to a partition replica when a cluster is resized. If `null` (default), all locally retained data is transferred.
+
+*Type:* integer
+
+*Accepted values:* [1, 9223372036854775] milliseconds
+
+**Default**: null
+
+*Related cluster property:* xref:./cluster-properties.adoc#initial_retention_local_target_ms[`initial_retention_local_target_ms`]
+
+**Related topics**:
+
+- xref:manage:tiered-storage.adoc#fast-commission-and-decommission[Fast commission and decommission through Tiered Storage]
+
+---
+[[redpandaremotedelete]]
+==== redpanda.remote.delete
+
+A flag that enables deletion of data from object storage for Tiered Storage when it's deleted from local storage for a topic.
+
+NOTE: `redpanda.remote.delete` doesn't apply to Remote Read Replica topics: a Remote Read Replica topic isn't deleted from object storage when this flag is `true`.
+
+**Default**:
+
+- `false` for topics created using Redpanda 22.2 or earlier.
+- `true` for topics created in Redpanda 22.3 and later, including new topics on upgraded clusters.
+
+**Related topics**:
+
+- xref:manage:tiered-storage.adoc[Tiered Storage]
+
+---
+[[redpandaremoteread]]
+==== redpanda.remote.read
+
+A flag for enabling Redpanda to fetch data for a topic from object storage to local storage. When set to `true` together with <<redpandaremotewrite, `redpanda.remote.write`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
+
+**Default**: false
+
+**Related topics**:
+
+- xref:manage:tiered-storage.adoc[Tiered Storage]
+
+---
+[[redpandaremoterecovery]]
+==== redpanda.remote.recovery
+
+A flag that enables the recovery or reproduction of a topic from object storage for Tiered Storage. The recovered data is saved in local storage, and the maximum amount of recovered data is determined by the local storage retention limits of the topic.
+
+TIP: You can only configure `redpanda.remote.recovery` when you create a topic. You cannot apply this setting to existing topics.
+
+**Default**: false
+
+**Related topics**:
+
+- xref:manage:tiered-storage.adoc[Tiered Storage]
+
+---
+[[redpandaremotewrite]]
+==== redpanda.remote.write
+
+A flag for enabling Redpanda to upload data for a topic from local storage to object storage. When set to `true` together with <<redpandaremoteread, `redpanda.remote.read`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
+
+**Default**: false
+
+**Related topics**:
+
+- xref:manage:tiered-storage.adoc[Tiered Storage]
+
+---
+[[retentionlocaltargetbytes]]
+==== retention.local.target.bytes
+
+A size-based retention limit for Tiered Storage that configures the maximum size that a topic partition in local storage can grow before becoming eligible for cleanup. It applies per partition and is equivalent to <<retentionbytes, `retention.bytes`>> without Tiered Storage.
+
+*Type:* integer
+
+*Accepted values:* [1, 9223372036854775807] bytes
+
+**Default**: null
+
+*Related cluster property:* xref:./cluster-properties.adoc#retention_local_target_bytes[`retention_local_target_bytes`]
+
+**Related topics**:
+
+- xref:manage:tiered-storage.adoc[Tiered Storage]
+
+---
+[[retentionlocaltargetms]]
+==== retention.local.target.ms
+
+A time-based retention limit for Tiered Storage that sets the maximum duration that a log's segment file for a topic is retained in local storage before it's eligible for cleanup. This property is equivalent to <<retentionms, `retention.ms`>> without Tiered Storage.
+
+*Type:* integer
+
+*Accepted values:* [1, 9223372036854775] milliseconds
+
+**Default**: 86400000
+
+*Related cluster property:* xref:./cluster-properties.adoc#retention_local_target_ms[`retention_local_target_ms`]
+
+**Related topics**:
+
+- xref:manage:tiered-storage.adoc[Tiered Storage]
+
+---
+### Remote Read Replica properties
+
+Configure properties to manage topics for xref:manage:remote-read-replicas.adoc[Remote Read Replicas].
+
+[[redpandaremotereadreplica]]
+==== redpanda.remote.readreplica
+
+The name of the object storage bucket for a Remote Read Replica topic.
+
+CAUTION: Setting `redpanda.remote.readreplica` together with either `redpanda.remote.read` or `redpanda.remote.write` results in an error.
+
+**Default**: null
+
+**Related topics**:
+
+- xref:manage:remote-read-replicas.adoc[Remote Read Replicas]
+
+---
+### Apache Iceberg integration properties
+
+Integrate Redpanda topics as Iceberg tables.
+
+[[redpandaicebergdelete]]
+==== redpanda.iceberg.delete
+
+Whether the corresponding Iceberg table is deleted upon deleting the topic.
+
+**Default**: `true`
+
+**Related topics**:
+
+- xref:manage:iceberg/about-iceberg-topics.adoc[]
+
+---
+[[redpandaiceberginvalidrecordaction]]
+==== redpanda.iceberg.invalid.record.action
+
+Whether to write invalid records to a dead-letter queue (DLQ).
+
+**Default**: `dlq_table`
+
+**Values**:
+
+- `drop`: Disable the DLQ and drop invalid records.
+- `dlq_table`: Write invalid records to a separate DLQ Iceberg table.
+
+**Related topics**:
+
+- xref:manage:iceberg/about-iceberg-topics.adoc#troubleshoot-errors[Troubleshoot errors]
+
+---
+[[redpandaicebergmode]]
+==== redpanda.iceberg.mode
+
+Enable the Iceberg integration for the topic. You can choose one of four modes.
+
+**Default**: `disabled`
+
+**Values**:
+
+- `key_value`: Creates an Iceberg table with a `Key` column and a `Value` column. Redpanda stores the raw topic content in the `Value` column.
+- `value_schema_id_prefix`: Creates an Iceberg table whose structure matches the Redpanda schema for the topic, with columns corresponding to each field. Redpanda uses the Schema Registry wire format, consisting of the "magic byte" and schema ID encoded in the payload header, to parse the topic values per field and store them in the corresponding table columns.
+- `value_schema_latest`: Creates an Iceberg table whose structure matches the latest schema version in Schema Registry that matches the subject name. This mode is compatible with Avro and Protobuf schemas and is used when you don't produce to the topic using the wire format. See xref:manage:iceberg/choose-iceberg-mode.adoc#override-value-schema-latest-default[Choose an Iceberg Mode] for details on using this mode.
+- `disabled`: Disables writing to an Iceberg table for the topic.
+
+**Related topics**:
+
+- xref:manage:iceberg/choose-iceberg-mode.adoc[]
+- xref:manage:iceberg/about-iceberg-topics.adoc[]
+
+---
+[[redpandaicebergpartitionspec]]
+==== redpanda.iceberg.partition.spec
+
+The [https://iceberg.apache.org/docs/nightly/partitioning/](https://iceberg.apache.org/docs/nightly/partitioning/)[partitioning^] specification for the Iceberg table.
+
+**Default**: `(hour(redpanda.timestamp))`
+
+**Related topics**:
+
+- xref:manage:iceberg/about-iceberg-topics.adoc#use-custom-partitioning[Use custom partitioning]
+
+---
+[[redpandaicebergtargetlagms]]
+==== redpanda.iceberg.target.lag.ms
+
+Controls how often the data in the Iceberg table is refreshed with new data from the topic. Redpanda attempts to commit all data produced to the topic within the lag target, subject to resource availability.
+
+**Default**: `60000`
+
+**Related topics**:
+
+- xref:manage:iceberg/about-iceberg-topics.adoc[]

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -25,8 +25,7 @@ NOTE: All topic properties take effect immediately after being set.
 | xref:./cluster-properties.adoc#log_compression_type[`log_compression_type`]
 
 | <<deleteretentionms,`delete.retention.ms`>>
-| xref:./cluster-properties.adoc#delete_retention_ms[`delete_retention_ms`]
-
+| xref:./cluster-properties.adoc#tombstone_retention_ms[`tombstone_retention_ms`]
 | <<flushbytes,`flush.bytes`>>
 | xref:./cluster-properties.adoc#flush_bytes[`flush_bytes`]
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -289,7 +289,7 @@ NOTE: The valid values of `compression.type` are taken from `log_compression_typ
 
 The maximum size of a message or batch of a topic. If a compression type is enabled, `max.message.bytes` sets the maximum size of the compressed message or batch.
 
-If `max.message.bytes` is set to a positive value, it overrides the cluster property xref:reference:properties/cluster-properties.adoc#kafka_batch_max_bytes[`kafka_batch_max_bytes`] for the topic.
+If `max.message.bytes` is set to a positive value, it overrides the cluster property xref:./cluster-properties.adoc#kafka_batch_max_bytes[`kafka_batch_max_bytes`] for the topic.
 
 *Type:* integer
 
@@ -330,7 +330,7 @@ When `message.timestamp.type` is set, it overrides the cluster property xref:./c
 
 The maximum size of an active log segment for a topic. When the size of an active segment exceeds `segment.bytes`, the segment is closed and a new active segment is created. The closed, inactive segment is then eligible to be cleaned up according to retention properties.
 
-When `segment.bytes` is set to a positive value, it overrides the cluster property xref:reference:properties/cluster-properties.adoc#log_segment_size[`log_segment_size`] for the topic.
+When `segment.bytes` is set to a positive value, it overrides the cluster property xref:./cluster-properties.adoc#log_segment_size[`log_segment_size`] for the topic.
 
 *Type:* integer
 
@@ -447,7 +447,7 @@ NOTE: Although `replication.factor` isn't returned or displayed by xref:referenc
 
 **Related topics**:
 
-- xref:develop:config-topics.adoc#choose-the-replication-factor.adoc[Choose the replication factor]
+- xref:develop:config-topics.adoc#choose-the-replication-factor[Choose the replication factor]
 - xref:develop:config-topics.adoc#change-the-replication-factor[Change the replication factor]
 
 ---

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -8,7 +8,7 @@ Many topic-level properties have corresponding xref:manage:cluster-maintenance/c
 
 For information on how to configure topic properties, see xref:manage:cluster-maintenance/topic-property-configuration.adoc[].
 
-NOTE: All topic properties take effect immediately after being set.
+include::develop:partial$topic-properties-warning.adoc[]
 
 == Topic property mappings
 
@@ -90,8 +90,6 @@ These properties control how data is stored, for how long, and when it is delete
 The cleanup policy to apply for log segments of a topic.
 
 When `cleanup.policy` is set, it overrides the cluster property xref:cluster-properties.adoc#log_cleanup_policy[`log_cleanup_policy`] for the topic.
-
-include::develop:partial$topic-properties-warning.adoc[]
 
 *Type:* string
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -79,17 +79,13 @@ NOTE: All topic properties take effect immediately after being set.
 
 |===
 
-== Topic properties
-
-Properties are grouped by feature area. Within each group, properties are listed in alphabetical order.
-
 ---
-=== Retention and Compaction Properties
+== Retention and Compaction Properties
 
 These properties control how data is stored, for how long, and when it is deleted or compacted.
 
 [[cleanuppolicy]]
-==== cleanup.policy
+=== cleanup.policy
 
 The cleanup policy to apply for log segments of a topic.
 
@@ -118,7 +114,7 @@ include::develop:partial$topic-properties-warning.adoc[]
 
 ---
 [[compactionstrategy]]
-==== compaction.strategy
+=== compaction.strategy
 
 Specifies the strategy used to determine which records to remove during log compaction. The compaction strategy controls how Redpanda identifies and removes duplicate records while preserving the latest value for each key.
 
@@ -134,7 +130,7 @@ Specifies the strategy used to determine which records to remove during log comp
 
 ---
 [[deleteretentionms]]
-==== delete.retention.ms
+=== delete.retention.ms
 
 The retention time for tombstone records in a compacted topic. Redpanda removes tombstone records after the retention limit is exceeded.
 
@@ -158,7 +154,7 @@ If both `delete.retention.ms` and the cluster property config_ref:tombstone_rete
 
 ---
 [[maxcompactionlagms]]
-==== max.compaction.lag.ms
+=== max.compaction.lag.ms
 
 The maximum amount of time (in ms) that a log segment can remain unaltered before it is eligible for compaction in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`] for the topic.
 
@@ -168,7 +164,7 @@ The maximum amount of time (in ms) that a log segment can remain unaltered befor
 
 *Accepted values:* [`1`, `9223372036854775`]
 
-**Default:* `9223372036854775`
+*Default:* `9223372036854775`
 
 *Related cluster property:* xref:./cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`]
 
@@ -178,7 +174,7 @@ The maximum amount of time (in ms) that a log segment can remain unaltered befor
 
 ---
 [[mincleanabledirtyratio]]
-==== min.cleanable.dirty.ratio
+=== min.cleanable.dirty.ratio
 
 The minimum ratio between the number of bytes in dirty segments and the total number of bytes in closed segments that must be reached before a partition's log is eligible for compaction in a compact topic.
 
@@ -196,7 +192,7 @@ The minimum ratio between the number of bytes in dirty segments and the total nu
 
 ---
 [[mincompactionlagms]]
-==== min.compaction.lag.ms
+=== min.compaction.lag.ms
 
 The minimum amount of time (in ms) that a log segment must remain unaltered before it can be compacted in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`] for the topic.
 
@@ -206,7 +202,7 @@ The minimum amount of time (in ms) that a log segment must remain unaltered befo
 
 *Accepted values:* [`0`, `9223372036854775`]
 
-**Default:* `0`
+*Default:* `0`
 
 *Related cluster property:* xref:./cluster-properties.adoc#min_compaction_lag_ms[`min_compaction_lag_ms`]
 
@@ -216,7 +212,7 @@ The minimum amount of time (in ms) that a log segment must remain unaltered befo
 
 ---
 [[retentionbytes]]
-==== retention.bytes
+=== retention.bytes
 
 A size-based retention limit that configures the maximum size that a topic partition can grow before becoming eligible for cleanup.
 
@@ -240,7 +236,7 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 
 ---
 [[retentionms]]
-==== retention.ms
+=== retention.ms
 
 A time-based retention limit that configures the maximum duration that a log's segment file for a topic is retained before it becomes eligible to be cleaned up. To consume all data, a consumer of the topic must read from a segment before its `retention.ms` elapses, otherwise the segment may be compacted and/or deleted. If a non-positive value, no per-topic limit is applied.
 
@@ -263,12 +259,12 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 - xref:manage:cluster-maintenance/disk-utilization.adoc#configure-message-retention[Configure message retention]
 
 ---
-### Segment and Message Properties
+== Segment and Message Properties
 
 These properties control the size and lifecycle of log segment files and settings for individual messages.
 
 [[compressiontype]]
-==== compression.type
+=== compression.type
 
 Redpanda ignores this property and always uses producer compression semantics. If producers send compressed data, Redpanda stores and serves it as-is. If producers send uncompressed data, Redpanda stores it uncompressed.
 
@@ -293,7 +289,7 @@ When set, this property overrides the cluster property xref:./cluster-properties
 
 ---
 [[maxmessagebytes]]
-==== max.message.bytes
+=== max.message.bytes
 
 The maximum size of a message or batch of a topic. If a compression type is enabled, `max.message.bytes` sets the maximum size of the compressed message or batch.
 
@@ -315,7 +311,7 @@ If `max.message.bytes` is set to a positive value, it overrides the cluster prop
 
 ---
 [[messagetimestamptype]]
-==== message.timestamp.type
+=== message.timestamp.type
 
 The source of a message's timestamp: either the message's creation time or its log append time.
 
@@ -336,7 +332,7 @@ When `message.timestamp.type` is set, it overrides the cluster property xref:./c
 
 ---
 [[segmentbytes]]
-==== segment.bytes
+=== segment.bytes
 
 The maximum size of an active log segment for a topic. When the size of an active segment exceeds `segment.bytes`, the segment is closed and a new active segment is created. The closed, inactive segment is then eligible to be cleaned up according to retention properties.
 
@@ -360,7 +356,7 @@ When `segment.bytes` is set to a positive value, it overrides the cluster proper
 
 ---
 [[segmentms]]
-==== segment.ms
+=== segment.ms
 
 The maximum duration that a log segment of a topic is active (open for writes and not deletable). A periodic event, with `segment.ms` as its period, forcibly closes the active segment and transitions, or rolls, to a new active segment. The closed (inactive) segment is then eligible to be cleaned up according to cleanup and retention properties.
 
@@ -381,12 +377,12 @@ If set to a positive duration, `segment.ms` overrides the cluster property xref:
 - xref:manage:cluster-maintenance/disk-utilization.adoc#log-rolling[Log rolling]
 
 ---
-### Performance and Cluster Properties
+== Performance and Cluster Properties
 
 These properties control disk flushing, replication, and how topics interact with the cluster.
 
 [[flushbytes]]
-==== flush.bytes
+=== flush.bytes
 
 The maximum bytes not fsynced per partition. If this configured threshold is reached, the log is automatically fsynced, even though it wasn't explicitly requested.
 
@@ -406,7 +402,7 @@ The maximum bytes not fsynced per partition. If this configured threshold is rea
 
 ---
 [[flushms]]
-==== flush.ms
+=== flush.ms
 
 The maximum delay (in ms) between two subsequent fsyncs. After this delay, the log is automatically fsynced.
 
@@ -426,7 +422,7 @@ The maximum delay (in ms) between two subsequent fsyncs. After this delay, the l
 
 ---
 [[redpandaleaderspreference]]
-==== redpanda.leaders.preference
+=== redpanda.leaders.preference
 
 The preferred location (rack) for partition leaders of a topic.
 
@@ -449,7 +445,7 @@ If the cluster configuration property config_ref:enable_rack_awareness,true,prop
 
 ---
 [[replicationfactor]]
-==== replication.factor
+=== replication.factor
 
 The number of replicas of a topic to save in different nodes (brokers) of a cluster.
 
@@ -472,7 +468,7 @@ NOTE: Although `replication.factor` isn't returned or displayed by xref:referenc
 
 ---
 [[writecaching]]
-==== write.caching
+=== write.caching
 
 The write caching mode to apply to a topic.
 
@@ -494,12 +490,12 @@ When `write.caching` is set, it overrides the cluster property xref:cluster-prop
 - xref:develop:config-topics.adoc#configure-write-caching[Write caching]
 
 ---
-### Tiered Storage properties
+== Tiered Storage properties
 
 Configure properties to manage topics for xref:manage:tiered-storage.adoc[Tiered Storage].
 
 [[initialretentionlocaltargetbytes]]
-==== initial.retention.local.target.bytes
+=== initial.retention.local.target.bytes
 
 A size-based initial retention limit for Tiered Storage that determines how much data in local storage is transferred to a partition replica when a cluster is resized. If `null` (default), all locally retained data is transferred.
 
@@ -519,7 +515,7 @@ A size-based initial retention limit for Tiered Storage that determines how much
 
 ---
 [[initialretentionlocaltargetms]]
-==== initial.retention.local.target.ms
+=== initial.retention.local.target.ms
 
 A time-based initial retention limit for Tiered Storage that determines how much data in local storage is transferred to a partition replica when a cluster is resized. If `null` (default), all locally retained data is transferred.
 
@@ -539,7 +535,7 @@ A time-based initial retention limit for Tiered Storage that determines how much
 
 ---
 [[redpandaremotedelete]]
-==== redpanda.remote.delete
+=== redpanda.remote.delete
 
 A flag that enables deletion of data from object storage for Tiered Storage when it's deleted from local storage for a topic.
 
@@ -558,7 +554,7 @@ NOTE: `redpanda.remote.delete` doesn't apply to Remote Read Replica topics: a Re
 
 ---
 [[redpandaremoteread]]
-==== redpanda.remote.read
+=== redpanda.remote.read
 
 A flag for enabling Redpanda to fetch data for a topic from object storage to local storage. When set to `true` together with <<redpandaremotewrite, `redpanda.remote.write`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
 
@@ -572,7 +568,7 @@ A flag for enabling Redpanda to fetch data for a topic from object storage to lo
 
 ---
 [[redpandaremoterecovery]]
-==== redpanda.remote.recovery
+=== redpanda.remote.recovery
 
 A flag that enables the recovery or reproduction of a topic from object storage for Tiered Storage. The recovered data is saved in local storage, and the maximum amount of recovered data is determined by the local storage retention limits of the topic.
 
@@ -588,7 +584,7 @@ TIP: You can only configure `redpanda.remote.recovery` when you create a topic. 
 
 ---
 [[redpandaremotewrite]]
-==== redpanda.remote.write
+=== redpanda.remote.write
 
 A flag for enabling Redpanda to upload data for a topic from local storage to object storage. When set to `true` together with <<redpandaremoteread, `redpanda.remote.read`>>, it enables the xref:manage:tiered-storage.adoc[Tiered Storage] feature.
 
@@ -602,7 +598,7 @@ A flag for enabling Redpanda to upload data for a topic from local storage to ob
 
 ---
 [[retentionlocaltargetbytes]]
-==== retention.local.target.bytes
+=== retention.local.target.bytes
 
 A size-based retention limit for Tiered Storage that configures the maximum size that a topic partition in local storage can grow before becoming eligible for cleanup. It applies per partition and is equivalent to <<retentionbytes, `retention.bytes`>> without Tiered Storage.
 
@@ -622,7 +618,7 @@ A size-based retention limit for Tiered Storage that configures the maximum size
 
 ---
 [[retentionlocaltargetms]]
-==== retention.local.target.ms
+=== retention.local.target.ms
 
 A time-based retention limit for Tiered Storage that sets the maximum duration that a log's segment file for a topic is retained in local storage before it's eligible for cleanup. This property is equivalent to <<retentionms, `retention.ms`>> without Tiered Storage.
 
@@ -641,12 +637,12 @@ A time-based retention limit for Tiered Storage that sets the maximum duration t
 - xref:manage:tiered-storage.adoc[Tiered Storage]
 
 ---
-### Remote Read Replica properties
+== Remote Read Replica properties
 
 Configure properties to manage topics for xref:manage:remote-read-replicas.adoc[Remote Read Replicas].
 
 [[redpandaremotereadreplica]]
-==== redpanda.remote.readreplica
+=== redpanda.remote.readreplica
 
 The name of the object storage bucket for a Remote Read Replica topic.
 
@@ -661,12 +657,12 @@ CAUTION: Setting `redpanda.remote.readreplica` together with either `redpanda.re
 - xref:manage:remote-read-replicas.adoc[Remote Read Replicas]
 
 ---
-### Apache Iceberg integration properties
+== Apache Iceberg integration properties
 
 Integrate Redpanda topics as Iceberg tables.
 
 [[redpandaicebergdelete]]
-==== redpanda.iceberg.delete
+=== redpanda.iceberg.delete
 
 Whether the corresponding Iceberg table is deleted upon deleting the topic.
 
@@ -680,7 +676,7 @@ Whether the corresponding Iceberg table is deleted upon deleting the topic.
 
 ---
 [[redpandaiceberginvalidrecordaction]]
-==== redpanda.iceberg.invalid.record.action
+=== redpanda.iceberg.invalid.record.action
 
 Whether to write invalid records to a dead-letter queue (DLQ).
 
@@ -699,7 +695,7 @@ Whether to write invalid records to a dead-letter queue (DLQ).
 
 ---
 [[redpandaicebergmode]]
-==== redpanda.iceberg.mode
+=== redpanda.iceberg.mode
 
 Enable the Iceberg integration for the topic. You can choose one of four modes.
 
@@ -721,7 +717,7 @@ Enable the Iceberg integration for the topic. You can choose one of four modes.
 
 ---
 [[redpandaicebergpartitionspec]]
-==== redpanda.iceberg.partition.spec
+=== redpanda.iceberg.partition.spec
 
 The link:https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] specification for the Iceberg table.
 
@@ -735,7 +731,7 @@ The link:https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] sp
 
 ---
 [[redpandaicebergtargetlagms]]
-==== redpanda.iceberg.target.lag.ms
+=== redpanda.iceberg.target.lag.ms
 
 Controls how often the data in the Iceberg table is refreshed with new data from the topic. Redpanda attempts to commit all data produced to the topic within the lag target, subject to resource availability.
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -679,7 +679,7 @@ Enable the Iceberg integration for the topic. You can choose one of four modes.
 [[redpandaicebergpartitionspec]]
 ==== redpanda.iceberg.partition.spec
 
-The [https://iceberg.apache.org/docs/nightly/partitioning/](https://iceberg.apache.org/docs/nightly/partitioning/)[partitioning^] specification for the Iceberg table.
+The link:https://iceberg.apache.org/docs/nightly/partitioning/[partitioning^] specification for the Iceberg table.
 
 **Default**: `(hour(redpanda.timestamp))`
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -66,16 +66,16 @@ NOTE: All topic properties take effect immediately after being set.
 | xref:./cluster-properties.adoc#retention_local_target_ms[`retention_local_target_ms`]
 
 | <<retentionms,`retention.ms`>>
-| xref:./cluster-properties.adoc#retention_ms[`retention_ms`]
+| xref:./cluster-properties.adoc#log_retention_ms[`log_retention_ms`]
 
 | <<segmentbytes,`segment.bytes`>>
 | xref:./cluster-properties.adoc#log_segment_size[`log_segment_size`]
 
 | <<segmentms,`segment.ms`>>
-| xref:./cluster-properties.adoc#segment_ms[`segment_ms`]
+| xref:./cluster-properties.adoc#log_segment_ms[`log_segment_ms`]
 
 | <<writecaching,`write.caching`>>
-| xref:./cluster-properties.adoc#write_caching[`write_caching`]
+| xref:./cluster-properties.adoc#write_caching_default[`write_caching_default`]
 
 |===
 
@@ -360,7 +360,7 @@ If set to a positive duration, `segment.ms` overrides the cluster property xref:
 
 **Default**: null
 
-*Related cluster property:* xref:./cluster-properties.adoc#segment_ms[`segment_ms`]
+*Related cluster property:* xref:./cluster-properties.adoc#log_segment_ms[`log_segment_ms`]
 
 **Related topics**:
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -144,7 +144,9 @@ If both `delete.retention.ms` and the cluster property config_ref:tombstone_rete
 
 *Type:* integer
 
-*Accepted values:* [`1`, `9223372036854775`] milliseconds
+*Unit:* milliseconds
+
+*Accepted values:* [`1`, `9223372036854775`]
 
 *Default:* null
 
@@ -161,6 +163,8 @@ If both `delete.retention.ms` and the cluster property config_ref:tombstone_rete
 The maximum amount of time (in ms) that a log segment can remain unaltered before it is eligible for compaction in a compact topic. Overrides the cluster property xref:cluster-properties.adoc#max_compaction_lag_ms[`max_compaction_lag_ms`] for the topic.
 
 *Type:* integer
+
+*Unit:* milliseconds
 
 *Accepted values:* [`1`, `9223372036854775`]
 
@@ -198,6 +202,8 @@ The minimum amount of time (in ms) that a log segment must remain unaltered befo
 
 *Type:* integer
 
+*Unit:* milliseconds
+
 *Accepted values:* [`0`, `9223372036854775`]
 
 **Default:* `0`
@@ -220,7 +226,9 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 
 *Type:* integer
 
-*Accepted values:* [`1`, `9223372036854775807`] bytes
+*Unit:* bytes
+
+*Accepted values:* [`1`, `9223372036854775807`]
 
 *Default:* null
 
@@ -242,7 +250,9 @@ When both size-based (`retention.bytes`) and time-based (`retention.ms`) retenti
 
 *Type:* integer
 
-*Accepted values:* [`-9223372036854775808`, `9223372036854775807`] milliseconds
+*Unit:* milliseconds
+
+*Accepted values:* [`-9223372036854775808`, `9223372036854775807`]
 
 *Default:* null
 
@@ -291,7 +301,9 @@ If `max.message.bytes` is set to a positive value, it overrides the cluster prop
 
 *Type:* integer
 
-*Accepted values:* [`1`, `2147483647`] bytes
+*Unit:* bytes
+
+*Accepted values:* [`1`, `2147483647`]
 
 *Default:* null
 
@@ -332,7 +344,9 @@ When `segment.bytes` is set to a positive value, it overrides the cluster proper
 
 *Type:* integer
 
-*Accepted values:* [`1`, `9223372036854775807`] bytes
+*Unit:* bytes
+
+*Accepted values:* [`1`, `9223372036854775807`]
 
 *Default:* null
 
@@ -354,7 +368,9 @@ If set to a positive duration, `segment.ms` overrides the cluster property xref:
 
 *Type:* integer
 
-*Accepted values:* [`600000`, `31536000000`] milliseconds (clamped by cluster bounds)
+*Unit:* milliseconds
+
+*Accepted values:* [`600000`, `31536000000`]
 
 *Default:* null
 
@@ -376,7 +392,9 @@ The maximum bytes not fsynced per partition. If this configured threshold is rea
 
 *Type:* integer
 
-*Accepted values:* [`1`, `9223372036854775807`] bytes
+*Unit:* bytes
+
+*Accepted values:* [`1`, `9223372036854775807`]
 
 *Default:* `262144`
 
@@ -394,7 +412,9 @@ The maximum delay (in ms) between two subsequent fsyncs. After this delay, the l
 
 *Type:* integer
 
-*Accepted values:* [`1`, `9223372036854775`] milliseconds
+*Unit:* milliseconds
+
+*Accepted values:* [`1`, `9223372036854775`]
 
 *Default:* `100`
 
@@ -485,7 +505,9 @@ A size-based initial retention limit for Tiered Storage that determines how much
 
 *Type:* integer
 
-*Accepted values:* [`1`, `9223372036854775807`] bytes
+*Unit:* bytes
+
+*Accepted values:* [`1`, `9223372036854775807`]
 
 *Default:* null
 
@@ -503,7 +525,9 @@ A time-based initial retention limit for Tiered Storage that determines how much
 
 *Type:* integer
 
-*Accepted values:* [`1`, `9223372036854775`] milliseconds
+*Unit:* milliseconds
+
+*Accepted values:* [`1`, `9223372036854775`]
 
 *Default:* null
 
@@ -584,7 +608,9 @@ A size-based retention limit for Tiered Storage that configures the maximum size
 
 *Type:* integer
 
-*Accepted values:* [`1`, `9223372036854775807`] bytes
+*Unit:* bytes
+
+*Accepted values:* [`1`, `9223372036854775807`]
 
 *Default:* null
 
@@ -602,7 +628,9 @@ A time-based retention limit for Tiered Storage that sets the maximum duration t
 
 *Type:* integer
 
-*Accepted values:* [`1`, `9223372036854775`] milliseconds
+*Unit:* milliseconds
+
+*Accepted values:* [`1`, `9223372036854775`]
 
 *Default:* 86400000
 


### PR DESCRIPTION
## Description

Heavily reorganize the topic properties documentation.
Split reference to action.
Increase guidelines on the action. 
Reorganize reference, adding new groups, adding background information, evaluating types, defaults and acceptable ranges.
Introduce new topic properties:

```
compaction.strategy
redpanda.iceberg.delete
redpanda.iceberg.invalid.record.action
redpanda.iceberg.mode
redpanda.iceberg.partition.spec
redpanda.iceberg.target.lag.ms
redpanda.leaders.preference
redpanda.remote.delete
redpanda.remote.readreplica
redpanda.remote.recovery
replication.factor
```

Related new automation 
https://github.com/redpanda-data/docs-extensions-and-macros/pull/126


Resolves https://redpandadata.atlassian.net/browse/DOC-145
Review deadline: Sept 1st 2025

## Page previews

[Topic property reference](https://deploy-preview-1337--redpanda-docs-preview.netlify.app/current/reference/properties/topic-properties/)

[Topic property configuration](https://deploy-preview-1337--redpanda-docs-preview.netlify.app/current/manage/cluster-maintenance/topic-property-configuration/)

## Diff checker
Github can be incovenient for this PR, as the liner numbers have diverged greatly. If you want to compare this version with previous, check latest content on main https://raw.githubusercontent.com/redpanda-data/docs/refs/heads/main/modules/reference/pages/properties/topic-properties.adoc

## Checks

- [x] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
