### PR TITLE
docs(iceberg): Add DLQ table retention note to Iceberg data retention section

### DIFF
--- a/modules/manage/pages/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/about-iceberg-topics.adoc
@@ -242,6 +242,8 @@ Data in an Iceberg-enabled topic is consumable from Kafka based on the configure
 - Explicitly delete data from the Iceberg table using a query engine.
 - Disable the Iceberg integration for the topic and delete the Parquet files in object storage.
 
+The DLQ table (`<topic-name>~dlq`) follows the same persistence rules as the main Iceberg table.
+
 == Schema evolution
 
 Redpanda supports schema evolution in accordance with the https://iceberg.apache.org/spec/#schema-evolution[Iceberg specification^]. Permitted schema evolutions include reordering fields and promoting field types. When you update the schema in Schema Registry, Redpanda automatically updates the Iceberg table schema to match the new schema.


### PR DESCRIPTION
## Description

No ticket.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
