### PR TITLE
Add Agentic Data Plane category

### DIFF
--- a/modules/ROOT/partials/valid-categories.yml
+++ b/modules/ROOT/partials/valid-categories.yml
@@ -84,3 +84,6 @@ page-valid-categories:
 
   - category: 'Emergency Response'
     definition: 'Operational practices, guidelines, and emergency procedures for responding to severe outages, data loss events, or infrastructure failures affecting Redpanda clusters, including incident handling and continuity planning.'
+
+  - category: 'Agentic Data Plane'
+    definition: 'Building AI agents and applications using the Redpanda Agentic Data Plane, including the AI Gateway, MCP servers, and dynamic tool discovery.'


### PR DESCRIPTION
## Summary

- Adds a new `Agentic Data Plane` category to `valid-categories.yml`
- Needed for the new AI agents labs module in redpanda-labs (see https://github.com/redpanda-data/redpanda-labs/pull/281)

🤖 Generated with [Claude Code](https://claude.com/claude-code)