### PR TITLE
docs (k8s): Add Cloud Topics for Kubernetes

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -112,6 +112,7 @@
 ***** xref:manage:kubernetes/storage/k-emptydir.adoc[emptyDir]
 **** xref:manage:kubernetes/storage/k-resize-persistentvolumes.adoc[Expand PersistentVolumes]
 **** xref:manage:kubernetes/storage/k-delete-persistentvolume.adoc[Delete PersistentVolumes]
+*** xref:manage:kubernetes/k-cloud-topics.adoc[Cloud Topics]
 *** xref:manage:kubernetes/tiered-storage/index.adoc[Tiered Storage]
 **** xref:manage:kubernetes/tiered-storage/k-tiered-storage.adoc[Use Tiered Storage]
 **** xref:manage:kubernetes/tiered-storage/k-fast-commission-decommission.adoc[]

--- a/modules/manage/pages/kubernetes/k-cloud-topics.adoc
+++ b/modules/manage/pages/kubernetes/k-cloud-topics.adoc
@@ -139,6 +139,8 @@ storage:
 --
 ======
 
+For details on IAM roles, access keys, and AWS KMS encryption, see xref:manage:kubernetes/tiered-storage/k-tiered-storage.adoc#amazon-s3[Amazon S3] in the Tiered Storage documentation.
+
 === Google Cloud Storage (GCS)
 
 [tabs]
@@ -199,6 +201,8 @@ storage:
 --
 ======
 
+For details on IAM roles, HMAC access keys, and customer-managed encryption keys, see xref:manage:kubernetes/tiered-storage/k-tiered-storage.adoc#google-cloud-storage[Google Cloud Storage] in the Tiered Storage documentation.
+
 === Azure Blob Storage
 
 [tabs]
@@ -250,6 +254,8 @@ storage:
 <1> Use `azure_aks_oidc_federation` instead if you are using an Azure managed identity. When using managed identities, omit `credentialsSecretRef` and configure workload identity annotations on the service account.
 --
 ======
+
+For details on managed identities and account access keys, see xref:manage:kubernetes/tiered-storage/k-tiered-storage.adoc#microsoft-absadls[Microsoft ABS/ADLS] in the Tiered Storage documentation.
 
 == Enable Cloud Topics
 

--- a/modules/manage/pages/kubernetes/k-cloud-topics.adoc
+++ b/modules/manage/pages/kubernetes/k-cloud-topics.adoc
@@ -56,7 +56,7 @@ Cloud Topics are best suited for latency-tolerant workloads, including:
 
 You must have the following:
 
-- **Kubectl**: Ensure you have the https://kubernetes.io/docs/tasks/tools/#kubectl[`kubectl`^] command-line tool installed and configured to communicate with your cluster.
+- **kubectl**: Ensure you have the https://kubernetes.io/docs/tasks/tools/#kubectl[`kubectl`^] command-line tool installed and configured to communicate with your cluster.
 - **Redpanda**: A xref:deploy:deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc[Redpanda Operator and a Redpanda resource deployed] in your Kubernetes cluster running Redpanda v26.1 or later.
 - **Object storage**: A configured object storage backend (Amazon S3, Google Cloud Storage, Azure Blob Storage, or an S3-compatible store such as MinIO).
 - **Enterprise license**: A valid Redpanda Enterprise license applied to the cluster.

--- a/modules/manage/pages/kubernetes/k-cloud-topics.adoc
+++ b/modules/manage/pages/kubernetes/k-cloud-topics.adoc
@@ -75,9 +75,181 @@ rpk cluster license info
 
 == Configure object storage
 
-Before enabling Cloud Topics, you must configure object storage access for your Redpanda cluster. If you have already configured object storage for Tiered Storage, you can skip this step.
+Cloud Topics use the same object storage configuration as Tiered Storage. If you have already configured object storage for Tiered Storage, you can skip this step and proceed to <<enable-cloud-topics>>.
 
-See xref:manage:kubernetes/tiered-storage/k-tiered-storage.adoc#configure-object-storage[Configure object storage] in the Tiered Storage documentation for instructions on configuring Amazon S3, Google Cloud Storage, or Azure Blob Storage.
+For detailed instructions including IAM role configuration, access key management, and encryption options, see xref:manage:kubernetes/tiered-storage/k-tiered-storage.adoc#configure-object-storage[Configure object storage] in the Tiered Storage documentation.
+
+The following examples show the minimum required configuration for each cloud provider.
+
+=== Amazon S3
+
+[tabs]
+======
+Helm + Operator::
++
+--
+.`redpanda-cluster.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  clusterSpec:
+    storage:
+      tiered:
+        credentialsSecretRef:
+          accessKey:
+            name: storage-secrets
+            key: access-key
+          secretKey:
+            name: storage-secrets
+            key: secret-key
+        config:
+          cloud_storage_enabled: true
+          cloud_storage_credentials_source: config_file # <1>
+          cloud_storage_region: <region>
+          cloud_storage_bucket: <bucket-name>
+----
+<1> Use `aws_instance_metadata` instead if you are using an IAM role attached to your nodes.
+--
+Helm::
++
+--
+.`cloud-storage.yaml`
+[,yaml]
+----
+storage:
+  tiered:
+    credentialsSecretRef:
+      accessKey:
+        name: storage-secrets
+        key: access-key
+      secretKey:
+        name: storage-secrets
+        key: secret-key
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: config_file # <1>
+      cloud_storage_region: <region>
+      cloud_storage_bucket: <bucket-name>
+----
+<1> Use `aws_instance_metadata` instead if you are using an IAM role attached to your nodes.
+--
+======
+
+=== Google Cloud Storage (GCS)
+
+[tabs]
+======
+Helm + Operator::
++
+--
+.`redpanda-cluster.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  clusterSpec:
+    storage:
+      tiered:
+        credentialsSecretRef:
+          accessKey:
+            name: storage-secrets
+            key: access-key
+          secretKey:
+            name: storage-secrets
+            key: secret-key
+        config:
+          cloud_storage_enabled: true
+          cloud_storage_credentials_source: config_file # <1>
+          cloud_storage_api_endpoint: storage.googleapis.com
+          cloud_storage_region: <region>
+          cloud_storage_bucket: <bucket-name>
+----
+<1> Use `gcp_instance_metadata` instead if you are using a GCP service account attached to your nodes.
+--
+Helm::
++
+--
+.`cloud-storage.yaml`
+[,yaml]
+----
+storage:
+  tiered:
+    credentialsSecretRef:
+      accessKey:
+        name: storage-secrets
+        key: access-key
+      secretKey:
+        name: storage-secrets
+        key: secret-key
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: config_file # <1>
+      cloud_storage_api_endpoint: storage.googleapis.com
+      cloud_storage_region: <region>
+      cloud_storage_bucket: <bucket-name>
+----
+<1> Use `gcp_instance_metadata` instead if you are using a GCP service account attached to your nodes.
+--
+======
+
+=== Azure Blob Storage
+
+[tabs]
+======
+Helm + Operator::
++
+--
+.`redpanda-cluster.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  clusterSpec:
+    storage:
+      tiered:
+        credentialsSecretRef:
+          accessKey:
+            name: storage-secrets
+            key: shared-key
+        config:
+          cloud_storage_enabled: true
+          cloud_storage_credentials_source: config_file # <1>
+          cloud_storage_azure_storage_account: <account-name>
+          cloud_storage_azure_container: <container-name>
+----
+<1> Use `azure_aks_oidc_federation` instead if you are using an Azure managed identity. When using managed identities, omit `credentialsSecretRef` and configure workload identity annotations on the service account.
+--
+Helm::
++
+--
+.`cloud-storage.yaml`
+[,yaml]
+----
+storage:
+  tiered:
+    credentialsSecretRef:
+      accessKey:
+        name: storage-secrets
+        key: shared-key
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: config_file # <1>
+      cloud_storage_azure_storage_account: <account-name>
+      cloud_storage_azure_container: <container-name>
+----
+<1> Use `azure_aks_oidc_federation` instead if you are using an Azure managed identity. When using managed identities, omit `credentialsSecretRef` and configure workload identity annotations on the service account.
+--
+======
 
 == Enable Cloud Topics
 
@@ -277,21 +449,21 @@ kubectl apply -f cloud-topic.yaml
 
 === Override the cluster default
 
-Topic-level storage mode settings override the cluster default. For example, if the cluster default is `cloud`, you can create a topic with `local` or `tiered` storage:
+Topic-level storage mode settings override the cluster default. For example, if the cluster default is `cloud`, you can create a topic that uses Tiered Storage instead:
 
-.`local-topic.yaml`
+.`tiered-topic.yaml`
 [,yaml]
 ----
 apiVersion: cluster.redpanda.com/v1alpha2
 kind: Topic
 metadata:
-  name: my-local-topic
+  name: my-tiered-topic
   namespace: <namespace>
 spec:
   partitions: 3
   replicationFactor: 3
   additionalConfig:
-    redpanda.storage.mode: "local"
+    redpanda.storage.mode: "tiered"
   cluster:
     clusterRef:
       name: redpanda

--- a/modules/manage/pages/kubernetes/k-cloud-topics.adoc
+++ b/modules/manage/pages/kubernetes/k-cloud-topics.adoc
@@ -7,7 +7,10 @@ Cloud Topics are a storage mode in Redpanda optimized for latency-tolerant, high
 
 This approach can eliminate over 90% of replication costs across network links in multi-AZ deployments.
 
-NOTE: include::shared:partial$enterprise-license.adoc[]
+[NOTE]
+====
+include::shared:partial$enterprise-license.adoc[]
+====
 
 == How Cloud Topics work
 
@@ -59,8 +62,11 @@ You must have the following:
 - **Redpanda**: A xref:deploy:deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc[Redpanda Operator and a Redpanda resource deployed] in your Kubernetes cluster running Redpanda v26.1 or later.
 - **Object storage**: A configured object storage backend (Amazon S3, Google Cloud Storage, Azure Blob Storage, or an S3-compatible store such as MinIO).
 - **Enterprise license**: A valid Redpanda Enterprise license applied to the cluster.
-
++
+[NOTE]
+====
 include::shared:partial$enterprise-license.adoc[]
+====
 
 To check if you already have a license key applied to your cluster:
 

--- a/modules/manage/pages/kubernetes/k-cloud-topics.adoc
+++ b/modules/manage/pages/kubernetes/k-cloud-topics.adoc
@@ -1,16 +1,18 @@
 = Cloud Topics on Kubernetes
 :description: Configure Cloud Topics on Kubernetes to optimize for latency-tolerant, high-throughput workloads using object storage as the primary data tier.
 :page-categories: Management, Data Replication
+:page-topic-type: how-to
 :env-kubernetes: true
 
 Cloud Topics are a storage mode in Redpanda optimized for latency-tolerant, high-throughput workloads where cross-AZ networking costs significantly impact expenses. Instead of replicating data across network links, Cloud Topics use durable object storage (such as Amazon S3, Google Cloud Storage, Azure Blob Storage, or MinIO) as the primary mechanism to replicate data and serve it to consumers.
 
 This approach can eliminate over 90% of replication costs across network links in multi-AZ deployments.
 
-[NOTE]
-====
-include::shared:partial$enterprise-license.adoc[]
-====
+After reading this page, you will be able to:
+
+* [ ] Configure object storage for Cloud Topics on Kubernetes.
+* [ ] Enable and create Cloud Topics using the Redpanda Operator or Helm.
+* [ ] Verify topic storage mode configuration.
 
 == How Cloud Topics work
 
@@ -65,7 +67,7 @@ You must have the following:
 ====
 include::shared:partial$enterprise-license.adoc[]
 ====
-
++
 To check if you already have a license key applied to your cluster:
 
 [,bash]

--- a/modules/manage/pages/kubernetes/k-cloud-topics.adoc
+++ b/modules/manage/pages/kubernetes/k-cloud-topics.adoc
@@ -1,0 +1,356 @@
+= Cloud Topics on Kubernetes
+:description: Configure Cloud Topics on Kubernetes to optimize for latency-tolerant, high-throughput workloads using object storage as the primary data tier.
+:page-categories: Management, Data Replication
+:env-kubernetes: true
+
+Cloud Topics are a storage mode in Redpanda optimized for latency-tolerant, high-throughput workloads where cross-AZ networking costs significantly impact expenses. Instead of replicating data across network links, Cloud Topics use durable object storage (such as Amazon S3, Google Cloud Storage, Azure Blob Storage, or MinIO) as the primary mechanism to replicate data and serve it to consumers.
+
+This approach can eliminate over 90% of replication costs across network links in multi-AZ deployments.
+
+NOTE: include::shared:partial$enterprise-license.adoc[]
+
+== How Cloud Topics work
+
+With standard Redpanda topics, data is replicated across brokers using Raft consensus and stored locally on each replica. Cloud Topics change this model: data is acknowledged only after it is uploaded to object storage, making object storage the source of truth for both replication and consumption.
+
+Because data isn't acknowledged until uploaded to object storage, produce latency is higher than with standard topics. Expected end-to-end latencies range from 500 ms to 1 second with public cloud object stores. Lower latencies are achievable in certain environments.
+
+=== Storage modes
+
+Redpanda supports multiple storage modes that you can set at the cluster or topic level using the `redpanda.storage.mode` property:
+
+|===
+| Mode | Behavior
+
+| `unset`
+| Follows legacy behavior.
+
+| `local`
+| Data is stored only on local disk. No remote storage is used.
+
+| `tiered`
+| Data is written locally and offloaded to object storage asynchronously using Tiered Storage.
+
+| `cloud`
+| Data is managed primarily in object storage. Local storage acts as a cache.
+|===
+
+When `redpanda.storage.mode` is set on a topic, it takes precedence over any legacy `redpanda.remote.read` and `redpanda.remote.write` settings, which are generally ignored.
+
+=== Ideal use cases
+
+Cloud Topics are best suited for latency-tolerant workloads, including:
+
+- Observability and logging streams
+- Offline analytics pipelines
+- AI/ML training data ingestion
+- Development and staging environments with flexible latency requirements
+
+=== Limitations
+
+- Once created, a Cloud Topic cannot be converted back to a standard topic using `local` or `tiered` storage mode.
+- Higher produce latency compared to standard topics (500 ms to 1 second with public cloud stores).
+
+== Prerequisites
+
+You must have the following:
+
+- **Kubectl**: Ensure you have the https://kubernetes.io/docs/tasks/tools/#kubectl[`kubectl`^] command-line tool installed and configured to communicate with your cluster.
+- **Redpanda**: A xref:deploy:deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc[Redpanda Operator and a Redpanda resource deployed] in your Kubernetes cluster running Redpanda v26.1 or later.
+- **Object storage**: A configured object storage backend (Amazon S3, Google Cloud Storage, Azure Blob Storage, or an S3-compatible store such as MinIO).
+- **Enterprise license**: A valid Redpanda Enterprise license applied to the cluster.
+
+include::shared:partial$enterprise-license.adoc[]
+
+To check if you already have a license key applied to your cluster:
+
+[,bash]
+----
+rpk cluster license info
+----
+
+== Configure object storage
+
+Before enabling Cloud Topics, you must configure object storage access for your Redpanda cluster. If you have already configured object storage for Tiered Storage, you can skip this step.
+
+See xref:manage:kubernetes/tiered-storage/k-tiered-storage.adoc#configure-object-storage[Configure object storage] in the Tiered Storage documentation for instructions on configuring Amazon S3, Google Cloud Storage, or Azure Blob Storage.
+
+== Enable Cloud Topics
+
+Enabling Cloud Topics is a two-step process:
+
+. Enable the `cloud_topics_enabled` cluster property.
+. Optionally set the default storage mode for all new topics to `cloud`.
+
+[tabs]
+======
+Helm + Operator::
++
+--
+
+. Add the following to your Redpanda custom resource to enable Cloud Topics and set the default storage mode:
++
+.`redpanda-cluster.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  clusterSpec:
+    storage:
+      tiered:
+        mountType: none
+        credentialsSecretRef:
+          accessKey:
+            name: cloud-storage-creds
+            key: access-key
+          secretKey:
+            name: cloud-storage-creds
+            key: secret-key
+        config:
+          cloud_storage_enabled: true
+          cloud_storage_region: <region>
+          cloud_storage_bucket: <bucket-name>
+    config:
+      cluster:
+        cloud_topics_enabled: true
+        default_redpanda_storage_mode: cloud # <1>
+----
+<1> Optional. Set to `cloud` to make all new topics Cloud Topics by default. Omit this to create Cloud Topics individually.
+
+. Apply the configuration:
++
+[,bash]
+----
+kubectl apply -f redpanda-cluster.yaml -n <namespace>
+----
+
+. The Redpanda Operator reconciles the configuration. Wait for the cluster to be ready:
++
+[,bash]
+----
+kubectl rollout status statefulset redpanda -n <namespace> --watch
+----
+
+. Verify that Cloud Topics are enabled:
++
+[,bash]
+----
+kubectl exec -n <namespace> redpanda-0 -c redpanda -- \
+  rpk cluster config get cloud_topics_enabled
+----
++
+Expected output: `true`
+
+--
+Helm::
++
+--
+
+. Add the following to your Helm values file:
++
+.`cloud-topics-values.yaml`
+[,yaml]
+----
+storage:
+  tiered:
+    mountType: none
+    credentialsSecretRef:
+      accessKey:
+        name: cloud-storage-creds
+        key: access-key
+      secretKey:
+        name: cloud-storage-creds
+        key: secret-key
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_region: <region>
+      cloud_storage_bucket: <bucket-name>
+config:
+  cluster:
+    cloud_topics_enabled: true
+    default_redpanda_storage_mode: cloud # <1>
+----
+<1> Optional. Set to `cloud` to make all new topics Cloud Topics by default. Omit this to create Cloud Topics individually.
+
+. Deploy or upgrade the Helm chart:
++
+[,bash]
+----
+helm upgrade --install redpanda redpanda/redpanda \
+  -n <namespace> --create-namespace \
+  -f cloud-topics-values.yaml
+----
+
+. Wait for the cluster to be ready:
++
+[,bash]
+----
+kubectl rollout status statefulset redpanda -n <namespace> --watch
+----
+
+. Verify that Cloud Topics are enabled:
++
+[,bash]
+----
+kubectl exec -n <namespace> redpanda-0 -c redpanda -- \
+  rpk cluster config get cloud_topics_enabled
+----
++
+Expected output: `true`
+--
+======
+
+== Create a Cloud Topic
+
+You can create Cloud Topics either by setting the cluster default storage mode to `cloud`, or by configuring individual topics.
+
+=== Create Cloud Topics by default
+
+If you set `default_redpanda_storage_mode` to `cloud` in the cluster configuration, all new topics inherit the `cloud` storage mode automatically.
+
+Verify the cluster default:
+
+[,bash]
+----
+kubectl exec -n <namespace> redpanda-0 -c redpanda -- \
+  rpk cluster config get default_redpanda_storage_mode
+----
+
+Expected output: `cloud`
+
+Any new topic created without an explicit storage mode inherits this default:
+
+[tabs]
+======
+Operator Topic resource::
++
+--
+.`cloud-topic.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Topic
+metadata:
+  name: my-cloud-topic
+  namespace: <namespace>
+spec:
+  partitions: 3
+  replicationFactor: 3
+  cluster:
+    clusterRef:
+      name: redpanda
+----
+
+[,bash]
+----
+kubectl apply -f cloud-topic.yaml
+----
+--
+rpk::
++
+--
+[,bash]
+----
+kubectl exec -n <namespace> redpanda-0 -c redpanda -- \
+  rpk topic create my-cloud-topic -p 3 -r 3
+----
+--
+======
+
+=== Create individual Cloud Topics
+
+If the cluster default storage mode is not set to `cloud`, you can create individual Cloud Topics by setting the `redpanda.storage.mode` property on the topic.
+
+[tabs]
+======
+Operator Topic resource::
++
+--
+.`cloud-topic.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Topic
+metadata:
+  name: my-cloud-topic
+  namespace: <namespace>
+spec:
+  partitions: 3
+  replicationFactor: 3
+  additionalConfig:
+    redpanda.storage.mode: "cloud"
+  cluster:
+    clusterRef:
+      name: redpanda
+----
+
+[,bash]
+----
+kubectl apply -f cloud-topic.yaml
+----
+--
+rpk::
++
+--
+[,bash]
+----
+kubectl exec -n <namespace> redpanda-0 -c redpanda -- \
+  rpk topic create my-cloud-topic -p 3 -r 3 -c redpanda.storage.mode=cloud
+----
+--
+======
+
+=== Override the cluster default
+
+Topic-level storage mode settings override the cluster default. For example, if the cluster default is `cloud`, you can create a topic with `local` or `tiered` storage:
+
+.`local-topic.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Topic
+metadata:
+  name: my-local-topic
+  namespace: <namespace>
+spec:
+  partitions: 3
+  replicationFactor: 3
+  additionalConfig:
+    redpanda.storage.mode: "local"
+  cluster:
+    clusterRef:
+      name: redpanda
+----
+
+== Verify topic storage mode
+
+To verify the storage mode of a topic, inspect its configuration through the Topic resource status:
+
+[,bash]
+----
+kubectl get topic <topic-name> -n <namespace> -o jsonpath=\
+  '{range .status.topicConfiguration[*]}{.name}={.value} ({.source}){"\n"}{end}' \
+  | grep storage.mode
+----
+
+Expected output for a Cloud Topic:
+
+----
+storage.mode=cloud (DEFAULT_CONFIG)
+----
+
+Or, if explicitly set on the topic:
+
+----
+storage.mode=cloud (DYNAMIC_TOPIC_CONFIG)
+----
+
+The `source` field indicates whether the value was inherited from the cluster default (`DEFAULT_CONFIG`) or explicitly set on the topic (`DYNAMIC_TOPIC_CONFIG`).
+
+== Suggested reading
+
+- xref:manage:kubernetes/tiered-storage/k-tiered-storage.adoc[Use Tiered Storage on Kubernetes]
+- xref:manage:kubernetes/k-manage-topics.adoc[Manage Topics with the Redpanda Operator]

--- a/modules/manage/pages/kubernetes/k-cloud-topics.adoc
+++ b/modules/manage/pages/kubernetes/k-cloud-topics.adoc
@@ -259,10 +259,7 @@ For details on managed identities and account access keys, see xref:manage:kuber
 
 == Enable Cloud Topics
 
-Enabling Cloud Topics is a two-step process:
-
-. Enable the `cloud_topics_enabled` cluster property.
-. Optionally set the default storage mode for all new topics to `cloud`.
+To enable Cloud Topics, set the `cloud_topics_enabled` cluster property to `true` and set the default storage mode for all new topics to `cloud`.
 
 [tabs]
 ======

--- a/modules/manage/pages/kubernetes/k-cloud-topics.adoc
+++ b/modules/manage/pages/kubernetes/k-cloud-topics.adoc
@@ -38,8 +38,6 @@ Redpanda supports multiple storage modes that you can set at the cluster or topi
 | Data is managed primarily in object storage. Local storage acts as a cache.
 |===
 
-When `redpanda.storage.mode` is set on a topic, it takes precedence over any legacy `redpanda.remote.read` and `redpanda.remote.write` settings, which are generally ignored.
-
 === Ideal use cases
 
 Cloud Topics are best suited for latency-tolerant workloads, including:
@@ -229,11 +227,6 @@ Expected output: `cloud`
 
 Any new topic created without an explicit storage mode inherits this default:
 
-[tabs]
-======
-Operator Topic resource::
-+
---
 .`cloud-topic.yaml`
 [,yaml]
 ----
@@ -254,27 +247,11 @@ spec:
 ----
 kubectl apply -f cloud-topic.yaml
 ----
---
-rpk::
-+
---
-[,bash]
-----
-kubectl exec -n <namespace> redpanda-0 -c redpanda -- \
-  rpk topic create my-cloud-topic -p 3 -r 3
-----
---
-======
 
 === Create individual Cloud Topics
 
 If the cluster default storage mode is not set to `cloud`, you can create individual Cloud Topics by setting the `redpanda.storage.mode` property on the topic.
 
-[tabs]
-======
-Operator Topic resource::
-+
---
 .`cloud-topic.yaml`
 [,yaml]
 ----
@@ -297,17 +274,6 @@ spec:
 ----
 kubectl apply -f cloud-topic.yaml
 ----
---
-rpk::
-+
---
-[,bash]
-----
-kubectl exec -n <namespace> redpanda-0 -c redpanda -- \
-  rpk topic create my-cloud-topic -p 3 -r 3 -c redpanda.storage.mode=cloud
-----
---
-======
 
 === Override the cluster default
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -864,47 +864,116 @@ When you enable Tiered Storage on a topic already containing data, Redpanda uplo
 
 ==== Enable Tiered Storage for a cluster
 
-To enable Tiered Storage for a cluster, set the `default_redpanda_storage_mode` cluster property to `tiered` (in addition to setting `cloud_storage_enabled` to `true`). This configures all new topics to use Tiered Storage by default.
+To enable Tiered Storage for a cluster (in addition to setting `cloud_storage_enabled` to `true`), set the following cluster-level properties to `true`:
+
+* config_ref:cloud_storage_enable_remote_write,true,properties/object-storage-properties[]
+* config_ref:cloud_storage_enable_remote_read,true,properties/object-storage-properties[]
 
 When you enable Tiered Storage for a cluster, you enable it for all existing topics in the cluster. When cluster-level properties are changed, the changes apply only to new topics, not existing topics. You must restart your cluster after enabling Tiered Storage.
 
+NOTE: The `cloud_storage_enable_remote_write` and `cloud_storage_enable_remote_read` cluster-level properties are essentially creation-time defaults for the `redpanda.remote.write` and `redpanda.remote.read` topic-level properties.
+
 ==== Enable Tiered Storage for specific topics
 
-To enable Tiered Storage for a new or existing topic (in addition to setting `cloud_storage_enabled` to `true`), set the `redpanda.storage.mode` topic property to `tiered`.
+To enable Tiered Storage for a new or existing topic (in addition to setting `cloud_storage_enabled` to `true`), set the following topic-level properties to `true`:
+
+* `redpanda.remote.write`
+* `redpanda.remote.read`
 
 For example, to create a new topic with Tiered Storage:
 
 [,bash]
 ----
-rpk topic create <topic_name> -c redpanda.storage.mode=tiered
+rpk topic create <topic_name> -c redpanda.remote.read=true -c redpanda.remote.write=true
 ----
 
 To enable Tiered Storage on an existing topic, run:
 
 [,bash]
 ----
-rpk topic alter-config <topic_name> --set redpanda.storage.mode=tiered
+rpk topic alter-config <topic_name> --set redpanda.remote.read=true --set redpanda.remote.write=true
 ----
 
-Topic-level properties override cluster-level properties. For example, if `default_redpanda_storage_mode` is set to `tiered`, you can set `redpanda.storage.mode` to `local` on a specific topic to keep it local-only.
+Topic-level properties override cluster-level properties. For example, for new topics, if `cloud_storage_enable_remote_write` is set to `true`, you can set `redpanda.remote.write` to `false` to turn it off for a particular topic.
 
 Tiered Storage topic-level properties:
 
 |===
 | Property | Description
 
-| `redpanda.storage.mode`
-| Controls the storage mode for the topic. Set to `tiered` to enable Tiered Storage. This property takes precedence over legacy `redpanda.remote.read` and `redpanda.remote.write` settings.
+| `redpanda.remote.write`
+| Uploads data from Redpanda to object storage. Overrides the cluster-level `cloud_storage_enable_remote_write` configuration for the topic.
+
+| `redpanda.remote.read`
+| Fetches data from object storage to Redpanda. Overrides the cluster-level `cloud_storage_enable_remote_read` configuration for the topic.
 
 | `redpanda.remote.recovery`
 | Recovers or reproduces a topic from object storage. Use this property during topic creation. It does not apply to existing topics.
 
 | `redpanda.remote.delete`
-| When set to `true`, deleting a topic also deletes its objects in object storage. Tiered Storage must be enabled, and the topic must not be a Remote Read Replica topic.
+| When set to `true`, deleting a topic also deletes its objects in object storage. Both `redpanda.remote.write` and `redpanda.remote.read` must be enabled, and the topic must not be a Remote Read Replica topic.
 
 When set to `false`, deleting a topic does not delete its objects in object storage.
 
 Default is `true` for new topics.
+|===
+
+The following tables list outcomes for combinations of cluster-level and topic-level configurations:
+
+|===
+| Cluster-level configuration with `cloud_storage_enable_remote_write` | Topic-level configuration with `redpanda.remote.write` | Outcome: whether remote write is enabled or disabled on the topic
+
+| `true`
+| Not set
+| Enabled
+
+| `true`
+| `false`
+| Disabled
+
+| `true`
+| `true`
+| Enabled
+
+| `false`
+| Not set
+| Disabled
+
+| `false`
+| `false`
+| Disabled
+
+| `false`
+| `true`
+| Enabled
+|===
+
+|===
+| Cluster-level configuration with `cloud_storage_enable_remote_read` | Topic-level configuration with `redpanda.remote.read` | Outcome: whether remote read is enabled or disabled on the topic
+
+| `true`
+| Not set
+| Enabled
+
+| `true`
+| `false`
+| Disabled
+
+| `true`
+| `true`
+| Enabled
+
+| `false`
+| Not set
+| Disabled
+
+| `false`
+| `false`
+| Disabled
+
+| `false`
+| `true`
+| Enabled
 |===
 
 
@@ -975,23 +1044,25 @@ Third-party tools that query space utilization from the Redpanda cluster might n
 
 Remote write is the process that constantly uploads log segments to object storage. The process is created for each partition and runs on the leader broker of the partition. It only uploads the segments that contain offsets that are smaller than the last stable offset. This is the latest offset that the client can read.
 
-To ensure all data is uploaded, you must enable Tiered Storage before any data is produced to the topic. If you enable Tiered Storage after data has been written to the topic, only the data that currently exists on disk based on local retention settings will be scheduled for uploading. Redpanda strongly recommends that you avoid repeatedly toggling Tiered Storage on and off, because this can result in inconsistent data and data gaps in Tiered Storage for a topic.
+To ensure all data is uploaded, you must enable remote write before any data is produced to the topic. If you enable remote write after data has been written to the topic, only the data that currently exists on disk based on local retention settings will be scheduled for uploading. Redpanda strongly recommends that you avoid repeatedly toggling remote write on and off, because this can result in inconsistent data and data gaps in Tiered Storage for a topic.
 
-To create a topic with Tiered Storage (remote write and read) enabled:
+To enable Tiered Storage, use both remote write and remote read.
 
-[,bash]
-----
-rpk topic create <topic_name> -c redpanda.storage.mode=tiered
-----
-
-To enable Tiered Storage on an existing topic:
+To create a topic with remote write enabled:
 
 [,bash]
 ----
-rpk topic alter-config <topic_name> --set redpanda.storage.mode=tiered
+rpk topic create <topic_name> -c redpanda.remote.write=true
 ----
 
-When Tiered Storage is enabled, log segments are not deleted until they're uploaded to object storage. Because of this, the log segments may exceed the configured retention period until they're uploaded, so the topic might require more disk space. This prevents data loss if segments cannot be uploaded fast enough or if the retention period is very short.
+To enable remote write on an existing topic:
+
+[,bash]
+----
+rpk topic alter-config <topic_name> --set redpanda.remote.write=true
+----
+
+If remote write is enabled, log segments are not deleted until they're uploaded to object storage. Because of this, the log segments may exceed the configured retention period until they're uploaded, so the topic might require more disk space. This prevents data loss if segments cannot be uploaded fast enough or if the retention period is very short.
 
 To see the object storage status for a given topic:
 
@@ -1029,7 +1100,7 @@ NOTE: The broker uploading to object storage is always with the partition leader
 
 Remote write uses a proportional derivative (PD) controller to minimize the backlog size for the write. The backlog consists of data that has not been uploaded to object storage but must be uploaded eventually.
 
-The upload backlog controller prevents Redpanda from running out of disk space. When Tiered Storage is enabled, Redpanda cannot evict log segments that have not been uploaded to object storage. If the remote write process cannot keep up with the amount of data that needs to be uploaded to object storage, the upload backlog controller increases priority for the upload process. The upload backlog controller measures the size of the upload periodically and tunes the priority of the remote write process.
+The upload backlog controller prevents Redpanda from running out of disk space. If `remote.write` is set to `true`, Redpanda cannot evict log segments that have not been uploaded to object storage. If the remote write process cannot keep up with the amount of data that needs to be uploaded to object storage, the upload backlog controller increases priority for the upload process. The upload backlog controller measures the size of the upload periodically and tunes the priority of the remote write process.
 
 === Data archiving
 
@@ -1053,9 +1124,23 @@ To delete archival data, adjust `retention.ms` or `retention.bytes`.
 
 Remote read fetches data from object storage using the Kafka API.
 
-Without Tiered Storage, when data is evicted locally, it is no longer available. If the consumer starts consuming the partition from the beginning, the first offset is the smallest offset available locally. However, when Tiered Storage is enabled (with `redpanda.storage.mode` set to `tiered`), data is always uploaded to object storage before it's deleted. This guarantees that data is always available either locally or remotely.
+Without Tiered Storage, when data is evicted locally, it is no longer available. If the consumer starts consuming the partition from the beginning, the first offset is the smallest offset available locally. However, when Tiered Storage is enabled with the `redpanda.remote.read` and `redpanda.remote.write` properties, data is always uploaded to object storage before it's deleted. This guarantees that data is always available either locally or remotely.
 
 When data is available remotely and Tiered Storage is enabled, clients can consume data, even if the data is no longer stored locally.
+
+To create a topic with remote read enabled:
+
+[,bash]
+----
+rpk topic create <topic_name> -c redpanda.remote.read=true
+----
+
+To enable remote read on an existing topic:
+
+[,bash]
+----
+rpk topic alter-config <topic_name> --set redpanda.remote.read=true
+----
 
 See also: xref:{topic-recovery-link}[Topic Recovery], xref:manage:kubernetes/k-remote-read-replicas.adoc[Remote Read Replicas]
 
@@ -1073,7 +1158,13 @@ Use the `redpanda_cloud_storage_paused_archivers` metric to monitor the status o
 
 [WARNING]
 ====
-Do not disable Tiered Storage to pause and resume segment uploads. Doing so can lead to a gap between local data and data in object storage. In such cases, it is possible that the oldest segment is not aligned with the last uploaded segment. Always use the `cloud_storage_enable_segment_uploads` property instead.
+Do not use `redpanda.remote.read` or `redpanda.remote.write` to pause and resume segment uploads. Doing so can lead to a gap between local data and data in object storage. In such cases, it is possible that the oldest segment is not aligned with the last uploaded segment. Given that these settings are unsafe, if you choose to set either `redpanda.remote.write` or the cluster configuration setting `cloud_storage_enable_remote_write` to `false`, you receive a warning:
+
+[source,bash]
+----
+Warning: disabling Tiered Storage may lead to data loss. If you only want to pause Tiered Storage temporarily, use the `cloud_storage_enable_segment_uploads` option. Abort?
+# The default is Yes.
+----
 ====
 
 

--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -864,116 +864,47 @@ When you enable Tiered Storage on a topic already containing data, Redpanda uplo
 
 ==== Enable Tiered Storage for a cluster
 
-To enable Tiered Storage for a cluster (in addition to setting `cloud_storage_enabled` to `true`), set the following cluster-level properties to `true`:
-
-* config_ref:cloud_storage_enable_remote_write,true,properties/object-storage-properties[]
-* config_ref:cloud_storage_enable_remote_read,true,properties/object-storage-properties[]
+To enable Tiered Storage for a cluster, set the `default_redpanda_storage_mode` cluster property to `tiered` (in addition to setting `cloud_storage_enabled` to `true`). This configures all new topics to use Tiered Storage by default.
 
 When you enable Tiered Storage for a cluster, you enable it for all existing topics in the cluster. When cluster-level properties are changed, the changes apply only to new topics, not existing topics. You must restart your cluster after enabling Tiered Storage.
 
-NOTE: The `cloud_storage_enable_remote_write` and `cloud_storage_enable_remote_read` cluster-level properties are essentially creation-time defaults for the `redpanda.remote.write` and `redpanda.remote.read` topic-level properties.
-
 ==== Enable Tiered Storage for specific topics
 
-To enable Tiered Storage for a new or existing topic (in addition to setting `cloud_storage_enabled` to `true`), set the following topic-level properties to `true`:
-
-* `redpanda.remote.write`
-* `redpanda.remote.read`
+To enable Tiered Storage for a new or existing topic (in addition to setting `cloud_storage_enabled` to `true`), set the `redpanda.storage.mode` topic property to `tiered`.
 
 For example, to create a new topic with Tiered Storage:
 
 [,bash]
 ----
-rpk topic create <topic_name> -c redpanda.remote.read=true -c redpanda.remote.write=true
+rpk topic create <topic_name> -c redpanda.storage.mode=tiered
 ----
 
 To enable Tiered Storage on an existing topic, run:
 
 [,bash]
 ----
-rpk topic alter-config <topic_name> --set redpanda.remote.read=true --set redpanda.remote.write=true
+rpk topic alter-config <topic_name> --set redpanda.storage.mode=tiered
 ----
 
-Topic-level properties override cluster-level properties. For example, for new topics, if `cloud_storage_enable_remote_write` is set to `true`, you can set `redpanda.remote.write` to `false` to turn it off for a particular topic.
+Topic-level properties override cluster-level properties. For example, if `default_redpanda_storage_mode` is set to `tiered`, you can set `redpanda.storage.mode` to `local` on a specific topic to keep it local-only.
 
 Tiered Storage topic-level properties:
 
 |===
 | Property | Description
 
-| `redpanda.remote.write`
-| Uploads data from Redpanda to object storage. Overrides the cluster-level `cloud_storage_enable_remote_write` configuration for the topic.
-
-| `redpanda.remote.read`
-| Fetches data from object storage to Redpanda. Overrides the cluster-level `cloud_storage_enable_remote_read` configuration for the topic.
+| `redpanda.storage.mode`
+| Controls the storage mode for the topic. Set to `tiered` to enable Tiered Storage. This property takes precedence over legacy `redpanda.remote.read` and `redpanda.remote.write` settings.
 
 | `redpanda.remote.recovery`
 | Recovers or reproduces a topic from object storage. Use this property during topic creation. It does not apply to existing topics.
 
 | `redpanda.remote.delete`
-| When set to `true`, deleting a topic also deletes its objects in object storage. Both `redpanda.remote.write` and `redpanda.remote.read` must be enabled, and the topic must not be a Remote Read Replica topic.
+| When set to `true`, deleting a topic also deletes its objects in object storage. Tiered Storage must be enabled, and the topic must not be a Remote Read Replica topic.
 
 When set to `false`, deleting a topic does not delete its objects in object storage.
 
 Default is `true` for new topics.
-|===
-
-The following tables list outcomes for combinations of cluster-level and topic-level configurations:
-
-|===
-| Cluster-level configuration with `cloud_storage_enable_remote_write` | Topic-level configuration with `redpanda.remote.write` | Outcome: whether remote write is enabled or disabled on the topic
-
-| `true`
-| Not set
-| Enabled
-
-| `true`
-| `false`
-| Disabled
-
-| `true`
-| `true`
-| Enabled
-
-| `false`
-| Not set
-| Disabled
-
-| `false`
-| `false`
-| Disabled
-
-| `false`
-| `true`
-| Enabled
-|===
-
-|===
-| Cluster-level configuration with `cloud_storage_enable_remote_read` | Topic-level configuration with `redpanda.remote.read` | Outcome: whether remote read is enabled or disabled on the topic
-
-| `true`
-| Not set
-| Enabled
-
-| `true`
-| `false`
-| Disabled
-
-| `true`
-| `true`
-| Enabled
-
-| `false`
-| Not set
-| Disabled
-
-| `false`
-| `false`
-| Disabled
-
-| `false`
-| `true`
-| Enabled
 |===
 
 
@@ -1044,25 +975,23 @@ Third-party tools that query space utilization from the Redpanda cluster might n
 
 Remote write is the process that constantly uploads log segments to object storage. The process is created for each partition and runs on the leader broker of the partition. It only uploads the segments that contain offsets that are smaller than the last stable offset. This is the latest offset that the client can read.
 
-To ensure all data is uploaded, you must enable remote write before any data is produced to the topic. If you enable remote write after data has been written to the topic, only the data that currently exists on disk based on local retention settings will be scheduled for uploading. Redpanda strongly recommends that you avoid repeatedly toggling remote write on and off, because this can result in inconsistent data and data gaps in Tiered Storage for a topic.
+To ensure all data is uploaded, you must enable Tiered Storage before any data is produced to the topic. If you enable Tiered Storage after data has been written to the topic, only the data that currently exists on disk based on local retention settings will be scheduled for uploading. Redpanda strongly recommends that you avoid repeatedly toggling Tiered Storage on and off, because this can result in inconsistent data and data gaps in Tiered Storage for a topic.
 
-To enable Tiered Storage, use both remote write and remote read.
-
-To create a topic with remote write enabled:
+To create a topic with Tiered Storage (remote write and read) enabled:
 
 [,bash]
 ----
-rpk topic create <topic_name> -c redpanda.remote.write=true
+rpk topic create <topic_name> -c redpanda.storage.mode=tiered
 ----
 
-To enable remote write on an existing topic:
+To enable Tiered Storage on an existing topic:
 
 [,bash]
 ----
-rpk topic alter-config <topic_name> --set redpanda.remote.write=true
+rpk topic alter-config <topic_name> --set redpanda.storage.mode=tiered
 ----
 
-If remote write is enabled, log segments are not deleted until they're uploaded to object storage. Because of this, the log segments may exceed the configured retention period until they're uploaded, so the topic might require more disk space. This prevents data loss if segments cannot be uploaded fast enough or if the retention period is very short.
+When Tiered Storage is enabled, log segments are not deleted until they're uploaded to object storage. Because of this, the log segments may exceed the configured retention period until they're uploaded, so the topic might require more disk space. This prevents data loss if segments cannot be uploaded fast enough or if the retention period is very short.
 
 To see the object storage status for a given topic:
 
@@ -1100,7 +1029,7 @@ NOTE: The broker uploading to object storage is always with the partition leader
 
 Remote write uses a proportional derivative (PD) controller to minimize the backlog size for the write. The backlog consists of data that has not been uploaded to object storage but must be uploaded eventually.
 
-The upload backlog controller prevents Redpanda from running out of disk space. If `remote.write` is set to `true`, Redpanda cannot evict log segments that have not been uploaded to object storage. If the remote write process cannot keep up with the amount of data that needs to be uploaded to object storage, the upload backlog controller increases priority for the upload process. The upload backlog controller measures the size of the upload periodically and tunes the priority of the remote write process.
+The upload backlog controller prevents Redpanda from running out of disk space. When Tiered Storage is enabled, Redpanda cannot evict log segments that have not been uploaded to object storage. If the remote write process cannot keep up with the amount of data that needs to be uploaded to object storage, the upload backlog controller increases priority for the upload process. The upload backlog controller measures the size of the upload periodically and tunes the priority of the remote write process.
 
 === Data archiving
 
@@ -1124,23 +1053,9 @@ To delete archival data, adjust `retention.ms` or `retention.bytes`.
 
 Remote read fetches data from object storage using the Kafka API.
 
-Without Tiered Storage, when data is evicted locally, it is no longer available. If the consumer starts consuming the partition from the beginning, the first offset is the smallest offset available locally. However, when Tiered Storage is enabled with the `redpanda.remote.read` and `redpanda.remote.write` properties, data is always uploaded to object storage before it's deleted. This guarantees that data is always available either locally or remotely.
+Without Tiered Storage, when data is evicted locally, it is no longer available. If the consumer starts consuming the partition from the beginning, the first offset is the smallest offset available locally. However, when Tiered Storage is enabled (with `redpanda.storage.mode` set to `tiered`), data is always uploaded to object storage before it's deleted. This guarantees that data is always available either locally or remotely.
 
 When data is available remotely and Tiered Storage is enabled, clients can consume data, even if the data is no longer stored locally.
-
-To create a topic with remote read enabled:
-
-[,bash]
-----
-rpk topic create <topic_name> -c redpanda.remote.read=true
-----
-
-To enable remote read on an existing topic:
-
-[,bash]
-----
-rpk topic alter-config <topic_name> --set redpanda.remote.read=true
-----
 
 See also: xref:{topic-recovery-link}[Topic Recovery], xref:manage:kubernetes/k-remote-read-replicas.adoc[Remote Read Replicas]
 
@@ -1158,13 +1073,7 @@ Use the `redpanda_cloud_storage_paused_archivers` metric to monitor the status o
 
 [WARNING]
 ====
-Do not use `redpanda.remote.read` or `redpanda.remote.write` to pause and resume segment uploads. Doing so can lead to a gap between local data and data in object storage. In such cases, it is possible that the oldest segment is not aligned with the last uploaded segment. Given that these settings are unsafe, if you choose to set either `redpanda.remote.write` or the cluster configuration setting `cloud_storage_enable_remote_write` to `false`, you receive a warning:
-
-[source,bash]
-----
-Warning: disabling Tiered Storage may lead to data loss. If you only want to pause Tiered Storage temporarily, use the `cloud_storage_enable_segment_uploads` option. Abort?
-# The default is Yes.
-----
+Do not disable Tiered Storage to pause and resume segment uploads. Doing so can lead to a gap between local data and data in object storage. In such cases, it is possible that the oldest segment is not aligned with the last uploaded segment. Always use the `cloud_storage_enable_segment_uploads` property instead.
 ====
 
 


### PR DESCRIPTION
**Do not merge until 26.1 GA**

Link: https://deploy-preview-1631--redpanda-docs-preview.netlify.app/current/manage/kubernetes/k-cloud-topics/

## Summary
- Adds a new **Cloud Topics** documentation page under Manage > Kubernetes, positioned above Tiered Storage in the navigation
- Provides step-by-step instructions for enabling and using Cloud Topics on Kubernetes for both **Helm + Operator** and **Helm** deployments
- Covers high-level overview (storage modes, use cases, limitations), prerequisites, object storage configuration, enabling cloud topics, creating cloud topics (by default and individually), overriding cluster defaults, and verifying topic storage mode
- Removes the remote.read/remote.write combination tables and simplifies related sections

## Preview pages
[Cloud Topics on Kubernetes](https://deploy-preview-1631--redpanda-docs-preview.netlify.app/current/manage/kubernetes/k-cloud-topics/)

## Test plan
- [ ] Verify the new Cloud Topics page renders correctly in the Antora preview
- [ ] Verify navigation shows Cloud Topics above Tiered Storage in Manage > Kubernetes
- [ ] Verify Tiered Storage page still renders correctly after remote.read/write removal
- [ ] Review YAML examples for correctness against Redpanda Operator CRD
- [ ] Confirm all xref links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)