### PR TITLE
DOC-1686 single source auto_create_topics_enabled

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1608-Document-Cloud-Feature-Finish-Rollout-topic-count-clamp-and-auto-topic-creation-in-cloud'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1608-Document-Cloud-Feature-Finish-Rollout-topic-count-clamp-and-auto-topic-creation-in-cloud'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -26,8 +26,6 @@ Redpanda Cloud supports 40,000 topics per cluster.
 
 endif::[]
 
-This section shows how to change default settings for a topic.
-
 === Choose the number of partitions
 
 A partition acts as a log file where topic data is written. Dividing topics into partitions allows producers to write messages in parallel and consumers to read messages in parallel. The higher the number of partitions, the greater the throughput.

--- a/modules/develop/pages/config-topics.adoc
+++ b/modules/develop/pages/config-topics.adoc
@@ -22,6 +22,8 @@ endif::[]
 ifdef::env-cloud[]
 This command creates a topic named `xyz` with one partition and three replicas, because these are the default values set in the cluster configuration file. Replicas are copies of partitions that are distributed across different brokers, so if one broker goes down, other brokers still have a copy of the data. 
 
+Redpanda Cloud supports 40,000 topics per cluster.
+
 endif::[]
 
 This section shows how to change default settings for a topic.

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -308,6 +308,7 @@ Defines the maximum amount of memory in bytes used by the audit buffer in each s
 ---
 
 
+// tag::auto_create_topics_enabled[]
 === auto_create_topics_enabled
 
 Allow automatic topic creation. To prevent excess topics, this property is not supported on Redpanda Cloud BYOC and Dedicated clusters. You should explicitly manage topic creation for these Redpanda Cloud clusters.
@@ -320,10 +321,13 @@ If you produce to a topic that doesn't exist, the topic will be created with def
 
 *Type:* boolean
 
+ifndef::env-cloud[]
 *Default:* `false`
+endif::[]
 
 ---
 
+// end::auto_create_topics_enabled[]
 
 === cluster_id
 


### PR DESCRIPTION
## Description

Related to https://github.com/redpanda-data/cloud-docs/pull/418:

* State that Redpanda Cloud supports up to 40,000 topics per cluster in the `config-topics.adoc` file.
* Add single sourcing for `auto_create_topics_enabled` cluster property

Resolves https://redpandadata.atlassian.net/browse/DOC-1686
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
