### PR TITLE
docs (k8s): Add CRD source file references to CRD index page

### DIFF
--- a/modules/reference/pages/k-crd-index.adoc
+++ b/modules/reference/pages/k-crd-index.adoc
@@ -35,22 +35,6 @@ The CRD source definitions are maintained in the https://github.com/redpanda-dat
 | RedpandaRole
 | https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_redpandaroles.yaml[`cluster.redpanda.com_redpandaroles.yaml`^]
 | Defines role-based access control resources.
-
-| ShadowLink
-| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_shadowlinks.yaml[`cluster.redpanda.com_shadowlinks.yaml`^]
-| Defines shadow linking resources for disaster recovery.
-
-| Group
-| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_groups.yaml[`cluster.redpanda.com_groups.yaml`^]
-| Defines consumer group resources.
-
-| NodePool
-| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_nodepools.yaml[`cluster.redpanda.com_nodepools.yaml`^]
-| Defines node pool resources for cluster scaling.
-
-| StretchCluster
-| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_stretchclusters.yaml[`cluster.redpanda.com_stretchclusters.yaml`^]
-| Defines stretch cluster resources for multi-datacenter deployments.
 |===
 
 All CRDs belong to the `cluster.redpanda.com` API group. The CRDs are installed automatically when you deploy the Redpanda Operator using Helm with `crds.enabled=true`.

--- a/modules/reference/pages/k-crd-index.adoc
+++ b/modules/reference/pages/k-crd-index.adoc
@@ -2,3 +2,57 @@
 :page-layout: index
 :description: Explore all custom resource definitions (CRDs) that are supported by the Redpanda Operator.
 :page-aliases: reference:topic-crd.adoc, reference:crd.adoc, reference:kubernetes-crd-index.adoc, reference:redpanda-operator/crd.adoc
+
+The Redpanda Operator uses custom resource definitions (CRDs) to manage Redpanda clusters, topics, users, and other resources declaratively in Kubernetes.
+
+== CRD source files
+
+The CRD source definitions are maintained in the https://github.com/redpanda-data/redpanda-operator[Redpanda Operator repository^] under https://github.com/redpanda-data/redpanda-operator/tree/main/operator/config/crd/bases[`operator/config/crd/bases`^]:
+
+|===
+| CRD | File | Description
+
+| Redpanda
+| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml[`cluster.redpanda.com_redpandas.yaml`^]
+| Defines Redpanda cluster resources.
+
+| Topic
+| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_topics.yaml[`cluster.redpanda.com_topics.yaml`^]
+| Defines Kafka topic resources.
+
+| User
+| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_users.yaml[`cluster.redpanda.com_users.yaml`^]
+| Defines SASL user resources.
+
+| Console
+| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_consoles.yaml[`cluster.redpanda.com_consoles.yaml`^]
+| Defines Redpanda Console resources.
+
+| Schema
+| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_schemas.yaml[`cluster.redpanda.com_schemas.yaml`^]
+| Defines Schema Registry resources.
+
+| RedpandaRole
+| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_redpandaroles.yaml[`cluster.redpanda.com_redpandaroles.yaml`^]
+| Defines role-based access control resources.
+
+| ShadowLink
+| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_shadowlinks.yaml[`cluster.redpanda.com_shadowlinks.yaml`^]
+| Defines shadow linking resources for disaster recovery.
+
+| Group
+| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_groups.yaml[`cluster.redpanda.com_groups.yaml`^]
+| Defines consumer group resources.
+
+| NodePool
+| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_nodepools.yaml[`cluster.redpanda.com_nodepools.yaml`^]
+| Defines node pool resources for cluster scaling.
+
+| StretchCluster
+| https://github.com/redpanda-data/redpanda-operator/blob/main/operator/config/crd/bases/cluster.redpanda.com_stretchclusters.yaml[`cluster.redpanda.com_stretchclusters.yaml`^]
+| Defines stretch cluster resources for multi-datacenter deployments.
+|===
+
+All CRDs belong to the `cluster.redpanda.com` API group. The CRDs are installed automatically when you deploy the Redpanda Operator using Helm with `crds.enabled=true`.
+
+For the full API reference of supported fields, see xref:reference:k-crd.adoc[cluster.redpanda.com/v1alpha2].

--- a/modules/reference/pages/k-crd-index.adoc
+++ b/modules/reference/pages/k-crd-index.adoc
@@ -1,5 +1,4 @@
 = Kubernetes Custom Resource Definitions
-:page-layout: index
 :description: Explore all custom resource definitions (CRDs) that are supported by the Redpanda Operator.
 :page-aliases: reference:topic-crd.adoc, reference:crd.adoc, reference:kubernetes-crd-index.adoc, reference:redpanda-operator/crd.adoc
 


### PR DESCRIPTION
## Summary
- Adds descriptive content to the CRD index page (`k-crd-index.adoc`) which was previously just a title
- Documents all 10 CRD source files from the [`redpanda-operator` repository](https://github.com/redpanda-data/redpanda-operator/tree/main/operator/config/crd/bases) in a table with direct links to each YAML file
- Covers: Redpanda, Topic, User, Console, Schema, RedpandaRole, ShadowLink, Group, NodePool, and StretchCluster CRDs
- Notes that CRDs are installed automatically via Helm with `crds.enabled=true`
- Direct link: https://deploy-preview-1634--redpanda-docs-preview.netlify.app/current/reference/k-crd-index/

## Test plan
- [ ] Verify the CRD index page renders correctly in the Antora preview
- [ ] Confirm all GitHub links to CRD YAML files resolve correctly
- [ ] Verify the xref link to `k-crd.adoc` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)