### PR TITLE
DOC-1631 dataplane API configure Kafka client quotas

### DIFF
--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -5,7 +5,7 @@
 
 Redpanda supports throughput throttling on both ingress and egress independently, and allows configuration at the broker and client levels. This helps prevent clients from causing unbounded network and disk usage on brokers. You can configure limits at two levels:
 
-* *Broker limits*: These apply to all clients connected to the broker and restrict total traffic on the broker. 
+* *Broker limits*: These apply to all clients connected to the broker and restrict total traffic on the broker. See <<broker-wide-throughput-limits, Broker-wide throughput limits>>.
 ifndef::env-cloud[]
 * *Client limits*: These apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker. You can manage client quotas with xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`], with {ui}, or with the Kafka API. When no quotas apply, the client has unlimited throughput. 
 endif::[]

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -5,7 +5,7 @@
 
 Redpanda supports throughput throttling on both ingress and egress independently, and allows configuration at the broker and client levels. This helps prevent clients from causing unbounded network and disk usage on brokers. You can configure limits at two levels:
 
-* *Broker limits*: These apply to all clients connected to the broker and restrict total traffic on the broker. 
+* *Broker limits*: These apply to all clients connected to the broker and restrict total traffic on the broker.  See <<Broker limits,broker-wide-throughput-limits>>
 ifndef::env-cloud[]
 * *Client limits*: These apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker. You can manage client quotas with xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`], with {ui}, or with the Kafka API. When no quotas apply, the client has unlimited throughput. 
 endif::[]

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -10,7 +10,7 @@ ifndef::env-cloud[]
 * *Client limits*: These apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker. You can manage client quotas with xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`], with {ui}, or with the Kafka API. When no quotas apply, the client has unlimited throughput. 
 endif::[]
 ifdef::env-cloud[]
-* *Client limits*: These apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker. You can manage client quotas with xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`], with the {ui} UI, with the link:/api/doc/cloud-dataplane/operation/operation-quotaservice_listquotas[Redpanda Cloud Data Plane API], or with the Kafka API. When no quotas apply, the client has unlimited throughput. 
+* *Client limits*: These apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker. You can manage client quotas with xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`], with the {ui} UI, with the link:https://docs.redpanda.com/api/doc/cloud-dataplane/operation/operation-quotaservice_listquotas[Redpanda Cloud Data Plane API], or with the Kafka API. When no quotas apply, the client has unlimited throughput. 
 
 NOTE: Throughput throttling is supported for BYOC and Dedicated clusters only.
 endif::[]
@@ -101,7 +101,7 @@ endif::[]
 === Individual client throughput limit
 
 ifdef::env-cloud[]
-NOTE: You can also manage client quotas with the link:/api/doc/cloud-dataplane/operation/operation-quotaservice_listquotas[Redpanda Cloud Data Plane API]
+NOTE: The following sections show how to manage throughput with `rpk`. You can also manage throughput with the link:https://docs.redpanda.com/api/doc/cloud-dataplane/operation/operation-quotaservice_listquotas[Redpanda Cloud Data Plane API]
 endif::[]
 
 To view current throughput quotas set through the Kafka API, run xref:reference:rpk/rpk-cluster/rpk-cluster-quotas-describe.adoc[`rpk cluster quotas describe`].

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -1,15 +1,18 @@
 = Manage Throughput
-:description: Manage the throughput of Kafka traffic with configurable properties.
+:description: Learn how to manage the throughput of Kafka traffic.
 :page-categories: Management, Networking
 // tag::single-source[]
 
-Redpanda supports throughput throttling on both ingress and egress independently, and allows configuration at the broker and client levels. This helps prevent clients from causing unbounded network and disk usage on brokers.
+Redpanda supports throughput throttling on both ingress and egress independently, and allows configuration at the broker and client levels. This helps prevent clients from causing unbounded network and disk usage on brokers. You can configure limits at two levels:
 
-* Broker-wide limits apply to all clients connected to the broker and restrict total traffic on the broker. 
-* Client limits apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker. You can manage client quotas with xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`] or with the Kafka API. When no quotas apply, the client has unlimited throughput. 
-
+* *Broker limits*: These apply to all clients connected to the broker and restrict total traffic on the broker. 
+ifndef::env-cloud[]
+* *Client limits*: These apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker. You can manage client quotas with xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`], with {ui}, or with the Kafka API. When no quotas apply, the client has unlimited throughput. 
+endif::[]
 ifdef::env-cloud[]
-NOTE: Throughput throttling is supported for BYOC and Dedicated clusters.
+* *Client limits*: These apply to a set of clients defined by their `client_id` and help prevent a set of clients from starving other clients using the same broker. You can manage client quotas with xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`], with the {ui} UI, with the link:/api/doc/cloud-dataplane/operation/operation-quotaservice_listquotas[Redpanda Cloud Data Plane API], or with the Kafka API. When no quotas apply, the client has unlimited throughput. 
+
+NOTE: Throughput throttling is supported for BYOC and Dedicated clusters only.
 endif::[]
 
 == Throughput throttling enforcement
@@ -237,9 +240,9 @@ Replace the placeholder values with the new quota values, accounting for the con
 rpk cluster config set kafka_client_group_byte_rate_quota=
 ----
 
-=== View throughput limits in Redpanda Console
+=== View throughput limits in {ui}
 
-You can also use Redpanda Console to view enforced limits. In the menu, go to **Quotas**.
+You can also use {ui} to view enforced limits. In the side menu, go to **Quotas**.
 
 === Monitor client throughput
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -44,13 +44,13 @@ The properties for broker-wide throughput quota balancing are configured at the 
 | A broker's total throughput limit for egress Kafka traffic.
 
 | xref:reference:cluster-properties.adoc#kafka_throughput_control[kafka_throughput_control]
-| List of clients for whom broker-wide limits do not apply
+| List of clients for whom broker-wide limits do not apply.
 
 | xref:reference:cluster-properties.adoc#kafka_throughput_controlled_api_keys[kafka_throughput_controlled_api_keys]
-| List of Kafka request types subject to broker-wide throughput limits; defaults to `produce` and `fetch`.
+| Kafka request types subject to broker-wide throughput limits; defaults to `produce` and `fetch`.
 
 | xref:reference:tunable-properties.adoc#max_kafka_throttle_delay_ms[max_kafka_throttle_delay_ms]
-| The maximum delay inserted in the data path of Kafka API requests to throttle them down. Configuring this to be less than the Kafka client timeout can ensure that the delay that's inserted won't be long enough to cause a client timeout by itself.
+| Maximum delay inserted in the data path of Kafka API requests to throttle them down. Setting this lower than the Kafka client timeout helps ensure throttling alone does not cause client timeouts. 
 
 |===
 
@@ -100,6 +100,10 @@ endif::[]
 
 === Individual client throughput limit
 
+ifdef::env-cloud[]
+NOTE: You can also manage client quotas with the link:/api/doc/cloud-dataplane/operation/operation-quotaservice_listquotas[Redpanda Cloud Data Plane API]
+endif::[]
+
 To view current throughput quotas set through the Kafka API, run xref:reference:rpk/rpk-cluster/rpk-cluster-quotas-describe.adoc[`rpk cluster quotas describe`].
 
 For example, to see the quotas for client ID `consumer-1`:
@@ -145,7 +149,7 @@ NOTE: A client group specified with `client-id-prefix` is not the equivalent of 
 
 You can apply default throughput limits to clients. Redpanda applies the default limits if no quotas are configured for a specific `client_id` or prefix.
 
-To specify a produce quota of 1 GBps through the Kafka API (which means a 1 GBps limit across all produce requests sent to a single Redpanda broker), run: 
+To specify a produce quota of 1 GB/s through the Kafka API (applies across all produce requests to a single broker), run:
 
 [,bash]
 ----

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -21,6 +21,10 @@ NOTE: As of v24.2, Redpanda enforces all throughput limits per broker, including
 
 Throughput limits are enforced by applying backpressure to clients. When a connection is in breach of the throughput limit, the throttler advises the client about the delay (throttle time) that would bring the rate back to the allowed level. Redpanda starts by adding a `throttle_time_ms` field to responses. If that isn't honored, delays are inserted on the connection's next read operation. 
 
+ifdef::env-cloud[]
+In Redpanda Cloud, the throttling delay is set to 30 seconds.
+endif::[]
+
 ifndef::env-cloud[]
 The throttling delay may not exceed the limit set by xref:reference:tunable-properties.adoc#max_kafka_throttle_delay_ms[`max_kafka_throttle_delay_ms`].
 endif::[]
@@ -101,7 +105,7 @@ endif::[]
 === Individual client throughput limit
 
 ifdef::env-cloud[]
-NOTE: The following sections show how to manage throughput with `rpk`. You can also manage throughput with the link:https://docs.redpanda.com/api/doc/cloud-dataplane/operation/operation-quotaservice_listquotas[Redpanda Cloud Data Plane API]
+NOTE: The following sections show how to manage throughput with `rpk`. You can also manage throughput with the link:https://docs.redpanda.com/api/doc/cloud-dataplane/operation/operation-quotaservice_listquotas[Redpanda Cloud Data Plane API].
 endif::[]
 
 To view current throughput quotas set through the Kafka API, run xref:reference:rpk/rpk-cluster/rpk-cluster-quotas-describe.adoc[`rpk cluster quotas describe`].


### PR DESCRIPTION
## Description
This pull request updates `manage-throughput.adoc` to add instructions for managing quotas in cloud environments using the UI and Data Plane API.

Resolves https://redpandadata.atlassian.net/browse/DOC-1631
Review deadline:

## Page previews
[Manage Throughput: Cloud](https://deploy-preview-1349--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/cluster-maintenance/manage-throughput/)
[Manage Throughput: Self-Managed](https://deploy-preview-1349--redpanda-docs-preview.netlify.app/current/manage/cluster-maintenance/manage-throughput/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
