### PR TITLE
DOC-180 Replace external links from whats new to concepts

### DIFF
--- a/modules/console/pages/config/security/tls-termination.adoc
+++ b/modules/console/pages/config/security/tls-termination.adoc
@@ -240,11 +240,11 @@ If you host Redpanda Console under a sub-path of your domain, such as `+https://
 
 include::shared:partial$suggested-reading.adoc[]
 
-* xref:reference:console/config.adoc[`server` configuration options].
+* xref:reference:console/config.adoc[`server` configuration options]
 * NGINX
 ** http://nginx.org/en/docs/beginners_guide.html[NGINX Beginner's Guide^]
 ** https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/[NGINX SSL Termination^]
-* https://www.haproxy.com/documentation/[HAProxy Documentation^]
-* https://docs.aws.amazon.com/elasticloadbalancing/[AWS Elastic Load Balancing Documentation^]
-* https://cloud.google.com/load-balancing/docs[Cloud Load Balancing Documentation^]
-* https://www.openssl.org/docs/[OpenSSL Documentation^]
+* https://www.haproxy.com/documentation/[HAProxy documentation^]
+* https://docs.aws.amazon.com/elasticloadbalancing/[AWS Elastic Load Balancing documentation^]
+* https://cloud.google.com/load-balancing/docs[Cloud Load Balancing documentation^]
+* https://www.openssl.org/docs/[OpenSSL documentation^]

--- a/modules/console/pages/config/security/tls-termination.adoc
+++ b/modules/console/pages/config/security/tls-termination.adoc
@@ -246,7 +246,6 @@ include::shared:partial$suggested-reading.adoc[]
 ** https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/[NGINX SSL Termination^]
 * HAProxy
 ** https://www.haproxy.com/documentation/[HAProxy Documentation^]
-** https://www.haproxy.com/blog/haproxy-ssl-termination[HAProxy SSL Termination^]
 * https://docs.aws.amazon.com/elasticloadbalancing/[AWS Elastic Load Balancing Documentation^]
 * https://cloud.google.com/load-balancing/docs[Cloud Load Balancing Documentation^]
 * https://www.openssl.org/docs/[OpenSSL Documentation^]

--- a/modules/console/pages/config/security/tls-termination.adoc
+++ b/modules/console/pages/config/security/tls-termination.adoc
@@ -244,8 +244,7 @@ include::shared:partial$suggested-reading.adoc[]
 * NGINX
 ** http://nginx.org/en/docs/beginners_guide.html[NGINX Beginner's Guide^]
 ** https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/[NGINX SSL Termination^]
-* HAProxy
-** https://www.haproxy.com/documentation/[HAProxy Documentation^]
+* https://www.haproxy.com/documentation/[HAProxy Documentation^]
 * https://docs.aws.amazon.com/elasticloadbalancing/[AWS Elastic Load Balancing Documentation^]
 * https://cloud.google.com/load-balancing/docs[Cloud Load Balancing Documentation^]
 * https://www.openssl.org/docs/[OpenSSL Documentation^]

--- a/modules/deploy/pages/redpanda/kubernetes/eks-guide.adoc
+++ b/modules/deploy/pages/redpanda/kubernetes/eks-guide.adoc
@@ -212,7 +212,7 @@ You need the https://docs.aws.amazon.com/cli/latest/userguide/getting-started-in
 
 After you've installed the AWS CLI, make sure to https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html[configure it^] with credentials for your IAM user.
 
-NOTE: If your account uses an identity provider in the IAM Identity Center (previously AWS SSO, https://docs.aws.amazon.com/cli/latest/userguide/sso-configure-profile-token.html[authenticate with the IAM Identity Center^] (`aws sso login`).
+NOTE: If your account uses an identity provider in the IAM Identity Center (previously AWS SSO, https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html[authenticate with the IAM Identity Center^] (`aws sso login`).
 
 For troubleshooting, see the https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#install-tshoot[AWS CLI documentation^].
 

--- a/modules/deploy/pages/redpanda/kubernetes/eks-guide.adoc
+++ b/modules/deploy/pages/redpanda/kubernetes/eks-guide.adoc
@@ -212,7 +212,7 @@ You need the https://docs.aws.amazon.com/cli/latest/userguide/getting-started-in
 
 After you've installed the AWS CLI, make sure to https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html[configure it^] with credentials for your IAM user.
 
-NOTE: If your account uses an identity provider in the IAM Identity Center (previously https://aws.amazon.com/about-aws/whats-new/2022/07/aws-single-sign-on-aws-sso-now-aws-iam-identity-center/[AWS SSO^]), https://docs.aws.amazon.com/cli/latest/userguide/sso-configure-profile-token.html[authenticate with the IAM Identity Center^] (`aws sso login`).
+NOTE: If your account uses an identity provider in the IAM Identity Center (previously AWS SSO, https://docs.aws.amazon.com/cli/latest/userguide/sso-configure-profile-token.html[authenticate with the IAM Identity Center^] (`aws sso login`).
 
 For troubleshooting, see the https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#install-tshoot[AWS CLI documentation^].
 

--- a/modules/manage/partials/audit-logging.adoc
+++ b/modules/manage/partials/audit-logging.adoc
@@ -7,7 +7,7 @@ include::shared:partial$enterprise-license.adoc[]
 
 endif::[]
 
-Many scenarios for streaming data include the need for fine-grained auditing of user activity related to the system. This is especially true for regulated industries such as finance, healthcare, and the public sector. Complying with https://pcidssguide.com/whats-new-in-pci-dss-v4-0/[PCI DSS v4] standards, for example, requires verbose and detailed activity auditing, alerting, and analysis capabilities.
+Many scenarios for streaming data include the need for fine-grained auditing of user activity related to the system. This is especially true for regulated industries such as finance, healthcare, and the public sector. Complying with https://pcidssguide.com/pci-dss-requirements/[PCI DSS v4] standards, for example, requires verbose and detailed activity auditing, alerting, and analysis capabilities.
 
 Redpanda's auditing capabilities support recording both administrative and operational interactions with topics and with users. Redpanda complies with the Open Cybersecurity Schema Framework (OCSF), providing a predictable and extensible solution that works seamlessly with industry standard tools.
 

--- a/modules/manage/partials/audit-logging.adoc
+++ b/modules/manage/partials/audit-logging.adoc
@@ -7,7 +7,7 @@ include::shared:partial$enterprise-license.adoc[]
 
 endif::[]
 
-Many scenarios for streaming data include the need for fine-grained auditing of user activity related to the system. This is especially true for regulated industries such as finance, healthcare, and the public sector. Complying with https://pcidssguide.com/pci-dss-requirements/[PCI DSS v4] standards, for example, requires verbose and detailed activity auditing, alerting, and analysis capabilities.
+Many scenarios for streaming data include the need for fine-grained auditing of user activity related to the system. This is especially true for regulated industries such as finance, healthcare, and the public sector. Complying with https://www.pcisecuritystandards.org/document_library/?document=pci_dss[PCI DSS v4] standards, for example, requires verbose and detailed activity auditing, alerting, and analysis capabilities.
 
 Redpanda's auditing capabilities support recording both administrative and operational interactions with topics and with users. Redpanda complies with the Open Cybersecurity Schema Framework (OCSF), providing a predictable and extensible solution that works seamlessly with industry standard tools.
 

--- a/modules/migrate/pages/kubernetes/strimzi.adoc
+++ b/modules/migrate/pages/kubernetes/strimzi.adoc
@@ -239,7 +239,7 @@ spec:
 
 In Strimzi, a single KafkaTopic resource is used to manage a single topic in a single Kafka cluster. In the following example, the resource has a label `strimzi.io/cluster` with the name of the target Kafka cluster. The Strimzi Operator communicates with this cluster and ensures that the specified topic is created or updated according to the desired configuration.
 
-In Redpanda, the Topic resource is also used to manage a single topic in a single Redpanda cluster. Like the https://strimzi.io/docs/operators/latest/overview#overview-concepts-topic-operator-str[Strimzi Topic Operator], the Redpanda Topic Controller is unidirectional. The controller reconciles topic changes in only one direction: from Kubernetes to Redpanda. For more details, see: xref:manage:kubernetes/k-manage-topics.adoc[].
+In Redpanda, the Topic resource is also used to manage a single topic in a single Redpanda cluster. Like the https://strimzi.io/docs/operators/latest/overview#overview-concepts-topic-operator-str[Strimzi Topic Operator], the Redpanda Topic Controller is unidirectional. The controller reconciles topic changes in only one direction: from Kubernetes to Redpanda. For more details, see xref:manage:kubernetes/k-manage-topics.adoc[].
 
 NOTE: Previous versions of the Strimzi Topic Operator supported bidirectional topic management. Redpanda Operator does not support bidirectional topic management.
 

--- a/modules/migrate/pages/kubernetes/strimzi.adoc
+++ b/modules/migrate/pages/kubernetes/strimzi.adoc
@@ -239,7 +239,7 @@ spec:
 
 In Strimzi, a single KafkaTopic resource is used to manage a single topic in a single Kafka cluster. In the following example, the resource has a label `strimzi.io/cluster` with the name of the target Kafka cluster. The Strimzi Operator communicates with this cluster and ensures that the specified topic is created or updated according to the desired configuration.
 
-In Redpanda, the Topic resource is also used to manage a single topic in a single Redpanda cluster. Like the https://strimzi.io/blog/2023/11/02/unidirectional-topic-operator/[Strimzi Topic Operator], the Redpanda Topic Controller is unidirectional. The controller reconciles topic changes in only one direction: from Kubernetes to Redpanda. For more details, see: xref:manage:kubernetes/k-manage-topics.adoc[].
+In Redpanda, the Topic resource is also used to manage a single topic in a single Redpanda cluster. Like the https://strimzi.io/docs/operators/latest/overview#overview-concepts-topic-operator-str[Strimzi Topic Operator], the Redpanda Topic Controller is unidirectional. The controller reconciles topic changes in only one direction: from Kubernetes to Redpanda. For more details, see: xref:manage:kubernetes/k-manage-topics.adoc[].
 
 NOTE: Previous versions of the Strimzi Topic Operator supported bidirectional topic management. Redpanda Operator does not support bidirectional topic management.
 


### PR DESCRIPTION
## Description
This pull request updates outdated links to more current or relevant resources and clarifying terminology related to AWS authentication.

* Updated the PCI DSS v4 reference link in the audit logging documentation to point to the main requirements page instead of the "What's New" section.
* Changed the Strimzi Topic Operator reference in the Kubernetes migration guide to use the official documentation link rather than a blog post, ensuring users get authoritative information.
* Removed the HAProxy SSL Termination blog link from the TLS termination suggested reading section to streamline recommended resources.
* Improved the note about AWS IAM Identity Center (formerly AWS SSO) in the EKS guide by clarifying the terminology and simplifying the explanation for authenticating with AWS CLI.

Resolves https://redpandadata.atlassian.net/browse/DOC-180
Review deadline:

## Page previews
[tls-termination](https://deploy-preview-1348--redpanda-docs-preview.netlify.app/current/console/config/security/tls-termination/#use-redpanda-console-for-tls-termination)
[EKS](https://deploy-preview-1348--redpanda-docs-preview.netlify.app/current/deploy/redpanda/kubernetes/eks-guide/#aws-cli)
[Audit logging](https://deploy-preview-1348--redpanda-docs-preview.netlify.app/current/manage/audit-logging/)
[Strimzi](https://deploy-preview-1348--redpanda-docs-preview.netlify.app/current/migrate/kubernetes/strimzi/#migrate-kafkatopic)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
