### PR TITLE
docs: Add 26.1 FIPS breaking change to rolling upgrade

### DIFF
--- a/modules/upgrade/partials/incompat-changes.adoc
+++ b/modules/upgrade/partials/incompat-changes.adoc
@@ -1,5 +1,8 @@
 === Review incompatible changes
 
+* *Breaking changes in Redpanda 26.1*:
+** If FIPS mode is enabled, change any SASL/SCRAM user passwords shorter than 14 characters to at least 14 characters before upgrading. FIPS 140-3 enforces stricter HMAC key size requirements than FIPS 140-2. Because Redpanda stores passwords in encrypted form, it cannot check the length of existing passwords. Clients with passwords shorter than 14 characters will fail to authenticate after the upgrade. See xref:manage:security/fips-compliance.adoc[Configure Redpanda for FIPS].
+
 * *Breaking changes in Redpanda 25.3*:
 ** {empty}
 +


### PR DESCRIPTION
## Summary
- Adds a new "Breaking changes in Redpanda 26.1" entry to the "Review incompatible changes" section on the rolling upgrade page
- Warns users with FIPS mode enabled to change SASL/SCRAM passwords shorter than 14 characters before upgrading (FIPS 140-3 stricter HMAC key size requirements)
- Cross-references the FIPS compliance page for details

## Page preview
[Review incompatible changes 26.1](https://deploy-preview-1640--redpanda-docs-preview.netlify.app/current/upgrade/rolling-upgrade/#review-incompatible-changes)

## Test plan
- [x] Local build passes with no new errors
- [x] Visually verified the new section renders correctly on the rolling upgrade page

🤖 Generated with [Claude Code](https://claude.com/claude-code)