### PR TITLE
Revert "Add Cloud Topic glossary term (#1621)"

### DIFF
--- a/modules/terms/partials/cloud-topic.adoc
+++ b/modules/terms/partials/cloud-topic.adoc
@@ -1,8 +1,0 @@
-=== Cloud Topic
-:term-name: Cloud Topic
-:hover-text: A Redpanda topic type requiring an Enterprise license, Cloud Topics use object storage (S3, GCS, or MinIO) as the primary data store (rather than replicating data across brokers). Unlike standard Redpanda topics, which do not require an Enterprise license, Cloud Topics allow users with flexible latency requirements to lower or eliminate costs associated with cross-AZ networking.
-:category: Redpanda features
-
-ifndef::env-cloud[]
-For more information, see xref:develop:manage-topics/cloud-topics.adoc[].
-endif::[]


### PR DESCRIPTION
Reverts the Cloud Topic glossary term from the shared branch.

The linked topic (PR #1469) has not yet merged, so the glossary entry should not be live until it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)