### PR TITLE
Configurable namespace for Iceberg

### DIFF
--- a/modules/manage/pages/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/about-iceberg-topics.adoc
@@ -77,7 +77,9 @@ ifdef::env-cloud[]
 To create an Iceberg table for a Redpanda topic, you must set the cluster configuration property config_ref:iceberg_enabled,true,properties/cluster-properties[`iceberg_enabled`] to `true`, and also configure the topic property `redpanda.iceberg.mode`. You can choose to provide a schema if you need the Iceberg table to be structured with defined columns.
 endif::[]
 
-. Set the `iceberg_enabled` configuration option on your cluster to `true`. 
+. Set the `iceberg_enabled` configuration option on your cluster to `true`.
++
+By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. To use a custom namespace, set config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] at the same time. This property cannot be changed after Iceberg is enabled.
 ifdef::env-cloud[]
 +
 [tabs]
@@ -89,6 +91,8 @@ rpk::
 ----
 rpk cloud login
 rpk profile create  --from-cloud <CLUSTER ID>
+# Optional: set a custom namespace (default is "redpanda")
+rpk cluster config set iceberg_default_catalog_namespace '["<custom-namespace>"]'
 rpk cluster config set iceberg_enabled true
 ----
 --
@@ -108,12 +112,12 @@ export RP_CLOUD_TOKEN=`curl -X POST "https://auth.prd.cloud.redpanda.com/oauth/t
     -d "client_id=<client-id>" \
     -d "client_secret=<client-secret>"`
 
-# Update cluster configuration to enable Iceberg topics
+# Enable Iceberg; omit iceberg_default_catalog_namespace to use the default "redpanda" namespace
 curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
   "https://api.cloud.redpanda.com/v1/clusters/${RP_CLUSTER_ID}" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
- -d '{"cluster_configuration":{"custom_properties": {"iceberg_enabled":true}}}'
+ -d '{"cluster_configuration":{"custom_properties": {"iceberg_default_catalog_namespace":["<custom-namespace>"], "iceberg_enabled":true}}}'
 ----
 
 The link:/api/doc/cloud-controlplane/operation/operation-clusterservice_updatecluster[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. The operation may take up to ten minutes to complete. You can check the status of the operation by polling the link:/api/doc/cloud-controlplane/operation/operation-operationservice_getoperation[`GET /operations/\{id}`] endpoint.
@@ -124,7 +128,9 @@ ifndef::env-cloud[]
 +
 [,bash]
 ----
-rpk cluster config set iceberg_enabled true 
+# Optional: set a custom namespace (default is "redpanda")
+rpk cluster config set iceberg_default_catalog_namespace '["<custom-namespace>"]'
+rpk cluster config set iceberg_enabled true
 ----
 +
 [,bash,role=no-copy]

--- a/modules/manage/pages/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/about-iceberg-topics.adoc
@@ -122,7 +122,7 @@ The link:/api/doc/cloud-controlplane/operation/operation-clusterservice_updatecl
 endif::[]
 ifndef::env-cloud[]
 +
-By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. To use a custom namespace, set config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] at the same time. This property cannot be changed after Iceberg is enabled.
+When multiple clusters write to the same catalog, each cluster must use a distinct namespace to avoid table name collisions. This is especially critical for REST catalog providers that offer a single global catalog per account (such as AWS Glue), where there is no other isolation mechanism. By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. To use a unique namespace for your cluster's REST catalog integration, set config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] at the same time. This property cannot be changed after you enable Iceberg topics on the cluster.
 +
 [,bash]
 ----

--- a/modules/manage/pages/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/about-iceberg-topics.adoc
@@ -78,8 +78,6 @@ To create an Iceberg table for a Redpanda topic, you must set the cluster config
 endif::[]
 
 . Set the `iceberg_enabled` configuration option on your cluster to `true`.
-+
-By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. To use a custom namespace, set config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] at the same time. This property cannot be changed after Iceberg is enabled.
 ifdef::env-cloud[]
 +
 [tabs]
@@ -91,8 +89,6 @@ rpk::
 ----
 rpk cloud login
 rpk profile create  --from-cloud <CLUSTER ID>
-# Optional: set a custom namespace (default is "redpanda")
-rpk cluster config set iceberg_default_catalog_namespace '["<custom-namespace>"]'
 rpk cluster config set iceberg_enabled true
 ----
 --
@@ -112,12 +108,12 @@ export RP_CLOUD_TOKEN=`curl -X POST "https://auth.prd.cloud.redpanda.com/oauth/t
     -d "client_id=<client-id>" \
     -d "client_secret=<client-secret>"`
 
-# Enable Iceberg; omit iceberg_default_catalog_namespace to use the default "redpanda" namespace
+# Update cluster configuration to enable Iceberg topics
 curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
   "https://api.cloud.redpanda.com/v1/clusters/${RP_CLUSTER_ID}" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
- -d '{"cluster_configuration":{"custom_properties": {"iceberg_default_catalog_namespace":["<custom-namespace>"], "iceberg_enabled":true}}}'
+ -d '{"cluster_configuration":{"custom_properties": {"iceberg_enabled":true}}}'
 ----
 
 The link:/api/doc/cloud-controlplane/operation/operation-clusterservice_updatecluster[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. The operation may take up to ten minutes to complete. You can check the status of the operation by polling the link:/api/doc/cloud-controlplane/operation/operation-operationservice_getoperation[`GET /operations/\{id}`] endpoint.
@@ -126,11 +122,13 @@ The link:/api/doc/cloud-controlplane/operation/operation-clusterservice_updatecl
 endif::[]
 ifndef::env-cloud[]
 +
+By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. To use a custom namespace, set config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] at the same time. This property cannot be changed after Iceberg is enabled.
++
 [,bash]
 ----
-# Optional: set a custom namespace (default is "redpanda")
-rpk cluster config set iceberg_default_catalog_namespace '["<custom-namespace>"]'
 rpk cluster config set iceberg_enabled true
+# Optional: set a custom namespace (default is "redpanda")
+# rpk cluster config set iceberg_default_catalog_namespace '["<custom-namespace>"]'
 ----
 +
 [,bash,role=no-copy]

--- a/modules/manage/pages/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/about-iceberg-topics.adoc
@@ -88,7 +88,7 @@ rpk::
 [,bash]
 ----
 rpk cloud login
-rpk profile create  --from-cloud <CLUSTER ID>
+rpk profile create  --from-cloud <cluster-id>
 rpk cluster config set iceberg_enabled true
 ----
 --

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -127,8 +127,10 @@ endif::[]
 
 To configure your Redpanda cluster to enable Iceberg on a topic and integrate with the AWS Glue Data Catalog:
 
-. Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below. By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. To use a custom namespace, set config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] at the same time. This property cannot be changed after Iceberg is enabled.
+. Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below.
 ifndef::env-cloud[]
++
+By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. To use a custom namespace, set config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] at the same time. This property cannot be changed after Iceberg is enabled.
 +
 Run `rpk cluster config edit` to update these properties:
 +
@@ -175,8 +177,6 @@ rpk profile create --from-cloud <cluster-id>
 
 rpk cluster config set \
   iceberg_enabled=true \
-  # Set a custom namespace (default is "redpanda")
-  iceberg_default_catalog_namespace='["<custom-namespace>"]'
   iceberg_catalog_type=rest \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -130,7 +130,7 @@ To configure your Redpanda cluster to enable Iceberg on a topic and integrate wi
 . Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below.
 ifndef::env-cloud[]
 +
-By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. To use a custom namespace, set config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] at the same time. This property cannot be changed after Iceberg is enabled.
+By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. Because AWS Glue provides a single catalog per account, each Redpanda cluster that writes to the same Glue catalog must use a distinct namespace to avoid table name collisions. To set a unique namespace, set config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] at the same time. This property cannot be changed after Iceberg is enabled.
 +
 Run `rpk cluster config edit` to update these properties:
 +

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -127,7 +127,7 @@ endif::[]
 
 To configure your Redpanda cluster to enable Iceberg on a topic and integrate with the AWS Glue Data Catalog:
 
-. Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below.
+. Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below. By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. To use a custom namespace, set config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] at the same time. This property cannot be changed after Iceberg is enabled.
 ifndef::env-cloud[]
 +
 Run `rpk cluster config edit` to update these properties:
@@ -135,6 +135,8 @@ Run `rpk cluster config edit` to update these properties:
 [,bash]
 ----
 iceberg_enabled: true
+# Set a custom namespace instead of the default "redpanda"
+iceberg_default_catalog_namespace: ["<custom-namespace>"]
 # Glue requires Redpanda Iceberg tables to be manually deleted
 iceberg_delete: false
 iceberg_catalog_type: rest
@@ -173,6 +175,8 @@ rpk profile create --from-cloud <cluster-id>
 
 rpk cluster config set \
   iceberg_enabled=true \
+  # Set a custom namespace (default is "redpanda")
+  iceberg_default_catalog_namespace='["<custom-namespace>"]'
   iceberg_catalog_type=rest \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -191,8 +191,8 @@ echo "hello world\nfoo bar\nbaz qux" | rpk topic produce <topic-name> --format='
 
 You should see the topic as a table with data in Unity Catalog. The data may take some time to become visible, depending on your config_ref:iceberg_target_lag_ms,true,properties/cluster-properties[`iceberg_target_lag_ms`] setting.
 
-. In Catalog Explorer, open your catalog. You should see a `redpanda` schema, in addition to `default` and `information_schema`.
-. The `redpanda` schema and the table residing within this schema are automatically added for you. The table name is the same as the topic name. 
+. In Catalog Explorer, open your catalog. You should see a `redpanda` schema (or the namespace you configured with config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`]), in addition to `default` and `information_schema`.
+. The schema and the table residing within it are automatically added for you. The table name is the same as the topic name.
 
 == Query Iceberg table using Databricks SQL
 

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -191,7 +191,12 @@ echo "hello world\nfoo bar\nbaz qux" | rpk topic produce <topic-name> --format='
 
 You should see the topic as a table with data in Unity Catalog. The data may take some time to become visible, depending on your config_ref:iceberg_target_lag_ms,true,properties/cluster-properties[`iceberg_target_lag_ms`] setting.
 
+ifndef::env-cloud[]
 . In Catalog Explorer, open your catalog. You should see a `redpanda` schema (or the namespace you configured with config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`]), in addition to `default` and `information_schema`.
+endif::[]
+ifdef::env-cloud[]
+. In Catalog Explorer, open your catalog. You should see a `redpanda` schema, in addition to `default` and `information_schema`.
+endif::[]
 . The schema and the table residing within it are automatically added for you. The table name is the same as the topic name.
 
 == Query Iceberg table using Databricks SQL

--- a/modules/manage/pages/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/query-iceberg-topics.adoc
@@ -97,6 +97,8 @@ endif::[]
 {"user_id": 2324, "event_type": "BUTTON_CLICK", "ts": "2024-11-25T20:23:59.380Z"}
 ----
 
+NOTE: The query examples on this page use `redpanda` as the Iceberg namespace, which is the default. If you configured a different namespace using config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`], replace `redpanda` with your configured namespace.
+
 === Topic with schema (`value_schema_id_prefix` mode)
 
 NOTE: The steps in this section also apply to the `value_schema_latest` mode, except the produce step. The `value_schema_latest` mode is not compatible with the Schema Registry wire format. The xref:reference:rpk/rpk-topic/rpk-topic-produce[`rpk topic produce`] command embeds the wire format header, so you must use your own producer code with `value_schema_latest`.

--- a/modules/manage/pages/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/query-iceberg-topics.adoc
@@ -97,7 +97,9 @@ endif::[]
 {"user_id": 2324, "event_type": "BUTTON_CLICK", "ts": "2024-11-25T20:23:59.380Z"}
 ----
 
+ifndef::env-cloud[]
 NOTE: The query examples on this page use `redpanda` as the Iceberg namespace, which is the default. If you configured a different namespace using config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`], replace `redpanda` with your configured namespace.
+endif::[]
 
 === Topic with schema (`value_schema_id_prefix` mode)
 

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -169,7 +169,7 @@ echo "hello world\nfoo bar\nbaz qux" | rpk topic produce <topic-name> --format='
 You should see the topic as a table in Open Catalog.
 
 . In Open Catalog, select *Catalogs*, then open your catalog. 
-. Under your catalog, you should see the `redpanda` namespace, and a table with the name of your topic. The `redpanda` namespace and the table are automatically added for you.
+. Under your catalog, you should see the `redpanda` namespace (or the namespace you configured with config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`]), and a table with the name of your topic. The namespace and the table are automatically added for you.
 
 == Query Iceberg table in Snowflake
 

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -169,7 +169,12 @@ echo "hello world\nfoo bar\nbaz qux" | rpk topic produce <topic-name> --format='
 You should see the topic as a table in Open Catalog.
 
 . In Open Catalog, select *Catalogs*, then open your catalog. 
+ifndef::env-cloud[]
 . Under your catalog, you should see the `redpanda` namespace (or the namespace you configured with config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`]), and a table with the name of your topic. The namespace and the table are automatically added for you.
+endif::[]
+ifdef::env-cloud[]
+. Under your catalog, you should see the `redpanda` namespace and a table with the name of your topic. The namespace and the table are automatically added for you.
+endif::[]
 
 == Query Iceberg table in Snowflake
 

--- a/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
@@ -90,6 +90,14 @@ To connect to a REST catalog, set the following cluster configuration properties
 
 NOTE: You must set `iceberg_rest_catalog_endpoint` at the same time that you set `iceberg_catalog_type` to `rest`.
 
+ifndef::env-cloud[]
+==== Configure table namespace
+
+When multiple clusters write to the same catalog, each cluster must use a distinct namespace to avoid table name collisions. This is critical for REST catalog providers that offer a single global catalog per account (such as AWS Glue), where there is no other isolation mechanism.
+
+By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. You can configure a unique namespace using the config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] cluster property. You must set this property before enabling the Iceberg integration or at the same time. After you have enabled Iceberg, do not change this property value.
+endif::[]
+
 ==== Configure authentication
 
 To authenticate with the REST catalog, set the following cluster properties:
@@ -273,9 +281,6 @@ SELECT * FROM streaming.redpanda.<table-name>;
 ----
 
 The Iceberg table name is the name of your Redpanda topic. By default, Redpanda creates Iceberg tables in a namespace called `redpanda`.
-ifndef::env-cloud[]
-You can configure a different namespace using the config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] cluster property. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for details.
-endif::[]
 
 TIP: You may need to explicitly create a table for the Iceberg data in your query engine. For an example, see xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[].
 

--- a/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
@@ -95,7 +95,7 @@ ifndef::env-cloud[]
 
 Check if your REST catalog provider has specific requirements or recommendations for namespaces. For example, AWS Glue offers only a single global catalog per account, and each cluster that writes to the same Glue catalog must use a distinct namespace to avoid table name collisions.
 
-To use a unique namespace, configure the config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] cluster property. You must set this property before enabling the Iceberg integration or at the same time. After you have enabled Iceberg, do not change this property value.
+By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. To use a unique namespace, configure the config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] cluster property. You must set this property before enabling the Iceberg integration or at the same time. After you have enabled Iceberg, do not change this property value.
 endif::[]
 
 ==== Configure authentication
@@ -280,7 +280,10 @@ The Spark engine can use the REST catalog to automatically discover the topic's 
 SELECT * FROM streaming.redpanda.<table-name>;
 ----
 
-The Iceberg table name is the name of your Redpanda topic. By default, Redpanda creates Iceberg tables in a namespace called `redpanda`.
+The Iceberg table name is the name of your Redpanda topic.
+ifndef::env-cloud[] 
+If you configured a different namespace using config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`], replace `redpanda` with your configured namespace.
+endif::[]
 
 TIP: You may need to explicitly create a table for the Iceberg data in your query engine. For an example, see xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[].
 

--- a/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
@@ -272,7 +272,7 @@ The Spark engine can use the REST catalog to automatically discover the topic's 
 SELECT * FROM streaming.redpanda.<table-name>;
 ----
 
-The Iceberg table name is the name of your Redpanda topic. Redpanda puts the Iceberg table into a namespace called `redpanda`, creating the namespace if necessary. 
+The Iceberg table name is the name of your Redpanda topic. By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. You can configure a different namespace using the config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] cluster property. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for details.
 
 TIP: You may need to explicitly create a table for the Iceberg data in your query engine. For an example, see xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[].
 

--- a/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
@@ -93,9 +93,9 @@ NOTE: You must set `iceberg_rest_catalog_endpoint` at the same time that you set
 ifndef::env-cloud[]
 ==== Configure table namespace
 
-When multiple clusters write to the same catalog, each cluster must use a distinct namespace to avoid table name collisions. This is critical for REST catalog providers that offer a single global catalog per account (such as AWS Glue), where there is no other isolation mechanism.
+Check if your REST catalog provider has specific requirements or recommendations for namespaces. For example, AWS Glue offers only a single global catalog per account, and each cluster that writes to the same Glue catalog must use a distinct namespace to avoid table name collisions.
 
-By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. You can configure a unique namespace using the config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] cluster property. You must set this property before enabling the Iceberg integration or at the same time. After you have enabled Iceberg, do not change this property value.
+To use a unique namespace, configure the config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] cluster property. You must set this property before enabling the Iceberg integration or at the same time. After you have enabled Iceberg, do not change this property value.
 endif::[]
 
 ==== Configure authentication

--- a/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
@@ -272,7 +272,10 @@ The Spark engine can use the REST catalog to automatically discover the topic's 
 SELECT * FROM streaming.redpanda.<table-name>;
 ----
 
-The Iceberg table name is the name of your Redpanda topic. By default, Redpanda creates Iceberg tables in a namespace called `redpanda`. You can configure a different namespace using the config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] cluster property. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for details.
+The Iceberg table name is the name of your Redpanda topic. By default, Redpanda creates Iceberg tables in a namespace called `redpanda`.
+ifndef::env-cloud[]
+You can configure a different namespace using the config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`] cluster property. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for details.
+endif::[]
 
 TIP: You may need to explicitly create a table for the Iceberg data in your query engine. For an example, see xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[].
 


### PR DESCRIPTION
## Description

This pull request updates the Iceberg documentation to clarify how Redpanda manages Iceberg table namespaces, especially regarding the default namespace (`redpanda`) and how to configure a custom namespace using the `iceberg_default_catalog_namespace` property. The changes also improve instructions and examples across several integration guides to ensure users understand namespace behavior in both cloud and self-managed environments.

NOTE: The property is still conditionalized out from Cloud docs

**Key documentation improvements:**

*Namespace configuration and usage:*
- Added explanations that Redpanda creates Iceberg tables in the `redpanda` namespace by default and clarified how to set a custom namespace with the `iceberg_default_catalog_namespace` property, including the important note that this property is immutable after enabling Iceberg. [[1]](diffhunk://#diff-dc0abfcef1c6313889a655a17b41bf76bece103878789615e6576b62bff87347R125-R131) [[2]](diffhunk://#diff-3bd481de18a4f29147c493bbbb9109ffe08bb6c449f20eb1ca2e1093a655ab68R133-R141) [[3]](diffhunk://#diff-1729d527b6d3e8bde7be05207c7332cb80605de4fc72ddc2eb86666dd7fc3e67L275-R278)
- Updated command examples and configuration snippets to show how to set the custom namespace, and clarified placeholder usage (e.g., `<cluster-id>` instead of `<CLUSTER ID>`). [[1]](diffhunk://#diff-dc0abfcef1c6313889a655a17b41bf76bece103878789615e6576b62bff87347L91-R91) [[2]](diffhunk://#diff-3bd481de18a4f29147c493bbbb9109ffe08bb6c449f20eb1ca2e1093a655ab68R133-R141)

*Integration-specific instructions and visibility:*
- Updated Databricks Unity and Snowflake integration guides to explain how the namespace appears in their respective catalogs, with conditional instructions for cloud and self-managed environments. [[1]](diffhunk://#diff-a8cc69134db34c0afe324812dbe0c1c9ec51c399f09a25e0c32d137913f81791R194-R200) [[2]](diffhunk://#diff-504f69a50b1fee44f43795311954bf91f6e3e8112bf49a18660430416be2b3b6L172-R177)
- Added notes to the query documentation reminding users to replace `redpanda` with their configured namespace in query examples if a custom namespace is used.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

About Iceberg Topics > [Enable Iceberg integration](https://deploy-preview-1622--redpanda-docs-preview.netlify.app/current/manage/iceberg/about-iceberg-topics/#enable-iceberg-integration)
Query Iceberg Topics > [Query examples](https://deploy-preview-1622--redpanda-docs-preview.netlify.app/current/manage/iceberg/query-iceberg-topics/#query-examples)
AWS Glue > [Update cluster configuration](https://deploy-preview-1622--redpanda-docs-preview.netlify.app/current/manage/iceberg/iceberg-topics-aws-glue/#update-cluster-configuration)


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
