### PR TITLE
Remove xrefs from glossary partials

### DIFF
--- a/modules/terms/partials/acl.adoc
+++ b/modules/terms/partials/acl.adoc
@@ -2,11 +2,3 @@
 :term-name: ACL
 :hover-text: A security feature used to define and enforce granular permissions to resources, ensuring only authorized users or applications can perform specific operations. ACLs act on principals. 
 :category: Redpanda security
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:security/authorization.adoc[].
-endif::[]
-
-ifdef::env-cloud[]
-For more information, see xref:security:authorization/cloud-authorization.adoc[].
-endif::[]

--- a/modules/terms/partials/authentication.adoc
+++ b/modules/terms/partials/authentication.adoc
@@ -2,12 +2,3 @@
 :term-name: authentication
 :hover-text: The process of verifying the identity of a principal, user, or service account. Also known as AuthN.
 :category: Redpanda security
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:security/authentication.adoc[].
-endif::[]
-
-ifdef::env-cloud[]
-For more information, see xref:security:cloud-authentication.adoc[].
-endif::[]
-

--- a/modules/terms/partials/authorization.adoc
+++ b/modules/terms/partials/authorization.adoc
@@ -2,11 +2,3 @@
 :term-name: authorization
 :hover-text: The process of specifying access rights to resources. Access rights are enforced through roles or access control lists (ACLs). Also known as AuthZ.
 :category: Redpanda security
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:security/authorization.adoc[].
-endif::[]
-
-ifdef::env-cloud[]
-For more information, see xref:security:authorization/cloud-authorization.adoc[].
-endif::[]

--- a/modules/terms/partials/bearer-token.adoc
+++ b/modules/terms/partials/bearer-token.adoc
@@ -2,11 +2,3 @@
 :term-name: bearer token
 :hover-text: An access token used for authentication and authorization in web applications and APIs. It holds user credentials, usually in the form of random strings of characters. 
 :category: Redpanda security
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:security/authentication.adoc[].
-endif::[]
-
-ifdef::env-cloud[]
-For more information, see xref:security:cloud-authentication.adoc[].
-endif::[]

--- a/modules/terms/partials/compaction.adoc
+++ b/modules/terms/partials/compaction.adoc
@@ -2,7 +2,3 @@
 :term-name: compaction
 :hover-text: Feature that retains the latest value for each key within a partition while discarding older values. 
 :category: Redpanda features
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:cluster-maintenance/compaction-settings.adoc[].
-endif::[]

--- a/modules/terms/partials/data-transforms.adoc
+++ b/modules/terms/partials/data-transforms.adoc
@@ -2,6 +2,3 @@
 :term-name: data transforms
 :hover-text: Framework to manipulate or enrich data written to Redpanda topics. You can develop custom data functions, which run asynchronously using a WebAssembly (Wasm) engine inside a Redpanda broker. 
 :category: Redpanda features
-
-
-For more information, see xref:develop:data-transforms/index.adoc[].

--- a/modules/terms/partials/helm.adoc
+++ b/modules/terms/partials/helm.adoc
@@ -2,7 +2,3 @@
 :term-name: Helm chart
 :hover-text: Generates and applies all the manifest files you need for deploying Redpanda in Kubernetes. 
 :category: Redpanda in Kubernetes
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:deploy:deployment-option/self-hosted/kubernetes/kubernetes-production-deployment.adoc[].
-endif::[]

--- a/modules/terms/partials/leader-pinning.adoc
+++ b/modules/terms/partials/leader-pinning.adoc
@@ -2,5 +2,3 @@
 :term-name: Leader Pinning
 :hover-text: Feature that places a topic's partition leaders in a preferred location, such as a cloud availability zone, to reduce networking costs and latency for nearby clients.
 :category: Redpanda features
-
-For more information, see xref:develop:produce-data/leader-pinning.adoc[].

--- a/modules/terms/partials/learner.adoc
+++ b/modules/terms/partials/learner.adoc
@@ -4,7 +4,3 @@
 :category: Redpanda core
 
 In a Raft group, a broker can be in learner status. Learners are followers that cannot vote and so do not count towards quorum (the majority). They cannot be elected to leader nor can they trigger leader elections. Brokers can be promoted or demoted between learner and voter. New Raft group members start as learners. 
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:raft-group-reconfiguration.adoc[].
-endif::[]

--- a/modules/terms/partials/listener.adoc
+++ b/modules/terms/partials/listener.adoc
@@ -2,7 +2,3 @@
 :term-name: listener
 :hover-text: Configuration on a broker that defines how it should accept client or inter-broker connections. Each listener is associated with a specific protocol, hostname, and port combination. The listener defines where the broker should listen for incoming connections.
 :category: Redpanda core
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:security/listener-configuration.adoc[].
-endif::[]

--- a/modules/terms/partials/maintenance-mode.adoc
+++ b/modules/terms/partials/maintenance-mode.adoc
@@ -2,7 +2,3 @@
 :term-name: maintenance mode
 :hover-text: A state where a Redpanda broker temporarily doesn't take any partition leaderships. It continues to store data as a follower. This is usually done for system maintenance or a rolling upgrade.
 :category: Redpanda features
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:node-management.adoc[].
-endif::[]

--- a/modules/terms/partials/mcp-tool.adoc
+++ b/modules/terms/partials/mcp-tool.adoc
@@ -2,13 +2,3 @@
 :term-name: MCP tool
 :hover-text: A function that an AI assistant can call to perform a specific task, such as fetching data from an API, querying a database, or processing streaming data. Each tool is defined using Redpanda Connect components and annotated with MCP metadata.
 :category: Redpanda Connect
-
-////
-ifndef::env-cloud[]
-For more information, see xref:redpanda-connect:ai-agents:mcp-server/concepts.adoc[].
-endif::[]
-
-ifdef::env-cloud[]
-For more information, see xref:redpanda-cloud:ai-agents:mcp/remote/concepts.adoc[].
-endif::[]
-////

--- a/modules/terms/partials/operator.adoc
+++ b/modules/terms/partials/operator.adoc
@@ -2,7 +2,3 @@
 :term-name: Redpanda Operator
 :hover-text: Extends Kubernetes with custom resource definitions (CRDs), which allow Redpanda clusters to be treated as native Kubernetes resources. 
 :category: Redpanda in Kubernetes
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:deploy:deployment-option/self-hosted/kubernetes/kubernetes-production-deployment.adoc[].
-endif::[]

--- a/modules/terms/partials/producer.adoc
+++ b/modules/terms/partials/producer.adoc
@@ -2,6 +2,3 @@
 :term-name: producer
 :hover-text: A client application that writes events to Redpanda. Redpanda stores these events in sequence and organizes them into topics.
 :category: Redpanda core
-
-
-For more information, see xref:develop:produce-data/configure-producers.adoc[].

--- a/modules/terms/partials/rack-awareness.adoc
+++ b/modules/terms/partials/rack-awareness.adoc
@@ -2,7 +2,3 @@
 :term-name: rack awareness
 :hover-text: Feature that lets you distribute replicas of the same partition across different racks to minimize data loss and improve fault tolerance in the event of a rack failure. 
 :category: Redpanda features
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:rack-awareness.adoc[].
-endif::[]

--- a/modules/terms/partials/rebalancing.adoc
+++ b/modules/terms/partials/rebalancing.adoc
@@ -9,6 +9,4 @@ Redpanda provides various topic-aware tools to balance clusters for best perform
 - Partition replica balancing moves partition replicas to alleviate disk pressure and to honor the configured replication factor across brokers and the additional redundancy across failure domains (such as racks). Redpanda provides partition replica rebalancing when brokers are added or decommissioned. 
 ifndef::env-cloud[]
 - With an Enterprise license, you can additionally enable Continuous Data Balancing to continuously monitor broker and rack availability and disk usage.
-
-For more information, see xref:ROOT:manage:cluster-maintenance/cluster-balancing.adoc[].
 endif::[]

--- a/modules/terms/partials/redpanda-connect-mcp-server.adoc
+++ b/modules/terms/partials/redpanda-connect-mcp-server.adoc
@@ -2,5 +2,3 @@
 :term-name: Redpanda Connect MCP server
 :hover-text: A process that exposes Redpanda Connect components to MCP clients. You write each tool's logic using Redpanda Connect configurations and annotate them with MCP metadata so clients can discover and invoke them.
 :category: Redpanda Connect
-
-For more information, see xref:redpanda-connect:ai-agents:mcp-server/overview.adoc[].

--- a/modules/terms/partials/redpanda-connect.adoc
+++ b/modules/terms/partials/redpanda-connect.adoc
@@ -2,11 +2,3 @@
 :term-name: Redpanda Connect
 :hover-text: A framework for building data streaming applications using declarative YAML configurations. Redpanda Connect provides components such as inputs, processors, outputs, and caches to define data flows and transformations.
 :category: Redpanda Connect
-
-ifndef::env-cloud[]
-For more information, see xref:redpanda-connect:ROOT:about.adoc[].
-endif::[]
-
-ifdef::env-cloud[]
-For more information, see xref:redpanda-cloud:develop:connect/about.adoc[].
-endif::[]

--- a/modules/terms/partials/remote-mcp.adoc
+++ b/modules/terms/partials/remote-mcp.adoc
@@ -2,5 +2,3 @@
 :term-name: Remote MCP
 :hover-text: An MCP server hosted in your Redpanda Cloud cluster. It exposes custom tools that AI assistants can call to access your data and workflows.
 :category: Redpanda Cloud
-
-For more information, see xref:redpanda-cloud:ai-agents:mcp/remote/overview.adoc[].

--- a/modules/terms/partials/retention.adoc
+++ b/modules/terms/partials/retention.adoc
@@ -2,7 +2,3 @@
 :term-name: retention
 :hover-text: The mechanism for determining how long Redpanda stores data on local disk or in object storage before purging it.
 :category: Redpanda core
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:cluster-maintenance/disk-utilization.adoc[].
-endif::[]

--- a/modules/terms/partials/rolling-upgrade.adoc
+++ b/modules/terms/partials/rolling-upgrade.adoc
@@ -2,7 +2,3 @@
 :term-name: rolling upgrade
 :hover-text: The process of upgrading each broker in a Redpanda cluster, one at a time, to minimize disruption and ensure continuous availability.
 :category: Redpanda features
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:upgrade:rolling-upgrade.adoc[].
-endif::[]

--- a/modules/terms/partials/schema-registry.adoc
+++ b/modules/terms/partials/schema-registry.adoc
@@ -2,5 +2,3 @@
 :term-name: Schema Registry
 :hover-text: Redpanda Schema Registry (pandaproxy) is the interface for storing and managing event schemas. Producers and consumers register and retrieve schemas they use from the registry. It is built into the Redpanda binary and uses the default port 8081.
 :category: Redpanda features
-
-For more information, see xref:manage:schema-registry.adoc[].

--- a/modules/terms/partials/tiered-storage.adoc
+++ b/modules/terms/partials/tiered-storage.adoc
@@ -2,7 +2,3 @@
 :term-name: Tiered Storage
 :hover-text: Feature that lets you offload log segments to object storage in near real-time, providing long-term data retention and topic recovery.
 :category: Redpanda features
-
-ifndef::env-cloud[]
-For more information, see xref:ROOT:manage:tiered-storage.adoc[].
-endif::[]


### PR DESCRIPTION
## Description

This pull request removes "For more information" reference links from multiple Redpanda documentation term partials. The goal is to prevent build errors and simplify these glossary entries by eliminating inline documentation cross-references.

Resolves https://redpandadata.atlassian.net/browse/DOC-2071
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
