### PR TITLE
docs(DOC-1841): add FIPS 140-3 SCRAM password length requirement

### DIFF
--- a/modules/manage/pages/security/fips-compliance.adoc
+++ b/modules/manage/pages/security/fips-compliance.adoc
@@ -20,11 +20,17 @@ rpk cluster license info
 
 Before configuring brokers to run in FIPS compliance mode (FIPS mode), check to make sure the `redpanda-rpk-fips` and `redpanda-fips` packages are xref:deploy:deployment-option/self-hosted/manual/production/production-deployment.adoc#install-redpanda-for-fips-compliance[installed]. These packages are required by both the `redpanda` and `redpanda-tuner` install packages.
 
+[IMPORTANT]
+====
+If you are upgrading to Redpanda 26.1 with FIPS mode enabled, ensure all SASL/SCRAM user passwords are at least 14 characters before upgrading. FIPS 140-3 enforces stricter HMAC key size requirements than FIPS 140-2. Redpanda stores passwords in encrypted form and cannot verify the length of existing passwords. Clients using passwords shorter than 14 characters may fail to authenticate after the upgrade.
+====
+
 == Limitations
 
 - Redpanda is not fully FIPS-compliant when used with the Redpanda Helm chart and Operator in a Kubernetes deployment.
 - Redpanda Console is not FIPS-compliant.
 - PKCS#12 keys for xref:manage:security/encryption.adoc[TLS encryption] are not supported when FIPS mode is enabled in Redpanda. The PKCS12KDF algorithm used in PKCS#12 is not FIPS-compliant. To use Redpanda in FIPS mode with TLS enabled, configure your certificates and keys in PEM format instead.
+- When FIPS mode is `enabled` or `permissive`, SASL/SCRAM passwords must be at least 14 characters. FIPS 140-3 enforces stricter HMAC key size requirements than FIPS 140-2.
 
 == Configure FIPS mode
 


### PR DESCRIPTION
## Summary

**DO NOT MERGE: See https://github.com/redpanda-data/docs/pull/1632#issuecomment-4156787058**

- Documents that SASL/SCRAM passwords must be at least 14 characters when running in FIPS mode (`enabled` or `permissive`)
- Adds an upgrade warning in Prerequisites for users upgrading to 26.1 with FIPS enabled
- Adds a Limitations bullet for the constraint

FIPS 140-3 enforces stricter HMAC key size requirements than FIPS 140-2. Customers with shorter SCRAM passwords must update them before upgrading to 26.1 or their clients may fail to authenticate.

## Test plan

- [ ] Verify build passes (exit 0)
- [ ] Confirm Prerequisites warning is visible and clearly communicates the upgrade risk
- [ ] Confirm Limitations bullet accurately reflects the constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)