### PR TITLE
Fix duplicate lines

### DIFF
--- a/modules/migrate/pages/console-v3.adoc
+++ b/modules/migrate/pages/console-v3.adoc
@@ -130,8 +130,6 @@ NOTE: OIDC-based group authorization is no longer available in Redpanda Console.
 
 Here is an example of how to migrate from Google OIDC in v2 to v3:
 
-Here is an example of how to migrate from Google OIDC in v2 to v3:
-
 [.side-by-side]
 --
 .V2 Google OIDC
@@ -212,11 +210,11 @@ authorization:
 ----
 --
 
-However, if you are using *impersonation* in v3, `roleBindings` are ignored. Instead, access is controlled by Redpanda using ACLs and RBAC.
-
 ==== Migrate Redpanda Console roles to Redpanda ACLs
 
-If you previously assigned roles in Redpanda Console, you must provision those users in Redpanda and grant them the appropriate permissions.
+If you are using *impersonation* in v3, `roleBindings` are ignored. Instead, access is controlled by Redpanda using ACLs and RBAC.
+
+You must provision your users in Redpanda and grant them the appropriate permissions.
 
 The following examples show how to map Redpanda Console roles (`viewer`, `editor`, `admin`) to Redpanda ACLs.
 


### PR DESCRIPTION
## Description

This pull request makes minor improvements to the documentation in `console-v3.adoc` for migrating from Redpanda Console v2 to v3. The changes clarify the instructions for migrating user roles and permissions, especially when using impersonation in v3.

- Documentation clarity:
  * Removed a redundant sentence introducing the Google OIDC migration example to avoid repetition.
  * Clarified the explanation about `roleBindings` and impersonation, making it clear that users must be provisioned and granted permissions in Redpanda when using impersonation in v3.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
