### PR TITLE
docs(iceberg): update JSON schema translation behavior

### DIFF
--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -11,9 +11,9 @@ This topic includes new content added in version {page-component-version}. For a
 
 Redpanda now supports additional JSON Schema patterns when translating to Iceberg tables:
 
-* `$ref` support - Internal references using `$ref` (for example, `"$ref": "#/definitions/myType"`) are resolved from schema resources declared in the same document. External references are not yet supported.
-* Map type from `additionalProperties` - `additionalProperties` objects that contain subschemas now translate to Iceberg `map<string, T>`.
-* `oneOf` nullable pattern - The `oneOf` keyword is now supported for the standard nullable pattern if exactly one branch is `{"type":"null"}` and the other is a non-null schema.
+* `$ref` support: Internal references using `$ref` (for example, `"$ref": "#/definitions/myType"`) are resolved from schema resources declared in the same document. External references are not yet supported.
+* Map type from `additionalProperties`: `additionalProperties` objects that contain subschemas now translate to Iceberg `map<string, T>`.
+* `oneOf` nullable pattern: The `oneOf` keyword is now supported for the standard nullable pattern if exactly one branch is `{"type":"null"}` and the other is a non-null schema.
 
 See xref:manage:iceberg/specify-iceberg-schema.adoc#how-iceberg-modes-translate-to-table-format[Specify Iceberg Schema] for JSON types mapping and updated requirements.
 

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -9,6 +9,8 @@ This topic includes new content added in version {page-component-version}. For a
 
 == Iceberg: Expanded JSON Schema support
 
+Redpanda now supports additional JSON Schema patterns when translating to Iceberg tables:
+
 * `$ref` support - Internal references using `$ref` (for example, `"$ref": "#/definitions/myType"`) are resolved from schema resources declared in the same document. External references are not yet supported.
 * Map type from `additionalProperties` - `additionalProperties` objects that contain subschemas now translate to Iceberg `map<string, T>`.
 * `oneOf` nullable pattern - The `oneOf` keyword is now supported for the standard nullable pattern if exactly one branch is `{"type":"null"}` and the other is a non-null schema.

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -7,6 +7,14 @@ This topic includes new content added in version {page-component-version}. For a
 * xref:redpanda-cloud:get-started:whats-new-cloud.adoc[]
 * xref:redpanda-cloud:get-started:cloud-overview.adoc#redpanda-cloud-vs-self-managed-feature-compatibility[Redpanda Cloud vs Self-Managed feature compatibility]
 
+== Iceberg: Expanded JSON Schema support
+
+* `$ref` support - Internal references using `$ref` (for example, `"$ref": "#/definitions/myType"`) are resolved from schema resources declared in the same document. External references are not yet supported.
+* Map type from `additionalProperties` - `additionalProperties` objects that contain subschemas now translate to Iceberg `map<string, T>`.
+* `oneOf` nullable pattern - The `oneOf` keyword is now supported for the standard nullable pattern if exactly one branch is `{"type":"null"}` and the other is a non-null schema.
+
+See xref:manage:iceberg/specify-iceberg-schema.adoc#how-iceberg-modes-translate-to-table-format[Specify Iceberg Schema] for JSON types mapping and updated requirements.
+
 == Ordered rack preference for Leader Pinning
 
 xref:develop:produce-data/leader-pinning.adoc[Leader Pinning] now supports the `ordered_racks` configuration value, which lets you specify preferred racks in priority order. Unlike `racks`, which distributes leaders uniformly across all listed racks, `ordered_racks` places leaders in the highest-priority available rack and fails over to subsequent racks only when higher-priority racks become unavailable.

--- a/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
+++ b/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
@@ -328,7 +328,7 @@ Requirements:
 | struct or map
 a| * Use `properties` to define `struct` fields and constrain their types. `additionalProperties: false` is supported for closed objects.
 * If `additionalProperties` contains a schema, it translates to an Iceberg `map<string, T>`.
-* You cannot combine `properties` and `additionalProperties`in an object if `additionalProperties` is set to a schema.
+* You cannot combine `properties` and `additionalProperties` in an object if `additionalProperties` is set to a schema.
 
 |===
 
@@ -343,7 +343,7 @@ a| * Use `properties` to define `struct` fields and constrain their types. `addi
 
 |===
 
-Keyword behavior:
+The following keywords have specific behavior:
 
 * The `$ref` keyword is supported for internal references resolved from schema resources declared in the same document (using `$id`), including relative and absolute URI forms. References to external resources and references to unknown keywords are not supported. A root-level `$ref` schema is not supported.
 * The `oneOf` keyword is supported only for the nullable serializer pattern where exactly one branch is `{"type":"null"}` and the other branch is a non-null schema (`T|null`).
@@ -356,7 +356,7 @@ The following are not supported for JSON Schema:
 * Conditional typing (`if`, `then`, `else`, `dependencies` keywords)
 * Boolean JSON Schema combinations (`allOf`, `anyOf`, and non-nullable `oneOf` patterns)
 * Dynamic object members with the `patternProperties` keyword
-* `additionalProperties: true`
+* The `additionalProperties` keyword when set to `true`
 --
 
 ======

--- a/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
+++ b/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
@@ -275,7 +275,7 @@ Requirements:
 
 - Only JSON Schema Draft-07 is currently supported.
 - You must declare the JSON Schema dialect using the `$schema` keyword, for example `"$schema": "http://json-schema.org/draft-07/schema#"`.
-- You must use a JSON Schema that constrains JSON documents to a strict type in order for Redpanda to translate to Iceberg; that is, each subschema must use the `type` keyword.
+- You must use a JSON Schema that constrains JSON documents to a strict type so Redpanda can translate to Iceberg. In most cases this means each subschema uses the `type` keyword, but a subschema can also use `$ref` if the referenced schema resolves to a strict type.
 
 .Valid JSON Schema example
 [,json]
@@ -310,7 +310,7 @@ Requirements:
 
 | null 
 | 
-| The `null` type is not supported except when it is paired with another type to indicate nullability.
+| The `null` type is only supported as a nullability marker, either in a `type` array (for example, `["string", "null"]`) or in an exclusive `oneOf` nullable pattern.
 
 | number 
 | double
@@ -325,9 +325,11 @@ Requirements:
 | The `format` keyword can be used for custom Iceberg types. See <<format-translation,`format` annotation translation>> for details.
 
 | object 
-| struct
-| The `properties` keyword must be used to define `struct` fields and constrain their types. The `additionalProperties` keyword is accepted only when it is set to `false`.
- 
+| struct or map
+a| * Use `properties` to define `struct` fields and constrain their types. `additionalProperties: false` is supported for closed objects.
+* If `additionalProperties` contains a schema, it translates to an Iceberg `map<string, T>`.
+* You cannot combine `properties` and `additionalProperties`in an object if `additionalProperties` is set to a schema.
+
 |===
 
 [[format-translation]]
@@ -341,13 +343,20 @@ Requirements:
 
 |===
 
+Keyword behavior:
+
+* The `$ref` keyword is supported for internal references resolved from schema resources declared in the same document (using `$id`), including relative and absolute URI forms. References to external resources and references to unknown keywords are not supported. A root-level `$ref` schema is not supported.
+* The `oneOf` keyword is supported only for the nullable serializer pattern where exactly one branch is `{"type":"null"}` and the other branch is a non-null schema (`T|null`).
+* In Iceberg output, Redpanda writes all fields as nullable regardless of serializer nullability annotations.
+
 The following are not supported for JSON Schema:
 
-* Relative and absolute (including external) references using `$ref` and `$dynamicRef` keywords
+* The `$dynamicRef` keyword
 * The `default` keyword 
-* Conditional typing (`if`, `then`, `else`, `dependent` keywords)
-* Boolean JSON Schema combinations (`allOf`, `anyOf`, `oneOf` keywords)
-* Dynamic object members (`patternProperties` and `additionalProperties` (except when it is set to `false`) keywords)
+* Conditional typing (`if`, `then`, `else`, `dependencies` keywords)
+* Boolean JSON Schema combinations (`allOf`, `anyOf`, and non-nullable `oneOf` patterns)
+* Dynamic object members with the `patternProperties` keyword
+* `additionalProperties: true`
 --
 
 ======


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1957
Review deadline: v26.1 release

## Page previews

https://deploy-preview-1603--redpanda-docs-preview.netlify.app/current/manage/iceberg/specify-iceberg-schema/
https://deploy-preview-1603--redpanda-docs-preview.netlify.app/current/get-started/release-notes/redpanda/#improved-json-schema-translation-for-iceberg-topics

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
