### PR TITLE
DOC-1684 update config client connections

### DIFF
--- a/modules/manage/pages/cluster-maintenance/configure-availability.adoc
+++ b/modules/manage/pages/cluster-maintenance/configure-availability.adoc
@@ -35,7 +35,7 @@ Configure the `kafka_connections_max_per_ip` property to limit the number of con
 
 IMPORTANT: Per-IP connection controls require Redpanda to see individual client IPs. If clients connect through private link endpoints, NAT gateways, or other shared-IP egress, the per-IP limit applies to the shared IP, affecting all clients behind it and preventing isolation of a single offending client. Similarly, multiple clients running on the same host will share the same IP address, and the limit applies collectively to all those clients.
 
-See also: xref:manage:cluster-maintenance/config-cluster.adoc[].
+See also: xref:manage:cluster-maintenance/config-cluster.adoc[]
 
 ==== Configure the limit
 

--- a/modules/manage/pages/cluster-maintenance/configure-availability.adoc
+++ b/modules/manage/pages/cluster-maintenance/configure-availability.adoc
@@ -7,7 +7,7 @@ Optimize the availability of your clusters by configuring and tuning properties.
 
 == Limit client connections
 
-A malicious Kafka client application may create many network connections to execute its attacks. A poorly configured application may also create an excessive number of connections. To mitigate the risk of a client creating too many connections and using too many system resources, you can configure a Redpanda cluster to impose limits on the number of created client connections.
+To mitigate the risk of a client creating too many connections and using too many system resources, you can configure a Redpanda cluster to impose limits on the number of client connections that can be created.
 
 The following Redpanda cluster properties limit the number of connections:
 

--- a/modules/manage/pages/cluster-maintenance/configure-availability.adoc
+++ b/modules/manage/pages/cluster-maintenance/configure-availability.adoc
@@ -31,9 +31,11 @@ endif::[]
 ifdef::env-cloud[]
 === Configure connection count limit by client IP
 
-Use the `kafka_connections_max_per_ip` property to limit the number of connections from each client IP address. 
+Configure the `kafka_connections_max_per_ip` property to limit the number of connections from each client IP address. 
 
 IMPORTANT: Per-IP connection controls require Redpanda to see individual client IPs. If clients connect through private link endpoints, NAT gateways, or other shared-IP egress, the per-IP limit applies to the shared IP, affecting all clients behind it and preventing isolation of a single offending client. Similarly, multiple clients running on the same host will share the same IP address, and the limit applies collectively to all those clients.
+
+See also: xref:manage:cluster-maintenance/config-cluster.adoc[].
 
 ==== Configure the limit
 
@@ -51,9 +53,11 @@ redpanda_rpc_active_connections{redpanda_id="CLOUD_CLUSTER_ID", redpanda_server=
 +
 image::shared:monitor_connections.png[Range of active connections over time]
 
-. Set the `kafka_connections_max_per_ip` value based on your analysis. Use the upper bound of normal connections from step 3, or use a lower value if you know how many connections per client IP are being opened.
+. Set the `kafka_connections_max_per_ip` value based on your analysis. Use the upper bound of normal connections from step 3, or use a lower value if you know how many connections per client IP are being opened. 
 
 . Continue monitoring the connection metrics after applying the limit to ensure that legitimate clients are not affected and that the problematic client is properly controlled.
+
+NOTE: When facing attacks from multiple IP addresses, `kafka_connections_max_per_ip` alone may be insufficient. If offending IPs outnumber legitimate client IPs, you'll need to set `kafka_connections_max_per_ip` so low that it affects legitimate clients. If this is the case, try using `kafka_connections_max_overrides` to exclude known legitimate client IPs from the connection limit.
 
 ==== Limitations
 

--- a/modules/manage/pages/cluster-maintenance/configure-availability.adoc
+++ b/modules/manage/pages/cluster-maintenance/configure-availability.adoc
@@ -53,11 +53,11 @@ redpanda_rpc_active_connections{redpanda_id="CLOUD_CLUSTER_ID", redpanda_server=
 +
 image::shared:monitor_connections.png[Range of active connections over time]
 
-. Set the `kafka_connections_max_per_ip` value based on your analysis. Use the upper bound of normal connections from step 3, or use a lower value if you know how many connections per client IP are being opened. 
+. Set the `kafka_connections_max_per_ip` value based on your analysis. Use the upper bound of normal connections observed, or use a lower value if you know how many connections per client IP are being opened. 
 
 . Continue monitoring the connection metrics after applying the limit to ensure that legitimate clients are not affected and that the problematic client is properly controlled.
 
-NOTE: When facing attacks from multiple IP addresses, `kafka_connections_max_per_ip` alone may be insufficient. If offending IPs outnumber legitimate client IPs, you'll need to set `kafka_connections_max_per_ip` so low that it affects legitimate clients. If this is the case, try using `kafka_connections_max_overrides` to exclude known legitimate client IPs from the connection limit.
+NOTE: When facing threats from multiple IP addresses, `kafka_connections_max_per_ip` alone may be insufficient. If offending IPs outnumber legitimate client IPs, you may need to set `kafka_connections_max_per_ip` so low that it affects legitimate clients. If this is the case, use `kafka_connections_max_overrides` to exempt known legitimate client IPs from the connection limit.
 
 ==== Limitations
 

--- a/modules/manage/pages/cluster-maintenance/configure-availability.adoc
+++ b/modules/manage/pages/cluster-maintenance/configure-availability.adoc
@@ -57,7 +57,7 @@ image::shared:monitor_connections.png[Range of active connections over time]
 
 . Continue monitoring the connection metrics after applying the limit to ensure that legitimate clients are not affected and that the problematic client is properly controlled.
 
-NOTE: When facing threats from multiple IP addresses, `kafka_connections_max_per_ip` alone may be insufficient. If offending IPs outnumber legitimate client IPs, you may need to set `kafka_connections_max_per_ip` so low that it affects legitimate clients. If this is the case, use `kafka_connections_max_overrides` to exempt known legitimate client IPs from the connection limit.
+NOTE: If you find a high load of unexpected connections from multiple IP addresses, `kafka_connections_max_per_ip` alone may be insufficient. If offending IPs outnumber legitimate client IPs, you may need to set `kafka_connections_max_per_ip` so low that it affects legitimate clients. If this is the case, use `kafka_connections_max_overrides` to exempt known legitimate client IPs from the connection limit.
 
 ==== Limitations
 


### PR DESCRIPTION
## Description
This pull request updates the documentation for configuring connection limits by client IP in Redpanda, clarifying how the `kafka_connections_max_per_ip` property works and adding guidance for handling attacks from multiple IPs. 

* Added a note explaining that when under attack from many IPs, `kafka_connections_max_per_ip` may not be sufficient, and suggested using `kafka_connections_max_overrides` to exempt known legitimate client IPs from the limit.
* Added a See also reference to the cluster configuration in RP doc.

Resolves https://redpandadata.atlassian.net/browse/DOC-1684
Review deadline:

## Page previews
[Configure Client Connections](https://deploy-preview-1364--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/cluster-maintenance/configure-availability/#configure-connection-count-limit-by-client-ip)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
