### PR TITLE
review fixes: chroot flags, dry-run usage, plugin-init example

### DIFF
--- a/modules/reference/pages/rpk/rpk-connect/rpk-connect-agent-run.adoc
+++ b/modules/reference/pages/rpk/rpk-connect/rpk-connect-agent-run.adoc
@@ -33,4 +33,12 @@ rpk connect agent run ./repo
 
 | --help, -h
 | Show help for the command.
+
+4+h| Linux only
+
+| --chroot
+| Chroot into the provided directory after parsing configuration. Common `/etc/` files are copied to the chroot directory, and the directory is made read-only.
+
+| --chroot-passthrough
+| Specify additional files to be copied into the chroot directory. Can be specified multiple times. Only valid when `--chroot` is used.
 |===

--- a/modules/reference/pages/rpk/rpk-connect/rpk-connect-dry-run.adoc
+++ b/modules/reference/pages/rpk/rpk-connect/rpk-connect-dry-run.adoc
@@ -5,7 +5,7 @@ Parse Redpanda Connect configs and test the connections of each plugin. Exits wi
 
 == Usage
 
- rpk connect dry-run [command options]
+ rpk connect dry-run [OPTIONS] [files...]
 
 == Example
 

--- a/modules/reference/pages/rpk/rpk-connect/rpk-connect-plugin-init.adoc
+++ b/modules/reference/pages/rpk/rpk-connect/rpk-connect-plugin-init.adoc
@@ -12,6 +12,13 @@ Generate a project on the local filesystem that can be used as a starting point 
 
  rpk connect plugin init [OPTIONS]
 
+== Example
+
+[,bash]
+----
+rpk connect plugin init ./my-plugin
+----
+
 == Options
 
 [cols="1m,2a"]


### PR DESCRIPTION
Review fixes for #1608:

- `rpk-connect-agent-run.adoc`: add Linux-only `--chroot` and `--chroot-passthrough` flags
- `rpk-connect-dry-run.adoc`: fix Usage line from `[command options]` to `[OPTIONS] [files...]`
- `rpk-connect-plugin-init.adoc`: add Example section