### PR TITLE
Enclose secrets in single quotes

### DIFF
--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -157,7 +157,7 @@ rpk cluster config set \
   iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
   iceberg_rest_catalog_aws_region=<glue-region>
   iceberg_rest_catalog_aws_access_key=<glue-access-key>
-  iceberg_rest_catalog_aws_secret_key=${secrets.<glue-secret-key-name>}
+  iceberg_rest_catalog_aws_secret_key='${secrets.<glue-secret-key-name>}'
 ----
 +
 Use your own values for the following placeholders:

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -154,9 +154,9 @@ rpk cluster config set \
   iceberg_catalog_type=rest \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
-  iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
-  iceberg_rest_catalog_aws_region=<glue-region>
-  iceberg_rest_catalog_aws_access_key=<glue-access-key>
+  iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path> \
+  iceberg_rest_catalog_aws_region=<glue-region> \
+  iceberg_rest_catalog_aws_access_key=<glue-access-key> \
   iceberg_rest_catalog_aws_secret_key='${secrets.<glue-secret-key-name>}'
 ----
 +

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -139,7 +139,7 @@ rpk cluster config set \
   iceberg_rest_catalog_oauth2_server_uri=https://<workspace-instance>/oidc/v1/token \
   iceberg_rest_catalog_oauth2_scope=all-apis \
   iceberg_rest_catalog_client_id=<service-principal-client-id> \
-  iceberg_rest_catalog_client_secret=${secrets.<service-principal-client-secret-name>} \
+  iceberg_rest_catalog_client_secret='${secrets.<service-principal-client-secret-name>}' \
   iceberg_rest_catalog_warehouse=<unity-catalog-name> \
   iceberg_disable_snapshot_tagging=true
 ----

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -76,7 +76,7 @@ rpk cluster config set \
   iceberg_rest_catalog_endpoint=https://<snowflake-orgname>-<open-catalog-account-name>.snowflakecomputing.com/polaris/api/catalog \
   iceberg_rest_catalog_authentication_mode=oauth2 \
   iceberg_rest_catalog_client_id=<open-catalog-connection-client-id> \
-  iceberg_rest_catalog_client_secret=${secrets.<open-catalog-client-secret-name>} \
+  iceberg_rest_catalog_client_secret='${secrets.<open-catalog-client-secret-name>}' \
   iceberg_rest_catalog_warehouse=<open-catalog-name>
 
 # Optional properties:

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -189,7 +189,7 @@ rpk::
 --
 [,bash]
 ----
-rpk cluster config set iceberg_rest_catalog_client_secret ${secrets.<secret-name>}
+rpk cluster config set iceberg_rest_catalog_client_secret '${secrets.<secret-name>}'
 ----
 --
 

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -230,6 +230,7 @@ Suppose you configure the following Redpanda cluster properties for connecting t
 iceberg_catalog_type: rest 
 iceberg_rest_catalog_endpoint: http://catalog-service:8181
 iceberg_rest_catalog_authentication_mode: oauth2
+iceberg_rest_catalog_oauth2_server_uri: <oauth-server-uri>
 iceberg_rest_catalog_client_id: <rest-connection-id>
 iceberg_rest_catalog_client_secret: <rest-connection-secret>
 ----


### PR DESCRIPTION
## Description

This PR modifies code examples that use a secret with `rpk cluster config set` to update cluster properties. Single quotes are added around the secret to ensure that the shell doesn't try to interpret the secret as a variable, and the secret value gets passed into the cluster config correctly.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
