### PR TITLE
auto-docs: Update property docs for tag v25.3.9

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -17,8 +17,8 @@ asciidoc:
     # Fallback versions
     # We try to fetch the latest versions from GitHub at build time
     # --
-    full-version: 25.3.8
-    latest-redpanda-tag: 'v25.3.8'
+    full-version: 25.3.9
+    latest-redpanda-tag: 'v25.3.9'
     latest-console-tag: 'v3.3.1'
     latest-release-commit: '6aa5af28b020b66e5caa966094882b7260497a53'
     latest-operator-version: 'v2.3.8-24.3.6'

--- a/docs-data/redpanda-property-changes-v25.3.8-to-v25.3.9.json
+++ b/docs-data/redpanda-property-changes-v25.3.8-to-v25.3.9.json
@@ -1,11 +1,11 @@
 {
   "comparison": {
-    "oldVersion": "v25.3.7",
-    "newVersion": "v25.3.8",
-    "timestamp": "2026-02-25T19:46:45.991Z"
+    "oldVersion": "v25.3.8",
+    "newVersion": "v25.3.9",
+    "timestamp": "2026-02-26T14:27:39.688Z"
   },
   "summary": {
-    "newProperties": 1,
+    "newProperties": 0,
     "changedDefaults": 0,
     "changedDescriptions": 0,
     "changedTypes": 0,
@@ -14,14 +14,7 @@
     "emptyDescriptions": 3
   },
   "details": {
-    "newProperties": [
-      {
-        "name": "log_compaction_max_priority_wait_ms",
-        "type": "integer",
-        "default": 3600000,
-        "description": "Maximum time a priority partition (for example, __consumer_offsets) can wait for compaction before preempting regular compaction."
-      }
-    ],
+    "newProperties": [],
     "changedDefaults": [],
     "changedDescriptions": [],
     "changedTypes": [],

--- a/modules/reference/attachments/redpanda-properties-v25.3.9.json
+++ b/modules/reference/attachments/redpanda-properties-v25.3.9.json
@@ -8600,6 +8600,7 @@
             "needs_restart": false,
             "nullable": false,
             "type": "integer",
+            "version": "v25.3.8",
             "visibility": "tunable"
         },
         "log_compaction_merge_max_ranges": {

--- a/modules/reference/partials/properties/cluster-properties.adoc
+++ b/modules/reference/partials/properties/cluster-properties.adoc
@@ -11384,6 +11384,10 @@ endif::[]
 
 === log_compaction_max_priority_wait_ms
 
+ifndef::env-cloud[]
+*Introduced in v25.3.8*
+endif::[]
+
 Maximum time a priority partition (for example, `__consumer_offsets`) can wait for compaction before preempting regular compaction.
 
 [cols="1s,2a"]


### PR DESCRIPTION
This PR auto-generates updated Redpanda property documentation for **v25.3.9**.