### PR TITLE
docs (k8s): Add Operator Console CRD deployment docs

### DIFF
--- a/modules/deploy/pages/console/kubernetes/deploy.adoc
+++ b/modules/deploy/pages/console/kubernetes/deploy.adoc
@@ -1,5 +1,5 @@
 = Deploy Redpanda Console on Kubernetes
-:description: Deploy Redpanda Console on Kubernetes using the Redpanda Operator or Helm charts.
+:description: Deploy Redpanda Console on Kubernetes using the Redpanda Operator, Helm charts, or YAML manifests.
 :env-kubernetes: true
 :page-topic-type: how-to
 :personas: platform_operator
@@ -20,6 +20,11 @@ Use this standalone deployment guide only when you need to:
 * Deploy multiple Redpanda Console instances for different environments.
 ====
 
+After reading this page, you will be able to:
+
+* [ ] {learning-objective-1}
+* [ ] {learning-objective-2}
+* [ ] {learning-objective-3}
 
 == Prerequisites
 
@@ -484,6 +489,7 @@ spec:
           enabled: true
           mechanism: SCRAM-SHA-256
           username: console-user
+          passwordFilepath: /etc/console/secrets/password
   secretMounts:
     - name: kafka-credentials
       secretName: console-kafka-credentials

--- a/modules/deploy/pages/console/kubernetes/deploy.adoc
+++ b/modules/deploy/pages/console/kubernetes/deploy.adoc
@@ -87,29 +87,6 @@ kubectl apply -f console.yaml --namespace redpanda
 
 The operator reconciles the Console CR and creates the necessary Deployment, Service, and ConfigMap resources.
 
-[#connect-external]
-=== Connect to external clusters
-
-If your Redpanda cluster is not managed by the Redpanda Operator, use `staticConfiguration` to specify the connection details:
-
-[,yaml]
-.`console.yaml`
-----
-apiVersion: cluster.redpanda.com/v1alpha2
-kind: Console
-metadata:
-  name: redpanda-console
-  namespace: redpanda
-spec:
-  cluster:
-    staticConfiguration:
-      kafka:
-        brokers:
-          - redpanda-0.redpanda.redpanda.svc.cluster.local:9092
-          - redpanda-1.redpanda.redpanda.svc.cluster.local:9092
-          - redpanda-2.redpanda.redpanda.svc.cluster.local:9092
-----
-
 --
 Helm::
 +

--- a/modules/deploy/pages/console/kubernetes/deploy.adoc
+++ b/modules/deploy/pages/console/kubernetes/deploy.adoc
@@ -1,6 +1,11 @@
 = Deploy Redpanda Console on Kubernetes
 :description: Deploy Redpanda Console on Kubernetes using the Redpanda Operator or Helm charts.
 :env-kubernetes: true
+:page-topic-type: how-to
+:personas: platform_operator
+:learning-objective-1: Deploy Redpanda Console on Kubernetes using the Redpanda Operator or Helm charts
+:learning-objective-2: Configure TLS and SASL authentication for Redpanda Console
+:learning-objective-3: Verify and scale a Redpanda Console deployment
 
 This page shows you how to deploy Redpanda Console as a standalone service on Kubernetes using the Redpanda Operator (Console custom resource) or Helm charts.
 
@@ -22,6 +27,8 @@ Use this standalone deployment guide only when you need to:
 * Review the xref:deploy:console/kubernetes/k-requirements.adoc[system requirements for Redpanda Console on Kubernetes].
 
 == Install Redpanda Console
+
+Choose your deployment method.
 
 [tabs]
 ======
@@ -72,7 +79,7 @@ spec:
           - console.example.com
 ----
 +
-<1> Reference to your Redpanda cluster CR. The operator automatically configures broker addresses, TLS, and authentication based on the referenced cluster. If your Redpanda cluster is not managed by the operator, use `staticConfiguration` instead of `clusterRef`. See <<connect-external>>.
+<1> Reference to your Redpanda cluster CR. The operator automatically configures broker addresses, TLS, and authentication based on the referenced cluster. If your Redpanda cluster is not managed by the operator, use `staticConfiguration` instead of `clusterRef`. See the TLS section for `staticConfiguration` examples.
 <2> For production, run at least two replicas for high availability and rolling upgrades.
 <3> Adjust resource requests and limits based on your expected workload and available node resources.
 <4> Use `LoadBalancer` for cloud environments or when you want Redpanda Console to be accessible from outside the cluster. Use `ClusterIP` for internal-only access.
@@ -230,7 +237,7 @@ spec:
       path: /etc/console/secrets
 ----
 
-. Apply the Console CR:
+. Apply the updated Console CR:
 +
 [,bash]
 ----
@@ -283,7 +290,7 @@ helm upgrade --install redpanda-console redpanda/console \
   --values console-values.yaml
 ----
 
-Redpanda Console will now connect securely to your Redpanda cluster using TLS. For production, set `insecureSkipTlsVerify: false` and use a trusted CA.
+Redpanda Console now connects securely to your Redpanda cluster using TLS. For production, set `insecureSkipTlsVerify: false` and use a trusted CA.
 
 --
 ======
@@ -425,6 +432,8 @@ For production deployments, configure:
 * **SASL authentication**: Configure SASL if Redpanda uses authentication
 * **RBAC**: Set up role-based access control
 
+Configure authentication based on your deployment method.
+
 [tabs]
 ======
 Operator::
@@ -508,6 +517,8 @@ See xref:console:config/security/index.adoc[].
 
 == Verify deployment
 
+Use the following steps to confirm that Redpanda Console is running and accessible.
+
 [tabs]
 ======
 Operator::
@@ -559,7 +570,7 @@ kubectl get svc -n redpanda redpanda-console -o jsonpath='{.status.loadBalancer.
 kubectl port-forward -n redpanda svc/redpanda-console 8080:8080
 ----
 
-Then open http://localhost:8080 in your browser.
+Open http://localhost:8080 in your browser.
 
 --
 Helm::
@@ -596,7 +607,7 @@ kubectl get svc -n redpanda redpanda-console -o jsonpath='{.status.loadBalancer.
 kubectl port-forward -n redpanda svc/redpanda-console 8080:8080
 ----
 
-Then open http://localhost:8080 in your browser.
+Open http://localhost:8080 in your browser.
 
 --
 ======

--- a/modules/deploy/pages/console/kubernetes/deploy.adoc
+++ b/modules/deploy/pages/console/kubernetes/deploy.adoc
@@ -1,8 +1,8 @@
 = Deploy Redpanda Console on Kubernetes
-:description: Deploy Redpanda Console on Kubernetes using Helm charts or YAML manifests.
+:description: Deploy Redpanda Console on Kubernetes using the Redpanda Operator or Helm charts.
 :env-kubernetes: true
 
-This page shows you how to deploy Redpanda Console as a standalone service on Kubernetes using Helm charts or YAML manifests.
+This page shows you how to deploy Redpanda Console as a standalone service on Kubernetes using the Redpanda Operator (Console custom resource) or Helm charts.
 
 [NOTE]
 ====
@@ -22,6 +22,98 @@ Use this standalone deployment guide only when you need to:
 * Review the xref:deploy:console/kubernetes/k-requirements.adoc[system requirements for Redpanda Console on Kubernetes].
 
 == Install Redpanda Console
+
+[tabs]
+======
+Operator::
++
+--
+
+The Redpanda Operator provides a `Console` custom resource (CR) that lets you deploy and manage Redpanda Console declaratively. The operator handles the lifecycle of the Console deployment, including creating the underlying Deployment, Service, and ConfigMap resources.
+
+. Create a Console custom resource:
++
+[,yaml]
+.`console.yaml`
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Console
+metadata:
+  name: redpanda-console
+  namespace: redpanda
+spec:
+  cluster:
+    clusterRef: <1>
+      name: redpanda
+  replicaCount: 2 <2>
+  resources: <3>
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 4000m
+      memory: 2Gi
+  service: <4>
+    type: LoadBalancer
+    port: 8080
+  ingress: <5>
+    enabled: true
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+    className: nginx
+    hosts:
+      - host: console.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: console-tls
+        hosts:
+          - console.example.com
+----
++
+<1> Reference to your Redpanda cluster CR. The operator automatically configures broker addresses, TLS, and authentication based on the referenced cluster. If your Redpanda cluster is not managed by the operator, use `staticConfiguration` instead of `clusterRef`. See <<connect-external>>.
+<2> For production, run at least two replicas for high availability and rolling upgrades.
+<3> Adjust resource requests and limits based on your expected workload and available node resources.
+<4> Use `LoadBalancer` for cloud environments or when you want Redpanda Console to be accessible from outside the cluster. Use `ClusterIP` for internal-only access.
+<5> Enable and configure Ingress if you want to expose Redpanda Console using a domain name and use TLS/HTTPS. Make sure your cluster has an Ingress controller installed.
+
+. Apply the Console CR:
++
+[,bash]
+----
+kubectl apply -f console.yaml --namespace redpanda
+----
+
+The operator reconciles the Console CR and creates the necessary Deployment, Service, and ConfigMap resources.
+
+[#connect-external]
+=== Connect to external clusters
+
+If your Redpanda cluster is not managed by the Redpanda Operator, use `staticConfiguration` to specify the connection details:
+
+[,yaml]
+.`console.yaml`
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Console
+metadata:
+  name: redpanda-console
+  namespace: redpanda
+spec:
+  cluster:
+    staticConfiguration:
+      kafka:
+        brokers:
+          - redpanda-0.redpanda.redpanda.svc.cluster.local:9092
+          - redpanda-1.redpanda.redpanda.svc.cluster.local:9092
+          - redpanda-2.redpanda.redpanda.svc.cluster.local:9092
+----
+
+--
+Helm::
++
+--
 
 . Create a values file:
 +
@@ -105,9 +197,73 @@ helm install redpanda-console redpanda/console \
   --values console-values.yaml
 ----
 
+--
+======
+
 === Connect to Redpanda clusters with TLS
 
-If your Redpanda cluster uses TLS encryption (the default for Helm deployments), you must configure Redpanda Console to connect securely:
+If your Redpanda cluster uses TLS encryption (the default for Helm deployments), you must configure Redpanda Console to connect securely.
+
+[tabs]
+======
+Operator::
++
+--
+
+When you use `clusterRef` to reference a Redpanda cluster managed by the operator, TLS is configured automatically. No additional steps are required.
+
+If you use `staticConfiguration` to connect to an external cluster with TLS:
+
+. Extract the CA certificate:
++
+[,bash]
+----
+kubectl get secret redpanda-default-root-certificate -n redpanda -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+----
+
+. Create a secret with the CA certificate:
++
+[,bash]
+----
+kubectl create secret generic redpanda-console-tls --from-file=ca.crt=ca.crt -n redpanda
+----
+
+. Configure the Console CR:
++
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Console
+metadata:
+  name: redpanda-console
+  namespace: redpanda
+spec:
+  cluster:
+    staticConfiguration:
+      kafka:
+        brokers:
+          - redpanda-0.redpanda.redpanda.svc.cluster.local:9093
+        tls:
+          caCertSecretRef:
+            name: redpanda-console-tls
+            key: ca.crt
+  secretMounts:
+    - name: redpanda-console-tls
+      secretName: redpanda-console-tls
+      path: /etc/console/secrets
+----
+
+. Apply the Console CR:
++
+[,bash]
+----
+kubectl apply -f console.yaml --namespace redpanda
+----
+
+--
+Helm::
++
+--
 
 . Run the following command to extract the CA certificate from the Redpanda Helm deployment:
 +
@@ -152,6 +308,8 @@ helm upgrade --install redpanda-console redpanda/console \
 
 Redpanda Console will now connect securely to your Redpanda cluster using TLS. For production, set `insecureSkipTlsVerify: false` and use a trusted CA.
 
+--
+======
 
 == Deploy Redpanda Console as standalone service with YAML manifests
 
@@ -274,11 +432,11 @@ kubectl apply -f console-service.yaml
 
 == Configuration
 
-Make sure to configure the following settings in your values file or ConfigMap:
+Make sure to configure the following settings in your Console CR, values file, or ConfigMap:
 
 === Connect to Redpanda
 
-Configure the connection to your Redpanda cluster by setting the broker addresses in your values file or ConfigMap.
+Configure the connection to your Redpanda cluster by setting the broker addresses in your Console CR or values file.
 
 See xref:console:config/connect-to-redpanda.adoc[].
 
@@ -289,6 +447,67 @@ For production deployments, configure:
 * **TLS encryption**: Enable TLS for secure communication
 * **SASL authentication**: Configure SASL if Redpanda uses authentication
 * **RBAC**: Set up role-based access control
+
+[tabs]
+======
+Operator::
++
+--
+
+When you use `clusterRef`, the operator automatically inherits SASL and TLS settings from the referenced Redpanda cluster. No additional Console configuration is needed.
+
+To configure SASL manually with `staticConfiguration`:
+
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Console
+metadata:
+  name: redpanda-console
+  namespace: redpanda
+spec:
+  cluster:
+    staticConfiguration:
+      kafka:
+        brokers:
+          - redpanda-0.redpanda.redpanda.svc.cluster.local:9092
+        sasl:
+          enabled: true
+          mechanism: SCRAM-SHA-256
+  secret:
+    kafka:
+      saslPassword: <console-password>
+----
+
+You can also reference an existing Kubernetes Secret for credentials:
+
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Console
+metadata:
+  name: redpanda-console
+  namespace: redpanda
+spec:
+  cluster:
+    staticConfiguration:
+      kafka:
+        brokers:
+          - redpanda-0.redpanda.redpanda.svc.cluster.local:9092
+        sasl:
+          enabled: true
+          mechanism: SCRAM-SHA-256
+          username: console-user
+  secretMounts:
+    - name: kafka-credentials
+      secretName: console-kafka-credentials
+      path: /etc/console/secrets
+----
+
+--
+Helm::
++
+--
 
 Example with SASL authentication:
 
@@ -305,9 +524,33 @@ config:
       password: console-password
 ----
 
+--
+======
+
 See xref:console:config/security/index.adoc[].
 
 == Verify deployment
+
+[tabs]
+======
+Operator::
++
+--
+
+. Check the Console CR status:
++
+[,bash]
+----
+kubectl get console -n redpanda
+----
++
+The output shows the replica status of your Console deployment:
++
+[,bash,role="no-copy"]
+----
+NAME                REPLICAS   UPDATED   READY   AVAILABLE
+redpanda-console    2          2         2       2
+----
 
 . Check pod status:
 +
@@ -340,6 +583,46 @@ kubectl port-forward -n redpanda svc/redpanda-console 8080:8080
 ----
 
 Then open http://localhost:8080 in your browser.
+
+--
+Helm::
++
+--
+
+. Check pod status:
++
+[,bash]
+----
+kubectl get pods -n redpanda -l app.kubernetes.io/name=console
+----
+
+. Check service status:
++
+[,bash]
+----
+kubectl get svc -n redpanda redpanda-console
+----
+
+. Access the Redpanda Console:
++
+.. If using LoadBalancer:
++
+[,bash]
+----
+kubectl get svc -n redpanda redpanda-console -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+----
+
+.. If using port-forward for testing:
++
+[,bash]
+----
+kubectl port-forward -n redpanda svc/redpanda-console 8080:8080
+----
+
+Then open http://localhost:8080 in your browser.
+
+--
+======
 
 == Scaling
 

--- a/modules/deploy/pages/console/kubernetes/deploy.adoc
+++ b/modules/deploy/pages/console/kubernetes/deploy.adoc
@@ -3,11 +3,11 @@
 :env-kubernetes: true
 :page-topic-type: how-to
 :personas: platform_operator
-:learning-objective-1: Deploy Redpanda Console on Kubernetes using the Redpanda Operator or Helm charts
+:learning-objective-1: Deploy Redpanda Console on Kubernetes using the Redpanda Operator, Helm charts, or YAML manifests
 :learning-objective-2: Configure TLS and SASL authentication for Redpanda Console
 :learning-objective-3: Verify and scale a Redpanda Console deployment
 
-This page shows you how to deploy Redpanda Console as a standalone service on Kubernetes using the Redpanda Operator (Console custom resource) or Helm charts.
+This page shows you how to deploy Redpanda Console as a standalone service on Kubernetes using the Redpanda Operator (Console custom resource), Helm charts, or YAML manifests.
 
 [NOTE]
 ====


### PR DESCRIPTION
## Summary
- Add Operator/Helm tabbed instructions for deploying Redpanda Console on Kubernetes using the Console custom resource (CRD)
- The Operator tab documents the `Console` CR with `clusterRef` for operator-managed Redpanda clusters and `staticConfiguration` for external clusters
- Tabs added to: Install Redpanda Console, Connect with TLS, Authentication and Security, and Verify Deployment sections

## Context
The Redpanda Operator now supports a standalone `Console` CRD (see redpanda-data/redpanda-operator#1177) that manages Console deployments declaratively. The existing docs only covered the Helm chart approach. This PR adds the Operator path alongside Helm using the same tab pattern used elsewhere in the Kubernetes docs.

## Preview docs
[Deploy Redpanda Console on Kubernetes ](https://deploy-preview-1629--redpanda-docs-preview.netlify.app/current/deploy/console/kubernetes/deploy/)

## Test plan
- [ ] Verify Operator tab YAML examples match the Console CRD spec (`cluster.redpanda.com/v1alpha2`)
- [ ] Verify Helm tab content is unchanged from the original
- [ ] Preview the rendered page to confirm tabs display correctly
- [ ] Check all xrefs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)