### PR TITLE
minor correction after DOCS-1114

### DIFF
--- a/modules/manage/partials/fast-commission-decommission.adoc
+++ b/modules/manage/partials/fast-commission-decommission.adoc
@@ -34,7 +34,7 @@ IMPORTANT: Because topics become more reliant on object storage to serve data, y
 Use the following to monitor fast commission and decommission:
 
 * The `vectorized_cluster_partition_start_offset` metric on newly-joined brokers should be greater than on existing brokers.
-* Raft protocol logs taking an on-demand snapshot are logged, for example:
+* Raft protocol logs taking an on-demand snapshot are logged. For example:
 +
 [,bash]
 ----

--- a/modules/manage/partials/fast-commission-decommission.adoc
+++ b/modules/manage/partials/fast-commission-decommission.adoc
@@ -34,7 +34,7 @@ IMPORTANT: Because topics become more reliant on object storage to serve data, y
 Use the following to monitor fast commission and decommission:
 
 * The `vectorized_cluster_partition_start_offset` metric on newly-joined brokers should be greater than on existing brokers.
-* Raft protocol logs taking an on-demand snapshot are logged at the `debug` level, for example:
+* Raft protocol logs taking an on-demand snapshot are logged, for example:
 +
 [,bash]
 ----


### PR DESCRIPTION
## Description

A followup fix after [DOC-1114. ](https://github.com/redpanda-data/docs/pull/1296).

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
