### PR TITLE
Add glossary term for leader pinning

### DIFF
--- a/modules/terms/partials/leader-pinning.adoc
+++ b/modules/terms/partials/leader-pinning.adoc
@@ -1,0 +1,6 @@
+=== Leader Pinning
+:term-name: Leader Pinning
+:hover-text: Feature that places a topic's partition leaders in a preferred location, such as a cloud availability zone, to reduce networking costs and latency for nearby clients.
+:category: Redpanda features
+
+For more information, see xref:develop:produce-data/leader-pinning.adoc[].


### PR DESCRIPTION
## Description

This pull request adds a new documentation partial for the "leader pinning" feature in Redpanda. It introduces a brief definition, hover text, and a reference link for further information.

Documentation update:

* Added a new partial `leader-pinning.adoc` describing the "leader pinning" feature, including its purpose, a hover-text explanation, and a link to detailed documentation.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
