### PR TITLE
docs: Remove broken Cloud Topics xref from glossary term

### DIFF
--- a/modules/terms/partials/cloud-topic.adoc
+++ b/modules/terms/partials/cloud-topic.adoc
@@ -3,6 +3,3 @@
 :hover-text: A Redpanda topic type, Cloud Topics use object storage (S3, GCS, or MinIO) as the primary data store (rather than replicating data across brokers). Unlike standard Redpanda topics, Cloud Topics allow users with flexible latency requirements to lower or eliminate costs associated with cross-AZ networking.
 :category: Redpanda features
 
-ifndef::env-cloud[]
-For more information, see xref:develop:manage-topics/cloud-topics.adoc[].
-endif::[]


### PR DESCRIPTION
## Summary
- Removes the xref to `develop:manage-topics/cloud-topics.adoc` from the Cloud Topic glossary term on the `shared` branch
- The target page only exists on `main` but the shared term is included by every versioned branch, causing build errors on v/23.3 through v/25.3
- The hover-text already provides a complete description of Cloud Topics

## Test plan
- [ ] Run a cloud-docs build (`npm run build`) and verify the `develop:manage-topics/cloud-topics.adoc` errors no longer appear for versioned branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)