### PR TITLE
Fix auto-update extension

### DIFF
--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [main, 'v/24.3', 'v/24.2', 'v/24.1', api]
+        branch: [main, 'v25.1', 'v/24.3', 'v/24.2', 'v/24.1']
 
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -14,7 +14,10 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [main, 'v25.1', 'v/24.3', 'v/24.2', 'v/24.1']
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, 'v/25.1', 'v/24.3', 'v/24.2', 'v/24.1']
 
     steps:
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, 'v/*']
+        branch: [main, 'v/*', shared]
 
     steps:
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, 'v/25.1', 'v/24.3', 'v/24.2', 'v/24.1']
+        branch: [main, 'v/*']
 
     steps:
       - uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Description

We have dependencies that require Node.js 20+. We also removed the `api` branch when we launch Bump and we also have a new v25.1 branch that will need updates.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
