### PR TITLE
docs: Add missing 26.1 features to release notes and fix cloud-docs xrefs

### DIFF
--- a/docs-data/property-overrides.json
+++ b/docs-data/property-overrides.json
@@ -775,10 +775,10 @@
       "config_scope": "cluster"
     },
     "default_redpanda_storage_mode": {
-      "description": "Set the default storage mode for new topics. This value applies to any topic created without an explicit <<redpandastoragemode,`redpanda.storage.mode`>> setting (that is, when the topic's `redpanda.storage.mode` is `unset`).\n\nAccepted values:\n\n* `unset`: Defer to the legacy <<cloud_storage_enable_remote_read,`redpanda.remote.read`>> and <<cloud_storage_enable_remote_write,`redpanda.remote.write`>> topic properties for Tiered Storage configuration.\n* `local`: Store data only on local disks, with no object storage involvement.\n* `tiered`: Store data on local disks and replicate it to object storage using xref:manage:tiered-storage.adoc[Tiered Storage]. Equivalent to setting `redpanda.remote.read` and `redpanda.remote.write` to `true`.\n* `cloud`: Store data primarily in object storage using xref:manage:tiered-storage.adoc#cloud-topics[cloud topics].",
+      "description": "Set the default storage mode for new topics. This value applies to any topic created without an explicit <<redpandastoragemode,`redpanda.storage.mode`>> setting (that is, when the topic's `redpanda.storage.mode` is `unset`).\n\nAccepted values:\n\n* `unset`: Defer to the legacy <<cloud_storage_enable_remote_read,`redpanda.remote.read`>> and <<cloud_storage_enable_remote_write,`redpanda.remote.write`>> topic properties for Tiered Storage configuration.\n* `local`: Store data only on local disks, with no object storage involvement.\n* `tiered`: Store data on local disks and replicate it to object storage using Tiered Storage. Equivalent to setting `redpanda.remote.read` and `redpanda.remote.write` to `true`.\n* `cloud`: Store data primarily in object storage using Cloud Topics.",
       "related_topics": [
-        "xref:manage:tiered-storage.adoc[Tiered Storage]",
-        "xref:develop:manage-topics/cloud-topics.adoc[Manage Cloud Topics]"
+        "self-managed-only: xref:manage:tiered-storage.adoc[Tiered Storage]",
+        "self-managed-only: xref:develop:manage-topics/cloud-topics.adoc[Manage Cloud Topics]"
       ],
       "config_scope": "cluster",
       "version": "v26.1.1"
@@ -1689,8 +1689,8 @@
     "redpanda.cloud_topic.enabled": {
       "description": "Enable Cloud Topic storage mode for this topic. When enabled, topic data is stored primarily in object storage with local storage used only as a write buffer.\n\nTIP: To configure storage modes with more flexibility, use <<redpandastorage-mode, `redpanda.storage.mode`>> which supports `local`, `tiered`, `cloud`, and `unset` modes.",
       "related_topics": [
-        "xref:develop:manage-topics/cloud-topics.adoc[Cloud Topics]",
-        "xref:manage:tiered-storage.adoc[Tiered Storage]"
+        "self-managed-only: xref:develop:manage-topics/cloud-topics.adoc[Cloud Topics]",
+        "self-managed-only: xref:manage:tiered-storage.adoc[Tiered Storage]"
       ],
       "config_scope": "topic",
       "category": "tiered-storage"
@@ -1795,10 +1795,10 @@
       "config_scope": "topic"
     },
     "redpanda.storage.mode": {
-      "description": "The storage mode for a topic. Determines how topic data is stored and whether it is eligible for upload to object storage.\n\nAccepted values:\n\n* `local`: Topic data is stored only on the broker's local disk. Object storage upload is disabled for the topic, regardless of cluster-level Tiered Storage settings.\n* `tiered`: Topic data is stored on local disk and also uploaded to object storage. Enables xref:manage:tiered-storage.adoc[Tiered Storage] for the topic.\n* `cloud`: Topic data is stored in object storage using the glossterm:Cloud Topic[,Cloud Topics] architecture. Local storage is used only as a write buffer.\n* `unset`: Specifies that the topic's storage mode is unset, regardless of the cluster default. The topic may still have Tiered Storage enabled through the legacy properties `redpanda.remote.read` and `redpanda.remote.write`.\n\nThis property overrides the cluster-wide config_ref:default_redpanda_storage_mode,true,properties/cluster-properties[] setting for individual topics.",
+      "description": "The storage mode for a topic. Determines how topic data is stored and whether it is eligible for upload to object storage.\n\nAccepted values:\n\n* `local`: Topic data is stored only on the broker's local disk. Object storage upload is disabled for the topic, regardless of cluster-level Tiered Storage settings.\n* `tiered`: Topic data is stored on local disk and also uploaded to object storage. Enables Tiered Storage for the topic.\n* `cloud`: Topic data is stored in object storage using the Cloud Topics architecture. Local storage is used only as a write buffer.\n* `unset`: Specifies that the topic's storage mode is unset, regardless of the cluster default. The topic may still have Tiered Storage enabled through the legacy properties `redpanda.remote.read` and `redpanda.remote.write`.\n\nThis property overrides the cluster-wide config_ref:default_redpanda_storage_mode,true,properties/cluster-properties[] setting for individual topics.",
       "related_topics": [
-        "xref:manage:tiered-storage.adoc[Tiered Storage]",
-        "xref:develop:manage-topics/cloud-topics.adoc[Manage Cloud Topics]"
+        "self-managed-only: xref:manage:tiered-storage.adoc[Tiered Storage]",
+        "self-managed-only: xref:develop:manage-topics/cloud-topics.adoc[Manage Cloud Topics]"
       ],
       "config_scope": "topic",
       "category": "tiered-storage",

--- a/modules/get-started/pages/release-notes/operator.adoc
+++ b/modules/get-started/pages/release-notes/operator.adoc
@@ -17,3 +17,21 @@ link:https://github.com/redpanda-data/redpanda-operator/blob/release/v26.1.x/ope
 === Prometheus ServiceMonitor for Console
 
 The Console custom resource supports a `monitoring` configuration that deploys a Prometheus `ServiceMonitor` to automatically discover and scrape Console metrics. See xref:deploy:console/kubernetes/deploy.adoc#prometheus-servicemonitor[Prometheus ServiceMonitor].
+
+=== Schema Registry ACLs
+
+The Redpanda custom resource supports configuring Schema Registry ACLs through the `schemaRegistry.authenticationMethod` field. This enables fine-grained access control for Schema Registry operations in clusters deployed with Kubernetes.
+
+When you enable Schema Registry authentication, you can control which users and service accounts can register, modify, and read schemas. See xref:manage:kubernetes/security/authentication/k-authentication.adoc[] for configuration details.
+
+=== Cloud Topics for Kubernetes
+
+The Redpanda custom resource supports Cloud Topics in Kubernetes deployments. You can configure topics to use cloud storage as the primary backing store by setting the appropriate storage mode properties.
+
+Cloud Topics in Kubernetes provide the same cost savings and architectural benefits as self-managed deployments. You configure them declaratively through the Redpanda custom resource. For setup instructions, see xref:develop:manage-topics/cloud-topics.adoc[].
+
+=== Group-based access control (GBAC)
+
+The Redpanda Operator supports group-based access control (GBAC) for Kubernetes deployments with OIDC authentication. You can assign roles and ACLs to OIDC groups, and users automatically inherit permissions from their group memberships.
+
+GBAC simplifies permission management in Kubernetes environments by integrating with your identity provider's group structure. See xref:manage:security/authorization/gbac.adoc[] for configuration and usage details.

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -55,6 +55,28 @@ Redpanda now supports throughput quotas based on authenticated user principals. 
 
 You can set quotas for individual users, default users, or fine-grained user/client combinations. See xref:manage:cluster-maintenance/about-throughput-quotas.adoc[] for conceptual details, and xref:manage:cluster-maintenance/manage-throughput.adoc#set-user-based-quotas[Set user-based quotas] to get started.
 
+== Cross-region Remote Read Replicas
+
+Remote Read Replica topics on AWS can be deployed in a different region from the origin cluster's S3 bucket. This enables cross-region disaster recovery and data locality scenarios while maintaining the read-only replication model.
+
+To create cross-region Remote Read Replica topics, configure dynamic upstreams that point to the origin cluster's S3 bucket location. Redpanda manages the number of concurrent dynamic upstreams based on your `cloud_storage_url_style` setting (virtual_host or path style).
+
+See xref:manage:tiered-storage.adoc#remote-read-replicas[Remote Read Replicas] for setup instructions and configuration details.
+
+== Automatic broker decommissioning
+
+When continuous partition balancing is enabled, Redpanda can automatically decommission brokers that remain unavailable for a configured duration. The xref:reference:properties/cluster-properties.adoc#partition_autobalancing_node_autodecommission_timeout_sec[`partition_autobalancing_node_autodecommission_timeout_sec`] property triggers permanent broker removal, unlike xref:reference:properties/cluster-properties.adoc#partition_autobalancing_node_availability_timeout_sec[`partition_autobalancing_node_availability_timeout_sec`] which only moves partitions temporarily.
+
+Key characteristics:
+
+* Disabled by default
+* Requires `partition_autobalancing_mode` set to `continuous`
+* Permanently removes the node from the cluster (the node cannot rejoin automatically)
+* Processes one decommission at a time to maintain cluster stability
+* Manual intervention required if decommission stalls
+
+See xref:manage:cluster-maintenance/continuous-data-balancing.adoc[] for configuration details.
+
 == New configuration properties
 
 **Storage mode:**

--- a/modules/reference/partials/properties/cluster-properties.adoc
+++ b/modules/reference/partials/properties/cluster-properties.adoc
@@ -4933,8 +4933,14 @@ Accepted values:
 
 * `unset`: Defer to the legacy <<cloud_storage_enable_remote_read,`redpanda.remote.read`>> and <<cloud_storage_enable_remote_write,`redpanda.remote.write`>> topic properties for Tiered Storage configuration.
 * `local`: Store data only on local disks, with no object storage involvement.
+ifndef::env-cloud[]
 * `tiered`: Store data on local disks and replicate it to object storage using xref:manage:tiered-storage.adoc[Tiered Storage]. Equivalent to setting `redpanda.remote.read` and `redpanda.remote.write` to `true`.
 * `cloud`: Store data primarily in object storage using xref:manage:tiered-storage.adoc#cloud-topics[cloud topics].
+endif::[]
+ifdef::env-cloud[]
+* `tiered`: Store data on local disks and replicate it to object storage using Tiered Storage. Equivalent to setting `redpanda.remote.read` and `redpanda.remote.write` to `true`.
+* `cloud`: Store data primarily in object storage using Cloud Topics.
+endif::[]
 
 [cols="1s,2a"]
 |===

--- a/modules/reference/partials/properties/topic-properties.adoc
+++ b/modules/reference/partials/properties/topic-properties.adoc
@@ -979,9 +979,11 @@ endif::[]
 
 | Related topics
 |
+ifndef::env-cloud[]
 * xref:develop:manage-topics/cloud-topics.adoc[Cloud Topics]
 
 * xref:manage:tiered-storage.adoc[Tiered Storage]
+endif::[]
 
 |===
 
@@ -1565,8 +1567,14 @@ The storage mode for a topic. Determines how topic data is stored and whether it
 Accepted values:
 
 * `local`: Topic data is stored only on the broker's local disk. Object storage upload is disabled for the topic, regardless of cluster-level Tiered Storage settings.
+ifndef::env-cloud[]
 * `tiered`: Topic data is stored on local disk and also uploaded to object storage. Enables xref:manage:tiered-storage.adoc[Tiered Storage] for the topic.
 * `cloud`: Topic data is stored in object storage using the glossterm:Cloud Topic[,Cloud Topics] architecture. Local storage is used only as a write buffer.
+endif::[]
+ifdef::env-cloud[]
+* `tiered`: Topic data is stored on local disk and also uploaded to object storage. Enables Tiered Storage for the topic.
+* `cloud`: Topic data is stored in object storage using the Cloud Topics architecture. Local storage is used only as a write buffer.
+endif::[]
 * `unset`: Specifies that the topic's storage mode is unset, regardless of the cluster default. The topic may still have Tiered Storage enabled through the legacy properties `redpanda.remote.read` and `redpanda.remote.write`.
 
 This property overrides the cluster-wide config_ref:default_redpanda_storage_mode,true,properties/cluster-properties[] setting for individual topics.
@@ -1610,9 +1618,11 @@ endif::[]
 
 | Related topics
 |
+ifndef::env-cloud[]
 * xref:manage:tiered-storage.adoc[Tiered Storage]
 
 * xref:develop:manage-topics/cloud-topics.adoc[Manage Cloud Topics]
+endif::[]
 
 |===
 


### PR DESCRIPTION


Release notes updates:
- Add cross-region Remote Read Replicas on AWS feature
- Add automatic broker decommissioning feature
- Add Schema Registry ACLs for Kubernetes
- Add Cloud Topics for Kubernetes support
- Add GBAC for Kubernetes
- Apply docs team standards (active voice, terminology consistency)

Property documentation fixes:
- Add self-managed-only prefixes to property override xrefs for:
  - default_redpanda_storage_mode
  - redpanda.cloud_topic.enabled
  - redpanda.storage.mode
- Add ifndef::env-cloud[] conditionals in property partials to prevent broken xrefs when single-sourced into cloud-docs

## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
