### PR TITLE
Add Cloud Topic glossary term

### DIFF
--- a/modules/terms/partials/cloud-topic.adoc
+++ b/modules/terms/partials/cloud-topic.adoc
@@ -1,6 +1,6 @@
 === Cloud Topic
 :term-name: Cloud Topic
-:hover-text: An Enterprise Redpanda topic type, requiring a license, that uses object storage (S3, ADLS, GCS, or MinIO) as the primary data store instead of replicating data across brokers. Unlike standard Redpanda topics, Cloud Topics trade higher produce latency (typically 250 ms–1 s) for significantly lower cross-AZ networking costs.
+:hover-text: A Redpanda topic type requiring an Enterprise license, Cloud Topics use object storage (S3, GCS, or MinIO) as the primary data store (rather than replicating data across brokers). Unlike standard Redpanda topics, which do not require an Enterprise license, Cloud Topics allow users with flexible latency requirements to lower or eliminate costs associated with cross-AZ networking.
 :category: Redpanda features
 
 ifndef::env-cloud[]

--- a/modules/terms/partials/cloud-topic.adoc
+++ b/modules/terms/partials/cloud-topic.adoc
@@ -1,0 +1,8 @@
+=== Cloud Topic
+:term-name: Cloud Topic
+:hover-text: An Enterprise Redpanda topic type, requiring a license, that uses object storage (S3, ADLS, GCS, or MinIO) as the primary data store instead of replicating data across brokers. Unlike standard Redpanda topics, Cloud Topics trade higher produce latency (typically 250 ms–1 s) for significantly lower cross-AZ networking costs.
+:category: Redpanda features
+
+ifndef::env-cloud[]
+For more information, see xref:develop:manage-topics/cloud-topics.adoc[].
+endif::[]


### PR DESCRIPTION
## Summary

- Adds `modules/terms/partials/cloud-topic.adoc` to the glossary
- Defines Cloud Topic as an Enterprise feature that uses object storage as primary data store
- Contrasts Cloud Topic with standard Redpanda topics (latency vs. cross-AZ cost trade-off)
- Includes a "For more information" link to the self-managed Cloud Topics page

## Related

Companion to https://github.com/redpanda-data/docs/pull/1469 (Cloud Topics GA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)