### PR TITLE
docs (k8s): Add config-watcher sidecar resource configuration

### DIFF
--- a/modules/manage/pages/kubernetes/k-manage-resources.adoc
+++ b/modules/manage/pages/kubernetes/k-manage-resources.adoc
@@ -509,6 +509,102 @@ resources:
     cores: 200m
 ----
 
+[[config-watcher]]
+== Configure config-watcher sidecar resources
+
+Each Redpanda Pod includes a config-watcher sidecar container that monitors for SASL user changes and configuration updates. The sidecar polls a Secret for user credential changes and synchronizes them with the running brokers.
+
+The config-watcher sidecar does not set any CPU or memory resource requests or limits by default. For most clusters, this is acceptable because the sidecar is lightweight. In practice, it typically consumes single-digit millicores of CPU and approximately 20-40 Mi of memory.
+
+However, you should configure explicit resource requests and limits for the config-watcher sidecar in the following cases:
+
+- Your namespace enforces a https://kubernetes.io/docs/concepts/policy/limit-range/[LimitRange^] policy that requires all containers to specify resource requests or limits.
+- Your namespace enforces a https://kubernetes.io/docs/concepts/policy/resource-quotas/[ResourceQuota^] that accounts for resource requests across all containers.
+- You want to ensure the <<qos, Guaranteed QoS class>> for your Redpanda Pods. Kubernetes requires every container in a Pod to have matching requests and limits to qualify.
+
+[tabs]
+======
+Operator::
++
+--
+.`redpanda-cluster.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  chartRef: {}
+  clusterSpec:
+    statefulset:
+      sideCars:
+        configWatcher:
+          resources:
+            requests:
+              cpu: 10m <1>
+              memory: 64Mi <2>
+            limits:
+              cpu: 100m
+              memory: 128Mi
+----
+
+```bash
+kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
+```
+
+--
+Helm::
++
+--
+[tabs]
+====
+--values::
++
+.`config-watcher-resources.yaml`
+[,yaml]
+----
+statefulset:
+  sideCars:
+    configWatcher:
+      resources:
+        requests:
+          cpu: 10m <1>
+          memory: 64Mi <2>
+        limits:
+          cpu: 100m
+          memory: 128Mi
+----
++
+```bash
+helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
+  --values config-watcher-resources.yaml --reuse-values
+```
+
+--set::
++
+```bash
+helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
+  --set statefulset.sideCars.configWatcher.resources.requests.cpu=10m \
+  --set statefulset.sideCars.configWatcher.resources.requests.memory=64Mi \
+  --set statefulset.sideCars.configWatcher.resources.limits.cpu=100m \
+  --set statefulset.sideCars.configWatcher.resources.limits.memory=128Mi
+```
+
+====
+--
+======
+
+<1> A CPU request of `10m` (10 millicores) is sufficient for typical config-watcher workloads. The sidecar spends most of its time idle between polling intervals.
+<2> A memory request of `64Mi` provides headroom for the sidecar process. Actual usage is typically 20-40 Mi.
+
+When the StatefulSet is deployed, verify that the sidecar container has the expected resource configuration:
+
+[source,bash]
+----
+kubectl --namespace <namespace> get pod <pod-name> -o jsonpath='{.spec.containers[?(@.name=="sidecar")].resources}{"\n"}'
+----
+
 include::shared:partial$suggested-reading.adoc[]
 
 - xref:reference:k-redpanda-helm-spec.adoc#resources[Redpanda Helm Specification]

--- a/modules/manage/pages/kubernetes/k-manage-resources.adoc
+++ b/modules/manage/pages/kubernetes/k-manage-resources.adoc
@@ -514,13 +514,13 @@ resources:
 
 Each Redpanda Pod includes a config-watcher sidecar container that monitors for SASL user changes and configuration updates. The sidecar polls a Secret for user credential changes and synchronizes them with the running brokers.
 
-The config-watcher sidecar does not set any CPU or memory resource requests or limits by default. For most clusters, this is acceptable because the sidecar is lightweight. In practice, it typically consumes single-digit millicores of CPU and approximately 20-40 Mi of memory.
+The config-watcher sidecar does not set any CPU or memory resource requests or limits by default. For most clusters, this is acceptable because the sidecar is lightweight. In practice, the sidecar typically consumes single-digit millicores of CPU and approximately 20-40 MiB of memory.
 
-However, you should configure explicit resource requests and limits for the config-watcher sidecar in the following cases:
+Configure explicit resource requests and limits for the config-watcher sidecar in the following cases:
 
-- Your namespace enforces a https://kubernetes.io/docs/concepts/policy/limit-range/[LimitRange^] policy that requires all containers to specify resource requests or limits.
-- Your namespace enforces a https://kubernetes.io/docs/concepts/policy/resource-quotas/[ResourceQuota^] that accounts for resource requests across all containers.
-- You want to ensure the <<qos, Guaranteed QoS class>> for your Redpanda Pods. Kubernetes requires every container in a Pod to have matching requests and limits to qualify.
+* Your namespace enforces a https://kubernetes.io/docs/concepts/policy/limit-range/[LimitRange^] policy that requires all containers to specify resource requests or limits.
+* Your namespace enforces a https://kubernetes.io/docs/concepts/policy/resource-quotas/[ResourceQuota^] that accounts for resource requests across all containers.
+* You want to ensure the <<qos, Guaranteed QoS class>> for your Redpanda Pods. Kubernetes requires every container in a Pod to have matching requests and limits to qualify.
 
 [tabs]
 ======
@@ -602,7 +602,7 @@ When the StatefulSet is deployed, verify that the sidecar container has the expe
 
 [source,bash]
 ----
-kubectl --namespace <namespace> get pod <pod-name> -o jsonpath='{.spec.containers[?(@.name=="sidecar")].resources}{"\n"}'
+kubectl --namespace <namespace> get pod <pod-name> -o jsonpath='{.spec.containers[?(@.name=="config-watcher")].resources}{"\n"}'
 ----
 
 include::shared:partial$suggested-reading.adoc[]


### PR DESCRIPTION
## Summary

- Adds a new "Configure config-watcher sidecar resources" section to the Manage Pod Resources page
- Explains what the config-watcher sidecar does (monitors SASL user changes and configuration updates)
- Documents that resources are unset by default and why that is acceptable for most clusters
- Lists scenarios where explicit resources are needed (LimitRange, ResourceQuota, Guaranteed QoS)
- Provides Operator and Helm examples with recommended values (10m/64Mi requests, 100m/128Mi limits)
- Includes a verification command to confirm the sidecar resources after deployment

## Preview docs
[Configure config-watcher sidecar resources](https://deploy-preview-1626--redpanda-docs-preview.netlify.app/current/manage/kubernetes/k-manage-resources/#config-watcher)

## Context

The config-watcher sidecar container does not set resource requests or limits by default, and the existing documentation does not describe how to configure them. Customers running in namespaces with LimitRange or ResourceQuota policies, or targeting Guaranteed QoS, need guidance on setting these values. The QoS section already references `sideCars.configWatcher.resources` but does not explain the sidecar or provide standalone configuration guidance.

## Test plan

- [ ] Verify AsciiDoc renders correctly in the docs site preview
- [ ] Confirm the `statefulset.sideCars.configWatcher.resources` path is valid in both Operator CRD and Helm values
- [ ] Verify the `kubectl jsonpath` verification command returns expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)