### PR TITLE
fix(DOC-1681): sentence-case headings in broker properties reference

### DIFF
--- a/modules/reference/pages/properties/broker-properties.adoc
+++ b/modules/reference/pages/properties/broker-properties.adoc
@@ -47,7 +47,7 @@ redpanda:
 include::reference:partial$properties/broker-properties.adoc[tags=category-redpanda;!deprecated;!exclude-from-docs]
 
 [[http_based_auth_method]]
-== HTTP-Based Authentication
+== HTTP-based authentication
 
 The `authentication_method` property configures authentication for HTTP-based API listeners (Schema Registry and HTTP Proxy).
 
@@ -97,7 +97,7 @@ schema_registry:
 include::reference:partial$properties/broker-properties.adoc[tags=category-schema-registry;!deprecated;!exclude-from-docs]
 
 
-== HTTP Proxy Client
+== HTTP Proxy client
 
 Configuration options for how the HTTP Proxy **connects to Kafka brokers**. 
 
@@ -130,9 +130,9 @@ Replace the following placeholders with your values:
 
 include::reference:partial$properties/broker-properties.adoc[tags=category-pandaproxy-client;!deprecated;!exclude-from-docs]
 
-== Schema Registry Client
+== Schema Registry client
 
-Configuration options for Schema Registry Client connections to Kafka brokers.
+Configuration options for Schema Registry client connections to Kafka brokers.
 
 .Example
 [,yaml]
@@ -159,13 +159,13 @@ Replace the following placeholders with your values:
 * `<username>`: SCRAM username for authentication
 * `<password>`: SCRAM password for authentication
 
-NOTE: Schema Registry Client uses the same configuration properties as HTTP Proxy Client but with different defaults optimized for Schema Registry operations. The client uses immediate batching (0ms delay, 0 record count) for low-latency schema operations.
+NOTE: Schema Registry client uses the same configuration properties as HTTP Proxy client but with different defaults optimized for Schema Registry operations. The client uses immediate batching (0ms delay, 0 record count) for low-latency schema operations.
 
 ---
 
-== Audit Log Client
+== Audit log client
 
-Configuration options for Audit Log Client connections to Kafka brokers.
+Configuration options for Audit log client connections to Kafka brokers.
 
 .Example
 [,yaml]

--- a/modules/reference/pages/properties/broker-properties.adoc
+++ b/modules/reference/pages/properties/broker-properties.adoc
@@ -159,7 +159,7 @@ Replace the following placeholders with your values:
 * `<username>`: SCRAM username for authentication
 * `<password>`: SCRAM password for authentication
 
-NOTE: Schema Registry client uses the same configuration properties as HTTP Proxy client but with different defaults optimized for Schema Registry operations. The client uses immediate batching (0ms delay, 0 record count) for low-latency schema operations.
+NOTE: Schema Registry client uses the same configuration properties as HTTP Proxy client but with different defaults optimized for Schema Registry operations. The client uses immediate batching (0 ms delay, 0 record count) for low-latency schema operations.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes four section headings and matching prose on the broker properties reference page to use sentence case per the style guide:

- `HTTP-Based Authentication` → `HTTP-based authentication`
- `HTTP Proxy Client` → `HTTP Proxy client`
- `Schema Registry Client` → `Schema Registry client`
- `Audit Log Client` → `Audit log client`

"HTTP Proxy" and "Schema Registry" remain capitalized as product names.

## Preview

- [Broker Configuration Properties](https://deploy-preview-1609--redpanda-docs-preview.netlify.app/current/reference/properties/broker-properties/)

## Test plan

- [x] Netlify deploy preview renders correctly
- [x] Headings display in sentence case on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)