### PR TITLE
Preview 26.1

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -16,9 +16,9 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [v/*, shared, site-search,'!v-end-of-life/*']
+    branches: [v-WIP/26.1, v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: '26.1'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -16,7 +16,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [v-WIP/26.1, v/*, shared, site-search,'!v-end-of-life/*']
+    branches: [main, v-WIP/26.1, v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
     branches: '26.1'
   - url: https://github.com/redpanda-data/redpanda-labs

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -16,7 +16,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [main, v-WIP/26.1, v/*, shared, site-search,'!v-end-of-life/*']
+    branches: [v-WIP/26.1, v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
     branches: '26.1'
   - url: https://github.com/redpanda-data/redpanda-labs

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -16,7 +16,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [v-WIP/26.1, v/*, shared, site-search,'!v-end-of-life/*']
+    branches: [v-WIP/26.1, v/*, '!v/25.3', shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
     branches: '26.1'
   - url: https://github.com/redpanda-data/redpanda-labs


### PR DESCRIPTION
This allows local builds to preview how the 26.1 release will look when published, including both self-managed and cloud documentation.

## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
