### PR TITLE
DOC-1485: Fix doc reference to configurable audit log retention

### DIFF
--- a/modules/manage/partials/audit-logging.adoc
+++ b/modules/manage/partials/audit-logging.adoc
@@ -397,15 +397,17 @@ ifdef::env-cloud[]
 
 == Configure retention for audit logs
 
-Ideally, you export audit events to your own SIEM for persistence supporting your audit and compliance needs rather than relying on in-cluster persistence.
+You can export audit events to your SIEM for long-term retention to support audit and compliance needs. Redpanda Data recommends that you retain audit logs for at least one year in a separate system like your SIEM, so if there is an issue with the Redpanda cluster you have access to the audit logs.
 
-As you assess the retention needs for your audit logs, if you find that you do not need to keep them for the default seven days, and you must revise the retention period:
+If you need to change the default seven-day retention period, update the retention settings using the `retention.ms` property for the `_redpanda.audit_log` topic:
 
-NOTE: Redpanda Data recommends that you retain audit logs for at least one year.
+[,bash]
+----
+# Set 1-year retention (in milliseconds) on the audit log topic
+rpk topic alter-config _redpanda.audit_log --set retention.ms=31536000000
+----
 
-. Remove `_redpanda.audit_log` topic from the `no_delete` topics list in your cluster configuration.
-. Update the `retention.ms` property for the `_redpanda.audit_log` topic.
-. Add the `_redpanda.audit_log` topic back to the `delete` topics list.
+NOTE: In Redpanda Cloud, both `retention.ms` (time-based) and `retention.bytes` (size-based) retention policies are applied simultaneously. Data becomes eligible for deletion when either limit is reached, depending on whichever occurs first. This means neither setting strictly takes precedence; the earliest limit (by time or size) triggers data cleanup. When updating audit log retention, check to make sure you do not already have a sized-based retention policy setting that might remove logs before the period you specify.
 
 == Next steps
 

--- a/modules/manage/partials/audit-logging.adoc
+++ b/modules/manage/partials/audit-logging.adoc
@@ -397,7 +397,15 @@ ifdef::env-cloud[]
 
 == Configure retention for audit logs
 
-Assess the retention needs for your audit logs. You may not need to keep the logs for the default seven days. This is controlled by setting the `retention.ms` property for the `_redpanda.audit_log` topic.
+Ideally, you export audit events to your own SIEM for persistence supporting your audit and compliance needs rather than relying on in-cluster persistence.
+
+As you assess the retention needs for your audit logs, if you find that you do not need to keep them for the default seven days, and you must revise the retention period:
+
+NOTE: Redpanda Data recommends that you retain audit logs for at least one year.
+
+. Remove `_redpanda.audit_log` topic from the `no_delete` topics list in your cluster configuration.
+. Update the `retention.ms` property for the `_redpanda.audit_log` topic.
+. Add the `_redpanda.audit_log` topic back to the `delete` topics list.
 
 == Next steps
 

--- a/modules/manage/partials/audit-logging.adoc
+++ b/modules/manage/partials/audit-logging.adoc
@@ -407,7 +407,7 @@ If you need to change the default seven-day retention period, update the retenti
 rpk topic alter-config _redpanda.audit_log --set retention.ms=31536000000
 ----
 
-NOTE: In Redpanda Cloud, both `retention.ms` (time-based) and `retention.bytes` (size-based) retention policies are applied simultaneously. Data becomes eligible for deletion when either limit is reached, depending on whichever occurs first. This means neither setting strictly takes precedence; the earliest limit (by time or size) triggers data cleanup. When updating audit log retention, check to make sure you do not already have a sized-based retention policy setting that might remove logs before the period you specify.
+NOTE: In Redpanda Cloud, both `retention.ms` (time-based) and `retention.bytes` (size-based) retention policies are applied simultaneously. Data becomes eligible for deletion when either limit is reached, depending on whichever occurs first. This means neither setting strictly takes precedence; the earliest limit (by time or size) triggers data cleanup. When updating audit log retention, check to make sure you do not already have a size-based retention policy that might remove logs before the period you specify.
 
 == Next steps
 


### PR DESCRIPTION
## Description

SMEs: Include in self-managed too?

Resolves https://redpandadata.atlassian.net/browse/DOC-1485
Review deadline:

## Page previews

[Configure retention for audit logs](https://github.com/redpanda-data/docs/pull/1338)
Cloud doc
## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
