### PR TITLE
docs (k8s): Document rolling restart impact during Helm to Operator migration

### DIFF
--- a/modules/migrate/pages/kubernetes/helm-to-operator.adoc
+++ b/modules/migrate/pages/kubernetes/helm-to-operator.adoc
@@ -77,7 +77,7 @@ TIP: Before implementing any changes in your production environment, Redpanda Da
 
 When you apply the Redpanda custom resource, the operator triggers a rolling restart of all broker pods. This restart occurs even if your `clusterSpec` values exactly match the existing Helm values. You cannot avoid this restart during migration.
 
-=== Why pods restart
+=== How the rolling restart works
 
 The migration triggers the following sequence:
 
@@ -116,8 +116,6 @@ To avoid message loss during the rolling restart, configure producers with the f
 - `acks=all` (or `-1`): Ensures the Raft quorum (majority of replicas) commits the write before acknowledging it.
 - `retries`: Handles `NOT_LEADER_FOR_PARTITION` errors during leader elections. Set this to a high value.
 - `enable.idempotence=true`: Prevents duplicate messages from retries.
-
-NOTE: Redpanda uses Raft-based replication, not the in-sync replica (ISR) mechanism used by Apache Kafka. With Raft, writes require a majority quorum (2 of 3 for RF=3). There is no `min.insync.replicas` setting to configure. The replication factor alone determines fault tolerance.
 
 == Migrate to the Redpanda Operator and Helm
 

--- a/modules/migrate/pages/kubernetes/helm-to-operator.adoc
+++ b/modules/migrate/pages/kubernetes/helm-to-operator.adoc
@@ -75,20 +75,23 @@ TIP: Before implementing any changes in your production environment, Redpanda Da
 
 == Expected impact: rolling restart of broker pods
 
-When you apply the Redpanda custom resource, the operator triggers a rolling restart of all broker pods. This happens even if your `clusterSpec` values exactly match the existing Helm values. There is no way to avoid this restart during migration.
+When you apply the Redpanda custom resource, the operator triggers a rolling restart of all broker pods. This restart occurs even if your `clusterSpec` values exactly match the existing Helm values. You cannot avoid this restart during migration.
 
 === Why pods restart
 
 The migration triggers the following sequence:
 
-. *Resource adoption*: The operator uses server-side apply to take ownership of the existing Helm-managed StatefulSet. This patches the StatefulSet with new labels (generation, config version, ownership) and sets the Redpanda custom resource as the owner reference.
+. *Resource adoption*: The operator uses server-side apply to take ownership of the existing Helm-managed StatefulSet. It patches the StatefulSet with new labels (generation, config version, and ownership) and sets the Redpanda custom resource as the owner reference.
 . *StatefulSet spec update*: The operator re-renders the StatefulSet from its own templates. Any difference, even metadata or label changes, creates a new `ControllerRevision`.
-. *Pod rolling*: The operator compares each pod's `StatefulSetRevisionLabel` against the latest `ControllerRevision`. Because the existing pods were created under the old Helm-managed revision, every pod is flagged for rolling.
+. *Pod rolling*: The operator compares each pod's `StatefulSetRevisionLabel` against the latest `ControllerRevision`. Because the existing pods were created under the old Helm-managed revision, the operator flags every pod for rolling.
 . *One-at-a-time deletion*: The operator deletes pods one at a time:
++
+--
 * Checks cluster health through the admin API.
-* If healthy, deletes the pod, then requeues after 10 seconds.
+* Deletes the pod if the cluster is healthy, then requeues after 10 seconds.
 * Waits for the cluster to stabilize before rolling the next pod.
-* If the cluster is unhealthy, skips deletion and requeues.
+* Skips deletion and requeues if the cluster is unhealthy.
+--
 
 === Impact by cluster configuration
 
@@ -97,10 +100,10 @@ The migration triggers the following sequence:
 | Scenario | Impact
 
 | 3+ brokers, replication factor (RF) >= 3
-| No data loss and no downtime for consumers or producers configured with `acks=all`. Individual broker restarts cause brief partition leader elections (typically a few seconds each). Redpanda uses Raft consensus, so writes require a majority quorum. With RF=3 and one broker restarting, the remaining two brokers maintain quorum and writes continue.
+| No data loss and no downtime for consumers or producers configured with `acks=all`. Individual broker restarts cause brief partition leader elections, typically a few seconds each. Redpanda uses Raft consensus, so writes require a majority quorum. With RF=3 and one broker restarting, the remaining two brokers maintain quorum and writes continue.
 
 | 3 brokers, RF = 1
-| Partitions hosted on the restarting broker are unavailable for the duration of that broker's restart.
+| Partitions on the restarting broker are unavailable for the duration of that broker's restart.
 
 | Single broker
 | Full outage for the duration of the restart.
@@ -108,13 +111,13 @@ The migration triggers the following sequence:
 
 === Recommended producer settings
 
-To avoid message loss during the rolling restart, configure producers with:
+To avoid message loss during the rolling restart, configure producers with the following settings:
 
-- `acks=all` (or `-1`): Waits for the write to be committed by the Raft quorum (majority of replicas).
-- `retries`: Set to a high value to handle `NOT_LEADER_FOR_PARTITION` errors during leader elections.
+- `acks=all` (or `-1`): Ensures the Raft quorum (majority of replicas) commits the write before acknowledging it.
+- `retries`: Handles `NOT_LEADER_FOR_PARTITION` errors during leader elections. Set this to a high value.
 - `enable.idempotence=true`: Prevents duplicate messages from retries.
 
-NOTE: Redpanda uses Raft-based replication, not Kafka's in-sync replica (ISR) mechanism. With Raft, writes require a majority quorum (2 of 3 for RF=3). There is no `min.insync.replicas` setting to configure. The replication factor alone determines fault tolerance.
+NOTE: Redpanda uses Raft-based replication, not the in-sync replica (ISR) mechanism used by Apache Kafka. With Raft, writes require a majority quorum (2 of 3 for RF=3). There is no `min.insync.replicas` setting to configure. The replication factor alone determines fault tolerance.
 
 == Migrate to the Redpanda Operator and Helm
 

--- a/modules/migrate/pages/kubernetes/helm-to-operator.adoc
+++ b/modules/migrate/pages/kubernetes/helm-to-operator.adoc
@@ -73,11 +73,11 @@ You should see your overrides in YAML format. You'll need to configure your Redp
 
 TIP: Before implementing any changes in your production environment, Redpanda Data recommends testing the migration in a non-production environment.
 
-== Expected impact: rolling restart of broker pods
+== Rolling restart during migration
 
-When you apply the Redpanda custom resource, the operator triggers a rolling restart of all broker pods. This restart occurs even if your `clusterSpec` values exactly match the existing Helm values. You cannot avoid this restart during migration.
+When you apply the Redpanda custom resource, the operator triggers a rolling restart of all broker pods. The rolling restart is unavoidable during migration, regardless of how closely your `clusterSpec` values match the existing Helm values.
 
-=== How the rolling restart for migrations works
+=== How the rolling restart works
 
 The migration triggers the following sequence:
 
@@ -99,7 +99,7 @@ The migration triggers the following sequence:
 |===
 | Scenario | Impact
 
-| 3+ brokers, replication factor (RF) >= 3
+| 3+ brokers, replication factor (RF) ≥ 3
 | No data loss and no downtime for consumers or producers configured with `acks=all`. Individual broker restarts cause brief partition leader elections, typically a few seconds each. Redpanda uses Raft consensus, so writes require a majority quorum. With RF=3 and one broker restarting, the remaining two brokers maintain quorum and writes continue.
 
 | 3 brokers, RF = 1
@@ -113,9 +113,9 @@ The migration triggers the following sequence:
 
 To avoid message loss during the rolling restart, configure producers with the following settings:
 
-- `acks=all` (or `-1`): Ensures the Raft quorum (majority of replicas) commits the write before acknowledging it.
-- `retries`: Handles `NOT_LEADER_FOR_PARTITION` errors during leader elections. Set this to a high value.
-- `enable.idempotence=true`: Prevents duplicate messages from retries.
+* `acks=all` (or `-1`): Ensures the Raft quorum (majority of replicas) commits the write before acknowledging it.
+* `retries`: Handles `NOT_LEADER_FOR_PARTITION` errors during leader elections. Set this to a high value.
+* `enable.idempotence=true`: Prevents duplicate messages from retries.
 
 == Migrate to the Redpanda Operator and Helm
 

--- a/modules/migrate/pages/kubernetes/helm-to-operator.adoc
+++ b/modules/migrate/pages/kubernetes/helm-to-operator.adoc
@@ -77,7 +77,7 @@ TIP: Before implementing any changes in your production environment, Redpanda Da
 
 When you apply the Redpanda custom resource, the operator triggers a rolling restart of all broker pods. This restart occurs even if your `clusterSpec` values exactly match the existing Helm values. You cannot avoid this restart during migration.
 
-=== How the rolling restart works
+=== How the rolling restart for migrations works
 
 The migration triggers the following sequence:
 

--- a/modules/migrate/pages/kubernetes/helm-to-operator.adoc
+++ b/modules/migrate/pages/kubernetes/helm-to-operator.adoc
@@ -73,6 +73,49 @@ You should see your overrides in YAML format. You'll need to configure your Redp
 
 TIP: Before implementing any changes in your production environment, Redpanda Data recommends testing the migration in a non-production environment.
 
+== Expected impact: rolling restart of broker pods
+
+When you apply the Redpanda custom resource, the operator triggers a rolling restart of all broker pods. This happens even if your `clusterSpec` values exactly match the existing Helm values. There is no way to avoid this restart during migration.
+
+=== Why pods restart
+
+The migration triggers the following sequence:
+
+. *Resource adoption*: The operator uses server-side apply to take ownership of the existing Helm-managed StatefulSet. This patches the StatefulSet with new labels (generation, config version, ownership) and sets the Redpanda custom resource as the owner reference.
+. *StatefulSet spec update*: The operator re-renders the StatefulSet from its own templates. Any difference, even metadata or label changes, creates a new `ControllerRevision`.
+. *Pod rolling*: The operator compares each pod's `StatefulSetRevisionLabel` against the latest `ControllerRevision`. Because the existing pods were created under the old Helm-managed revision, every pod is flagged for rolling.
+. *One-at-a-time deletion*: The operator deletes pods one at a time:
+* Checks cluster health through the admin API.
+* If healthy, deletes the pod, then requeues after 10 seconds.
+* Waits for the cluster to stabilize before rolling the next pod.
+* If the cluster is unhealthy, skips deletion and requeues.
+
+=== Impact by cluster configuration
+
+[cols="2a,4a"]
+|===
+| Scenario | Impact
+
+| 3+ brokers, replication factor (RF) >= 3
+| No data loss and no downtime for consumers or producers configured with `acks=all`. Individual broker restarts cause brief partition leader elections (typically a few seconds each). Redpanda uses Raft consensus, so writes require a majority quorum. With RF=3 and one broker restarting, the remaining two brokers maintain quorum and writes continue.
+
+| 3 brokers, RF = 1
+| Partitions hosted on the restarting broker are unavailable for the duration of that broker's restart.
+
+| Single broker
+| Full outage for the duration of the restart.
+|===
+
+=== Recommended producer settings
+
+To avoid message loss during the rolling restart, configure producers with:
+
+- `acks=all` (or `-1`): Waits for the write to be committed by the Raft quorum (majority of replicas).
+- `retries`: Set to a high value to handle `NOT_LEADER_FOR_PARTITION` errors during leader elections.
+- `enable.idempotence=true`: Prevents duplicate messages from retries.
+
+NOTE: Redpanda uses Raft-based replication, not Kafka's in-sync replica (ISR) mechanism. With Raft, writes require a majority quorum (2 of 3 for RF=3). There is no `min.insync.replicas` setting to configure. The replication factor alone determines fault tolerance.
+
 == Migrate to the Redpanda Operator and Helm
 
 To migrate to the latest Redpanda Operator and use it to manage your Helm deployment, follow these steps.


### PR DESCRIPTION
## Summary

- Adds a new "Expected impact: rolling restart of broker pods" section to the Helm-to-Operator migration guide
- Explains *why* pods restart (resource adoption, StatefulSet re-render, ControllerRevision mismatch)
- Documents impact by cluster configuration (3+ brokers RF>=3, RF=1, single broker)
- Adds recommended producer settings (`acks=all`, retries, idempotence) for zero-downtime migration
- Clarifies that Redpanda uses Raft consensus (not Kafka ISR), so there is no `min.insync.replicas` to configure

## Context

Customers migrating from Helm to Operator were surprised that broker pods restart during migration, even when `clusterSpec` values match existing Helm values and `updateStrategy.type: OnDelete` is set. The current docs don't warn about this. The restart is unavoidable because the operator re-renders the StatefulSet from its own templates, creating a new ControllerRevision that triggers pod rolling.

## Preview docs
[Migrate from the Redpanda Helm chart](https://deploy-preview-1625--redpanda-docs-preview.netlify.app/current/migrate/kubernetes/helm-to-operator/)

## Test plan

- [ ] Verify AsciiDoc renders correctly in the docs site preview
- [ ] Confirm technical accuracy of the rolling restart sequence against operator source code
- [ ] Review producer settings recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)