### PR TITLE
DOC-1013 update monitoring connectors doc

### DIFF
--- a/modules/manage/partials/monitor-connectors.adoc
+++ b/modules/manage/partials/monitor-connectors.adoc
@@ -32,7 +32,7 @@ helm version
 endif::[]
 
 ifndef::env-kubernetes[]
-You can monitor the health of your Redpanda managed connectors with
+You can monitor the health of Kafka Connect with
 metrics that Redpanda exports through a Prometheus HTTPS endpoint. You
 can use Grafana to visualize the metrics and set up alerts.
 
@@ -43,7 +43,7 @@ The most important metrics to be monitored by alerts are:
 
 == View connector logs
 
-Connector logs are written to the system topic `__redpanda.connectors_logs`. You can view logs in {ui}, or you can download logs with `rpk`:
+Connector logs are written to the system topic `__redpanda.connectors_logs`. You can view logs in {ui}, or you can download logs with `rpk`. For example:
 
 [,bash]
 ----
@@ -56,7 +56,7 @@ rpk topic consume __redpanda.connectors_logs -o @-10m:end
 # Stream new logs only (like tail -f)
 rpk topic consume __redpanda.connectors_logs -o end
 
-# Quick filter by connector name, as it appears in {ui}} (JSON logs)
+# Quick filter by connector name, as the name appears in the console (JSON logs)
 rpk topic consume __redpanda.connectors_logs -o @-10m:end -O json \
   | jq -r 'select(.message | test("<connector-name>"; "i"))'
 

--- a/modules/manage/partials/monitor-connectors.adoc
+++ b/modules/manage/partials/monitor-connectors.adoc
@@ -43,7 +43,7 @@ The most important metrics to be monitored by alerts are:
 
 == View connector logs
 
-Connector logs are written to the system topic `__redpanda.connectors_logs`. You can view logs in {ui}, or you can download logs with `rpk`. For example:
+Connector logs are written to the system topic `__redpanda.connectors_logs`. You can view logs in {ui} on the Topics page for your cluster, or you can download logs with `rpk`. For example:
 
 [,bash]
 ----
@@ -56,7 +56,7 @@ rpk topic consume __redpanda.connectors_logs -o @-10m:end
 # Stream new logs only (like tail -f)
 rpk topic consume __redpanda.connectors_logs -o end
 
-# Quick filter by connector name, as the name appears in the console (JSON logs)
+# Filter by connector name 
 rpk topic consume __redpanda.connectors_logs -o @-10m:end -O json \
   | jq -r 'select(.message | test("<connector-name>"; "i"))'
 

--- a/modules/manage/partials/monitor-connectors.adoc
+++ b/modules/manage/partials/monitor-connectors.adoc
@@ -43,7 +43,7 @@ The most important metrics to be monitored by alerts are:
 
 == View connector logs
 
-In {ui}, connector logs are written to the system topic `__redpanda.connectors_logs`. For example:
+Connector logs are written to the system topic `__redpanda.connectors_logs`. In {ui}, you can view them or pull them with `rpk`. For example:
 
 [,bash]
 ----
@@ -56,8 +56,9 @@ rpk topic consume __redpanda.connectors_logs -o @-10m:end
 # Stream new logs only (like tail -f)
 rpk topic consume __redpanda.connectors_logs -o end
 
-# Quick filter for one connector (case-insensitive)
-rpk topic consume __redpanda.connectors_logs -o @-10m:end | grep -i "<connector-name>"
+# Quick filter by connector name (JSON logs)
+rpk topic consume __redpanda.connectors_logs -o @-10m:end -O json \
+  | jq -r 'select(.message | test("<connector-name>"; "i"))'
 
 ----
 

--- a/modules/manage/partials/monitor-connectors.adoc
+++ b/modules/manage/partials/monitor-connectors.adoc
@@ -61,7 +61,7 @@ rpk topic consume __redpanda.connectors_logs -o @-10m:end | grep -i "<connector-
 
 ----
 
-NOTE: The logs topic may be access-restricted and subject to retention policies.
+NOTE: Access to system topics may be restricted by organization/project roles. Log retention follows cluster/system-topic policies and messages may expire.
 
 
 endif::[]

--- a/modules/manage/partials/monitor-connectors.adoc
+++ b/modules/manage/partials/monitor-connectors.adoc
@@ -41,6 +41,23 @@ The most important metrics to be monitored by alerts are:
 * connector failed tasks
 * connector lag / connector lag rate
 
+== View connector logs
+
+In {ui}, connector logs are written to the system topic `__redpanda.connectors_logs`. For example:
+
+[,bash]
+----
+# Tail recent logs
+rpk topic consume __redpanda.connectors_logs -n 100
+
+# Quick filter for one connector
+rpk topic consume __redpanda.connectors_logs -n 500 | grep "<connector-name>"
+
+----
+
+NOTE: The logs topic may be access-restricted and subject to retention policies.
+
+
 endif::[]
 
 == Limitations

--- a/modules/manage/partials/monitor-connectors.adoc
+++ b/modules/manage/partials/monitor-connectors.adoc
@@ -43,7 +43,7 @@ The most important metrics to be monitored by alerts are:
 
 == View connector logs
 
-Connector logs are written to the system topic `__redpanda.connectors_logs`. In {ui}, you can view them or pull them with `rpk`. For example:
+Connector logs are written to the system topic `__redpanda.connectors_logs`. You can view logs in {ui}, or you can download logs with `rpk`:
 
 [,bash]
 ----
@@ -56,7 +56,7 @@ rpk topic consume __redpanda.connectors_logs -o @-10m:end
 # Stream new logs only (like tail -f)
 rpk topic consume __redpanda.connectors_logs -o end
 
-# Quick filter by connector name (JSON logs)
+# Quick filter by connector name, as it appears in {ui}} (JSON logs)
 rpk topic consume __redpanda.connectors_logs -o @-10m:end -O json \
   | jq -r 'select(.message | test("<connector-name>"; "i"))'
 

--- a/modules/manage/partials/monitor-connectors.adoc
+++ b/modules/manage/partials/monitor-connectors.adoc
@@ -47,11 +47,17 @@ In {ui}, connector logs are written to the system topic `__redpanda.connectors_l
 
 [,bash]
 ----
-# Tail recent logs
-rpk topic consume __redpanda.connectors_logs -n 100
+# Last 100 messages (most recent)
+rpk topic consume __redpanda.connectors_logs -o -100 -n 100
 
-# Quick filter for one connector
-rpk topic consume __redpanda.connectors_logs -n 500 | grep "<connector-name>"
+# Last 10 minutes
+rpk topic consume __redpanda.connectors_logs -o @-10m:end
+
+# Stream new logs only (like tail -f)
+rpk topic consume __redpanda.connectors_logs -o end
+
+# Quick filter for one connector (case-insensitive)
+rpk topic consume __redpanda.connectors_logs -o @-10m:end | grep -i "<connector-name>"
 
 ----
 


### PR DESCRIPTION
## Description
This pull request adds doc to help users view connector logs for Kafka Connect in the Redpanda Cloud.

* Added a "View connector logs" section explaining that connector logs are written to the system topic `__redpanda.connectors_logs` and providing example `rpk` commands for tailing and filtering logs.
* Included a note about potential access restrictions and retention policies for the logs topic.

Resolves https://redpandadata.atlassian.net/browse/DOC-1013
Review deadline:

## Page previews
[Monitor Kafka Connect](https://deploy-preview-1350--redpanda-docs-preview.netlify.app/redpanda-cloud/develop/managed-connectors/monitor-connectors/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
