### PR TITLE
Iceberg Cloud docs: BYOVPC, IAM auth

### DIFF
--- a/modules/manage/pages/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/about-iceberg-topics.adoc
@@ -45,7 +45,7 @@ When you enable the Iceberg integration for a Redpanda topic, Redpanda brokers s
 To enable Iceberg for Redpanda topics, you must have the following:
 
 ifdef::env-cloud[]
-* A running xref:get-started:cluster-types/byoc/index.adoc[BYOC] cluster on Redpanda version 25.1 or later. The Iceberg integration is supported only for BYOC, and the cluster properties to configure Iceberg are available with v25.1.
+* A running xref:get-started:cluster-types/byoc/index.adoc[BYOC] or BYOVPC cluster on Redpanda version 25.1 or later. The Iceberg integration is supported only for BYOC and BYOVPC, and the cluster properties to configure Iceberg are available with v25.1.
 * rpk: See xref:get-started:rpk-install.adoc[].
 * Familiarity with the Redpanda Cloud API. You must link:/api/doc/cloud-controlplane/authentication[authenticate] to the Cloud API and use the Control Plane API to update your cluster configuration.
 endif::[]
@@ -189,26 +189,9 @@ ifdef::env-cloud[]
 
 === Access Iceberg data
 
-To query the Iceberg table, you need access to the object storage bucket or container where the Iceberg data is stored. For BYOC clusters, the bucket name and table location are as follows:
+To query the Iceberg table, you need access to the object storage bucket or container where the Iceberg data is stored.
 
-|===
-| Cloud provider | Bucket or container name | Iceberg table location
-
-| AWS
-| `redpanda-cloud-storage-<cluster-id>`
-.3+a| `redpanda-iceberg-catalog/redpanda/<topic-name>`
-
-| Azure
-a| `<cluster-id>`
-
-The Redpanda cluster ID is also used as the container name (ID) and the storage account ID.
-
-
-| GCP
-| `redpanda-cloud-storage-<cluster-id>`
-
-
-|===
+include::manage:partial$iceberg-access-table.adoc[]
 
 For Azure clusters, you must add the public IP addresses or ranges from the REST catalog service, or other clients requiring access to the Iceberg data, to your cluster's allow list. Alternatively, add subnet IDs to the allow list if the requests originate from the same Azure region.
 

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -154,8 +154,8 @@ iceberg_delete: false
 iceberg_catalog_type: rest
 iceberg_rest_catalog_endpoint: https://glue.<glue-region>.amazonaws.com/iceberg
 iceberg_rest_catalog_authentication_mode: aws_sigv4
- # Because Tiered Storage does not support the use of distinct buckets for Iceberg,
- # always place iceberg_rest_catalog_base_location in the same S3 bucket as cloud_storage_bucket
+# Because Tiered Storage does not support the use of distinct buckets for Iceberg,
+# always place iceberg_rest_catalog_base_location in the same S3 bucket as cloud_storage_bucket
 iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
 # Use the iceberg_rest_catalog_aws_* properties if you want to 
 # use separate AWS credentials for the catalog, or omit these lines to reuse S3 
@@ -189,12 +189,14 @@ rpk profile create --from-cloud <cluster-id>
 [tabs]
 ======
 IAM role (instance metadata)::
-+
+
 --
 [,bash]
 ----
 rpk cluster config set \
   iceberg_enabled=true \
+  # Glue requires Redpanda Iceberg tables to be manually deleted
+  iceberg_delete=false \
   iceberg_catalog_type=rest \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
@@ -204,12 +206,14 @@ rpk cluster config set \
 ----
 --
 Static credentials::
-+
+
 --
 [,bash]
 ----
 rpk cluster config set \
   iceberg_enabled=true \
+  # Glue requires Redpanda Iceberg tables to be manually deleted
+  iceberg_delete=false \
   iceberg_catalog_type=rest \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -74,9 +74,9 @@ When `iceberg_delete` or the topic override `redpanda.iceberg.delete` is set to 
 == Authorize access to AWS Glue
 
 ifdef::env-cloud[]
-For BYOC clusters created in March 2026 or later, the required AWS Glue IAM policy is automatically provisioned and attached to the Redpanda broker role when Iceberg is enabled. You don't need to manually create IAM policies or roles for Glue access.
+For BYOC clusters created in March 2026 or later, the required AWS Glue IAM policy is automatically provisioned and attached to the cluster's IAM role when Iceberg is enabled. You don't need to manually create IAM policies or roles for Glue access.
 
-For clusters created before March 2026, you must run `rpk byoc apply` to provision the Glue IAM policy before enabling Iceberg. This is a one-time operation that updates the broker role with the necessary Glue permissions.
+For clusters created before March 2026, you must run `rpk byoc apply` to provision the Glue IAM policy before enabling Iceberg. This is a one-time operation that updates the cluster's IAM role with the necessary Glue permissions.
 endif::[]
 
 ifndef::env-cloud[]

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -129,9 +129,9 @@ endif::[]
 ifdef::env-cloud[]
 You can configure credentials for the AWS Glue Data Catalog integration in either of the following ways:
 
-* Allow Redpanda to use the same `cloud_storage_*` credential properties already configured for S3. If you do not configure the overrides listed below, Redpanda uses the same credentials for both S3 and AWS Glue. This is the recommended approach, especially in BYOC deployments where the broker's IAM role already includes the necessary Glue permissions.
+* Allow Redpanda to use the same object storage credential properties already configured for S3. If you do not configure the overrides listed below, Redpanda uses the same credentials for both S3 and AWS Glue. This is the recommended approach, especially in BYOC deployments where the cluster's existing AWS credentials already include the necessary Glue permissions.
 * If you want to configure authentication to AWS Glue separately from authentication to S3, there are equivalent credential configuration properties named `iceberg_rest_catalog_aws_*` that override the object storage credentials. These properties only apply to REST catalog authentication, and never to S3 authentication:
-** config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`] overrides config_ref:cloud_storage_credentials_source,true,properties/cluster-properties[`cloud_storage_credentials_source`]. To use the broker's IAM role, set the property to `aws_instance_metadata`. To use static credentials, set to `config_file`.
+** config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`]. To use the cluster's IAM role, set the property to `aws_instance_metadata`. To use static credentials, set to `config_file`.
 ** config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`] (static credentials only)
 ** config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`] (static credentials only), added as a secret value (see the <<update-cluster-configuration,next section>> for details)
 ** config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`]
@@ -158,7 +158,7 @@ iceberg_delete: false
 iceberg_catalog_type: rest
 iceberg_rest_catalog_endpoint: https://glue.<glue-region>.amazonaws.com/iceberg
 iceberg_rest_catalog_authentication_mode: aws_sigv4
-# Because Tiered Storage does not support the use of distinct buckets for Iceberg,
+# Because Redpanda does not support the use of distinct buckets for Iceberg,
 # always place iceberg_rest_catalog_base_location in the same S3 bucket as cloud_storage_bucket
 iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
 # Use the iceberg_rest_catalog_aws_* properties if you want to 
@@ -177,11 +177,11 @@ Use your own values for the following placeholders:
 +
 --
 * `<glue-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in either your config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`] or config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
-* `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. This must be the same bucket used for Tiered Storage (your `cloud_storage_bucket`). You cannot specify a different bucket for Iceberg data.
+* `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. This must be the same bucket used for object storage (your `cloud_storage_bucket`). You cannot specify a different bucket for Iceberg data.
 +
 `<warehouse-path>` is a name you choose (such as `iceberg`) as the logical name for the warehouse represented by all Redpanda Iceberg topic data in the cluster.
 +
-As a security best practice, do not use the bucket root for the base location. Always specify a subfolder to avoid interfering with Tiered Storage data.
+As a security best practice, do not use the bucket root for the base location. Always specify a subfolder to avoid interfering with your cluster's data in object storage.
 --
 endif::[]
 ifdef::env-cloud[]
@@ -239,12 +239,12 @@ Use your own values for the following placeholders:
 --
 * `<glue-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in your config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
 * `<cluster-storage-bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<cluster-storage-bucket-name>/iceberg`.
-** Bucket name: For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`. For BYOVPC clusters, use the name of the bucket you created as a customer-managed resource. 
+** Bucket name: For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`. For BYOVPC clusters, use the name of the object storage bucket you created as a xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc#configure-the-redpanda-network-and-cluster[customer-managed resource]. 
 +
-This must be the same bucket used for Tiered Storage. You cannot specify a different bucket for Iceberg data.
+This must be the same bucket used for your cluster's object storage. You cannot specify a different bucket for Iceberg data.
 ** Warehouse: This is a name you choose as the logical name (such as `iceberg`) for the warehouse represented by all Redpanda Iceberg topic data in the cluster.
 +
-As a security best practice, do not use the bucket root for the base location. Always specify a subfolder to avoid interfering with Tiered Storage data.
+As a security best practice, do not use the bucket root for the base location. Always specify a subfolder to avoid interfering with the rest of your cluster's data in object storage.
 * `<glue-access-key>` (static credentials only): The AWS access key ID for your Glue service account.
 * `<glue-secret-key-name>` (static credentials only): The name of the secret that stores the AWS secret access key for your Glue service account. To reference a secret in a cluster property, for example `iceberg_rest_catalog_aws_secret_key`, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value].
 --

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -118,7 +118,7 @@ endif::[]
 ifndef::env-cloud[]
 You must configure credentials for the AWS Glue Data Catalog integration in either of the following ways:
 
-* Allow Redpanda to use the same `cloud_storage_*` credential properties configured for S3. If you do not configure the overrides listed below, Redpanda uses the same credentials for both S3 and AWS Glue. This is the recommended approach.
+* Allow Redpanda to use the same `cloud_storage_*` credential properties configured for S3. This is the recommended approach.
 * If you want to configure authentication to AWS Glue separately from authentication to S3, there are equivalent credential configuration properties named `iceberg_rest_catalog_aws_*` that override the object storage credentials. These properties only apply to REST catalog authentication, and never to S3 authentication:
 ** config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`] overrides config_ref:cloud_storage_credentials_source,true,properties/cluster-properties[`cloud_storage_credentials_source`]
 ** config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`] overrides config_ref:cloud_storage_access_key,true,properties/cluster-properties[`cloud_storage_access_key`]
@@ -129,7 +129,7 @@ endif::[]
 ifdef::env-cloud[]
 You can configure credentials for the AWS Glue Data Catalog integration in either of the following ways:
 
-* Allow Redpanda to use the same object storage credential properties already configured for S3. If you do not configure the overrides listed below, Redpanda uses the same credentials for both S3 and AWS Glue. This is the recommended approach, especially in BYOC deployments where the cluster's existing AWS credentials already include the necessary Glue permissions.
+* Allow Redpanda to use the same object storage credential properties already configured for S3. This is the recommended approach, especially in BYOC deployments where the cluster's existing AWS credentials already include the necessary Glue permissions.
 * If you want to configure authentication to AWS Glue separately from authentication to S3, there are equivalent credential configuration properties named `iceberg_rest_catalog_aws_*` that override the object storage credentials. These properties only apply to REST catalog authentication, and never to S3 authentication:
 ** config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`]. To use the cluster's IAM role, set the property to `aws_instance_metadata`. To use static credentials, set to `config_file`.
 ** config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`] (static credentials only)

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -23,6 +23,10 @@ This guide walks you through querying Redpanda topics as Iceberg tables stored i
 
 == Prerequisites
 
+* An AWS account with access to https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html[AWS Glue Data Catalog^].
+ifdef::env-cloud[]
+** The AWS Glue Data Catalog must be in the same AWS account and region as the cluster.
+endif::[]
 * Redpanda version {rp_version} or later.
 * xref:{rpk_install_doc}[`rpk`] installed or updated to the latest version.
 ifdef::env-cloud[]
@@ -66,12 +70,6 @@ ifdef::env-cloud[]
 endif::[]
 
 When `iceberg_delete` or the topic override `redpanda.iceberg.delete` is set to `false`, you can delete the Redpanda topic, and then delete the table in AWS Glue and the Iceberg data and metadata files in the S3 bucket. If you plan to re-create the topic after deleting it, you must delete the table data entirely before re-creating the topic.
-
-ifdef::env-cloud[]
-=== Same AWS account required
-
-For BYOC and BYOVPC deployments, the AWS Glue Data Catalog must be in the same AWS account as the cluster. Cross-account Glue access has not been tested or certified. If you need to use a Glue catalog in a different AWS account, contact https://support.redpanda.com[Redpanda support^].
-endif::[]
 
 == Authorize access to AWS Glue
 

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -120,10 +120,10 @@ You must configure credentials for the AWS Glue Data Catalog integration in eith
 
 * Allow Redpanda to use the same `cloud_storage_*` credential properties configured for S3. If you do not configure the overrides listed below, Redpanda uses the same credentials for both S3 and AWS Glue. This is the recommended approach.
 * If you want to configure authentication to AWS Glue separately from authentication to S3, there are equivalent credential configuration properties named `iceberg_rest_catalog_aws_*` that override the object storage credentials. These properties only apply to REST catalog authentication, and never to S3 authentication:
+** config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`] overrides config_ref:cloud_storage_credentials_source,true,properties/cluster-properties[`cloud_storage_credentials_source`]
 ** config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`] overrides config_ref:cloud_storage_access_key,true,properties/cluster-properties[`cloud_storage_access_key`]
 ** config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`] overrides config_ref:cloud_storage_secret_key,true,properties/cluster-properties[`cloud_storage_secret_key`]
 ** config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] overrides config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`]
-** config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`] overrides config_ref:cloud_storage_credentials_source,true,properties/cluster-properties[`cloud_storage_credentials_source`]
 endif::[]
 
 ifdef::env-cloud[]
@@ -189,7 +189,7 @@ Use `rpk` like in the following examples, or use the Cloud API to xref:manage:cl
 +
 [tabs]
 ======
-IAM role (instance metadata)::
+Use cluster's IAM credentials::
 +
 --
 [,bash]
@@ -212,7 +212,7 @@ rpk cluster config set \
 ----
 --
 
-Static credentials::
+Use static credentials (override IAM)::
 +
 --
 [,bash]

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -193,7 +193,7 @@ As a security best practice, do not use the bucket root for the base location. A
 --
 endif::[]
 ifdef::env-cloud[]
-Use `rpk` as shown in the following examples, or use the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
+Use `rpk` as shown in the following examples, or xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[use the Cloud API] to update these cluster properties. The update might take several minutes to complete.
 +
 [tabs]
 ======

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -67,6 +67,12 @@ endif::[]
 
 When `iceberg_delete` or the topic override `redpanda.iceberg.delete` is set to `false`, you can delete the Redpanda topic, and then delete the table in AWS Glue and the Iceberg data and metadata files in the S3 bucket. If you plan to re-create the topic after deleting it, you must delete the table data entirely before re-creating the topic.
 
+ifdef::env-cloud[]
+=== Same AWS account required
+
+For BYOC and BYOVPC deployments, the AWS Glue Data Catalog must be in the same AWS account as the cluster. Cross-account Glue access has not been tested or certified. If you need to use a Glue catalog in a different AWS account, contact https://support.redpanda.com[Redpanda support^].
+endif::[]
+
 == Authorize access to AWS Glue
 
 ifdef::env-cloud[]
@@ -172,8 +178,12 @@ iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
 Use your own values for the following placeholders:
 +
 --
-- `<glue-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in either your config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`] or config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
-- `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. As a security best practice, Redpanda Data recommends specifying a subfolder (using prefixes) rather than the root of the bucket.
+* `<glue-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in either your config_ref:cloud_storage_region,true,properties/cluster-properties[`cloud_storage_region`] or config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
+* `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. This must be the same bucket used for Tiered Storage (your `cloud_storage_bucket`). You cannot specify a different bucket for Iceberg data.
++
+`<warehouse-path>` is a name you choose (such as `iceberg`) as the logical name for the warehouse represented by all Redpanda Iceberg topic data in the cluster.
++
+As a security best practice, do not use the bucket root for the base location. Always specify a subfolder to avoid interfering with Tiered Storage data.
 --
 endif::[]
 ifdef::env-cloud[]
@@ -200,7 +210,7 @@ rpk cluster config set \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
   iceberg_rest_catalog_credentials_source=aws_instance_metadata \
   iceberg_rest_catalog_aws_region=<glue-region> \
-  iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
+  iceberg_rest_catalog_base_location=s3://<cluster-storage-bucket-name>/<warehouse-path>
 ----
 --
 
@@ -221,7 +231,7 @@ rpk cluster config set \
   iceberg_rest_catalog_aws_region=<glue-region> \
   iceberg_rest_catalog_aws_access_key=<glue-access-key> \
   iceberg_rest_catalog_aws_secret_key='${secrets.<glue-secret-key-name>}' \
-  iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
+  iceberg_rest_catalog_base_location=s3://<cluster-storage-bucket-name>/<warehouse-path>
 ----
 --
 ======
@@ -229,12 +239,16 @@ rpk cluster config set \
 Use your own values for the following placeholders:
 +
 --
-- `<glue-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in your config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
-- `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`. For BYOVPC clusters, use the name of the bucket you created as a customer-managed resource.
+* `<glue-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in your config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
+* `<cluster-storage-bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<cluster-storage-bucket-name>/iceberg`.
+** Bucket name: For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`. For BYOVPC clusters, use the name of the bucket you created as a customer-managed resource. 
 +
-As a security best practice, Redpanda Data recommends specifying a subfolder (using prefixes) rather than the root of the bucket.
-- `<glue-access-key>` (static credentials only): The AWS access key ID for your Glue service account.
-- `<glue-secret-key-name>` (static credentials only): The name of the secret that stores the AWS secret access key for your Glue service account. To reference a secret in a cluster property, for example `iceberg_rest_catalog_aws_secret_key`, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value].
+This must be the same bucket used for Tiered Storage. You cannot specify a different bucket for Iceberg data.
+** Warehouse: This is a name you choose as the logical name (such as `iceberg`) for the warehouse represented by all Redpanda Iceberg topic data in the cluster.
++
+As a security best practice, do not use the bucket root for the base location. Always specify a subfolder to avoid interfering with Tiered Storage data.
+* `<glue-access-key>` (static credentials only): The AWS access key ID for your Glue service account.
+* `<glue-secret-key-name>` (static credentials only): The name of the secret that stores the AWS secret access key for your Glue service account. To reference a secret in a cluster property, for example `iceberg_rest_catalog_aws_secret_key`, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value].
 --
 endif::[]
 +

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -179,20 +179,17 @@ endif::[]
 ifdef::env-cloud[]
 Use `rpk` like in the following examples, or use the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
 +
+[tabs]
+======
+IAM role (instance metadata)::
++
+--
 [,bash]
 ----
 rpk cloud login
 
 rpk profile create --from-cloud <cluster-id>
-----
-+
-[tabs]
-======
-IAM role (instance metadata)::
 
---
-[,bash]
-----
 rpk cluster config set \
   iceberg_enabled=true \
   # Glue requires Redpanda Iceberg tables to be manually deleted
@@ -205,8 +202,9 @@ rpk cluster config set \
   iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
 ----
 --
-Static credentials::
 
+Static credentials::
++
 --
 [,bash]
 ----

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -25,7 +25,7 @@ This guide walks you through querying Redpanda topics as Iceberg tables stored i
 
 * An AWS account with access to https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html[AWS Glue Data Catalog^].
 ifdef::env-cloud[]
-** The AWS Glue Data Catalog must be in the same AWS account and region as the cluster.
+** AWS Glue Data Catalog must be in the same AWS account and region as the cluster.
 endif::[]
 * Redpanda version {rp_version} or later.
 * xref:{rpk_install_doc}[`rpk`] installed or updated to the latest version.

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -130,11 +130,19 @@ ifdef::env-cloud[]
 You can configure credentials for the AWS Glue Data Catalog integration in either of the following ways:
 
 * Allow Redpanda to use the same object storage credential properties already configured for S3. This is the recommended approach, especially in BYOC deployments where the cluster's existing AWS credentials already include the necessary Glue permissions.
++
+For an example cluster configuration that uses the same IAM credentials for both S3 and AWS Glue, see the *Use cluster's IAM credentials* tab in the <<update-cluster-configuration,next section>>.
 * If you want to configure authentication to AWS Glue separately from authentication to S3, there are equivalent credential configuration properties named `iceberg_rest_catalog_aws_*` that override the object storage credentials. These properties only apply to REST catalog authentication, and never to S3 authentication:
++
+--
 ** config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`]. To use the cluster's IAM role, set the property to `aws_instance_metadata`. To use static credentials, set to `config_file`.
 ** config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`] (static credentials only)
 ** config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`] (static credentials only), added as a secret value (see the <<update-cluster-configuration,next section>> for details)
 ** config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`]
+--
++
+For an example cluster configuration that uses separate access keys for AWS Glue, see the *Use static credentials (override IAM)* tab in the <<update-cluster-configuration,next section>>.
+
 endif::[]
 
 == Update cluster configuration

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -185,7 +185,7 @@ As a security best practice, do not use the bucket root for the base location. A
 --
 endif::[]
 ifdef::env-cloud[]
-Use `rpk` like in the following examples, or use the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
+Use `rpk` as shown in the following examples, or use the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
 +
 [tabs]
 ======

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -186,13 +186,14 @@ IAM role (instance metadata)::
 --
 [,bash]
 ----
+# Glue requires Redpanda Iceberg tables to be manually deleted
+# so iceberg_delete is set to false.
 rpk cloud login
 
 rpk profile create --from-cloud <cluster-id>
 
 rpk cluster config set \
   iceberg_enabled=true \
-  # Glue requires Redpanda Iceberg tables to be manually deleted
   iceberg_delete=false \
   iceberg_catalog_type=rest \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
@@ -208,9 +209,10 @@ Static credentials::
 --
 [,bash]
 ----
+# Glue requires Redpanda Iceberg tables to be manually deleted
+# so iceberg_delete is set to false.
 rpk cluster config set \
   iceberg_enabled=true \
-  # Glue requires Redpanda Iceberg tables to be manually deleted
   iceberg_delete=false \
   iceberg_catalog_type=rest \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -69,6 +69,13 @@ When `iceberg_delete` or the topic override `redpanda.iceberg.delete` is set to 
 
 == Authorize access to AWS Glue
 
+ifdef::env-cloud[]
+For BYOC clusters created in March 2026 or later, the required AWS Glue IAM policy is automatically provisioned and attached to the Redpanda broker role when Iceberg is enabled. You don't need to manually create IAM policies or roles for Glue access.
+
+For clusters created before March 2026, you must run `rpk byoc apply` to provision the Glue IAM policy before enabling Iceberg. This is a one-time operation that updates the broker role with the necessary Glue permissions.
+endif::[]
+
+ifndef::env-cloud[]
 You must allow Redpanda access to AWS Glue services in your AWS account. You can use the same access credentials that you configured for S3 (IAM role, access keys, and KMS key), as long as you have also added read and write access to AWS Glue Data Catalog.
 
 For example, you could create a separate IAM policy that manages access to AWS Glue and attach it to the IAM role that Redpanda also uses to access S3. Add all AWS Glue API actions in the policy (`"glue:*"`) on the following resources:
@@ -100,6 +107,7 @@ Your IAM policy should include a statement similar to the following:
 ----
 
 For more information on configuring IAM permissions, see the https://docs.aws.amazon.com/glue/latest/dg/configure-iam-for-glue.html[AWS Glue documentation^].
+endif::[]
 
 == Configure authentication and credentials
 
@@ -115,12 +123,14 @@ You must configure credentials for the AWS Glue Data Catalog integration in eith
 endif::[]
 
 ifdef::env-cloud[]
-You must configure credentials for the AWS Glue Data Catalog integration using the following properties:
+You can configure credentials for the AWS Glue Data Catalog integration in either of the following ways:
 
-* config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`] set to `config_file`
-* config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`]
-* config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`], added as a secret value (see the <<update-cluster-configuration,next section>> for details)
-* config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`]
+* Allow Redpanda to use the same `cloud_storage_*` credential properties already configured for S3. If you do not configure the overrides listed below, Redpanda uses the same credentials for both S3 and AWS Glue. This is the recommended approach, especially in BYOC deployments where the broker's IAM role already includes the necessary Glue permissions.
+* If you want to configure authentication to AWS Glue separately from authentication to S3, there are equivalent credential configuration properties named `iceberg_rest_catalog_aws_*` that override the object storage credentials. These properties only apply to REST catalog authentication, and never to S3 authentication:
+** config_ref:iceberg_rest_catalog_credentials_source,true,properties/cluster-properties[`iceberg_rest_catalog_credentials_source`] overrides config_ref:cloud_storage_credentials_source,true,properties/cluster-properties[`cloud_storage_credentials_source`]. To use the broker's IAM role, set the property to `aws_instance_metadata`. To use static credentials, set to `config_file`.
+** config_ref:iceberg_rest_catalog_aws_access_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_access_key`] (static credentials only)
+** config_ref:iceberg_rest_catalog_aws_secret_key,true,properties/cluster-properties[`iceberg_rest_catalog_aws_secret_key`] (static credentials only), added as a secret value (see the <<update-cluster-configuration,next section>> for details)
+** config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`]
 endif::[]
 
 == Update cluster configuration
@@ -167,37 +177,58 @@ Use your own values for the following placeholders:
 --
 endif::[]
 ifdef::env-cloud[]
-Use `rpk` like in the following example, or use the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
+Use `rpk` like in the following examples, or use the Cloud API to xref:manage:cluster-maintenance/config-cluster.adoc#set-cluster-configuration-properties[update these cluster properties]. The update might take several minutes to complete.
 +
 [,bash]
 ----
 rpk cloud login
 
 rpk profile create --from-cloud <cluster-id>
-
+----
++
+[tabs]
+======
+IAM role (instance metadata)::
++
+--
+[,bash]
+----
 rpk cluster config set \
   iceberg_enabled=true \
   iceberg_catalog_type=rest \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
-  # Because Tiered Storage does not support the use of distinct buckets for Iceberg,
-  # always place iceberg_rest_catalog_base_location in the same S3 bucket as cloud_storage_bucket
-  iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path> \
-  # Set credentials source to config_file if using
-  # iceberg_rest_catalog_aws_access_key and iceberg_rest_catalog_aws_secret_key
+  iceberg_rest_catalog_credentials_source=aws_instance_metadata \
+  iceberg_rest_catalog_aws_region=<glue-region> \
+  iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
+----
+--
+Static credentials::
++
+--
+[,bash]
+----
+rpk cluster config set \
+  iceberg_enabled=true \
+  iceberg_catalog_type=rest \
+  iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
+  iceberg_rest_catalog_authentication_mode=aws_sigv4 \
   iceberg_rest_catalog_credentials_source=config_file \
   iceberg_rest_catalog_aws_region=<glue-region> \
   iceberg_rest_catalog_aws_access_key=<glue-access-key> \
-  iceberg_rest_catalog_aws_secret_key='${secrets.<glue-secret-key-name>}'
+  iceberg_rest_catalog_aws_secret_key='${secrets.<glue-secret-key-name>}' \
+  iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path>
 ----
+--
+======
 +
 Use your own values for the following placeholders:
 +
 --
 - `<glue-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in your config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
 - `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. As a security best practice, Redpanda Data recommends specifying a subfolder (using prefixes) rather than the root of the bucket.
-- `<glue-access-key>`: The AWS access key ID for your Glue service account.
-- `<glue-secret-key-name>`: The name of the secret that stores the AWS secret access key for your Glue service account. To reference a secret in a cluster property, for example `iceberg_rest_catalog_aws_secret_key`, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value].
+- `<glue-access-key>` (static credentials only): The AWS access key ID for your Glue service account.
+- `<glue-secret-key-name>` (static credentials only): The name of the secret that stores the AWS secret access key for your Glue service account. To reference a secret in a cluster property, for example `iceberg_rest_catalog_aws_secret_key`, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value].
 --
 endif::[]
 +

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -230,7 +230,9 @@ Use your own values for the following placeholders:
 +
 --
 - `<glue-region>`: The AWS region where your Data Catalog is located. The region in the AWS Glue endpoint must match the region specified in your config_ref:iceberg_rest_catalog_aws_region,true,properties/cluster-properties[`iceberg_rest_catalog_aws_region`] property.
-- `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. As a security best practice, Redpanda Data recommends specifying a subfolder (using prefixes) rather than the root of the bucket.
+- `<bucket-name>` and `<warehouse-path>`: AWS Glue requires you to specify the base location where Redpanda stores Iceberg data and metadata files. You must use an S3 URI; for example, `s3://<bucket-name>/iceberg`. For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`. For BYOVPC clusters, use the name of the bucket you created as a customer-managed resource.
++
+As a security best practice, Redpanda Data recommends specifying a subfolder (using prefixes) rather than the root of the bucket.
 - `<glue-access-key>` (static credentials only): The AWS access key ID for your Glue service account.
 - `<glue-secret-key-name>` (static credentials only): The name of the secret that stores the AWS secret access key for your Glue service account. To reference a secret in a cluster property, for example `iceberg_rest_catalog_aws_secret_key`, you must first xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[store the secret value].
 --

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -76,7 +76,7 @@ When `iceberg_delete` or the topic override `redpanda.iceberg.delete` is set to 
 ifdef::env-cloud[]
 For BYOC clusters created in March 2026 or later, the required AWS Glue IAM policy is automatically provisioned and attached to the cluster's IAM role when Iceberg is enabled. You don't need to manually create IAM policies or roles for Glue access.
 
-For clusters created before March 2026, you must run `rpk byoc apply` to provision the Glue IAM policy before enabling Iceberg. This is a one-time operation that updates the cluster's IAM role with the necessary Glue permissions.
+For clusters created before March 2026, you must re-run `rpk byoc apply` to provision the Glue IAM policy before enabling Iceberg. This is a one-time operation that updates the cluster's IAM role with the necessary Glue permissions.
 endif::[]
 
 ifndef::env-cloud[]

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -73,7 +73,7 @@ Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog
 The external location stores the Unity Catalog-managed Iceberg metadata, and the Iceberg data written by Redpanda. You must use the same bucket configured for glossterm:Tiered Storage[] for your Redpanda cluster.
 
 ifdef::env-cloud[]
-For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`, where `<cluster-id>` is the ID of your Redpanda cluster.
+For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`, where `<cluster-id>` is the ID of your Redpanda cluster. For BYOVPC clusters, the bucket name is the name you chose when you created the Tiered Storage bucket as a customer-managed resource.
 endif::[]
 
 Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/external-locations[Databricks documentation] to *manually* create an external location. You can create the external location in the Catalog Explorer or with SQL. You must create the external location manually because the location needs to be associated with the existing Tiered Storage bucket URL, `s3://<bucket-name>`.

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -73,7 +73,7 @@ Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog
 The external location stores the Unity Catalog-managed Iceberg metadata, and the Iceberg data written by Redpanda. You must use the same bucket configured for glossterm:Tiered Storage[] for your Redpanda cluster.
 
 ifdef::env-cloud[]
-For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`, where `<cluster-id>` is the ID of your Redpanda cluster. For BYOVPC clusters, the bucket name is the name you chose when you created the Tiered Storage bucket as a customer-managed resource.
+For BYOC clusters, the bucket name is `redpanda-cloud-storage-<cluster-id>`, where `<cluster-id>` is the ID of your Redpanda cluster. For BYOVPC clusters, the bucket name is the name you chose when you created the object storage bucket as a customer-managed resource.
 endif::[]
 
 Follow the steps in the https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/external-locations[Databricks documentation] to *manually* create an external location. You can create the external location in the Catalog Explorer or with SQL. You must create the external location manually because the location needs to be associated with the existing Tiered Storage bucket URL, `s3://<bucket-name>`.

--- a/modules/manage/pages/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/query-iceberg-topics.adoc
@@ -27,24 +27,7 @@ endif::[]
 ifdef::env-cloud[]
 Redpanda generates an Iceberg table with the same name as the topic. Depending on the processing engine and your Iceberg catalog implementation, you may also need to define the table (for example using `CREATE TABLE`) to point the data lakehouse to its location in the catalog.
 
-For BYOC clusters, the bucket name and table location are as follows:
-
-|===
-| Cloud provider | Bucket or container name | Iceberg table location
-
-| AWS
-| `redpanda-cloud-storage-<cluster-id>`
-.3+a| `redpanda-iceberg-catalog/redpanda/<topic-name>`
-
-| Azure
-a| `<cluster-id>`
-
-The Redpanda cluster ID is also used as the container name (ID) and the storage account ID.
-
-| GCP
-| `redpanda-cloud-storage-<cluster-id>`
-
-|===
+include::manage:partial$iceberg-access-table.adoc[]
 
 For Azure clusters, you must add the public IP addresses or ranges from the REST catalog service, or other clients requiring access to the Iceberg data, to your cluster's allow list. Alternatively, add subnet IDs to the allow list if the requests originate from the same Azure region.
 

--- a/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
@@ -14,7 +14,7 @@ include::shared:partial$enterprise-license.adoc[]
 ====
 endif::[]
 
-To read from the Redpanda-generated xref:{about-iceberg-doc}[Iceberg table], your Iceberg-compatible client or tool needs access to the catalog to retrieve the table metadata and know the current state of the table. The catalog provides the current table metadata, which includes locations for all the table's data files. You can configure Redpanda to either connect to a REST-based catalog, or use a filesystem-based catalog. 
+To read from the Redpanda-generated xref:{about-iceberg-doc}[Iceberg table], your Iceberg-compatible client or tool needs access to the catalog to retrieve the table metadata and know the current state of the table. The catalog provides the current table metadata, which includes locations for all the table's data files. You can configure Redpanda to either connect to a REST-based catalog, or use a filesystem-based catalog.
 
 For production deployments, Redpanda recommends <<rest,using an external REST catalog>> to manage Iceberg metadata. This enables built-in table maintenance, safely handles multiple engines and tools accessing tables at the same time, facilitates data governance, and maximizes data discovery. However, if it is not possible to use a REST catalog, you can <<object-storage,use the filesystem-based catalog>> (`object_storage` catalog type), which does not require you to maintain a separate service to access the Iceberg data. 
 
@@ -24,6 +24,8 @@ After you have selected a catalog type at the cluster level and xref:{about-iceb
 
 [[rest]]
 == Connect to a REST catalog
+
+NOTE: Redpanda connects to an Iceberg catalog that you provision and manage. Redpanda does not create or manage the catalog service, its databases, or any associated network configuration.
 
 Connect to an Iceberg REST catalog using the standard https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml[REST API^] supported by many catalog providers. Use this catalog integration type with REST-enabled Iceberg catalog services, such as https://docs.databricks.com/en/data-governance/unity-catalog/index.html[Databricks Unity^] and https://other-docs.snowflake.com/en/opencatalog/overview[Snowflake Open Catalog^].
 

--- a/modules/manage/partials/iceberg-access-table.adoc
+++ b/modules/manage/partials/iceberg-access-table.adoc
@@ -1,0 +1,20 @@
+For BYOC clusters, the bucket name and table location are as follows:
+
+|===
+| Cloud provider | Bucket or container name | Iceberg table location
+
+| AWS
+| `redpanda-cloud-storage-<cluster-id>`
+.3+a| `redpanda-iceberg-catalog/redpanda/<topic-name>`
+
+| Azure
+a| `<cluster-id>`
+
+The Redpanda cluster ID is also used as the container name (ID) and the storage account ID.
+
+| GCP
+| `redpanda-cloud-storage-<cluster-id>`
+
+|===
+
+For BYOVPC clusters, the bucket name is the name you chose when you created the Tiered Storage bucket as a customer-managed resource.

--- a/modules/manage/partials/iceberg-access-table.adoc
+++ b/modules/manage/partials/iceberg-access-table.adoc
@@ -17,4 +17,4 @@ The Redpanda cluster ID is also used as the container name (ID) and the storage 
 
 |===
 
-For BYOVPC clusters, the bucket name is the name you chose when you created the Tiered Storage bucket as a customer-managed resource.
+For BYOVPC clusters, the bucket name is the name you chose when you created the object storage bucket as a customer-managed resource.

--- a/modules/reference/partials/properties/cluster-properties.adoc
+++ b/modules/reference/partials/properties/cluster-properties.adoc
@@ -8015,6 +8015,7 @@ endif::[]
 
 // end::redpanda-cloud[]
 
+// tag::redpanda-cloud[]
 === iceberg_rest_catalog_aws_credentials_source
 
 *Accepted values*: `aws_instance_metadata`, `azure_aks_oidc_federation`, `azure_vm_instance_metadata`, `config_file`, `gcp_instance_metadata`, `sts`.
@@ -8075,6 +8076,7 @@ endif::[]
 
 |===
 
+// end::redpanda-cloud[]
 
 // tag::redpanda-cloud[]
 === iceberg_rest_catalog_aws_region

--- a/modules/reference/partials/properties/object-storage-properties.adoc
+++ b/modules/reference/partials/properties/object-storage-properties.adoc
@@ -1519,6 +1519,7 @@ endif::[]
 |===
 
 
+// tag::redpanda-cloud[]
 === cloud_storage_credentials_source
 
 The source of credentials used to authenticate to object storage services.
@@ -1574,6 +1575,7 @@ endif::[]
 
 |===
 
+// end::redpanda-cloud[]
 
 === cloud_storage_crl_file
 

--- a/modules/reference/partials/properties/object-storage-properties.adoc
+++ b/modules/reference/partials/properties/object-storage-properties.adoc
@@ -1519,7 +1519,6 @@ endif::[]
 |===
 
 
-// tag::redpanda-cloud[]
 === cloud_storage_credentials_source
 
 The source of credentials used to authenticate to object storage services.
@@ -1575,7 +1574,6 @@ endif::[]
 
 |===
 
-// end::redpanda-cloud[]
 
 === cloud_storage_crl_file
 


### PR DESCRIPTION
## Description

- Add BYOVPC cluster support to Iceberg prerequisites                                                                                                                                           
- Add IAM role authentication option for AWS Glue (alternative to static keys)
- Clarify that Redpanda does not manage the catalog service                                                                                                                                     
- Clarify S3 base location requirements and bucket naming        
- Consolidate duplicated bucket name/table location info into a shared partial                                                                                                                  
- Make credential source properties visible on Cloud reference pages

Resolves https://redpandadata.atlassian.net/browse/DOC-1920
Resolves https://redpandadata.atlassian.net/browse/DOC-2064
Review deadline:

## Page previews

Cloud:
[AWS Glue doc](https://deploy-preview-1633--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/iceberg-topics-aws-glue)
Object Storage Properties > [`cloud_storage_credentials_source`](https://deploy-preview-1633--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/properties/object-storage-properties/#cloud_storage_credentials_source)
Self-managed:
[AWS Glue doc](https://deploy-preview-1633--redpanda-docs-preview.netlify.app/current/manage/iceberg/iceberg-topics-aws-glue/)


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
