### PR TITLE
Develop Data Transforms: Ensure learning objective attributes inside single source tag

### DIFF
--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -3,10 +3,10 @@
 :page-categories: Development, Stream Processing, Data Transforms
 :page-topic-type: how-to
 :personas: streaming_developer, application_developer
+// tag::single-source[]
 :learning-objective-1: Initialize a data transforms project using the rpk CLI
 :learning-objective-2: Build transform functions that process records and write to output topics
 :learning-objective-3: Implement multi-topic routing patterns with Schema Registry integration
-// tag::single-source[]
 
 {description}
 
@@ -513,7 +513,7 @@ output_topics:
 
 The transform extracts each update and routes it to the appropriate topic based on the `table` field. Schemas are registered dynamically in the `main()` function using the Schema Registry client, which returns the schema IDs needed for encoding messages in the wire format.
 
-NOTE: In this example, it is assumed that you have created the output topics and have the schema definitions ready. The transform registers the schemas dynamically on startup using the `{topic-name}-value` naming convention for schema subjects (for example, `orders-value`, `inventory-value`).
+NOTE: In this example, it is assumed that you have created the output topics and have the schema definitions ready. The transform registers the schemas dynamically on startup using the `\{topic-name}-value` naming convention for schema subjects (for example, `orders-value`, `inventory-value`).
 
 [tabs]
 ======


### PR DESCRIPTION
## Description

We recently updated the [Develop Data Transforms](https://docs.redpanda.com/current/develop/data-transforms/build/) doc and included new :learning-objective: attributes, but these currently do not render on the [Cloud version of the doc](https://docs.redpanda.com/redpanda-cloud/develop/data-transforms/build/) because the new attributes are not inside the single source tags. This PR moves the tag above the attributes and ensures that they display correctly on both versions of the doc.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

Cloud: [Develop Data Transforms](https://deploy-preview-1606--redpanda-docs-preview.netlify.app/redpanda-cloud/develop/data-transforms/build/)
SM: [Develop Data Transforms](https://deploy-preview-1606--redpanda-docs-preview.netlify.app/current/develop/data-transforms/build/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
